### PR TITLE
feat: add project-local runner scheduler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ temp/
 .cache/
 .wayfinder_runs/*
 !.wayfinder_runs/README.md
+.wayfinder/
 
 # Jupyter
 .ipynb_checkpoints/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,63 @@ Run scripts with poetry: `poetry run python .wayfinder_runs/my_script.py`
 When a user wants a **repeatable/automated system** (recurring jobs):
 
 - Create or modify a strategy under `wayfinder_paths/strategies/` and follow the normal manifests/tests workflow.
+- Use the project-local runner to call strategy `update` on an interval (no cron needed).
+
+Runner CLI (project-local state in `./.wayfinder/runner/`):
+
+```bash
+# Start the daemon (recommended: detached/background)
+poetry run wayfinder runner start --detach
+
+# Idempotent: start if needed, otherwise no-op
+poetry run wayfinder runner ensure
+
+# Add an interval job (every 10 minutes)
+poetry run wayfinder runner add-job \
+  --name basis-update \
+  --type strategy \
+  --strategy basis_trading_strategy \
+  --action update \
+  --interval 600 \
+  --config ./config.json
+
+# Add an interval job for a local one-off script (must live in .wayfinder_runs/ by default)
+poetry run wayfinder runner add-job \
+  --name hourly-report \
+  --type script \
+  --script-path .wayfinder_runs/report.py \
+  --arg --verbose \
+  --interval 3600
+
+# Inspect / control
+poetry run wayfinder runner status
+poetry run wayfinder runner run-once basis-update
+poetry run wayfinder runner pause basis-update
+poetry run wayfinder runner resume basis-update
+poetry run wayfinder runner delete basis-update
+poetry run wayfinder runner stop
+```
+
+Architecture/extensibility notes live in `RUNNER_ARCHITECTURE.md`.
+
+Runner MCP tool (controls the daemon via its local Unix socket):
+
+- `mcp__wayfinder__runner(action="status")`
+- `mcp__wayfinder__runner(action="daemon_status")`
+- `mcp__wayfinder__runner(action="ensure_started")` (starts detached if needed)
+- `mcp__wayfinder__runner(action="daemon_stop")`
+- `mcp__wayfinder__runner(action="add_job", name="basis-update", interval_seconds=600, strategy="basis_trading_strategy", strategy_action="update", config="./config.json")`
+- `mcp__wayfinder__runner(action="add_job", name="hourly-report", type="script", interval_seconds=3600, script_path=".wayfinder_runs/report.py", args=["--verbose"])`
+- `mcp__wayfinder__runner(action="pause_job", name="basis-update")`
+- `mcp__wayfinder__runner(action="resume_job", name="basis-update")`
+- `mcp__wayfinder__runner(action="delete_job", name="basis-update")`
+- `mcp__wayfinder__runner(action="run_once", name="basis-update")`
+- `mcp__wayfinder__runner(action="job_runs", name="basis-update", limit=20)`
+- `mcp__wayfinder__runner(action="run_report", run_id=123, tail_bytes=4000)`
+
+Safety note:
+
+- Runner executions are local automation and do **not** go through the Claude safety review prompt. Treat `update/deposit/withdraw/exit` as live fund-moving actions.
 
 Token identifiers (important for quoting/execution):
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,49 @@ poetry run python -m wayfinder_paths.run_strategy boros_hype_strategy --action q
 poetry run python -m wayfinder_paths.run_strategy boros_hype_strategy --action run --interval 300
 ```
 
+## Runner (local scheduler)
+
+Run strategies on an interval without cron:
+
+```bash
+# Start the daemon (recommended: detached/background)
+poetry run wayfinder runner start --detach
+
+# Idempotent: start if needed, otherwise no-op
+poetry run wayfinder runner ensure
+
+# Add a job (run update every 10 minutes)
+poetry run wayfinder runner add-job \
+  --name basis-update \
+  --type strategy \
+  --strategy basis_trading_strategy \
+  --action update \
+  --interval 600 \
+  --config ./config.json
+
+# Schedule a local one-off script (must live in .wayfinder_runs/ by default)
+poetry run wayfinder runner add-job \
+  --name hourly-report \
+  --type script \
+  --script-path .wayfinder_runs/report.py \
+  --arg --verbose \
+  --interval 3600
+
+# Observe / control
+poetry run wayfinder runner status
+poetry run wayfinder runner run-once basis-update
+poetry run wayfinder runner pause basis-update
+poetry run wayfinder runner resume basis-update
+poetry run wayfinder runner delete basis-update
+poetry run wayfinder runner runs basis-update --limit 20
+poetry run wayfinder runner run-report 1 --tail-bytes 4000
+poetry run wayfinder runner stop
+```
+
+Runner state (SQLite + per-run logs) is stored in `./.wayfinder/runner/`.
+
+For architecture/extensibility notes (e.g. future Docker/VM runner), see `RUNNER_ARCHITECTURE.md`.
+
 ## Claude MCP Integration
 
 The repo includes an MCP server for Claude Code (see `.mcp.json`).
@@ -183,6 +226,7 @@ poetry run python -m wayfinder_paths.mcp.server
 | `run_strategy` | Status, policy, and strategy actions |
 | `run_script` | Execute a local Python script inside `.wayfinder_runs/` |
 | `wallets` | Create or list local wallets |
+| `runner` | Control the local runner daemon (status/add jobs/pause/resume) |
 
 ### MCP Resources (read-only)
 

--- a/RUNNER_ARCHITECTURE.md
+++ b/RUNNER_ARCHITECTURE.md
@@ -1,0 +1,63 @@
+# Runner Architecture (extensible)
+
+This repo includes a **project-local runner daemon** that schedules jobs (strategies + scripts) on an interval.
+
+The current implementation is **local-only** (Unix domain socket control plane + subprocess workers), but the
+code is intentionally split so we can add a **remote/cloud runner** later without rewriting the scheduler.
+
+## Components
+
+### `runnerd` (daemon)
+
+- Code: `wayfinder_paths/runner/daemon.py`
+- Owns:
+  - SQLite state (`state.db`) and job/run history
+  - Interval scheduling loop (tick-based)
+  - Spawning worker subprocesses and collecting exit status
+  - Per-run log files
+
+### Control plane (transport-agnostic routing)
+
+- Request/response protocol: `wayfinder_paths/runner/protocol.py`
+  - JSON-line RPC framing and encode/decode helpers.
+  - This stays stable as we add new transports.
+- Method routing: `wayfinder_paths/runner/api.py`
+  - Maps `method` → `daemon.ctl_*` calls.
+  - Transport-independent so it can be reused by a future HTTP server.
+
+### Control transport (pluggable)
+
+- Transport interface + Unix socket transport: `wayfinder_paths/runner/transport.py`
+  - Today: `UnixSocketTransport` → `./.wayfinder/runner/runner.sock`
+  - Future: add an `HttpTransport` and an HTTP server that calls the same `api.dispatch()`.
+- Client: `wayfinder_paths/runner/client.py`
+  - Uses the protocol helpers + transport to issue control calls.
+
+## State directory (container-friendly)
+
+By default runner state lives in the repo:
+
+- `./.wayfinder/runner/state.db`
+- `./.wayfinder/runner/logs/`
+- `./.wayfinder/runner/runner.sock`
+
+For Docker/VM deployments you can move the runner state (DB + logs + socket) with:
+
+- `WAYFINDER_RUNNER_DIR=/path/to/state` (or `WAYFINDER_RUNNER_STATE_DIR`)
+
+If the path is relative, it’s resolved relative to the repo root.
+
+## Future: remote/cloud runner (planned)
+
+When we add a cloud/remote deployment, we can do it with minimal changes by extending the seams above:
+
+1. Add a **new control transport** (HTTP) alongside Unix sockets.
+2. Add an HTTP server that:
+   - uses the same JSON request/response shapes (or a thin mapping layer)
+   - calls `wayfinder_paths.runner.api.dispatch()` for behavior
+3. Add “profiles/endpoints” to CLI/MCP so `runner status/add-job/...` can target either:
+   - local runner (Unix socket)
+   - remote runner (HTTP + token), running in a VM/container with a persistent volume for `WAYFINDER_RUNNER_DIR`
+
+We’re not enabling the remote transport yet; this document just describes the intended extension path.
+

--- a/poetry.lock
+++ b/poetry.lock
@@ -754,7 +754,7 @@ version = "8.3.1"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6"},
     {file = "click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a"},
@@ -774,7 +774,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "sys_platform == \"win32\"", dev = "sys_platform == \"win32\" or platform_system == \"Windows\""}
+markers = {main = "sys_platform == \"win32\" or platform_system == \"Windows\"", dev = "platform_system == \"Windows\" or sys_platform == \"win32\""}
 
 [[package]]
 name = "coverage"
@@ -4255,4 +4255,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "617457ff39caaa04206663ff43199cf8fe27a878a5a62f84b83a35025c2e029c"
+content-hash = "44bb83a52aa3625c7db05c6ca878d4ab570bdc77ff818e5b29a765e6810ece99"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ numpy = "^1.26.0"
 pandas = "^2.2.0"
 hyperliquid-felix = "*"
 aiocache = "^0.12.3"
+click = "^8.1.7"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.4.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ aiohttp>=3.13.0
 python-dotenv>=1.1.1
 loguru>=0.7.3
 PyYAML>=6.0.1
+click>=8.1.7
 
 # Data handling
 pydantic>=2.11.9

--- a/wayfinder_paths/core/utils/test_transaction.py
+++ b/wayfinder_paths/core/utils/test_transaction.py
@@ -200,10 +200,6 @@ class TestGasPriceTransaction:
                 assert "maxFeePerGas" not in result
                 assert "maxPriorityFeePerGas" not in result
                 assert result["gasPrice"] > 0
-            elif chain_id == 999:
-                assert "gasPrice" not in result
-                assert result["maxFeePerGas"] > 0
-                assert result["maxPriorityFeePerGas"] == 0
             else:
                 assert "gasPrice" not in result
                 assert result["maxFeePerGas"] > 0

--- a/wayfinder_paths/core/utils/transaction.py
+++ b/wayfinder_paths/core/utils/transaction.py
@@ -14,6 +14,7 @@ from wayfinder_paths.core.constants.base import (
     SUGGESTED_PRIORITY_FEE_MULTIPLIER,
 )
 from wayfinder_paths.core.constants.chains import (
+    CHAIN_ID_HYPEREVM,
     PRE_EIP_1559_CHAIN_IDS,
 )
 from wayfinder_paths.core.utils.web3 import (
@@ -103,6 +104,11 @@ async def gas_price_transaction(transaction: dict):
     async def _get_gas_price(web3: AsyncWeb3) -> int:
         return await web3.eth.gas_price
 
+    async def _get_hyperevm_big_block_gas_price(web3: AsyncWeb3) -> int:
+        # Hyperevm exposes a chain-specific RPC for a recommended max fee and does not
+        # use EIP-1559 priority fees in the normal way.
+        return await web3.hype.big_block_gas_price()
+
     async def _get_base_fee(web3: AsyncWeb3) -> int:
         latest_block = await web3.eth.get_block("latest")
         return latest_block.baseFeePerGas
@@ -123,6 +129,13 @@ async def gas_price_transaction(transaction: dict):
             gas_price = max(gas_prices)
 
             transaction["gasPrice"] = int(gas_price * SUGGESTED_GAS_PRICE_MULTIPLIER)
+        elif chain_id == CHAIN_ID_HYPEREVM:
+            big_block_prices = await asyncio.gather(
+                *[_get_hyperevm_big_block_gas_price(web3) for web3 in web3s]
+            )
+            max_fee = max(big_block_prices)
+            transaction["maxFeePerGas"] = int(max_fee * SUGGESTED_GAS_PRICE_MULTIPLIER)
+            transaction["maxPriorityFeePerGas"] = 0
         else:
             base_fees = await asyncio.gather(*[_get_base_fee(web3) for web3 in web3s])
             priority_fees = await asyncio.gather(

--- a/wayfinder_paths/mcp/cli.py
+++ b/wayfinder_paths/mcp/cli.py
@@ -9,33 +9,13 @@ Usage:
   poetry run python -m wayfinder_paths.mcp.cli discover --kind strategies
 """
 
-import click
-
+from wayfinder_paths.mcp.cli_builder import build_cli
+from wayfinder_paths.mcp.server import mcp
 from wayfinder_paths.runner.cli import runner_cli
 
 
 def main():
-    # Runner should work even if optional MCP dependencies aren't installed.
-    try:
-        from wayfinder_paths.mcp.cli_builder import build_cli
-        from wayfinder_paths.mcp.server import mcp
-
-        cli = build_cli(mcp)
-    except ModuleNotFoundError as exc:
-        if str(exc.name) != "mcp":
-            raise
-
-        cli = click.Group(
-            name="wayfinder",
-            help="Wayfinder Paths CLI (runner-only; install MCP deps for tools).",
-        )
-
-        @cli.command(name="mcp-help", help="Explain how to enable MCP tool commands.")
-        def _mcp_help() -> None:
-            click.echo(
-                "MCP dependencies are not installed. Install the project's dev dependencies to enable MCP tools."
-            )
-
+    cli = build_cli(mcp)
     cli.add_command(runner_cli)
     cli(standalone_mode=True)
 

--- a/wayfinder_paths/mcp/server.py
+++ b/wayfinder_paths/mcp/server.py
@@ -40,6 +40,7 @@ from wayfinder_paths.mcp.tools.execute import execute
 from wayfinder_paths.mcp.tools.hyperliquid import hyperliquid, hyperliquid_execute
 from wayfinder_paths.mcp.tools.quotes import quote_swap
 from wayfinder_paths.mcp.tools.run_script import run_script
+from wayfinder_paths.mcp.tools.runner import runner
 from wayfinder_paths.mcp.tools.strategies import run_strategy
 from wayfinder_paths.mcp.tools.wallets import wallets
 
@@ -73,6 +74,7 @@ mcp.tool()(run_strategy)
 mcp.tool()(run_script)
 mcp.tool()(execute)
 mcp.tool()(wallets)
+mcp.tool()(runner)
 
 
 def main() -> None:

--- a/wayfinder_paths/mcp/tools/runner.py
+++ b/wayfinder_paths/mcp/tools/runner.py
@@ -1,0 +1,415 @@
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any, Literal
+
+from wayfinder_paths.mcp.utils import err, ok, read_text_excerpt, repo_root
+from wayfinder_paths.runner.client import RunnerControlClient
+from wayfinder_paths.runner.constants import JOB_TYPE_SCRIPT, JOB_TYPE_STRATEGY
+from wayfinder_paths.runner.lifecycle import ensure_daemon_started, try_status
+from wayfinder_paths.runner.paths import RunnerPaths, get_runner_paths
+
+
+def _default_sock_path() -> Path:
+    paths = get_runner_paths(repo_root=repo_root())
+    return paths.sock_path
+
+
+def _client(sock_path: str | None) -> RunnerControlClient:
+    path = Path(sock_path) if sock_path else _default_sock_path()
+    return RunnerControlClient(sock_path=path)
+
+
+def _paths_for_client(*, root: Path, client: RunnerControlClient) -> RunnerPaths:
+    runner_dir = client.sock_path.parent
+    return RunnerPaths(
+        repo_root=root,
+        runner_dir=runner_dir,
+        db_path=runner_dir / "state.db",
+        logs_dir=runner_dir / "logs",
+        sock_path=client.sock_path,
+    )
+
+
+async def runner(
+    action: Literal[
+        "daemon_status",
+        "daemon_start",
+        "daemon_stop",
+        "ensure_started",
+        "status",
+        "add_job",
+        "update_job",
+        "pause_job",
+        "resume_job",
+        "delete_job",
+        "run_once",
+        "job_runs",
+        "run_report",
+    ],
+    *,
+    sock_path: str | None = None,
+    # daemon start options
+    tick_seconds: float | None = None,
+    max_workers: int | None = None,
+    max_failures: int | None = None,
+    default_timeout_seconds: int | None = None,
+    log_level: str | None = None,
+    # Job fields
+    name: str | None = None,
+    type: str | None = None,  # noqa: A002 (matches CLI/API)
+    payload: dict[str, Any] | None = None,
+    interval_seconds: int | None = None,
+    limit: int | None = None,
+    run_id: int | None = None,
+    tail_bytes: int | None = None,
+    # Strategy payload fields
+    strategy: str | None = None,
+    strategy_action: str | None = None,
+    config: str | None = None,
+    wallet_label: str | None = None,
+    timeout_seconds: int | None = None,
+    # Script payload fields
+    script_path: str | None = None,
+    args: list[str] | None = None,
+    env: dict[str, str] | None = None,
+    debug: bool = False,
+) -> dict[str, Any]:
+    """Control the local runner daemon via its Unix socket.
+
+    Notes:
+      - Use `daemon_status`/`ensure_started`/`daemon_start`/`daemon_stop` to manage the daemon lifecycle.
+      - `add_job` creates a new job; `run_once` triggers an immediate execution.
+    """
+
+    client = _client(sock_path)
+
+    try:
+        if action == "daemon_status":
+            started, status, err_obj = try_status(client)
+            return ok(
+                {
+                    "started": bool(started),
+                    "sock_path": str(client.sock_path),
+                    "status": status,
+                    "error": err_obj,
+                }
+            )
+
+        if action == "daemon_start":
+            started, status, _ = try_status(client)
+            if started and status is not None:
+                return ok(
+                    {
+                        "started": True,
+                        "already_running": True,
+                        "sock_path": str(client.sock_path),
+                        "status": status,
+                    }
+                )
+
+            root = repo_root()
+            paths = _paths_for_client(root=root, client=client)
+            env_out = os.environ.copy()
+            env_out["WAYFINDER_RUNNER_DIR"] = str(paths.runner_dir)
+
+            ok_started, info = ensure_daemon_started(
+                paths=paths,
+                tick_seconds=float(tick_seconds) if tick_seconds is not None else 1.0,
+                max_workers=int(max_workers) if max_workers is not None else 4,
+                max_failures=int(max_failures) if max_failures is not None else 5,
+                default_timeout_seconds=int(default_timeout_seconds)
+                if default_timeout_seconds is not None
+                else 20 * 60,
+                log_level=str(log_level) if log_level is not None else "INFO",
+                banner="[mcp]",
+                env=env_out,
+            )
+            if not ok_started:
+                log_path_s = str(info.get("log_path") or "")
+                log_path = Path(log_path_s) if log_path_s else None
+                return err(
+                    "runner_start_failed",
+                    "Runner daemon did not become ready in time",
+                    details={
+                        **info,
+                        "log_tail": read_text_excerpt(log_path, max_chars=1200)
+                        if log_path is not None
+                        else None,
+                    },
+                )
+
+            status = info.get("status")
+            daemon_pid = info.get("pid")
+            if daemon_pid is None and isinstance(status, dict):
+                daemon_pid = status.get("pid")
+
+            return ok(
+                {
+                    "started": True,
+                    "already_running": bool(info.get("already_running")),
+                    "pid": daemon_pid,
+                    "spawn_pid": daemon_pid,
+                    "sock_path": str(paths.sock_path),
+                    "log_path": info.get("log_path"),
+                    "status": status,
+                }
+            )
+
+        if action == "daemon_stop":
+            started, _, _ = try_status(client)
+            if not started:
+                return ok(
+                    {
+                        "stopped": True,
+                        "already_stopped": True,
+                        "sock_path": str(client.sock_path),
+                    }
+                )
+
+            resp = client.call("shutdown")
+            if not resp.get("ok"):
+                return err(
+                    "runner_error", str(resp.get("error") or "unknown"), details=resp
+                )
+
+            deadline = time.time() + 10.0
+            while time.time() < deadline:
+                if not client.sock_path.exists():
+                    return ok({"stopped": True, "sock_path": str(client.sock_path)})
+                ping = client.call("status")
+                if not ping.get("ok"):
+                    return ok(
+                        {
+                            "stopped": True,
+                            "sock_path": str(client.sock_path),
+                            "note": "daemon unreachable",
+                        }
+                    )
+                time.sleep(0.1)
+
+            return ok(
+                {
+                    "stopped": False,
+                    "sock_path": str(client.sock_path),
+                    "note": "timeout waiting for shutdown",
+                }
+            )
+
+        if action == "ensure_started":
+            started, status, _ = try_status(client)
+            if started and status is not None:
+                return ok(
+                    {
+                        "started": True,
+                        "sock_path": str(client.sock_path),
+                        "status": status,
+                    }
+                )
+
+            started_resp = await runner(  # type: ignore[misc]
+                action="daemon_start",
+                sock_path=sock_path,
+                tick_seconds=tick_seconds,
+                max_workers=max_workers,
+                max_failures=max_failures,
+                default_timeout_seconds=default_timeout_seconds,
+                log_level=log_level,
+            )
+            if not started_resp.get("ok"):
+                return started_resp
+
+            # Re-fetch full status after start.
+            resp = _client(sock_path).call("status")
+            if resp.get("ok"):
+                return ok(
+                    {
+                        "started": True,
+                        "sock_path": str(_client(sock_path).sock_path),
+                        "status": resp.get("result"),
+                    }
+                )
+            return err(
+                "runner_error", str(resp.get("error") or "unknown"), details=resp
+            )
+
+        # Remaining actions require an already-running daemon.
+        if not client.sock_path.exists():
+            return err(
+                "runner_not_running",
+                "Runner daemon socket not found. Start it with: poetry run wayfinder runner ensure",
+                details={"sock_path": str(client.sock_path)},
+            )
+
+        if action == "status":
+            resp = client.call("status")
+            if resp.get("ok"):
+                return ok(resp.get("result"))
+            return err(
+                "runner_error", str(resp.get("error") or "unknown"), details=resp
+            )
+
+        if action == "job_runs":
+            if not name:
+                return err("invalid_request", "name is required for job_runs")
+            lim = int(limit) if isinstance(limit, int) else 50
+            resp = client.call("job_runs", {"name": str(name).strip(), "limit": lim})
+            if resp.get("ok"):
+                return ok(resp.get("result"))
+            return err(
+                "runner_error", str(resp.get("error") or "unknown"), details=resp
+            )
+
+        if action == "run_report":
+            if run_id is None:
+                return err("invalid_request", "run_id is required for run_report")
+            tb = int(tail_bytes) if isinstance(tail_bytes, int) else 4000
+            resp = client.call("run_report", {"run_id": int(run_id), "tail_bytes": tb})
+            if resp.get("ok"):
+                return ok(resp.get("result"))
+            return err(
+                "runner_error", str(resp.get("error") or "unknown"), details=resp
+            )
+
+        if action == "add_job":
+            if not name:
+                return err("invalid_request", "name is required for add_job")
+            interval = interval_seconds
+            if interval is None:
+                return err(
+                    "invalid_request", "interval_seconds is required for add_job"
+                )
+            if not isinstance(interval, int) or interval <= 0:
+                return err(
+                    "invalid_request", "interval_seconds must be a positive integer"
+                )
+
+            job_type = str(type or JOB_TYPE_STRATEGY).strip().lower()
+            if job_type not in {JOB_TYPE_STRATEGY, JOB_TYPE_SCRIPT}:
+                return err("invalid_request", f"unsupported job type: {job_type}")
+
+            job_payload: dict[str, Any] = {"debug": bool(debug)}
+            if wallet_label:
+                job_payload["wallet_label"] = str(wallet_label).strip()
+            if timeout_seconds is not None:
+                job_payload["timeout_seconds"] = int(timeout_seconds)
+            if env is not None:
+                if not isinstance(env, dict):
+                    return err("invalid_request", "env must be an object")
+                job_payload["env"] = {str(k): str(v) for k, v in env.items()}
+
+            if job_type == JOB_TYPE_STRATEGY:
+                strat = (strategy or "").strip()
+                if not strat:
+                    return err("invalid_request", "strategy is required for add_job")
+                job_payload.update(
+                    {
+                        "strategy": strat,
+                        "action": (strategy_action or "update").strip(),
+                        "config": (config or "config.json").strip(),
+                    }
+                )
+            else:
+                sp = (script_path or "").strip()
+                if not sp:
+                    return err(
+                        "invalid_request",
+                        "script_path is required for add_job when type=script",
+                    )
+                argv = [str(a) for a in (args or []) if str(a).strip()]
+                job_payload.update(
+                    {
+                        "script_path": sp,
+                        "args": argv,
+                    }
+                )
+
+            resp = client.call(
+                "add_job",
+                {
+                    "name": str(name).strip(),
+                    "type": job_type,
+                    "payload": job_payload,
+                    "interval_seconds": int(interval),
+                },
+            )
+            if resp.get("ok"):
+                return ok(resp.get("result"))
+            return err(
+                "runner_error", str(resp.get("error") or "unknown"), details=resp
+            )
+
+        if action == "update_job":
+            if not name:
+                return err("invalid_request", "name is required for update_job")
+            if payload is not None and not isinstance(payload, dict):
+                return err("invalid_request", "payload must be an object")
+            if interval_seconds is not None and (
+                not isinstance(interval_seconds, int) or interval_seconds <= 0
+            ):
+                return err(
+                    "invalid_request", "interval_seconds must be a positive integer"
+                )
+            resp = client.call(
+                "update_job",
+                {
+                    "name": str(name).strip(),
+                    "payload": payload,
+                    "interval_seconds": interval_seconds,
+                },
+            )
+            if resp.get("ok"):
+                return ok(resp.get("result"))
+            return err(
+                "runner_error", str(resp.get("error") or "unknown"), details=resp
+            )
+
+        if action == "pause_job":
+            if not name:
+                return err("invalid_request", "name is required for pause_job")
+            resp = client.call("pause_job", {"name": str(name).strip()})
+            if resp.get("ok"):
+                return ok(resp.get("result"))
+            return err(
+                "runner_error", str(resp.get("error") or "unknown"), details=resp
+            )
+
+        if action == "resume_job":
+            if not name:
+                return err("invalid_request", "name is required for resume_job")
+            resp = client.call("resume_job", {"name": str(name).strip()})
+            if resp.get("ok"):
+                return ok(resp.get("result"))
+            return err(
+                "runner_error", str(resp.get("error") or "unknown"), details=resp
+            )
+
+        if action == "delete_job":
+            if not name:
+                return err("invalid_request", "name is required for delete_job")
+            resp = client.call("delete_job", {"name": str(name).strip()})
+            if resp.get("ok"):
+                return ok(resp.get("result"))
+            return err(
+                "runner_error", str(resp.get("error") or "unknown"), details=resp
+            )
+
+        if action == "run_once":
+            if not name:
+                return err("invalid_request", "name is required for run_once")
+            resp = client.call("run_once", {"name": str(name).strip()})
+            if resp.get("ok"):
+                return ok(resp.get("result"))
+            return err(
+                "runner_error", str(resp.get("error") or "unknown"), details=resp
+            )
+
+        return err("invalid_request", f"unknown action: {action}")
+    except Exception as exc:  # noqa: BLE001
+        return err(
+            "runner_unreachable",
+            str(exc),
+            details={"sock_path": str(client.sock_path)},
+        )

--- a/wayfinder_paths/run_strategy.py
+++ b/wayfinder_paths/run_strategy.py
@@ -23,14 +23,22 @@ from wayfinder_paths.core.utils.evm_helpers import resolve_private_key_for_from_
 from wayfinder_paths.core.utils.web3 import get_transaction_chain_id, web3_from_chain_id
 
 
-def get_strategy_config(strategy_name: str) -> dict[str, Any]:
+def get_strategy_config(
+    strategy_name: str,
+    *,
+    wallet_label: str | None = None,
+    main_wallet_label: str | None = None,
+) -> dict[str, Any]:
     config = dict(CONFIG.get("strategy", {}))
     wallets = {w["label"]: w for w in CONFIG.get("wallets", [])}
 
-    if "main_wallet" not in config and "main" in wallets:
-        config["main_wallet"] = {"address": wallets["main"]["address"]}
-    if "strategy_wallet" not in config and strategy_name in wallets:
-        config["strategy_wallet"] = {"address": wallets[strategy_name]["address"]}
+    main_label = str(main_wallet_label).strip() if main_wallet_label else "main"
+    strat_label = str(wallet_label).strip() if wallet_label else strategy_name
+
+    if "main_wallet" not in config and main_label in wallets:
+        config["main_wallet"] = {"address": wallets[main_label]["address"]}
+    if "strategy_wallet" not in config and strat_label in wallets:
+        config["strategy_wallet"] = {"address": wallets[strat_label]["address"]}
 
     by_addr = {w["address"].lower(): w for w in CONFIG.get("wallets", [])}
     for key in ("main_wallet", "strategy_wallet"):
@@ -60,7 +68,13 @@ def find_strategy_class(module) -> type[Strategy]:
 
 
 async def run_strategy(strategy_name: str, action: str = "status", **kw):
-    config = get_strategy_config(strategy_name)
+    wallet_label = kw.pop("wallet_label", None)
+    main_wallet_label = kw.pop("main_wallet_label", None)
+    config = get_strategy_config(
+        strategy_name,
+        wallet_label=wallet_label,
+        main_wallet_label=main_wallet_label,
+    )
 
     def signing_cb(key: str):
         if addr := config.get(key, {}).get("address"):
@@ -134,7 +148,17 @@ async def run_strategy(strategy_name: str, action: str = "status", **kw):
 
 def main():
     p = argparse.ArgumentParser()
-    p.add_argument("strategy")
+    p.add_argument(
+        "strategy_pos",
+        nargs="?",
+        help="Strategy name (positional; or use --strategy)",
+    )
+    p.add_argument(
+        "--strategy",
+        dest="strategy",
+        default=None,
+        help="Strategy name (preferred over positional)",
+    )
     p.add_argument(
         "--action",
         default="status",
@@ -176,8 +200,24 @@ def main():
         help="Polling interval seconds for withdraw waits (withdraw action only)",
     )
     p.add_argument("--wallet-id", dest="wallet_id")
+    p.add_argument(
+        "--wallet-label",
+        dest="wallet_label",
+        default=None,
+        help="Wallet label to use as the strategy wallet (overrides strategy name lookup)",
+    )
+    p.add_argument(
+        "--main-wallet-label",
+        dest="main_wallet_label",
+        default=None,
+        help="Wallet label to use as the main wallet (default: main)",
+    )
     p.add_argument("--debug", action="store_true")
     args = p.parse_args()
+
+    strategy_name = args.strategy or args.strategy_pos
+    if not strategy_name:
+        raise SystemExit("strategy is required (positional or via --strategy)")
 
     logger.remove()
     logger.add(sys.stderr, level="DEBUG" if args.debug else "INFO")
@@ -190,7 +230,7 @@ def main():
 
     asyncio.run(
         run_strategy(
-            args.strategy,
+            str(strategy_name),
             args.action,
             amount=args.amount,
             main_token_amount=args.main_token_amount,
@@ -199,6 +239,8 @@ def main():
             max_wait_s=args.max_wait_s,
             poll_interval_s=args.poll_interval_s,
             wallet_id=args.wallet_id,
+            wallet_label=args.wallet_label,
+            main_wallet_label=args.main_wallet_label,
         )
     )
 

--- a/wayfinder_paths/runner/__init__.py
+++ b/wayfinder_paths/runner/__init__.py
@@ -1,0 +1,3 @@
+"""Wayfinder Paths local runner daemon and control plane."""
+
+from __future__ import annotations

--- a/wayfinder_paths/runner/api.py
+++ b/wayfinder_paths/runner/api.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def dispatch(daemon, *, method: str, params: dict[str, Any]) -> dict[str, Any]:
+    """Dispatch a control-plane method to the daemon implementation.
+
+    This module is intentionally transport-agnostic (Unix socket today; HTTP later).
+    """
+
+    if method == "status":
+        return daemon.ctl_status()
+    if method == "shutdown":
+        return daemon.ctl_shutdown()
+    if method == "job_runs":
+        return daemon.ctl_job_runs(
+            name=params.get("name"),
+            limit=params.get("limit"),
+        )
+    if method == "run_report":
+        return daemon.ctl_run_report(
+            run_id=params.get("run_id"),
+            tail_bytes=params.get("tail_bytes"),
+        )
+    if method == "add_job":
+        return daemon.ctl_add_job(
+            name=params.get("name"),
+            job_type=params.get("type"),
+            payload=params.get("payload") or {},
+            interval_seconds=params.get("interval_seconds"),
+        )
+    if method == "update_job":
+        return daemon.ctl_update_job(
+            name=params.get("name"),
+            payload=params.get("payload"),
+            interval_seconds=params.get("interval_seconds"),
+        )
+    if method == "pause_job":
+        return daemon.ctl_pause_job(name=params.get("name"))
+    if method == "resume_job":
+        return daemon.ctl_resume_job(name=params.get("name"))
+    if method == "run_once":
+        return daemon.ctl_run_once(name=params.get("name"))
+    if method == "delete_job":
+        return daemon.ctl_delete_job(name=params.get("name"))
+
+    return {"ok": False, "error": f"unknown_method: {method}"}

--- a/wayfinder_paths/runner/cli.py
+++ b/wayfinder_paths/runner/cli.py
@@ -90,6 +90,7 @@ def start_cmd(
         max_workers=max_workers,
         max_failures=max_failures,
         default_timeout_seconds=default_timeout_seconds,
+        log_level=log_level,
     )
     daemon.start()
 

--- a/wayfinder_paths/runner/cli.py
+++ b/wayfinder_paths/runner/cli.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import click
+from loguru import logger
+
+from wayfinder_paths.runner.client import RunnerControlClient
+from wayfinder_paths.runner.constants import JOB_TYPE_SCRIPT, JOB_TYPE_STRATEGY
+from wayfinder_paths.runner.daemon import RunnerDaemon
+from wayfinder_paths.runner.lifecycle import ensure_daemon_started, try_status
+from wayfinder_paths.runner.paths import get_runner_paths
+
+
+def _echo_json(data: Any) -> None:
+    click.echo(json.dumps(data, indent=2, default=str))
+
+
+def _client(sock_path: Path) -> RunnerControlClient:
+    return RunnerControlClient(sock_path=sock_path)
+
+
+@click.group(name="runner", help="Local runner daemon for strategies and scripts.")
+def runner_cli() -> None:
+    pass
+
+
+@runner_cli.command(name="start", help="Start the runner daemon.")
+@click.option("--tick-seconds", type=float, default=1.0, show_default=True)
+@click.option("--max-workers", type=int, default=4, show_default=True)
+@click.option("--max-failures", type=int, default=5, show_default=True)
+@click.option("--default-timeout-seconds", type=int, default=20 * 60, show_default=True)
+@click.option(
+    "--log-level",
+    type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR"], case_sensitive=False),
+    default="INFO",
+    show_default=True,
+)
+@click.option(
+    "--detach/--no-detach",
+    default=False,
+    show_default=True,
+    help="Run the daemon in the background (recommended for long-lived use).",
+)
+def start_cmd(
+    tick_seconds: float,
+    max_workers: int,
+    max_failures: int,
+    default_timeout_seconds: int,
+    log_level: str,
+    detach: bool,
+) -> None:
+    paths = get_runner_paths()
+
+    if detach:
+        ok_started, info = ensure_daemon_started(
+            paths=paths,
+            tick_seconds=tick_seconds,
+            max_workers=max_workers,
+            max_failures=max_failures,
+            default_timeout_seconds=default_timeout_seconds,
+            log_level=log_level,
+        )
+        if ok_started:
+            _echo_json({"ok": True, "result": {"started": True, **info}})
+        else:
+            _echo_json(
+                {
+                    "ok": False,
+                    "error": "runner_start_failed",
+                    "details": info,
+                }
+            )
+        return
+
+    running, status, _ = try_status(_client(paths.sock_path))
+    if running and status is not None:
+        click.echo(f"Runner already running at {paths.sock_path}.")
+        return
+
+    logger.remove()
+    logger.add(sys.stderr, level=str(log_level).upper())
+
+    daemon = RunnerDaemon(
+        paths=paths,
+        tick_seconds=tick_seconds,
+        max_workers=max_workers,
+        max_failures=max_failures,
+        default_timeout_seconds=default_timeout_seconds,
+    )
+    daemon.start()
+
+
+@runner_cli.command(
+    name="ensure",
+    help="Ensure the runner daemon is running (starts detached if needed).",
+)
+@click.option("--tick-seconds", type=float, default=1.0, show_default=True)
+@click.option("--max-workers", type=int, default=4, show_default=True)
+@click.option("--max-failures", type=int, default=5, show_default=True)
+@click.option("--default-timeout-seconds", type=int, default=20 * 60, show_default=True)
+@click.option(
+    "--log-level",
+    type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR"], case_sensitive=False),
+    default="INFO",
+    show_default=True,
+)
+def ensure_cmd(
+    tick_seconds: float,
+    max_workers: int,
+    max_failures: int,
+    default_timeout_seconds: int,
+    log_level: str,
+) -> None:
+    paths = get_runner_paths()
+    ok_started, info = ensure_daemon_started(
+        paths=paths,
+        tick_seconds=tick_seconds,
+        max_workers=max_workers,
+        max_failures=max_failures,
+        default_timeout_seconds=default_timeout_seconds,
+        log_level=log_level,
+    )
+    if ok_started:
+        _echo_json({"ok": True, "result": {"started": True, **info}})
+    else:
+        _echo_json({"ok": False, "error": "runner_start_failed", "details": info})
+
+
+@runner_cli.command(name="stop", help="Stop the runner daemon (via local socket).")
+def stop_cmd() -> None:
+    paths = get_runner_paths()
+    resp = _client(paths.sock_path).call("shutdown")
+    _echo_json(resp)
+
+
+@runner_cli.command(name="status", help="Show runner + job status.")
+def status_cmd() -> None:
+    paths = get_runner_paths()
+    resp = _client(paths.sock_path).call("status")
+    _echo_json(resp)
+
+
+@runner_cli.command(name="add-job", help="Add a job without restarting the daemon.")
+@click.option("--name", required=True)
+@click.option(
+    "--type",
+    "job_type",
+    type=click.Choice([JOB_TYPE_STRATEGY, JOB_TYPE_SCRIPT], case_sensitive=False),
+    default=JOB_TYPE_STRATEGY,
+    show_default=True,
+)
+@click.option("--strategy", default=None, help="Strategy name (strategy jobs only).")
+@click.option("--action", default="update", show_default=True, help="Strategy action.")
+@click.option(
+    "--script-path",
+    default=None,
+    help="Path to a .py script inside .wayfinder_runs/ (script jobs only).",
+)
+@click.option(
+    "--arg",
+    "script_args",
+    multiple=True,
+    help="Script argument (repeatable; script jobs only).",
+)
+@click.option(
+    "--interval",
+    "interval_seconds",
+    type=int,
+    required=True,
+    help="Seconds between runs.",
+)
+@click.option("--config", "config_path", default="config.json", show_default=True)
+@click.option("--wallet-label", default=None)
+@click.option(
+    "--timeout",
+    "timeout_seconds",
+    type=int,
+    default=None,
+    help="Per-run timeout seconds.",
+)
+@click.option(
+    "--env-json", default=None, help="JSON object of env vars for the worker."
+)
+@click.option("--debug/--no-debug", default=False, show_default=True)
+def add_job_cmd(
+    name: str,
+    job_type: str,
+    strategy: str | None,
+    action: str,
+    script_path: str | None,
+    script_args: tuple[str, ...],
+    interval_seconds: int,
+    config_path: str,
+    wallet_label: str | None,
+    timeout_seconds: int | None,
+    env_json: str | None,
+    debug: bool,
+) -> None:
+    paths = get_runner_paths()
+    jt = str(job_type).lower().strip()
+
+    env_payload: dict[str, Any] | None = None
+    if env_json is not None:
+        decoded = json.loads(env_json)
+        if not isinstance(decoded, dict):
+            raise click.UsageError("--env-json must decode to an object")
+        env_payload = {str(k): str(v) for k, v in decoded.items()}
+
+    payload: dict[str, Any]
+    if jt == JOB_TYPE_STRATEGY:
+        if not strategy:
+            raise click.UsageError("--strategy is required for type=strategy")
+        payload = {
+            "strategy": str(strategy),
+            "action": str(action),
+            "config": str(config_path),
+            "debug": bool(debug),
+        }
+        if wallet_label:
+            payload["wallet_label"] = str(wallet_label)
+        if timeout_seconds is not None:
+            payload["timeout_seconds"] = int(timeout_seconds)
+        if env_payload is not None:
+            payload["env"] = env_payload
+    elif jt == JOB_TYPE_SCRIPT:
+        if not script_path:
+            raise click.UsageError("--script-path is required for type=script")
+        args_list = [str(a) for a in script_args if str(a).strip()]
+        payload = {
+            "script_path": str(script_path),
+            "args": args_list,
+            "debug": bool(debug),
+        }
+        if wallet_label:
+            payload["wallet_label"] = str(wallet_label)
+        if timeout_seconds is not None:
+            payload["timeout_seconds"] = int(timeout_seconds)
+        if env_payload is not None:
+            payload["env"] = env_payload
+    else:
+        raise click.UsageError(f"Unsupported type: {job_type}")
+
+    resp = _client(paths.sock_path).call(
+        "add_job",
+        {
+            "name": str(name),
+            "type": str(job_type),
+            "payload": payload,
+            "interval_seconds": int(interval_seconds),
+        },
+    )
+    _echo_json(resp)
+
+
+@runner_cli.command(name="update-job", help="Update a job definition.")
+@click.option("--name", required=True)
+@click.option(
+    "--interval",
+    "interval_seconds",
+    type=int,
+    default=None,
+    help="New interval seconds.",
+)
+@click.option("--payload-json", default=None, help="Full replacement payload JSON.")
+def update_job_cmd(
+    name: str, interval_seconds: int | None, payload_json: str | None
+) -> None:
+    payload = None
+    if payload_json is not None:
+        payload = json.loads(payload_json)
+        if not isinstance(payload, dict):
+            raise click.UsageError("--payload-json must decode to an object")
+
+    paths = get_runner_paths()
+    resp = _client(paths.sock_path).call(
+        "update_job",
+        {"name": str(name), "interval_seconds": interval_seconds, "payload": payload},
+    )
+    _echo_json(resp)
+
+
+@runner_cli.command(name="pause", help="Pause a job by name.")
+@click.argument("name")
+def pause_cmd(name: str) -> None:
+    paths = get_runner_paths()
+    resp = _client(paths.sock_path).call("pause_job", {"name": str(name)})
+    _echo_json(resp)
+
+
+@runner_cli.command(name="resume", help="Resume a paused/error job by name.")
+@click.argument("name")
+def resume_cmd(name: str) -> None:
+    paths = get_runner_paths()
+    resp = _client(paths.sock_path).call("resume_job", {"name": str(name)})
+    _echo_json(resp)
+
+
+@runner_cli.command(name="delete", help="Delete a job by name.")
+@click.argument("name")
+def delete_cmd(name: str) -> None:
+    paths = get_runner_paths()
+    resp = _client(paths.sock_path).call("delete_job", {"name": str(name)})
+    _echo_json(resp)
+
+
+@runner_cli.command(name="run-once", help="Trigger a job to run immediately once.")
+@click.argument("name")
+def run_once_cmd(name: str) -> None:
+    paths = get_runner_paths()
+    resp = _client(paths.sock_path).call("run_once", {"name": str(name)})
+    _echo_json(resp)
+
+
+@runner_cli.command(name="runs", help="List recent runs for a job.")
+@click.argument("name")
+@click.option("--limit", type=int, default=20, show_default=True)
+def runs_cmd(name: str, limit: int) -> None:
+    paths = get_runner_paths()
+    resp = _client(paths.sock_path).call(
+        "job_runs", {"name": str(name), "limit": int(limit)}
+    )
+    _echo_json(resp)
+
+
+@runner_cli.command(name="run-report", help="Show run details and tail the run log.")
+@click.argument("run_id", type=int)
+@click.option("--tail-bytes", type=int, default=4000, show_default=True)
+def run_report_cmd(run_id: int, tail_bytes: int) -> None:
+    paths = get_runner_paths()
+    resp = _client(paths.sock_path).call(
+        "run_report", {"run_id": int(run_id), "tail_bytes": int(tail_bytes)}
+    )
+    _echo_json(resp)

--- a/wayfinder_paths/runner/client.py
+++ b/wayfinder_paths/runner/client.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from wayfinder_paths.runner.protocol import decode_response_bytes, encode_request
+from wayfinder_paths.runner.transport import RunnerTransport, UnixSocketTransport
+
+
+class RunnerControlClient:
+    def __init__(
+        self, *, sock_path: Path, transport: RunnerTransport | None = None
+    ) -> None:
+        self._sock_path = Path(sock_path)
+        self._transport = transport or UnixSocketTransport(self._sock_path)
+
+    @property
+    def sock_path(self) -> Path:
+        return self._sock_path
+
+    def call(self, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        try:
+            payload = encode_request(method, params)
+            buf = self._transport.roundtrip(payload)
+        except OSError as exc:
+            return {
+                "ok": False,
+                "error": "connect_failed",
+                "message": str(exc),
+                "sock_path": str(self._sock_path),
+            }
+        return decode_response_bytes(buf)

--- a/wayfinder_paths/runner/constants.py
+++ b/wayfinder_paths/runner/constants.py
@@ -1,18 +1,22 @@
 from __future__ import annotations
 
+from enum import StrEnum
 from typing import Final
 
-# Job status values
-JOB_STATUS_ACTIVE: Final[str] = "ACTIVE"
-JOB_STATUS_PAUSED: Final[str] = "PAUSED"
-JOB_STATUS_ERROR: Final[str] = "ERROR"
 
-# Run status values
-RUN_STATUS_RUNNING: Final[str] = "RUNNING"
-RUN_STATUS_OK: Final[str] = "OK"
-RUN_STATUS_FAILED: Final[str] = "FAILED"
-RUN_STATUS_TIMEOUT: Final[str] = "TIMEOUT"
-RUN_STATUS_ABORTED: Final[str] = "ABORTED"
+class JobStatus(StrEnum):
+    ACTIVE = "ACTIVE"
+    PAUSED = "PAUSED"
+    ERROR = "ERROR"
+
+
+class RunStatus(StrEnum):
+    RUNNING = "RUNNING"
+    OK = "OK"
+    FAILED = "FAILED"
+    TIMEOUT = "TIMEOUT"
+    ABORTED = "ABORTED"
+
 
 # Supported job types
 JOB_TYPE_STRATEGY: Final[str] = "strategy"

--- a/wayfinder_paths/runner/constants.py
+++ b/wayfinder_paths/runner/constants.py
@@ -21,3 +21,6 @@ class RunStatus(StrEnum):
 # Supported job types
 JOB_TYPE_STRATEGY: Final[str] = "strategy"
 JOB_TYPE_SCRIPT: Final[str] = "script"
+
+# Control protocol limits
+MAX_LINE_BYTES: Final[int] = 1024 * 1024

--- a/wayfinder_paths/runner/constants.py
+++ b/wayfinder_paths/runner/constants.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Final
+
+# Job status values
+JOB_STATUS_ACTIVE: Final[str] = "ACTIVE"
+JOB_STATUS_PAUSED: Final[str] = "PAUSED"
+JOB_STATUS_ERROR: Final[str] = "ERROR"
+
+# Run status values
+RUN_STATUS_RUNNING: Final[str] = "RUNNING"
+RUN_STATUS_OK: Final[str] = "OK"
+RUN_STATUS_FAILED: Final[str] = "FAILED"
+RUN_STATUS_TIMEOUT: Final[str] = "TIMEOUT"
+RUN_STATUS_ABORTED: Final[str] = "ABORTED"
+
+# Supported job types
+JOB_TYPE_STRATEGY: Final[str] = "strategy"
+JOB_TYPE_SCRIPT: Final[str] = "script"

--- a/wayfinder_paths/runner/control.py
+++ b/wayfinder_paths/runner/control.py
@@ -8,8 +8,8 @@ from pathlib import Path
 from loguru import logger
 
 from wayfinder_paths.runner.api import dispatch
+from wayfinder_paths.runner.constants import MAX_LINE_BYTES
 from wayfinder_paths.runner.protocol import (
-    MAX_LINE_BYTES,
     ProtocolError,
     decode_request_line,
     encode_response,

--- a/wayfinder_paths/runner/control.py
+++ b/wayfinder_paths/runner/control.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import os
+import socketserver
+import threading
+from pathlib import Path
+
+from loguru import logger
+
+from wayfinder_paths.runner.api import dispatch
+from wayfinder_paths.runner.protocol import (
+    MAX_LINE_BYTES,
+    ProtocolError,
+    decode_request_line,
+    encode_response,
+)
+
+
+class _Handler(socketserver.StreamRequestHandler):
+    def handle(self) -> None:  # noqa: D401
+        """Handle a single JSON-line request and respond with a JSON line."""
+        raw = self.rfile.readline(MAX_LINE_BYTES)
+        if not raw:
+            return
+        try:
+            method, params = decode_request_line(raw)
+        except ProtocolError as exc:
+            self.wfile.write(encode_response({"ok": False, "error": exc.code}))
+            return
+
+        daemon = getattr(self.server, "daemon", None)
+        if daemon is None:
+            self.wfile.write(
+                encode_response({"ok": False, "error": "daemon_unavailable"})
+            )
+            return
+
+        try:
+            resp = dispatch(daemon, method=method, params=params)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception(f"Control dispatch error: {exc}")
+            resp = {"ok": False, "error": str(exc)}
+
+        self.wfile.write(encode_response(resp))
+
+
+class RunnerControlServer:
+    def __init__(self, *, sock_path: Path, daemon) -> None:
+        self._sock_path = Path(sock_path)
+        self._daemon = daemon
+        self._thread: threading.Thread | None = None
+        self._server: socketserver.UnixStreamServer | None = None
+
+    @property
+    def sock_path(self) -> Path:
+        return self._sock_path
+
+    def start(self) -> None:
+        self._sock_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            if self._sock_path.exists():
+                self._sock_path.unlink()
+        except OSError:
+            pass
+
+        class _Server(socketserver.ThreadingMixIn, socketserver.UnixStreamServer):
+            daemon_threads = True
+            allow_reuse_address = True
+
+        self._server = _Server(str(self._sock_path), _Handler)
+        self._server.daemon = self._daemon  # type: ignore[attr-defined]
+
+        try:
+            os.chmod(self._sock_path, 0o600)
+        except OSError:
+            pass
+
+        def _serve() -> None:
+            assert self._server is not None
+            self._server.serve_forever(poll_interval=0.5)
+
+        self._thread = threading.Thread(
+            target=_serve, name="runner-control", daemon=True
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        if self._server is not None:
+            try:
+                self._server.shutdown()
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                self._server.server_close()
+            except Exception:  # noqa: BLE001
+                pass
+            self._server = None
+
+        if self._thread is not None:
+            self._thread.join(timeout=2)
+            self._thread = None
+
+        try:
+            if self._sock_path.exists():
+                self._sock_path.unlink()
+        except OSError:
+            pass

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -1,0 +1,672 @@
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from wayfinder_paths import __version__
+from wayfinder_paths.runner.constants import (
+    JOB_STATUS_ACTIVE,
+    JOB_STATUS_PAUSED,
+    JOB_TYPE_SCRIPT,
+    JOB_TYPE_STRATEGY,
+    RUN_STATUS_FAILED,
+    RUN_STATUS_OK,
+    RUN_STATUS_TIMEOUT,
+)
+from wayfinder_paths.runner.db import RunnerDB
+from wayfinder_paths.runner.paths import RunnerPaths
+from wayfinder_paths.runner.script_resolver import resolve_script_path
+
+
+def _utc_epoch_s() -> int:
+    return int(time.time())
+
+
+def _safe_job_dirname(name: str) -> str:
+    cleaned = "".join(ch if ch.isalnum() or ch in ("-", "_") else "_" for ch in name)
+    return cleaned.strip("_") or "job"
+
+
+def _tail_text(path: Path, *, max_bytes: int = 4000) -> str | None:
+    try:
+        with path.open("rb") as f:
+            f.seek(0, os.SEEK_END)
+            size = f.tell()
+            start = max(0, size - int(max_bytes))
+            f.seek(start, os.SEEK_SET)
+            data = f.read()
+    except OSError:
+        return None
+    text = data.decode("utf-8", errors="replace").strip()
+    if not text:
+        return None
+    return text[-max_bytes:]
+
+
+def _kill_process_group(pid: int, *, sig: int) -> None:
+    try:
+        os.killpg(int(pid), sig)
+    except ProcessLookupError:
+        return
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(f"Failed to kill process group {pid}: {exc}")
+
+
+def _clamp_int(value: Any, *, min_value: int, max_value: int, default: int) -> int:
+    try:
+        i = int(value)
+    except (TypeError, ValueError):
+        return int(default)
+    return max(int(min_value), min(int(max_value), i))
+
+
+def _with_repo_pythonpath(env: dict[str, str], *, repo_root: Path) -> dict[str, str]:
+    root = str(repo_root)
+    cur = env.get("PYTHONPATH", "").strip()
+    env_out = dict(env)
+    env_out["PYTHONPATH"] = f"{root}{os.pathsep}{cur}" if cur else root
+    return env_out
+
+
+@dataclass
+class RunningProcess:
+    run_id: int
+    job_id: int
+    job_name: str
+    started_at: int
+    timeout_seconds: int | None
+    popen: subprocess.Popen[bytes]
+    log_path: Path
+
+
+class RunnerDaemon:
+    def __init__(
+        self,
+        *,
+        paths: RunnerPaths,
+        tick_seconds: float = 1.0,
+        max_workers: int = 4,
+        max_failures: int = 5,
+        default_timeout_seconds: int = 20 * 60,
+    ) -> None:
+        self._paths = paths
+        self._tick_seconds = float(tick_seconds)
+        self._max_workers = int(max_workers)
+        self._max_failures = int(max_failures)
+        self._default_timeout_seconds = int(default_timeout_seconds)
+
+        self._db = RunnerDB(paths.db_path)
+        self._started_at = _utc_epoch_s()
+        self._last_tick_at: int | None = None
+
+        self._lock = threading.Lock()
+        self._shutdown = threading.Event()
+        self._running: dict[int, RunningProcess] = {}
+        self._running_by_job: dict[int, int] = {}
+
+        self._control = None
+
+    @property
+    def paths(self) -> RunnerPaths:
+        return self._paths
+
+    def start(self) -> None:
+        self._paths.runner_dir.mkdir(parents=True, exist_ok=True)
+        self._paths.logs_dir.mkdir(parents=True, exist_ok=True)
+
+        aborted = self._db.mark_stale_running_runs_aborted(note="runner restarted")
+        if aborted:
+            logger.warning(f"Marked {aborted} stale RUNNING runs as ABORTED")
+
+        from wayfinder_paths.runner.control import RunnerControlServer
+
+        self._control = RunnerControlServer(
+            sock_path=self._paths.sock_path, daemon=self
+        )
+        self._control.start()
+        logger.info(
+            f"Runner daemon v{__version__} listening on {self._paths.sock_path}"
+        )
+
+        self._install_signal_handlers()
+        try:
+            self._loop()
+        finally:
+            self._shutdown.set()
+            self._stop_control()
+            self._shutdown_running_processes()
+            self._db.close()
+
+    def stop(self) -> None:
+        self._shutdown.set()
+
+    def _install_signal_handlers(self) -> None:
+        def _handle(sig, _frame):  # type: ignore[no-untyped-def]
+            logger.info(f"Received signal {sig}; shutting down")
+            self.stop()
+
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            try:
+                signal.signal(sig, _handle)
+            except Exception:  # noqa: BLE001
+                continue
+
+    def _stop_control(self) -> None:
+        if self._control is not None:
+            self._control.stop()
+            self._control = None
+
+    def _loop(self) -> None:
+        while not self._shutdown.is_set():
+            tick_started = time.monotonic()
+            try:
+                self.tick()
+            except Exception as exc:  # noqa: BLE001
+                logger.exception(f"Runner tick error: {exc}")
+            elapsed = time.monotonic() - tick_started
+            sleep_s = max(0.0, self._tick_seconds - elapsed)
+            time.sleep(sleep_s)
+
+    def tick(self) -> None:
+        now = _utc_epoch_s()
+        with self._lock:
+            self._last_tick_at = now
+            self._reap(now=now)
+
+            for job in self._db.due_jobs(now=now):
+                self._maybe_start_job(job=job, now=now, reason="schedule")
+
+    def _reap(self, *, now: int) -> None:
+        for run_id, rp in list(self._running.items()):
+            proc = rp.popen
+            exit_code = proc.poll()
+            if exit_code is None:
+                if (
+                    rp.timeout_seconds is not None
+                    and now - rp.started_at > rp.timeout_seconds
+                ):
+                    logger.warning(
+                        f"Run {run_id} timed out after {rp.timeout_seconds}s; killing process group"
+                    )
+                    _kill_process_group(proc.pid, sig=signal.SIGTERM)
+                    try:
+                        proc.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        _kill_process_group(proc.pid, sig=signal.SIGKILL)
+                        try:
+                            proc.wait(timeout=5)
+                        except subprocess.TimeoutExpired:
+                            pass
+                    self._finish_run(
+                        rp,
+                        finished_at=now,
+                        status=RUN_STATUS_TIMEOUT,
+                        exit_code=proc.returncode,
+                        error_text=f"timeout after {rp.timeout_seconds}s",
+                    )
+                continue
+
+            status = RUN_STATUS_OK if int(exit_code) == 0 else RUN_STATUS_FAILED
+            error_text = None
+            if status != RUN_STATUS_OK:
+                error_text = _tail_text(rp.log_path) or f"exit_code={exit_code}"
+            self._finish_run(
+                rp,
+                finished_at=now,
+                status=status,
+                exit_code=int(exit_code),
+                error_text=error_text,
+            )
+
+    def _finish_run(
+        self,
+        rp: RunningProcess,
+        *,
+        finished_at: int,
+        status: str,
+        exit_code: int | None,
+        error_text: str | None,
+    ) -> None:
+        self._db.finish_run(
+            run_id=rp.run_id,
+            finished_at=finished_at,
+            status=status,
+            exit_code=exit_code,
+            summary={"error": error_text} if error_text else None,
+        )
+
+        if status == RUN_STATUS_OK:
+            self._db.record_job_success(job_id=rp.job_id, ok_at=finished_at)
+        else:
+            msg = error_text or status
+            failures, job_status = self._db.record_job_failure(
+                job_id=rp.job_id,
+                error_text=msg,
+                max_failures=self._max_failures,
+            )
+            if job_status != JOB_STATUS_ACTIVE:
+                logger.error(
+                    f"Job {rp.job_name} entered {job_status} after {failures} failures"
+                )
+
+        self._running.pop(rp.run_id, None)
+        self._running_by_job[rp.job_id] = max(
+            0, self._running_by_job.get(rp.job_id, 1) - 1
+        )
+
+    def _shutdown_running_processes(self) -> None:
+        with self._lock:
+            running = list(self._running.values())
+        if not running:
+            return
+        logger.info(f"Shutting down {len(running)} running worker(s)")
+        for rp in running:
+            try:
+                _kill_process_group(rp.popen.pid, sig=signal.SIGTERM)
+            except Exception:  # noqa: BLE001
+                continue
+
+    def _maybe_start_job(
+        self, *, job: dict[str, Any], now: int, reason: str
+    ) -> int | None:
+        if len(self._running) >= self._max_workers:
+            return None
+        job_id = int(job["id"])
+        job_name = str(job["name"])
+        if self._running_by_job.get(job_id, 0) >= 1:
+            return None
+
+        interval = int(job.get("interval_seconds") or 0)
+        next_run_at = now + max(1, interval)
+        self._db.set_job_last_run(job_id=job_id, last_run_at=now)
+        self._db.set_next_run_at(job_id=job_id, next_run_at=next_run_at)
+
+        job_dir = self._paths.logs_dir / _safe_job_dirname(job_name)
+        job_dir.mkdir(parents=True, exist_ok=True)
+
+        run_id = self._db.create_run(
+            job_id=job_id,
+            started_at=now,
+        )
+        log_path = job_dir / f"{run_id}.log"
+        self._db.update_run_log_path(run_id=run_id, log_path=str(log_path))
+
+        payload = job.get("payload") or {}
+        timeout_seconds = (
+            payload.get("timeout_seconds") or payload.get("timeout") or None
+        )
+        if timeout_seconds is None:
+            timeout_seconds = self._default_timeout_seconds
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "WAYFINDER_RUN_ID": str(run_id),
+                "WAYFINDER_JOB_ID": str(job_id),
+                "WAYFINDER_JOB_NAME": str(job_name),
+                "WAYFINDER_RUNNER_DIR": str(self._paths.runner_dir),
+                "WAYFINDER_KV_NAMESPACE": str(job_name),
+                "WAYFINDER_RUNNER_REASON": str(reason),
+            }
+        )
+        payload_env = payload.get("env")
+        if isinstance(payload_env, dict):
+            env.update({str(k): str(v) for k, v in payload_env.items()})
+        if payload.get("wallet_label"):
+            env["WAYFINDER_WALLET_LABEL"] = str(payload.get("wallet_label"))
+        env = _with_repo_pythonpath(env, repo_root=self._paths.repo_root)
+
+        try:
+            cmd = self._build_worker_cmd(job=job)
+        except Exception as exc:  # noqa: BLE001
+            err_text = f"build worker cmd failed: {exc}"
+            try:
+                log_path.write_text(err_text + "\n", encoding="utf-8")
+            except OSError:
+                pass
+            self._db.finish_run(
+                run_id=run_id,
+                finished_at=now,
+                status=RUN_STATUS_FAILED,
+                exit_code=None,
+                summary={"error": err_text},
+            )
+            self._db.record_job_failure(
+                job_id=job_id,
+                error_text=err_text,
+                max_failures=self._max_failures,
+            )
+            return None
+        logger.info(f"Starting job {job_name} (run_id={run_id})")
+
+        try:
+            with log_path.open("ab", buffering=0) as log_f:
+                log_f.write(
+                    (
+                        f"[runner] job={job_name} run_id={run_id} started_at={now} reason={reason}\n"
+                    ).encode()
+                )
+                popen = subprocess.Popen(  # noqa: S603
+                    cmd,
+                    cwd=str(self._paths.repo_root),
+                    env=env,
+                    stdout=log_f,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+        except Exception as exc:  # noqa: BLE001
+            err_text = f"spawn failed: {exc}"
+            self._db.finish_run(
+                run_id=run_id,
+                finished_at=now,
+                status=RUN_STATUS_FAILED,
+                exit_code=None,
+                summary={"error": err_text},
+            )
+            self._db.record_job_failure(
+                job_id=job_id,
+                error_text=err_text,
+                max_failures=self._max_failures,
+            )
+            return None
+
+        self._db.update_run_pid(run_id=run_id, pid=int(popen.pid))
+
+        self._running[run_id] = RunningProcess(
+            run_id=run_id,
+            job_id=job_id,
+            job_name=job_name,
+            started_at=now,
+            timeout_seconds=int(timeout_seconds) if timeout_seconds else None,
+            popen=popen,
+            log_path=log_path,
+        )
+        self._running_by_job[job_id] = self._running_by_job.get(job_id, 0) + 1
+        return run_id
+
+    def _build_worker_cmd(self, *, job: dict[str, Any]) -> list[str]:
+        job_type = str(job.get("type") or "")
+        payload: dict[str, Any] = dict(job.get("payload") or {})
+        if job_type == JOB_TYPE_STRATEGY:
+            strategy = str(payload.get("strategy") or "").strip()
+            action = str(payload.get("action") or "update").strip()
+            config_path = str(payload.get("config") or "config.json")
+            wallet_label = payload.get("wallet_label") or payload.get("wallet") or None
+            debug = bool(payload.get("debug") or False)
+
+            cmd = [
+                sys.executable,
+                "-m",
+                "wayfinder_paths.run_strategy",
+                "--strategy",
+                strategy,
+                "--action",
+                action,
+                "--config",
+                config_path,
+            ]
+            if wallet_label:
+                cmd.extend(["--wallet-label", str(wallet_label)])
+            if debug:
+                cmd.append("--debug")
+            return cmd
+
+        if job_type == JOB_TYPE_SCRIPT:
+            sp = (
+                payload.get("script_path")
+                or payload.get("script")
+                or payload.get("path")
+            )
+            if not sp:
+                raise ValueError("payload.script_path is required for script jobs")
+
+            script = resolve_script_path(self._paths, str(sp))
+            args = payload.get("args") or []
+            if args is None:
+                args = []
+            if not isinstance(args, list):
+                raise ValueError("payload.args must be a list of strings")
+            arg_list = [str(a) for a in args if str(a).strip()]
+            return [sys.executable, str(script), *arg_list]
+
+        raise ValueError(f"Unsupported job type: {job_type}")
+
+    # Control-plane methods (called by runnerctl over the local socket)
+    def ctl_status(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "ok": True,
+                "result": {
+                    "version": __version__,
+                    "pid": os.getpid(),
+                    "ppid": os.getppid(),
+                    "started_at": self._started_at,
+                    "uptime_s": max(0, _utc_epoch_s() - self._started_at),
+                    "last_tick_at": self._last_tick_at,
+                    "repo_root": str(self._paths.repo_root),
+                    "runner_dir": str(self._paths.runner_dir),
+                    "db_path": str(self._paths.db_path),
+                    "sock_path": str(self._paths.sock_path),
+                    "running_workers": len(self._running),
+                    "max_workers": self._max_workers,
+                    "jobs": self._db.list_jobs(),
+                    "recent_runs": self._db.last_runs(limit=20),
+                },
+            }
+
+    def ctl_shutdown(self) -> dict[str, Any]:
+        self.stop()
+        return {"ok": True, "result": {"shutdown": True}}
+
+    def ctl_job_runs(self, *, name: str, limit: int | None = None) -> dict[str, Any]:
+        if name is None:
+            return {"ok": False, "error": "name is required"}
+        name = str(name).strip()
+        if not name:
+            return {"ok": False, "error": "name is required"}
+
+        lim = _clamp_int(limit, min_value=1, max_value=500, default=50)
+        try:
+            job, _ = self._db.get_job(name=name)
+        except KeyError as exc:
+            return {"ok": False, "error": str(exc)}
+
+        runs = self._db.runs_for_job(job_id=job.id, limit=lim)
+        return {
+            "ok": True,
+            "result": {"name": job.name, "job_id": job.id, "runs": runs},
+        }
+
+    def ctl_run_report(
+        self, *, run_id: int, tail_bytes: int | None = None
+    ) -> dict[str, Any]:
+        try:
+            rid = int(run_id)
+        except (TypeError, ValueError):
+            return {"ok": False, "error": "run_id must be an integer"}
+
+        tbytes = _clamp_int(tail_bytes, min_value=200, max_value=200_000, default=4000)
+
+        run = self._db.get_run(run_id=rid)
+        if run is None:
+            return {"ok": False, "error": f"run not found: {rid}"}
+
+        duration_s = None
+        if run.get("finished_at") is not None:
+            duration_s = max(0, int(run["finished_at"]) - int(run["started_at"]))
+
+        log_tail = None
+        log_path_s = run.get("log_path")
+        if log_path_s:
+            try:
+                log_path = Path(str(log_path_s)).resolve()
+                logs_root = self._paths.logs_dir.resolve()
+                if log_path.is_relative_to(logs_root):
+                    log_tail = _tail_text(log_path, max_bytes=tbytes)
+            except Exception:  # noqa: BLE001
+                log_tail = None
+
+        return {
+            "ok": True,
+            "result": {
+                "run": run,
+                "duration_s": duration_s,
+                "log_tail": log_tail,
+                "tail_bytes": tbytes,
+            },
+        }
+
+    def ctl_add_job(
+        self,
+        *,
+        name: str,
+        job_type: str,
+        payload: dict[str, Any],
+        interval_seconds: int,
+    ) -> dict[str, Any]:
+        if name is None:
+            return {"ok": False, "error": "name is required"}
+        name = str(name).strip()
+        if not name:
+            return {"ok": False, "error": "name is required"}
+
+        if interval_seconds is None:
+            return {"ok": False, "error": "interval_seconds is required"}
+        try:
+            interval_i = int(interval_seconds)
+        except (TypeError, ValueError):
+            return {"ok": False, "error": "interval_seconds must be an integer"}
+        if interval_i <= 0:
+            return {"ok": False, "error": "interval_seconds must be > 0"}
+
+        if job_type is None:
+            return {"ok": False, "error": "type is required"}
+        job_type = str(job_type).strip()
+        if job_type not in {JOB_TYPE_STRATEGY, JOB_TYPE_SCRIPT}:
+            return {"ok": False, "error": f"unsupported job type: {job_type}"}
+
+        if not isinstance(payload, dict):
+            return {"ok": False, "error": "payload must be an object"}
+
+        payload_norm: dict[str, Any] = dict(payload)
+        if job_type == JOB_TYPE_STRATEGY:
+            strategy = str(payload_norm.get("strategy") or "").strip()
+            if not strategy:
+                return {"ok": False, "error": "payload.strategy is required"}
+        elif job_type == JOB_TYPE_SCRIPT:
+            sp = (
+                payload_norm.get("script_path")
+                or payload_norm.get("script")
+                or payload_norm.get("path")
+            )
+            if not sp:
+                return {"ok": False, "error": "payload.script_path is required"}
+            try:
+                resolved = resolve_script_path(self._paths, str(sp))
+            except Exception as exc:  # noqa: BLE001
+                return {"ok": False, "error": str(exc)}
+            try:
+                rel = resolved.relative_to(self._paths.repo_root)
+                payload_norm["script_path"] = str(rel)
+            except ValueError:
+                payload_norm["script_path"] = str(resolved)
+
+            args = payload_norm.get("args")
+            if args is not None and not isinstance(args, list):
+                return {"ok": False, "error": "payload.args must be a list of strings"}
+            env = payload_norm.get("env")
+            if env is not None and not isinstance(env, dict):
+                return {"ok": False, "error": "payload.env must be an object"}
+        try:
+            job_id = self._db.add_job(
+                name=name,
+                job_type=job_type,
+                payload=payload_norm,
+                interval_seconds=interval_i,
+                status=JOB_STATUS_ACTIVE,
+                next_run_at=_utc_epoch_s(),
+            )
+        except Exception as exc:  # noqa: BLE001
+            return {"ok": False, "error": str(exc)}
+        return {"ok": True, "result": {"job_id": job_id, "name": name}}
+
+    def ctl_update_job(
+        self, *, name: str, payload: dict[str, Any] | None, interval_seconds: int | None
+    ) -> dict[str, Any]:
+        if payload is not None and not isinstance(payload, dict):
+            return {"ok": False, "error": "payload must be an object"}
+        try:
+            self._db.update_job(
+                name=name, payload=payload, interval_seconds=interval_seconds
+            )
+            return {"ok": True, "result": {"name": name}}
+        except KeyError as exc:
+            return {"ok": False, "error": str(exc)}
+
+    def ctl_pause_job(self, *, name: str) -> dict[str, Any]:
+        try:
+            self._db.set_job_status(name=name, status=JOB_STATUS_PAUSED)
+            return {"ok": True, "result": {"name": name, "status": JOB_STATUS_PAUSED}}
+        except KeyError as exc:
+            return {"ok": False, "error": str(exc)}
+
+    def ctl_resume_job(self, *, name: str) -> dict[str, Any]:
+        try:
+            job, _ = self._db.get_job(name=name)
+            self._db.set_job_status(name=name, status=JOB_STATUS_ACTIVE)
+            self._db.set_next_run_at(job_id=job.id, next_run_at=_utc_epoch_s())
+            return {"ok": True, "result": {"name": name, "status": JOB_STATUS_ACTIVE}}
+        except KeyError as exc:
+            return {"ok": False, "error": str(exc)}
+
+    def ctl_run_once(self, *, name: str) -> dict[str, Any]:
+        now = _utc_epoch_s()
+        try:
+            job, state = self._db.get_job(name=name)
+        except KeyError as exc:
+            return {"ok": False, "error": str(exc)}
+        if state.status != JOB_STATUS_ACTIVE:
+            return {"ok": False, "error": f"job is not ACTIVE (status={state.status})"}
+
+        job_dict: dict[str, Any] = {
+            "id": job.id,
+            "name": job.name,
+            "type": job.type,
+            "payload": job.payload,
+            "interval_seconds": job.interval_seconds,
+        }
+        with self._lock:
+            run_id = self._maybe_start_job(job=job_dict, now=now, reason="run_once")
+        if run_id is None:
+            return {
+                "ok": False,
+                "error": "job could not be started (running or at capacity)",
+            }
+        return {"ok": True, "result": {"name": name, "run_id": run_id}}
+
+    def ctl_delete_job(self, *, name: str) -> dict[str, Any]:
+        try:
+            job, _ = self._db.get_job(name=name)
+        except KeyError as exc:
+            return {"ok": False, "error": str(exc)}
+
+        job_id = int(job.id)
+        with self._lock:
+            if self._running_by_job.get(job_id, 0) >= 1:
+                return {"ok": False, "error": "job is currently running"}
+            try:
+                self._db.delete_job(name=str(name))
+            except KeyError as exc:
+                return {"ok": False, "error": str(exc)}
+            self._running_by_job.pop(job_id, None)
+
+        return {"ok": True, "result": {"name": str(name), "deleted": True}}

--- a/wayfinder_paths/runner/db.py
+++ b/wayfinder_paths/runner/db.py
@@ -1,0 +1,632 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from wayfinder_paths.runner.constants import (
+    JOB_STATUS_ACTIVE,
+    JOB_STATUS_ERROR,
+    JOB_STATUS_PAUSED,
+    RUN_STATUS_ABORTED,
+    RUN_STATUS_RUNNING,
+)
+
+
+def _utc_epoch_s() -> int:
+    return int(time.time())
+
+
+def _json_dumps(obj: Any) -> str:
+    return json.dumps(obj, separators=(",", ":"), ensure_ascii=False, default=str)
+
+
+@dataclass(frozen=True)
+class JobRow:
+    id: int
+    name: str
+    type: str
+    payload: dict[str, Any]
+    interval_seconds: int
+    created_at: int
+    updated_at: int
+
+
+@dataclass(frozen=True)
+class JobStateRow:
+    job_id: int
+    status: str
+    next_run_at: int
+    last_run_at: int | None
+    last_ok_at: int | None
+    consecutive_failures: int
+    last_error: str | None
+
+
+class RunnerDB:
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = Path(db_path)
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self._conn = sqlite3.connect(
+            str(self._db_path),
+            check_same_thread=False,
+            isolation_level=None,  # autocommit
+        )
+        self._conn.row_factory = sqlite3.Row
+        with self._lock:
+            self._init_schema()
+
+    @property
+    def path(self) -> Path:
+        return self._db_path
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()
+
+    def _init_schema(self) -> None:
+        cur = self._conn.cursor()
+        cur.execute("PRAGMA journal_mode=WAL;")
+        cur.execute("PRAGMA foreign_keys=ON;")
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS job_defs (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              name TEXT NOT NULL UNIQUE,
+              type TEXT NOT NULL,
+              payload_json TEXT NOT NULL,
+              interval_seconds INTEGER NOT NULL,
+              created_at INTEGER NOT NULL,
+              updated_at INTEGER NOT NULL
+            );
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS job_state (
+              job_id INTEGER PRIMARY KEY,
+              status TEXT NOT NULL,
+              next_run_at INTEGER NOT NULL,
+              last_run_at INTEGER,
+              last_ok_at INTEGER,
+              consecutive_failures INTEGER NOT NULL DEFAULT 0,
+              last_error TEXT,
+              FOREIGN KEY(job_id) REFERENCES job_defs(id) ON DELETE CASCADE
+            );
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS runs (
+              run_id INTEGER PRIMARY KEY AUTOINCREMENT,
+              job_id INTEGER NOT NULL,
+              started_at INTEGER NOT NULL,
+              finished_at INTEGER,
+              status TEXT NOT NULL,
+              exit_code INTEGER,
+              log_path TEXT,
+              summary_json TEXT,
+              pid INTEGER,
+              FOREIGN KEY(job_id) REFERENCES job_defs(id) ON DELETE CASCADE
+            );
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS kv (
+              namespace TEXT NOT NULL,
+              key TEXT NOT NULL,
+              value_json TEXT NOT NULL,
+              updated_at INTEGER NOT NULL,
+              PRIMARY KEY(namespace, key)
+            );
+            """
+        )
+        cur.execute(
+            "CREATE INDEX IF NOT EXISTS idx_job_state_due ON job_state(status, next_run_at);"
+        )
+        cur.execute(
+            "CREATE INDEX IF NOT EXISTS idx_runs_job_status ON runs(job_id, status);"
+        )
+
+    def mark_stale_running_runs_aborted(self, *, note: str) -> int:
+        now = _utc_epoch_s()
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                """
+                UPDATE runs
+                SET status = ?, finished_at = ?, summary_json = ?
+                WHERE status = ?
+                """,
+                (
+                    RUN_STATUS_ABORTED,
+                    now,
+                    _json_dumps({"note": note}),
+                    RUN_STATUS_RUNNING,
+                ),
+            )
+            return int(cur.rowcount or 0)
+
+    def add_job(
+        self,
+        *,
+        name: str,
+        job_type: str,
+        payload: dict[str, Any],
+        interval_seconds: int,
+        status: str = JOB_STATUS_ACTIVE,
+        next_run_at: int | None = None,
+    ) -> int:
+        if status not in {JOB_STATUS_ACTIVE, JOB_STATUS_PAUSED, JOB_STATUS_ERROR}:
+            raise ValueError(f"Invalid job status: {status}")
+        now = _utc_epoch_s()
+        nra = int(next_run_at if next_run_at is not None else now)
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                """
+                INSERT INTO job_defs(name, type, payload_json, interval_seconds, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (name, job_type, _json_dumps(payload), int(interval_seconds), now, now),
+            )
+            job_id = int(cur.lastrowid)
+            cur.execute(
+                """
+                INSERT INTO job_state(job_id, status, next_run_at, last_run_at, last_ok_at, consecutive_failures, last_error)
+                VALUES (?, ?, ?, NULL, NULL, 0, NULL)
+                """,
+                (job_id, status, nra),
+            )
+            return job_id
+
+    def update_job(
+        self,
+        *,
+        name: str,
+        payload: dict[str, Any] | None = None,
+        interval_seconds: int | None = None,
+    ) -> None:
+        now = _utc_epoch_s()
+        sets: list[str] = ["updated_at = ?"]
+        params: list[Any] = [now]
+        if payload is not None:
+            sets.append("payload_json = ?")
+            params.append(_json_dumps(payload))
+        if interval_seconds is not None:
+            sets.append("interval_seconds = ?")
+            params.append(int(interval_seconds))
+        if len(sets) == 1:
+            return
+        params.append(name)
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                f"UPDATE job_defs SET {', '.join(sets)} WHERE name = ?",
+                params,
+            )
+            if cur.rowcount == 0:
+                raise KeyError(f"Job not found: {name}")
+
+    def delete_job(self, *, name: str) -> None:
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute("DELETE FROM job_defs WHERE name = ?", (str(name),))
+            if cur.rowcount == 0:
+                raise KeyError(f"Job not found: {name}")
+
+    def get_job(self, *, name: str) -> tuple[JobRow, JobStateRow]:
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                """
+                SELECT d.*, s.status AS state_status, s.next_run_at, s.last_run_at, s.last_ok_at,
+                       s.consecutive_failures, s.last_error
+                FROM job_defs d
+                JOIN job_state s ON s.job_id = d.id
+                WHERE d.name = ?
+                """,
+                (name,),
+            )
+            row = cur.fetchone()
+            if row is None:
+                raise KeyError(f"Job not found: {name}")
+            payload = json.loads(row["payload_json"]) if row["payload_json"] else {}
+            job = JobRow(
+                id=int(row["id"]),
+                name=str(row["name"]),
+                type=str(row["type"]),
+                payload=payload,
+                interval_seconds=int(row["interval_seconds"]),
+                created_at=int(row["created_at"]),
+                updated_at=int(row["updated_at"]),
+            )
+            state = JobStateRow(
+                job_id=job.id,
+                status=str(row["state_status"]),
+                next_run_at=int(row["next_run_at"]),
+                last_run_at=int(row["last_run_at"])
+                if row["last_run_at"] is not None
+                else None,
+                last_ok_at=int(row["last_ok_at"])
+                if row["last_ok_at"] is not None
+                else None,
+                consecutive_failures=int(row["consecutive_failures"] or 0),
+                last_error=str(row["last_error"])
+                if row["last_error"] is not None
+                else None,
+            )
+            return job, state
+
+    def list_jobs(self) -> list[dict[str, Any]]:
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                """
+                SELECT d.*, s.status AS state_status, s.next_run_at, s.last_run_at, s.last_ok_at,
+                       s.consecutive_failures, s.last_error
+                FROM job_defs d
+                JOIN job_state s ON s.job_id = d.id
+                ORDER BY d.id ASC
+                """
+            )
+            rows = cur.fetchall()
+        out: list[dict[str, Any]] = []
+        for r in rows:
+            payload = json.loads(r["payload_json"]) if r["payload_json"] else {}
+            out.append(
+                {
+                    "id": int(r["id"]),
+                    "name": str(r["name"]),
+                    "type": str(r["type"]),
+                    "payload": payload,
+                    "interval_seconds": int(r["interval_seconds"]),
+                    "created_at": int(r["created_at"]),
+                    "updated_at": int(r["updated_at"]),
+                    "status": str(r["state_status"]),
+                    "next_run_at": int(r["next_run_at"]),
+                    "last_run_at": int(r["last_run_at"])
+                    if r["last_run_at"] is not None
+                    else None,
+                    "last_ok_at": int(r["last_ok_at"])
+                    if r["last_ok_at"] is not None
+                    else None,
+                    "consecutive_failures": int(r["consecutive_failures"] or 0),
+                    "last_error": str(r["last_error"])
+                    if r["last_error"] is not None
+                    else None,
+                }
+            )
+        return out
+
+    def set_job_status(self, *, name: str, status: str) -> None:
+        if status not in {JOB_STATUS_ACTIVE, JOB_STATUS_PAUSED, JOB_STATUS_ERROR}:
+            raise ValueError(f"Invalid job status: {status}")
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                """
+                UPDATE job_state
+                SET status = ?
+                WHERE job_id = (SELECT id FROM job_defs WHERE name = ?)
+                """,
+                (status, name),
+            )
+            if cur.rowcount == 0:
+                raise KeyError(f"Job not found: {name}")
+
+    def set_next_run_at(self, *, job_id: int, next_run_at: int) -> None:
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                "UPDATE job_state SET next_run_at = ? WHERE job_id = ?",
+                (int(next_run_at), int(job_id)),
+            )
+
+    def set_job_last_run(self, *, job_id: int, last_run_at: int) -> None:
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                "UPDATE job_state SET last_run_at = ? WHERE job_id = ?",
+                (int(last_run_at), int(job_id)),
+            )
+
+    def record_job_success(self, *, job_id: int, ok_at: int) -> None:
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                """
+                UPDATE job_state
+                SET last_ok_at = ?, consecutive_failures = 0, last_error = NULL
+                WHERE job_id = ?
+                """,
+                (int(ok_at), int(job_id)),
+            )
+
+    def record_job_failure(
+        self,
+        *,
+        job_id: int,
+        error_text: str,
+        max_failures: int,
+    ) -> tuple[int, str]:
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                """
+                UPDATE job_state
+                SET consecutive_failures = consecutive_failures + 1,
+                    last_error = ?
+                WHERE job_id = ?
+                """,
+                (str(error_text), int(job_id)),
+            )
+            cur.execute(
+                "SELECT consecutive_failures FROM job_state WHERE job_id = ?",
+                (int(job_id),),
+            )
+            row = cur.fetchone()
+            failures = int(row["consecutive_failures"] if row else 0)
+            status = JOB_STATUS_ACTIVE
+            if failures >= int(max_failures):
+                status = JOB_STATUS_ERROR
+                cur.execute(
+                    "UPDATE job_state SET status = ? WHERE job_id = ?",
+                    (JOB_STATUS_ERROR, int(job_id)),
+                )
+            return failures, status
+
+    def due_jobs(self, *, now: int) -> list[dict[str, Any]]:
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                """
+                SELECT d.id, d.name, d.type, d.payload_json, d.interval_seconds,
+                       s.status, s.next_run_at, s.last_run_at, s.last_ok_at,
+                       s.consecutive_failures, s.last_error
+                FROM job_defs d
+                JOIN job_state s ON s.job_id = d.id
+                WHERE s.status = ? AND s.next_run_at <= ?
+                ORDER BY s.next_run_at ASC, d.id ASC
+                """,
+                (JOB_STATUS_ACTIVE, int(now)),
+            )
+            rows = cur.fetchall()
+        out: list[dict[str, Any]] = []
+        for r in rows:
+            out.append(
+                {
+                    "id": int(r["id"]),
+                    "name": str(r["name"]),
+                    "type": str(r["type"]),
+                    "payload": json.loads(r["payload_json"])
+                    if r["payload_json"]
+                    else {},
+                    "interval_seconds": int(r["interval_seconds"]),
+                    "status": str(r["status"]),
+                    "next_run_at": int(r["next_run_at"]),
+                    "last_run_at": int(r["last_run_at"])
+                    if r["last_run_at"] is not None
+                    else None,
+                    "last_ok_at": int(r["last_ok_at"])
+                    if r["last_ok_at"] is not None
+                    else None,
+                    "consecutive_failures": int(r["consecutive_failures"] or 0),
+                    "last_error": str(r["last_error"])
+                    if r["last_error"] is not None
+                    else None,
+                }
+            )
+        return out
+
+    def create_run(
+        self,
+        *,
+        job_id: int,
+        started_at: int,
+        status: str = RUN_STATUS_RUNNING,
+        log_path: str | None = None,
+        pid: int | None = None,
+    ) -> int:
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                """
+                INSERT INTO runs(job_id, started_at, finished_at, status, exit_code, log_path, summary_json, pid)
+                VALUES (?, ?, NULL, ?, NULL, ?, NULL, ?)
+                """,
+                (int(job_id), int(started_at), str(status), log_path, pid),
+            )
+            return int(cur.lastrowid)
+
+    def finish_run(
+        self,
+        *,
+        run_id: int,
+        finished_at: int,
+        status: str,
+        exit_code: int | None,
+        summary: dict[str, Any] | None = None,
+    ) -> None:
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                """
+                UPDATE runs
+                SET finished_at = ?, status = ?, exit_code = ?, summary_json = ?
+                WHERE run_id = ?
+                """,
+                (
+                    int(finished_at),
+                    str(status),
+                    int(exit_code) if exit_code is not None else None,
+                    _json_dumps(summary) if summary is not None else None,
+                    int(run_id),
+                ),
+            )
+
+    def update_run_pid(self, *, run_id: int, pid: int) -> None:
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                "UPDATE runs SET pid = ? WHERE run_id = ?",
+                (int(pid), int(run_id)),
+            )
+
+    def update_run_log_path(self, *, run_id: int, log_path: str) -> None:
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                "UPDATE runs SET log_path = ? WHERE run_id = ?",
+                (str(log_path), int(run_id)),
+            )
+
+    def last_runs(self, *, limit: int = 50) -> list[dict[str, Any]]:
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                """
+                SELECT r.run_id, r.job_id, d.name AS job_name, r.started_at, r.finished_at, r.status,
+                       r.exit_code, r.log_path, r.summary_json, r.pid
+                FROM runs r
+                JOIN job_defs d ON d.id = r.job_id
+                ORDER BY r.run_id DESC
+                LIMIT ?
+                """,
+                (int(limit),),
+            )
+            rows = cur.fetchall()
+        out: list[dict[str, Any]] = []
+        for r in rows:
+            out.append(
+                {
+                    "run_id": int(r["run_id"]),
+                    "job_id": int(r["job_id"]),
+                    "job_name": str(r["job_name"]),
+                    "started_at": int(r["started_at"]),
+                    "finished_at": int(r["finished_at"])
+                    if r["finished_at"] is not None
+                    else None,
+                    "status": str(r["status"]),
+                    "exit_code": int(r["exit_code"])
+                    if r["exit_code"] is not None
+                    else None,
+                    "log_path": str(r["log_path"])
+                    if r["log_path"] is not None
+                    else None,
+                    "summary": json.loads(r["summary_json"])
+                    if r["summary_json"]
+                    else None,
+                    "pid": int(r["pid"]) if r["pid"] is not None else None,
+                }
+            )
+        return out
+
+    def runs_for_job(self, *, job_id: int, limit: int = 50) -> list[dict[str, Any]]:
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                """
+                SELECT r.run_id, r.job_id, d.name AS job_name, r.started_at, r.finished_at, r.status,
+                       r.exit_code, r.log_path, r.summary_json, r.pid
+                FROM runs r
+                JOIN job_defs d ON d.id = r.job_id
+                WHERE r.job_id = ?
+                ORDER BY r.run_id DESC
+                LIMIT ?
+                """,
+                (int(job_id), int(limit)),
+            )
+            rows = cur.fetchall()
+        out: list[dict[str, Any]] = []
+        for r in rows:
+            out.append(
+                {
+                    "run_id": int(r["run_id"]),
+                    "job_id": int(r["job_id"]),
+                    "job_name": str(r["job_name"]),
+                    "started_at": int(r["started_at"]),
+                    "finished_at": int(r["finished_at"])
+                    if r["finished_at"] is not None
+                    else None,
+                    "status": str(r["status"]),
+                    "exit_code": int(r["exit_code"])
+                    if r["exit_code"] is not None
+                    else None,
+                    "log_path": str(r["log_path"])
+                    if r["log_path"] is not None
+                    else None,
+                    "summary": json.loads(r["summary_json"])
+                    if r["summary_json"]
+                    else None,
+                    "pid": int(r["pid"]) if r["pid"] is not None else None,
+                }
+            )
+        return out
+
+    def get_run(self, *, run_id: int) -> dict[str, Any] | None:
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                """
+                SELECT r.run_id, r.job_id, d.name AS job_name, r.started_at, r.finished_at, r.status,
+                       r.exit_code, r.log_path, r.summary_json, r.pid
+                FROM runs r
+                JOIN job_defs d ON d.id = r.job_id
+                WHERE r.run_id = ?
+                """,
+                (int(run_id),),
+            )
+            r = cur.fetchone()
+        if not r:
+            return None
+        return {
+            "run_id": int(r["run_id"]),
+            "job_id": int(r["job_id"]),
+            "job_name": str(r["job_name"]),
+            "started_at": int(r["started_at"]),
+            "finished_at": int(r["finished_at"])
+            if r["finished_at"] is not None
+            else None,
+            "status": str(r["status"]),
+            "exit_code": int(r["exit_code"]) if r["exit_code"] is not None else None,
+            "log_path": str(r["log_path"]) if r["log_path"] is not None else None,
+            "summary": json.loads(r["summary_json"]) if r["summary_json"] else None,
+            "pid": int(r["pid"]) if r["pid"] is not None else None,
+        }
+
+    def kv_get(self, *, namespace: str, key: str) -> Any | None:
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                "SELECT value_json FROM kv WHERE namespace = ? AND key = ?",
+                (namespace, key),
+            )
+            row = cur.fetchone()
+        if not row:
+            return None
+        try:
+            return json.loads(row["value_json"])
+        except Exception:  # noqa: BLE001
+            return None
+
+    def kv_set(self, *, namespace: str, key: str, value: Any) -> None:
+        now = _utc_epoch_s()
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                """
+                INSERT INTO kv(namespace, key, value_json, updated_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(namespace, key) DO UPDATE SET
+                  value_json = excluded.value_json,
+                  updated_at = excluded.updated_at
+                """,
+                (namespace, key, _json_dumps(value), now),
+            )

--- a/wayfinder_paths/runner/lifecycle.py
+++ b/wayfinder_paths/runner/lifecycle.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+from wayfinder_paths.runner.client import RunnerControlClient
+from wayfinder_paths.runner.paths import RunnerPaths
+
+
+def daemon_log_path(paths: RunnerPaths) -> Path:
+    return paths.runner_dir / "runnerd.log"
+
+
+def build_daemon_start_cmd(
+    *,
+    tick_seconds: float,
+    max_workers: int,
+    max_failures: int,
+    default_timeout_seconds: int,
+    log_level: str,
+) -> list[str]:
+    return [
+        sys.executable,
+        "-m",
+        "wayfinder_paths.runnerd",
+        "start",
+        "--tick-seconds",
+        str(float(tick_seconds)),
+        "--max-workers",
+        str(int(max_workers)),
+        "--max-failures",
+        str(int(max_failures)),
+        "--default-timeout-seconds",
+        str(int(default_timeout_seconds)),
+        "--log-level",
+        str(log_level),
+    ]
+
+
+def spawn_detached(
+    *,
+    cmd: list[str],
+    repo_root: Path,
+    log_path: Path,
+    banner: str = "[runnerctl]",
+    env: dict[str, str] | None = None,
+) -> int:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    env_out = dict(env) if env is not None else os.environ.copy()
+
+    popen_kwargs: dict[str, Any] = {
+        "cwd": str(repo_root),
+        "env": env_out,
+        "stdin": subprocess.DEVNULL,
+        "stderr": subprocess.STDOUT,
+    }
+
+    if os.name == "nt":
+        popen_kwargs["creationflags"] = (
+            getattr(subprocess, "DETACHED_PROCESS", 0x00000008)
+            | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200)
+            | getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)
+        )
+    else:
+        popen_kwargs["start_new_session"] = True
+
+    with log_path.open("ab", buffering=0) as log_f:
+        log_f.write(
+            f"{banner} starting runner: {' '.join(cmd)}\n".encode(
+                "utf-8", errors="replace"
+            )
+        )
+        popen = subprocess.Popen(cmd, stdout=log_f, **popen_kwargs)  # noqa: S603
+        return int(popen.pid)
+
+
+def try_status(
+    client: RunnerControlClient,
+) -> tuple[bool, dict[str, Any] | None, dict[str, Any] | None]:
+    if not client.sock_path.exists():
+        return (
+            False,
+            None,
+            {"error": "sock_missing", "sock_path": str(client.sock_path)},
+        )
+    resp = client.call("status")
+    if resp.get("ok"):
+        return True, resp.get("result"), None
+    return False, None, resp
+
+
+def wait_for_started(
+    client: RunnerControlClient, *, timeout_s: float = 10.0
+) -> tuple[bool, dict[str, Any] | None]:
+    deadline = time.time() + float(timeout_s)
+    last_error: dict[str, Any] | None = None
+    while time.time() < deadline:
+        started, status, err_obj = try_status(client)
+        if started and status is not None:
+            return True, status
+        last_error = err_obj
+        time.sleep(0.1)
+    return False, last_error
+
+
+def ensure_daemon_started(
+    *,
+    paths: RunnerPaths,
+    tick_seconds: float,
+    max_workers: int,
+    max_failures: int,
+    default_timeout_seconds: int,
+    log_level: str,
+    timeout_s: float = 10.0,
+    banner: str = "[runnerctl]",
+    env: dict[str, str] | None = None,
+) -> tuple[bool, dict[str, Any]]:
+    client = RunnerControlClient(sock_path=paths.sock_path)
+    started, status, err_obj = try_status(client)
+    if started and status is not None:
+        return True, {
+            "already_running": True,
+            "sock_path": str(paths.sock_path),
+            "status": status,
+        }
+
+    cmd = build_daemon_start_cmd(
+        tick_seconds=tick_seconds,
+        max_workers=max_workers,
+        max_failures=max_failures,
+        default_timeout_seconds=default_timeout_seconds,
+        log_level=log_level,
+    )
+    log_path = daemon_log_path(paths)
+    pid = spawn_detached(
+        cmd=cmd,
+        repo_root=paths.repo_root,
+        log_path=log_path,
+        banner=banner,
+        env=env,
+    )
+
+    ok_started, info = wait_for_started(client, timeout_s=timeout_s)
+    if not ok_started:
+        return False, {
+            "pid": pid,
+            "sock_path": str(paths.sock_path),
+            "log_path": str(log_path),
+            "last_error": info,
+            "previous_error": err_obj,
+        }
+
+    return True, {
+        "already_running": False,
+        "pid": pid,
+        "sock_path": str(paths.sock_path),
+        "log_path": str(log_path),
+        "status": info,
+    }

--- a/wayfinder_paths/runner/paths.py
+++ b/wayfinder_paths/runner/paths.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+def find_repo_root(*, start: Path | None = None) -> Path:
+    cur = (start or Path.cwd()).resolve()
+    for parent in [cur, *cur.parents]:
+        if (parent / "pyproject.toml").exists():
+            return parent
+    return cur
+
+
+@dataclass(frozen=True)
+class RunnerPaths:
+    repo_root: Path
+    runner_dir: Path
+    db_path: Path
+    logs_dir: Path
+    sock_path: Path
+
+
+def get_runner_paths(*, repo_root: Path | None = None) -> RunnerPaths:
+    root = (repo_root or find_repo_root()).resolve()
+    runner_dir_override = os.environ.get("WAYFINDER_RUNNER_DIR") or os.environ.get(
+        "WAYFINDER_RUNNER_STATE_DIR"
+    )
+    if runner_dir_override:
+        rd = Path(runner_dir_override).expanduser()
+        if not rd.is_absolute():
+            rd = root / rd
+        runner_dir = rd.resolve()
+    else:
+        runner_dir = root / ".wayfinder" / "runner"
+    return RunnerPaths(
+        repo_root=root,
+        runner_dir=runner_dir,
+        db_path=runner_dir / "state.db",
+        logs_dir=runner_dir / "logs",
+        sock_path=runner_dir / "runner.sock",
+    )

--- a/wayfinder_paths/runner/protocol.py
+++ b/wayfinder_paths/runner/protocol.py
@@ -4,8 +4,6 @@ import json
 from dataclasses import dataclass
 from typing import Any
 
-MAX_LINE_BYTES = 1024 * 1024
-
 
 @dataclass(frozen=True)
 class ProtocolError(Exception):

--- a/wayfinder_paths/runner/protocol.py
+++ b/wayfinder_paths/runner/protocol.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+MAX_LINE_BYTES = 1024 * 1024
+
+
+@dataclass(frozen=True)
+class ProtocolError(Exception):
+    code: str
+
+
+def encode_request(method: str, params: dict[str, Any] | None = None) -> bytes:
+    req = {"method": str(method), "params": params or {}}
+    return (json.dumps(req, separators=(",", ":"), ensure_ascii=False) + "\n").encode(
+        "utf-8"
+    )
+
+
+def decode_request_line(raw: bytes) -> tuple[str, dict[str, Any]]:
+    if not raw:
+        raise ProtocolError("empty_request")
+    try:
+        req = json.loads(raw.decode("utf-8", errors="replace"))
+    except json.JSONDecodeError as exc:  # noqa: PERF203
+        raise ProtocolError("invalid_json") from exc
+    if not isinstance(req, dict):
+        raise ProtocolError("invalid_request")
+
+    method = str(req.get("method") or "")
+    params = req.get("params") or {}
+    if not isinstance(params, dict):
+        params = {}
+    return method, params
+
+
+def encode_response(resp: dict[str, Any]) -> bytes:
+    data = json.dumps(resp, separators=(",", ":"), ensure_ascii=False, default=str)
+    return (data + "\n").encode("utf-8")
+
+
+def decode_response_bytes(raw: bytes) -> dict[str, Any]:
+    line = raw.split(b"\n", 1)[0].strip()
+    if not line:
+        return {"ok": False, "error": "empty_response"}
+    try:
+        out = json.loads(line.decode("utf-8", errors="replace"))
+    except json.JSONDecodeError:
+        return {
+            "ok": False,
+            "error": "invalid_response",
+            "raw": line.decode("utf-8", errors="replace"),
+        }
+    if isinstance(out, dict):
+        return out
+    return {"ok": False, "error": "invalid_response_type", "raw": out}

--- a/wayfinder_paths/runner/script_resolver.py
+++ b/wayfinder_paths/runner/script_resolver.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from wayfinder_paths.runner.paths import RunnerPaths
+
+
+def runs_root(paths: RunnerPaths) -> Path:
+    candidate = (os.getenv("WAYFINDER_RUNS_DIR") or ".wayfinder_runs").strip()
+    p = Path(candidate)
+    if not p.is_absolute():
+        p = paths.repo_root / p
+    return p.resolve(strict=False)
+
+
+def resolve_script_path(paths: RunnerPaths, script_path: str) -> Path:
+    raw = str(script_path).strip()
+    if not raw:
+        raise ValueError("script_path is required")
+
+    p = Path(raw)
+    if not p.is_absolute():
+        p = paths.repo_root / p
+    resolved = p.resolve(strict=False)
+
+    root = runs_root(paths)
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(
+            f"script_path must be inside the local runs directory ({root})"
+        ) from exc
+
+    if not resolved.exists():
+        raise FileNotFoundError(f"Script file not found: {resolved}")
+
+    if resolved.suffix.lower() != ".py":
+        raise ValueError("Only .py scripts are supported")
+
+    return resolved

--- a/wayfinder_paths/runner/transport.py
+++ b/wayfinder_paths/runner/transport.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import errno
+import socket
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+
+class RunnerTransport(Protocol):
+    def roundtrip(self, payload: bytes) -> bytes: ...
+
+    def describe(self) -> str: ...
+
+
+@dataclass(frozen=True)
+class UnixSocketTransport:
+    sock_path: Path
+    timeout_s: float = 5.0
+
+    def roundtrip(self, payload: bytes) -> bytes:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
+            s.settimeout(float(self.timeout_s))
+            s.connect(str(self.sock_path))
+            s.sendall(payload)
+            try:
+                s.shutdown(socket.SHUT_WR)
+            except OSError as exc:
+                # Best-effort: some platforms can raise ENOTCONN here even after a
+                # successful connect/send. The request is newline-delimited, so we
+                # can proceed without a half-close.
+                if exc.errno not in {errno.ENOTCONN, errno.EINVAL}:
+                    raise
+
+            buf = b""
+            while b"\n" not in buf:
+                chunk = s.recv(1024 * 1024)
+                if not chunk:
+                    break
+                buf += chunk
+            return buf
+
+    def describe(self) -> str:
+        return f"unix:{self.sock_path}"

--- a/wayfinder_paths/runnerd.py
+++ b/wayfinder_paths/runnerd.py
@@ -1,0 +1,18 @@
+"""Entry point for starting/controlling the local runner.
+
+Usage:
+  poetry run python -m wayfinder_paths.runnerd start
+  poetry run python -m wayfinder_paths.runnerd status
+"""
+
+from __future__ import annotations
+
+from wayfinder_paths.runner.cli import runner_cli
+
+
+def main() -> None:
+    runner_cli(standalone_mode=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/wayfinder_paths/tests/test_mcp_runner_tool.py
+++ b/wayfinder_paths/tests/test_mcp_runner_tool.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import tempfile
+import time
+from pathlib import Path
+
+from wayfinder_paths.mcp.tools.runner import runner
+from wayfinder_paths.runner.control import RunnerControlServer
+
+
+class _FakeDaemon:
+    def __init__(self) -> None:
+        self.control: RunnerControlServer | None = None
+
+    def ctl_status(self) -> dict:
+        return {"ok": True, "result": {"hello": "world"}}
+
+    def ctl_shutdown(self) -> dict:
+        if self.control is not None:
+            self.control.stop()
+        return {"ok": True, "result": {"shutdown": True}}
+
+    def ctl_job_runs(self, **_kw) -> dict:  # type: ignore[no-untyped-def]
+        return {"ok": True, "result": {"runs": [{"run_id": 1}]}}
+
+    def ctl_run_report(self, **_kw) -> dict:  # type: ignore[no-untyped-def]
+        return {"ok": True, "result": {"run": {"run_id": 1}, "log_tail": "ok"}}
+
+    def ctl_add_job(self, **_kw) -> dict:  # type: ignore[no-untyped-def]
+        return {"ok": True, "result": {"job_id": 1}}
+
+    def ctl_update_job(self, **_kw) -> dict:  # type: ignore[no-untyped-def]
+        return {"ok": True, "result": {"updated": True}}
+
+    def ctl_pause_job(self, **_kw) -> dict:  # type: ignore[no-untyped-def]
+        return {"ok": True, "result": {"paused": True}}
+
+    def ctl_resume_job(self, **_kw) -> dict:  # type: ignore[no-untyped-def]
+        return {"ok": True, "result": {"resumed": True}}
+
+    def ctl_run_once(self, **_kw) -> dict:  # type: ignore[no-untyped-def]
+        return {"ok": True, "result": {"run_id": 123}}
+
+    def ctl_delete_job(self, **_kw) -> dict:  # type: ignore[no-untyped-def]
+        return {"ok": True, "result": {"deleted": True}}
+
+
+def test_mcp_runner_tool_status_roundtrip() -> None:
+    sock = Path(tempfile.gettempdir()) / f"wayfinder-runner-mcp-{time.time_ns()}.sock"
+    daemon = _FakeDaemon()
+    server = RunnerControlServer(sock_path=sock, daemon=daemon)
+    daemon.control = server
+    server.start()
+    try:
+        out = _run(runner(action="daemon_status", sock_path=str(sock)))
+        assert out["ok"] is True
+        assert out["result"]["started"] is True
+
+        out = _run(runner(action="status", sock_path=str(sock)))
+        assert out["ok"] is True
+        assert out["result"]["hello"] == "world"
+
+        out = _run(runner(action="job_runs", sock_path=str(sock), name="job", limit=5))
+        assert out["ok"] is True
+        assert out["result"]["runs"][0]["run_id"] == 1
+
+        out = _run(runner(action="run_report", sock_path=str(sock), run_id=1))
+        assert out["ok"] is True
+        assert out["result"]["run"]["run_id"] == 1
+
+        out = _run(runner(action="delete_job", sock_path=str(sock), name="job"))
+        assert out["ok"] is True
+        assert out["result"]["deleted"] is True
+
+        out = _run(runner(action="daemon_stop", sock_path=str(sock)))
+        assert out["ok"] is True
+        assert out["result"]["stopped"] is True
+    finally:
+        server.stop()
+
+
+def _run(coro):  # type: ignore[no-untyped-def]
+    import asyncio
+
+    return asyncio.run(coro)

--- a/wayfinder_paths/tests/test_runner_control.py
+++ b/wayfinder_paths/tests/test_runner_control.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import tempfile
+import time
+from pathlib import Path
+
+from wayfinder_paths.runner.client import RunnerControlClient
+from wayfinder_paths.runner.control import RunnerControlServer
+
+
+class _FakeDaemon:
+    def ctl_status(self) -> dict:
+        return {"ok": True, "result": {"hello": "world"}}
+
+    def ctl_shutdown(self) -> dict:
+        return {"ok": True, "result": {"shutdown": True}}
+
+    def ctl_job_runs(self, **_kw) -> dict:  # type: ignore[no-untyped-def]
+        return {"ok": True, "result": {"runs": [{"run_id": 1}]}}
+
+    def ctl_run_report(self, **_kw) -> dict:  # type: ignore[no-untyped-def]
+        return {"ok": True, "result": {"run": {"run_id": 1}, "log_tail": "ok"}}
+
+    def ctl_add_job(self, **_kw) -> dict:  # type: ignore[no-untyped-def]
+        return {"ok": True, "result": {"job_id": 1}}
+
+    def ctl_update_job(self, **_kw) -> dict:  # type: ignore[no-untyped-def]
+        return {"ok": True, "result": {"updated": True}}
+
+    def ctl_pause_job(self, **_kw) -> dict:  # type: ignore[no-untyped-def]
+        return {"ok": True}
+
+    def ctl_resume_job(self, **_kw) -> dict:  # type: ignore[no-untyped-def]
+        return {"ok": True}
+
+    def ctl_run_once(self, **_kw) -> dict:  # type: ignore[no-untyped-def]
+        return {"ok": True, "result": {"run_id": 123}}
+
+    def ctl_delete_job(self, **_kw) -> dict:  # type: ignore[no-untyped-def]
+        return {"ok": True, "result": {"deleted": True}}
+
+
+def test_runner_control_roundtrip(tmp_path: Path) -> None:
+    # macOS has a short AF_UNIX path limit; tmp_path can be too long. Use /tmp.
+    sock = Path(tempfile.gettempdir()) / f"wayfinder-runner-{time.time_ns()}.sock"
+    server = RunnerControlServer(sock_path=sock, daemon=_FakeDaemon())
+    server.start()
+    try:
+        client = RunnerControlClient(sock_path=sock)
+
+        # Be robust to thread scheduling delays: wait until we can successfully
+        # roundtrip a request (not just until the socket file appears).
+        deadline = time.time() + 2.0
+        resp = None
+        while time.time() < deadline:
+            resp = client.call("status")
+            if resp.get("ok") is True:
+                break
+            time.sleep(0.02)
+        assert resp is not None
+        assert resp.get("ok") is True, resp
+        assert resp["result"]["hello"] == "world"
+
+        resp = client.call("job_runs", {"name": "job", "limit": 5})
+        assert resp.get("ok") is True, resp
+        assert resp["result"]["runs"][0]["run_id"] == 1
+
+        resp = client.call("run_report", {"run_id": 1, "tail_bytes": 1000})
+        assert resp.get("ok") is True, resp
+        assert resp["result"]["run"]["run_id"] == 1
+
+        resp = client.call("delete_job", {"name": "job"})
+        assert resp.get("ok") is True, resp
+        assert resp["result"]["deleted"] is True
+
+        resp = client.call("shutdown")
+        assert resp.get("ok") is True, resp
+        assert resp["result"]["shutdown"] is True
+    finally:
+        server.stop()

--- a/wayfinder_paths/tests/test_runner_db.py
+++ b/wayfinder_paths/tests/test_runner_db.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from wayfinder_paths.runner.constants import (
+    JOB_STATUS_ACTIVE,
+    JOB_STATUS_ERROR,
+    JOB_TYPE_STRATEGY,
+)
+from wayfinder_paths.runner.db import RunnerDB
+
+
+def test_runner_db_add_and_due_jobs(tmp_path: Path) -> None:
+    db = RunnerDB(tmp_path / "state.db")
+    job_id = db.add_job(
+        name="basis-update",
+        job_type=JOB_TYPE_STRATEGY,
+        payload={
+            "strategy": "basis_trading_strategy",
+            "action": "update",
+            "config": "config.json",
+        },
+        interval_seconds=600,
+        status=JOB_STATUS_ACTIVE,
+        next_run_at=int(time.time()) - 1,
+    )
+    assert isinstance(job_id, int) and job_id > 0
+
+    jobs = db.list_jobs()
+    assert len(jobs) == 1
+    assert jobs[0]["name"] == "basis-update"
+    assert jobs[0]["status"] == JOB_STATUS_ACTIVE
+
+    due = db.due_jobs(now=int(time.time()))
+    assert len(due) == 1
+    assert due[0]["id"] == job_id
+
+
+def test_runner_db_failure_circuit_breaker(tmp_path: Path) -> None:
+    db = RunnerDB(tmp_path / "state.db")
+    job_id = db.add_job(
+        name="job",
+        job_type=JOB_TYPE_STRATEGY,
+        payload={"strategy": "basis_trading_strategy"},
+        interval_seconds=10,
+        status=JOB_STATUS_ACTIVE,
+        next_run_at=int(time.time()),
+    )
+
+    failures, status = db.record_job_failure(
+        job_id=job_id, error_text="boom", max_failures=2
+    )
+    assert failures == 1
+    assert status == JOB_STATUS_ACTIVE
+
+    failures, status = db.record_job_failure(
+        job_id=job_id, error_text="boom2", max_failures=2
+    )
+    assert failures == 2
+    assert status == JOB_STATUS_ERROR
+
+
+def test_runner_db_delete_job_cascades_state_and_runs(tmp_path: Path) -> None:
+    db = RunnerDB(tmp_path / "state.db")
+    now = int(time.time())
+    job_id = db.add_job(
+        name="job",
+        job_type=JOB_TYPE_STRATEGY,
+        payload={"strategy": "basis_trading_strategy"},
+        interval_seconds=10,
+        status=JOB_STATUS_ACTIVE,
+        next_run_at=now,
+    )
+
+    run_id = db.create_run(job_id=job_id, started_at=now)
+    assert db.get_run(run_id=run_id) is not None
+
+    db.delete_job(name="job")
+    assert db.list_jobs() == []
+    assert db.get_run(run_id=run_id) is None

--- a/wayfinder_paths/tests/test_runner_db.py
+++ b/wayfinder_paths/tests/test_runner_db.py
@@ -4,9 +4,8 @@ import time
 from pathlib import Path
 
 from wayfinder_paths.runner.constants import (
-    JOB_STATUS_ACTIVE,
-    JOB_STATUS_ERROR,
     JOB_TYPE_STRATEGY,
+    JobStatus,
 )
 from wayfinder_paths.runner.db import RunnerDB
 
@@ -22,7 +21,7 @@ def test_runner_db_add_and_due_jobs(tmp_path: Path) -> None:
             "config": "config.json",
         },
         interval_seconds=600,
-        status=JOB_STATUS_ACTIVE,
+        status=JobStatus.ACTIVE,
         next_run_at=int(time.time()) - 1,
     )
     assert isinstance(job_id, int) and job_id > 0
@@ -30,7 +29,7 @@ def test_runner_db_add_and_due_jobs(tmp_path: Path) -> None:
     jobs = db.list_jobs()
     assert len(jobs) == 1
     assert jobs[0]["name"] == "basis-update"
-    assert jobs[0]["status"] == JOB_STATUS_ACTIVE
+    assert jobs[0]["status"] == JobStatus.ACTIVE
 
     due = db.due_jobs(now=int(time.time()))
     assert len(due) == 1
@@ -44,7 +43,7 @@ def test_runner_db_failure_circuit_breaker(tmp_path: Path) -> None:
         job_type=JOB_TYPE_STRATEGY,
         payload={"strategy": "basis_trading_strategy"},
         interval_seconds=10,
-        status=JOB_STATUS_ACTIVE,
+        status=JobStatus.ACTIVE,
         next_run_at=int(time.time()),
     )
 
@@ -52,13 +51,13 @@ def test_runner_db_failure_circuit_breaker(tmp_path: Path) -> None:
         job_id=job_id, error_text="boom", max_failures=2
     )
     assert failures == 1
-    assert status == JOB_STATUS_ACTIVE
+    assert status == JobStatus.ACTIVE
 
     failures, status = db.record_job_failure(
         job_id=job_id, error_text="boom2", max_failures=2
     )
     assert failures == 2
-    assert status == JOB_STATUS_ERROR
+    assert status == JobStatus.ERROR
 
 
 def test_runner_db_delete_job_cascades_state_and_runs(tmp_path: Path) -> None:
@@ -69,7 +68,7 @@ def test_runner_db_delete_job_cascades_state_and_runs(tmp_path: Path) -> None:
         job_type=JOB_TYPE_STRATEGY,
         payload={"strategy": "basis_trading_strategy"},
         interval_seconds=10,
-        status=JOB_STATUS_ACTIVE,
+        status=JobStatus.ACTIVE,
         next_run_at=now,
     )
 

--- a/wayfinder_paths/tests/test_runner_e2e.py
+++ b/wayfinder_paths/tests/test_runner_e2e.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from wayfinder_paths.runner.client import RunnerControlClient
+from wayfinder_paths.runner.constants import JOB_STATUS_ACTIVE, JOB_TYPE_SCRIPT
+from wayfinder_paths.runner.daemon import RunnerDaemon
+from wayfinder_paths.runner.db import RunnerDB
+from wayfinder_paths.runner.paths import RunnerPaths, find_repo_root
+
+
+def _short_runner_dir(prefix: str) -> Path:
+    base = Path("/tmp") if Path("/tmp").exists() else Path(tempfile.gettempdir())
+    short_prefix = "".join(ch for ch in prefix if ch.isalnum() or ch in ("-", "_"))[:12]
+    return base / f"{short_prefix}-{time.time_ns()}"
+
+
+def _wait_for_status(client: RunnerControlClient, *, timeout_s: float = 10.0) -> dict:
+    deadline = time.time() + float(timeout_s)
+    last = None
+    while time.time() < deadline:
+        resp = client.call("status")
+        if resp.get("ok"):
+            return resp
+        last = resp
+        time.sleep(0.1)
+    raise AssertionError(f"Runner did not become ready in time (last={last})")
+
+
+def _wait_for_job_run_id(
+    client: RunnerControlClient, *, name: str, timeout_s: float = 10.0
+) -> int:
+    deadline = time.time() + float(timeout_s)
+    last = None
+    while time.time() < deadline:
+        resp = client.call("job_runs", {"name": str(name), "limit": 1})
+        if resp.get("ok") and resp.get("result", {}).get("runs"):
+            return int(resp["result"]["runs"][0]["run_id"])
+        last = resp
+        time.sleep(0.05)
+    raise AssertionError(f"Run was not created in time (last={last})")
+
+
+def _wait_for_run_finished(
+    client: RunnerControlClient, *, run_id: int, timeout_s: float = 10.0
+) -> dict:
+    deadline = time.time() + float(timeout_s)
+    last_report = None
+    while time.time() < deadline:
+        report = client.call("run_report", {"run_id": int(run_id), "tail_bytes": 5000})
+        assert report.get("ok") is True, report
+        last_report = report
+        status = report["result"]["run"]["status"]
+        if status != "RUNNING":
+            return report
+        time.sleep(0.05)
+    raise AssertionError(f"Run did not finish in time (last={last_report})")
+
+
+def test_runner_daemon_runs_script_job_end_to_end(tmp_path: Path) -> None:
+    runner_dir = _short_runner_dir("wayfinder-runner-e2e")
+    if runner_dir.exists():
+        shutil.rmtree(runner_dir, ignore_errors=True)
+    runner_dir.mkdir(parents=True, exist_ok=True)
+
+    runs_dir = tmp_path / ".wayfinder_runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    script = runs_dir / "hello.py"
+    script.write_text("print('HELLO_FROM_SCRIPT')\n", encoding="utf-8")
+
+    paths = RunnerPaths(
+        repo_root=tmp_path,
+        runner_dir=runner_dir,
+        db_path=runner_dir / "state.db",
+        logs_dir=runner_dir / "logs",
+        sock_path=runner_dir / "runner.sock",
+    )
+
+    daemon = RunnerDaemon(paths=paths, tick_seconds=0.05, max_workers=2)
+    t = threading.Thread(target=daemon.start, name="runner-e2e-daemon")
+    t.start()
+
+    client = RunnerControlClient(sock_path=paths.sock_path)
+    try:
+        _wait_for_status(client, timeout_s=10.0)
+
+        add = client.call(
+            "add_job",
+            {
+                "name": "hello",
+                "type": "script",
+                "payload": {"script_path": ".wayfinder_runs/hello.py", "args": []},
+                "interval_seconds": 3600,
+            },
+        )
+        assert add.get("ok") is True, add
+
+        run_id = _wait_for_job_run_id(client, name="hello", timeout_s=5.0)
+        report = _wait_for_run_finished(client, run_id=run_id, timeout_s=10.0)
+        assert report["result"]["run"]["status"] == "OK"
+        tail = report["result"]["log_tail"]
+        assert isinstance(tail, str) and "HELLO_FROM_SCRIPT" in tail
+    finally:
+        try:
+            client.call("shutdown")
+        except Exception:  # noqa: BLE001
+            daemon.stop()
+        t.join(timeout=5)
+        assert not t.is_alive()
+        shutil.rmtree(runner_dir, ignore_errors=True)
+
+
+def test_runner_daemon_run_once_executes_job_when_not_due(tmp_path: Path) -> None:
+    runner_dir = _short_runner_dir("wayfinder-runner-once")
+    if runner_dir.exists():
+        shutil.rmtree(runner_dir, ignore_errors=True)
+    runner_dir.mkdir(parents=True, exist_ok=True)
+
+    runs_dir = tmp_path / ".wayfinder_runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    script = runs_dir / "hello.py"
+    script.write_text("print('HELLO_FROM_RUN_ONCE')\n", encoding="utf-8")
+
+    paths = RunnerPaths(
+        repo_root=tmp_path,
+        runner_dir=runner_dir,
+        db_path=runner_dir / "state.db",
+        logs_dir=runner_dir / "logs",
+        sock_path=runner_dir / "runner.sock",
+    )
+
+    daemon = RunnerDaemon(paths=paths, tick_seconds=0.05, max_workers=2)
+    t = threading.Thread(target=daemon.start, name="runner-e2e-daemon-once")
+    t.start()
+
+    client = RunnerControlClient(sock_path=paths.sock_path)
+    try:
+        _wait_for_status(client, timeout_s=10.0)
+
+        # Insert a job directly with a future next_run_at so the scheduler does not
+        # start it before we call run_once.
+        db = RunnerDB(paths.db_path)
+        db.add_job(
+            name="hello",
+            job_type=JOB_TYPE_SCRIPT,
+            payload={"script_path": ".wayfinder_runs/hello.py", "args": []},
+            interval_seconds=3600,
+            status=JOB_STATUS_ACTIVE,
+            next_run_at=int(time.time()) + 3600,
+        )
+        db.close()
+
+        once = client.call("run_once", {"name": "hello"})
+        assert once.get("ok") is True, once
+        run_id = int(once["result"]["run_id"])
+
+        report = _wait_for_run_finished(client, run_id=run_id, timeout_s=10.0)
+        assert report["result"]["run"]["status"] == "OK"
+        tail = report["result"]["log_tail"]
+        assert isinstance(tail, str) and "HELLO_FROM_RUN_ONCE" in tail
+    finally:
+        try:
+            client.call("shutdown")
+        except Exception:  # noqa: BLE001
+            daemon.stop()
+        t.join(timeout=5)
+        assert not t.is_alive()
+        shutil.rmtree(runner_dir, ignore_errors=True)
+
+
+def test_detached_daemon_survives_parent_process_group_termination() -> None:
+    if os.name == "nt":
+        pytest.skip("POSIX-only (relies on process groups via killpg)")
+
+    runner_dir = _short_runner_dir("wayfinder-runner-detach")
+    if runner_dir.exists():
+        shutil.rmtree(runner_dir, ignore_errors=True)
+    runner_dir.mkdir(parents=True, exist_ok=True)
+
+    repo_root = find_repo_root(start=Path(__file__).resolve())
+    env = os.environ.copy()
+    env["WAYFINDER_RUNNER_DIR"] = str(runner_dir)
+
+    wrapper_code = "\n".join(
+        [
+            "import os, subprocess, sys, time",
+            "subprocess.Popen([sys.executable, '-m', 'wayfinder_paths.runnerd', 'start', '--detach'], cwd=os.getcwd(), env=os.environ.copy())",
+            "time.sleep(60)",
+        ]
+    )
+
+    wrapper = subprocess.Popen(  # noqa: S603
+        [sys.executable, "-c", wrapper_code],
+        cwd=str(repo_root),
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+    client = RunnerControlClient(sock_path=runner_dir / "runner.sock")
+    daemon_pid = None
+    try:
+        status = _wait_for_status(client, timeout_s=10.0)
+        daemon_pid = int(status["result"]["pid"])
+
+        os.killpg(wrapper.pid, signal.SIGTERM)
+        try:
+            wrapper.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            os.killpg(wrapper.pid, signal.SIGKILL)
+            wrapper.wait(timeout=5)
+
+        # The daemon should still be alive (it was started detached into a new session).
+        after = _wait_for_status(client, timeout_s=5.0)
+        assert int(after["result"]["pid"]) == daemon_pid
+
+        # Extra sanity: ensure we can still stop it cleanly.
+        resp = client.call("shutdown")
+        assert resp.get("ok") is True, resp
+    finally:
+        if wrapper.poll() is None:
+            try:
+                os.killpg(wrapper.pid, signal.SIGKILL)
+            except Exception:  # noqa: BLE001
+                pass
+
+        if daemon_pid is not None:
+            try:
+                client.call("shutdown")
+            except Exception:  # noqa: BLE001
+                pass
+        shutil.rmtree(runner_dir, ignore_errors=True)

--- a/wayfinder_paths/tests/test_runner_e2e.py
+++ b/wayfinder_paths/tests/test_runner_e2e.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import pytest
 
 from wayfinder_paths.runner.client import RunnerControlClient
-from wayfinder_paths.runner.constants import JOB_STATUS_ACTIVE, JOB_TYPE_SCRIPT
+from wayfinder_paths.runner.constants import JOB_TYPE_SCRIPT, JobStatus, RunStatus
 from wayfinder_paths.runner.daemon import RunnerDaemon
 from wayfinder_paths.runner.db import RunnerDB
 from wayfinder_paths.runner.paths import RunnerPaths, find_repo_root
@@ -107,7 +107,7 @@ def test_runner_daemon_runs_script_job_end_to_end(tmp_path: Path) -> None:
 
         run_id = _wait_for_job_run_id(client, name="hello", timeout_s=5.0)
         report = _wait_for_run_finished(client, run_id=run_id, timeout_s=10.0)
-        assert report["result"]["run"]["status"] == "OK"
+        assert report["result"]["run"]["status"] == RunStatus.OK
         tail = report["result"]["log_tail"]
         assert isinstance(tail, str) and "HELLO_FROM_SCRIPT" in tail
     finally:
@@ -155,7 +155,7 @@ def test_runner_daemon_run_once_executes_job_when_not_due(tmp_path: Path) -> Non
             job_type=JOB_TYPE_SCRIPT,
             payload={"script_path": ".wayfinder_runs/hello.py", "args": []},
             interval_seconds=3600,
-            status=JOB_STATUS_ACTIVE,
+            status=JobStatus.ACTIVE,
             next_run_at=int(time.time()) + 3600,
         )
         db.close()
@@ -165,7 +165,7 @@ def test_runner_daemon_run_once_executes_job_when_not_due(tmp_path: Path) -> Non
         run_id = int(once["result"]["run_id"])
 
         report = _wait_for_run_finished(client, run_id=run_id, timeout_s=10.0)
-        assert report["result"]["run"]["status"] == "OK"
+        assert report["result"]["run"]["status"] == RunStatus.OK
         tail = report["result"]["log_tail"]
         assert isinstance(tail, str) and "HELLO_FROM_RUN_ONCE" in tail
     finally:

--- a/wayfinder_paths/tests/test_runner_paths.py
+++ b/wayfinder_paths/tests/test_runner_paths.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from wayfinder_paths.runner.paths import get_runner_paths
+
+
+def test_get_runner_paths_default_location(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.delenv("WAYFINDER_RUNNER_DIR", raising=False)
+    monkeypatch.delenv("WAYFINDER_RUNNER_STATE_DIR", raising=False)
+
+    paths = get_runner_paths(repo_root=tmp_path)
+    assert paths.runner_dir == (tmp_path / ".wayfinder" / "runner")
+    assert paths.db_path.name == "state.db"
+    assert paths.sock_path.name == "runner.sock"
+
+
+def test_get_runner_paths_env_override_relative(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv("WAYFINDER_RUNNER_DIR", "custom/runner")
+    paths = get_runner_paths(repo_root=tmp_path)
+    assert paths.runner_dir == (tmp_path / "custom" / "runner").resolve()
+
+
+def test_get_runner_paths_env_override_absolute(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    abs_dir = (tmp_path / "abs-runner").resolve()
+    monkeypatch.setenv("WAYFINDER_RUNNER_STATE_DIR", str(abs_dir))
+    paths = get_runner_paths(repo_root=tmp_path)
+    assert paths.runner_dir == abs_dir
+    assert os.fspath(paths.sock_path).startswith(os.fspath(abs_dir))

--- a/wayfinder_paths/tests/test_runner_script_jobs.py
+++ b/wayfinder_paths/tests/test_runner_script_jobs.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from wayfinder_paths.runner.daemon import RunnerDaemon
+from wayfinder_paths.runner.db import RunnerDB
+from wayfinder_paths.runner.paths import RunnerPaths
+from wayfinder_paths.runner.script_resolver import resolve_script_path
+
+
+def _paths(tmp_path: Path) -> RunnerPaths:
+    runner_dir = tmp_path / ".wayfinder" / "runner"
+    return RunnerPaths(
+        repo_root=tmp_path,
+        runner_dir=runner_dir,
+        db_path=runner_dir / "state.db",
+        logs_dir=runner_dir / "logs",
+        sock_path=runner_dir / "runner.sock",
+    )
+
+
+def test_resolve_script_path_only_allows_wayfinder_runs(tmp_path: Path) -> None:
+    p = _paths(tmp_path)
+    runs_dir = tmp_path / ".wayfinder_runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    script = runs_dir / "hello.py"
+    script.write_text("print('hi')\n", encoding="utf-8")
+
+    resolved = resolve_script_path(p, ".wayfinder_runs/hello.py")
+    assert resolved.exists()
+    assert resolved.name == "hello.py"
+
+    outside = tmp_path / "nope.py"
+    outside.write_text("print('no')\n", encoding="utf-8")
+    try:
+        resolve_script_path(p, "nope.py")
+    except ValueError as exc:
+        assert "local runs directory" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for script outside .wayfinder_runs")
+
+
+def test_script_job_builds_worker_cmd(tmp_path: Path) -> None:
+    p = _paths(tmp_path)
+    runs_dir = tmp_path / ".wayfinder_runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    script = runs_dir / "hello.py"
+    script.write_text("print('hi')\n", encoding="utf-8")
+
+    daemon = RunnerDaemon(paths=p)
+    cmd = daemon._build_worker_cmd(
+        job={
+            "type": "script",
+            "payload": {
+                "script_path": ".wayfinder_runs/hello.py",
+                "args": ["--x", "1"],
+            },
+        }
+    )
+    assert cmd[0] == sys.executable
+    assert cmd[1].endswith("hello.py")
+    assert cmd[-2:] == ["--x", "1"]
+
+
+def test_daemon_adds_script_job_with_relative_path(tmp_path: Path) -> None:
+    p = _paths(tmp_path)
+    runs_dir = tmp_path / ".wayfinder_runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    script = runs_dir / "hello.py"
+    script.write_text("print('hi')\n", encoding="utf-8")
+
+    daemon = RunnerDaemon(paths=p)
+    resp = daemon.ctl_add_job(
+        name="script-job",
+        job_type="script",
+        payload={"script_path": str(script), "args": []},
+        interval_seconds=60,
+    )
+    assert resp["ok"] is True
+
+    db = RunnerDB(p.db_path)
+    jobs = db.list_jobs()
+    job = next(j for j in jobs if j["name"] == "script-job")
+    stored = str(job["payload"]["script_path"])
+    assert stored.endswith("hello.py")
+    assert not Path(stored).is_absolute()

--- a/wayfinder_paths/tests/test_runner_status_enums.py
+++ b/wayfinder_paths/tests/test_runner_status_enums.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import json
+
+from wayfinder_paths.runner.constants import JobStatus, RunStatus
+
+
+def test_job_status_is_str_enum() -> None:
+    assert str(JobStatus.ACTIVE) == "ACTIVE"
+    assert JobStatus("ACTIVE") is JobStatus.ACTIVE
+    assert json.dumps({"status": JobStatus.PAUSED}) == '{"status": "PAUSED"}'
+
+
+def test_run_status_is_str_enum() -> None:
+    assert str(RunStatus.ABORTED) == "ABORTED"
+    assert RunStatus("OK") is RunStatus.OK
+    assert json.dumps({"status": RunStatus.TIMEOUT}) == '{"status": "TIMEOUT"}'


### PR DESCRIPTION
Project-local runner daemon for scheduled strategies/scripts (CLI + MCP + persistent state)

  Summary
  This PR adds a repo-local “runner” service to schedule strategy updates (and one-off scripts) on a simple interval loop, without cron/APScheduler. It runs as a detached daemon, persists job definitions + run history in SQLite
  under ./.wayfinder/runner/, and exposes a small control plane usable from both the CLI and the MCP server.

  What’s included

  - Runner daemon with tick scheduler + subprocess workers + per-run logs (wayfinder_paths/runner/daemon.py)
  - Persistent state + run history in SQLite (./.wayfinder/runner/state.db) (wayfinder_paths/runner/db.py)
  - Control plane over local Unix socket (./.wayfinder/runner/runner.sock) with transport-agnostic routing for future remote support (wayfinder_paths/runner/protocol.py, wayfinder_paths/runner/api.py, wayfinder_paths/runner/transport.py,
    wayfinder_paths/runner/client.py, wayfinder_paths/runner/control.py)
  - CLI commands: wayfinder runner ensure/start/stop/status/add-job/update-job/pause/resume/run-once/runs/run-report/delete (wayfinder_paths/runner/cli.py, wayfinder_paths/mcp/cli.py, pyproject.toml)
  - MCP tool runner(...) for daemon lifecycle + job management + run reports (wayfinder_paths/mcp/tools/runner.py, registered in wayfinder_paths/mcp/server.py)
  - Shared daemon lifecycle helper to avoid duplicated start/wait logic across CLI/MCP (wayfinder_paths/runner/lifecycle.py)
  - Docs for Claude + users (CLAUDE.md, README.md, RUNNER_ARCHITECTURE.md)
  - Tests covering DB, control plane, MCP tool, detached survival, script job E2E (wayfinder_paths/tests/test_runner_*.py)
  - Small reliability improvement for unix-socket half-close behavior (wayfinder_paths/runner/transport.py)

  Key UX

  - Start/ensure runner: poetry run wayfinder runner ensure
  - Schedule basis trading updates every 10m:
    poetry run wayfinder runner add-job --name basis-update --type strategy --strategy basis_trading_strategy --action update --interval 600 --config ./config.json
  - Query status/runs/logs via CLI or MCP.
  - Jobs can be deleted (delete_job), which removes job + cascades state/history.

  Notes / future extensibility

  - The control plane is split into protocol + dispatch + transport so we can add an HTTP transport and a remote runner later with minimal churn (RUNNER_ARCHITECTURE.md).

  Validation

  - poetry run ruff check .
  - poetry run ruff format --check .
  - poetry run pytest -q