### PR TITLE
release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Added
 2. Project-local runner scheduler.
 3. CLI support for other platforms.
 4. Strategy + Adapter creation script.
-5. Plasma HL deposit wait.
+5. Added Plasma chain support (chain ID 9745) with default RPCs.
 
 Changed
 
@@ -22,6 +22,7 @@ Fixed
 3. Withdraw failure due to unexpected kwargs.
 4. policies now async + awaited.
 5. CLI vars return None when not provided.
+6. Improved Hyperliquid deposit confirmation (ledger-based checks, avoids extra wait).
 
 Chore / Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+## [0.2.0] - 2026-02-06
+
+Added
+
+1. Hyperliquid Spot support.
+2. Project-local runner scheduler.
+3. CLI support for other platforms.
+4. Strategy + Adapter creation script.
+5. Plasma HL deposit wait.
+
+Changed
+
+1. Hyperliquid utils no longer a class; removed dead functions.
+2. Hyperliquid utils squashed into Exchange.
+
+Fixed
+
+1. Zero address handling for native tokens in swap quoting.
+2. Strategy status tuples bug.
+3. Withdraw failure due to unexpected kwargs.
+4. policies now async + awaited.
+5. CLI vars return None when not provided.
+
+Chore / Docs
+
+1. Remove dead simulation param.
+2. Remove defensive import / variable reassignment.
+3. Update repo clone URL in README.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wayfinder-paths"
-version = "0.1.0"
+version = "0.2.0"
 description = "Wayfinder Path: strategies and adapters"
 readme = "README.md"
 authors = ["Wayfinder <dev@wayfinder.ai>"]


### PR DESCRIPTION
Cutting minor release 0.2.0 with the following changes.

Added

1. Hyperliquid Spot support.
2. Project-local runner scheduler.
3. CLI support for other platforms.
4. Strategy + Adapter creation script.
5. Added Plasma chain support (chain ID 9745) with default RPCs.

Changed

1. Hyperliquid utils no longer a class; removed dead functions.
2. Hyperliquid utils squashed into Exchange.

Fixed

1. Zero address handling for native tokens in swap quoting.
2. Strategy status tuples bug.
3. Withdraw failure due to unexpected kwargs.
4. policies now async + awaited.
5. CLI vars return None when not provided.
6. Improved Hyperliquid deposit confirmation (ledger-based checks, avoids extra wait).

Chore / Docs

1. Remove dead simulation param.
2. Remove defensive import / variable reassignment.
3. Update repo clone URL in README.
