### PR TITLE
Hot-reload strategy modules and config on MCP calls

### DIFF
--- a/wayfinder_paths/mcp/tools/strategies.py
+++ b/wayfinder_paths/mcp/tools/strategies.py
@@ -5,7 +5,7 @@ import importlib
 from pathlib import Path
 from typing import Any, Literal
 
-from wayfinder_paths.core.config import CONFIG
+from wayfinder_paths.core.config import CONFIG, load_config
 from wayfinder_paths.core.engine.manifest import load_strategy_manifest
 from wayfinder_paths.core.strategies.Strategy import Strategy
 from wayfinder_paths.core.utils.evm_helpers import resolve_private_key_for_from_address
@@ -25,10 +25,12 @@ def _load_strategy_class(strategy_name: str) -> tuple[type[Strategy], str]:
     manifest = load_strategy_manifest(str(manifest_path))
     module_path, class_name = manifest.entrypoint.rsplit(".", 1)
     module = importlib.import_module(module_path)
+    importlib.reload(module)  # pick up code changes without MCP restart
     return getattr(module, class_name), manifest.status
 
 
 def _get_strategy_config(strategy_name: str) -> dict[str, Any]:
+    load_config()  # re-read config.json so new wallets are visible
     config = dict(CONFIG.get("strategy", {}))
     wallets = {w["label"]: w for w in CONFIG.get("wallets", [])}
 

--- a/wayfinder_paths/mcp/tools/wallets.py
+++ b/wayfinder_paths/mcp/tools/wallets.py
@@ -5,6 +5,7 @@ import importlib
 import time
 from typing import Any, Literal
 
+from wayfinder_paths.core.config import load_config
 from wayfinder_paths.core.utils.wallets import make_random_wallet, write_wallet_to_json
 from wayfinder_paths.mcp.state.profile_store import WalletProfileStore
 from wayfinder_paths.mcp.utils import (
@@ -169,6 +170,7 @@ async def wallets(
         w = make_random_wallet()
         w["label"] = want
         write_wallet_to_json(w, out_dir=root, filename="config.json")
+        load_config()  # refresh in-memory CONFIG so strategies see the new wallet
 
         refreshed = load_wallets()
         return ok(


### PR DESCRIPTION
## Summary
- Reload strategy modules on each run to pick up code changes without MCP restart
- Re-read config.json before strategy execution so new wallets are visible immediately
- Refresh in-memory CONFIG after wallet creation

## Motivation
During development, editing strategy code or creating new wallets currently requires restarting the MCP server. These changes enable hot-reloading so the server picks up changes automatically.

## Test plan
- [ ] Edit a strategy file while MCP server is running, verify changes take effect on next call
- [ ] Create a wallet via MCP, verify it's immediately usable by strategies without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)