### PR TITLE
Fix strategies failing on withdraw due to unexpected kwargs

### DIFF
--- a/wayfinder_paths/strategies/basis_trading_strategy/strategy.py
+++ b/wayfinder_paths/strategies/basis_trading_strategy/strategy.py
@@ -781,7 +781,7 @@ class BasisTradingStrategy(BasisSnapshotMixin, Strategy):
         c2 = coin2[1:] if coin2.startswith("U") and len(coin2) > 1 else coin2
         return c1 == c2
 
-    async def withdraw(self, amount: float | None = None) -> StatusTuple:
+    async def withdraw(self, amount: float | None = None, **kwargs) -> StatusTuple:
         address = self._get_strategy_wallet_address()
         usdc_token_id = "usd-coin-arbitrum"
 

--- a/wayfinder_paths/strategies/hyperlend_stable_yield_strategy/strategy.py
+++ b/wayfinder_paths/strategies/hyperlend_stable_yield_strategy/strategy.py
@@ -778,7 +778,7 @@ class HyperlendStableYieldStrategy(Strategy):
         except Exception:
             return None
 
-    async def withdraw(self, amount: float | None = None) -> StatusTuple:
+    async def withdraw(self, amount: float | None = None, **kwargs) -> StatusTuple:
         messages = []
 
         active_token = self.current_token

--- a/wayfinder_paths/strategies/moonwell_wsteth_loop_strategy/strategy.py
+++ b/wayfinder_paths/strategies/moonwell_wsteth_loop_strategy/strategy.py
@@ -3423,7 +3423,7 @@ class MoonwellWstethLoopStrategy(Strategy):
 
         return await self._repay_weth(weth_bal, remaining_debt)
 
-    async def withdraw(self, amount: float | None = None) -> StatusTuple:
+    async def withdraw(self, amount: float | None = None, **kwargs) -> StatusTuple:
         logger.info("")
         logger.info("*" * 60)
         logger.info("* MOONWELL STRATEGY WITHDRAW CALLED")

--- a/wayfinder_paths/strategies/stablecoin_yield_strategy/strategy.py
+++ b/wayfinder_paths/strategies/stablecoin_yield_strategy/strategy.py
@@ -853,7 +853,7 @@ class StablecoinYieldStrategy(Strategy):
             logger.error(f"Deposit process failed: {e}")
             return (False, f"Deposit error: {e}")
 
-    async def withdraw(self, amount: float | None = None) -> StatusTuple:
+    async def withdraw(self, amount: float | None = None, **kwargs) -> StatusTuple:
         logger.info(f"Starting withdrawal process for amount: {amount}")
         start_time = time.time()
 

--- a/wayfinder_paths/tests/test_strategy_interface.py
+++ b/wayfinder_paths/tests/test_strategy_interface.py
@@ -1,0 +1,55 @@
+"""Verify all strategies conform to expected interface."""
+
+import inspect
+from importlib import import_module
+from pathlib import Path
+
+import pytest
+
+from wayfinder_paths.core.strategies import Strategy
+
+
+def get_all_strategy_classes():
+    """Discover all Strategy subclasses in wayfinder_paths/strategies/."""
+    strategies_dir = Path(__file__).parent.parent / "strategies"
+    strategy_classes = []
+
+    for strategy_dir in strategies_dir.iterdir():
+        if not strategy_dir.is_dir() or strategy_dir.name.startswith("_"):
+            continue
+        strategy_file = strategy_dir / "strategy.py"
+        if not strategy_file.exists():
+            continue
+
+        module_path = f"wayfinder_paths.strategies.{strategy_dir.name}.strategy"
+        try:
+            module = import_module(module_path)
+            for _name, obj in inspect.getmembers(module, inspect.isclass):
+                if issubclass(obj, Strategy) and obj is not Strategy:
+                    strategy_classes.append((strategy_dir.name, obj))
+        except ImportError:
+            continue
+
+    return strategy_classes
+
+
+@pytest.mark.parametrize("strategy_name,strategy_class", get_all_strategy_classes())
+def test_withdraw_accepts_run_strategy_kwargs(strategy_name, strategy_class):
+    """
+    Verify withdraw() accepts max_wait_s and poll_interval_s kwargs.
+
+    run_strategy.py always passes these to withdraw(), so all strategies
+    must accept **kwargs to avoid TypeError.
+    """
+    sig = inspect.signature(strategy_class.withdraw)
+    params = sig.parameters
+
+    # Must accept **kwargs (VAR_KEYWORD)
+    has_var_keyword = any(
+        p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
+    )
+
+    assert has_var_keyword, (
+        f"{strategy_class.__name__}.withdraw() must accept **kwargs. "
+        f"run_strategy.py passes max_wait_s and poll_interval_s to all strategies."
+    )


### PR DESCRIPTION
Add **kwargs to withdraw() in all strategies to accept max_wait_s and poll_interval_s passed by run_strategy.py. Add regression test.