### PR TITLE
Remove configurable Gorlami base URL in favor of derived URL

### DIFF
--- a/CONFIG_GUIDE.md
+++ b/CONFIG_GUIDE.md
@@ -20,8 +20,7 @@ The `config.json` file has three main sections:
 {
   "system": {
     "api_base_url": "https://api.wayfinder.ai",
-    "api_key": "sk_live_...",
-    "gorlami_base_url": "https://strategies.wayfinder.ai/api/v1/blockchain/gorlami"
+    "api_key": "sk_live_..."
   },
   "strategy": {
     "rpc_urls": {
@@ -51,7 +50,6 @@ The `config.json` file has three main sections:
 |-------|----------|-------------|
 | `api_key` | Yes | Wayfinder API key (sent as `X-API-KEY` header) |
 | `api_base_url` | No | API endpoint (default: `https://api.wayfinder.ai`) |
-| `gorlami_base_url` | No | Base URL for Gorlami forks (default: `https://strategies.wayfinder.ai/api/v1/blockchain/gorlami`) |
 
 The API key is automatically loaded and included in all API requests (including Gorlami dry-runs). You don't need to pass it explicitly to strategies or clients.
 

--- a/wayfinder_paths/core/config.py
+++ b/wayfinder_paths/core/config.py
@@ -102,8 +102,4 @@ _GORLAMI_PATH = "/blockchain/gorlami"
 
 
 def get_gorlami_base_url() -> str:
-    system = CONFIG.get("system", {}) if isinstance(CONFIG, dict) else {}
-    explicit = system.get("gorlami_base_url")
-    if explicit and isinstance(explicit, str):
-        return explicit.strip()
     return f"{get_api_base_url().rstrip('/')}{_GORLAMI_PATH}"


### PR DESCRIPTION
## Summary
This PR removes the ability to configure a custom Gorlami base URL via the `config.json` file. The Gorlami base URL is now always derived from the API base URL by appending a fixed path suffix.

## Changes
- **CONFIG_GUIDE.md**: Removed documentation for the `gorlami_base_url` configuration option from both the example config and the configuration table
- **wayfinder_paths/core/config.py**: Simplified `get_gorlami_base_url()` function to always compute the URL by appending `_GORLAMI_PATH` to the API base URL, removing the logic that checked for an explicit `gorlami_base_url` configuration value

## Implementation Details
The `get_gorlami_base_url()` function now has a single responsibility: derive the Gorlami URL from the configured API base URL. This eliminates configuration complexity and ensures the Gorlami endpoint is always consistent with the primary API endpoint.

https://claude.ai/code/session_01GuDw5FzRhNi2AHXbCJDNN1