### PR TITLE
Refactor wallet address resolution into shared utility

### DIFF
--- a/wayfinder_paths/mcp/resources/hyperliquid.py
+++ b/wayfinder_paths/mcp/resources/hyperliquid.py
@@ -4,20 +4,13 @@ import json
 import re
 
 from wayfinder_paths.adapters.hyperliquid_adapter.adapter import HyperliquidAdapter
-from wayfinder_paths.mcp.utils import find_wallet_by_label, normalize_address
+from wayfinder_paths.mcp.utils import resolve_wallet_address
 
 _PERP_SUFFIX_RE = re.compile(r"[-_ ]?perp$", re.IGNORECASE)
 
 
-def _resolve_wallet_address(label: str) -> str | None:
-    w = find_wallet_by_label(label)
-    if not w:
-        return None
-    return normalize_address(w.get("address"))
-
-
 async def get_user_state(label: str) -> str:
-    addr = _resolve_wallet_address(label)
+    addr, _ = resolve_wallet_address(wallet_label=label)
     if not addr:
         return json.dumps({"error": f"Wallet not found: {label}"})
 
@@ -29,7 +22,7 @@ async def get_user_state(label: str) -> str:
 
 
 async def get_spot_user_state(label: str) -> str:
-    addr = _resolve_wallet_address(label)
+    addr, _ = resolve_wallet_address(wallet_label=label)
     if not addr:
         return json.dumps({"error": f"Wallet not found: {label}"})
 

--- a/wayfinder_paths/mcp/tools/hyperliquid.py
+++ b/wayfinder_paths/mcp/tools/hyperliquid.py
@@ -16,24 +16,10 @@ from wayfinder_paths.mcp.utils import (
     load_config_json,
     normalize_address,
     ok,
+    resolve_wallet_address,
 )
 
 _PERP_SUFFIX_RE = re.compile(r"[-_ ]?perp$", re.IGNORECASE)
-
-
-def _resolve_wallet_address(
-    *, wallet_label: str | None, wallet_address: str | None
-) -> str | None:
-    waddr = normalize_address(wallet_address)
-    if waddr:
-        return waddr
-    want = (wallet_label or "").strip()
-    if not want:
-        return None
-    w = find_wallet_by_label(want)
-    if not w:
-        return None
-    return normalize_address(w.get("address"))
 
 
 def _resolve_builder_fee(
@@ -148,7 +134,7 @@ async def hyperliquid(
 ) -> dict[str, Any]:
     adapter = HyperliquidAdapter()
 
-    addr = _resolve_wallet_address(
+    addr, _ = resolve_wallet_address(
         wallet_label=wallet_label, wallet_address=wallet_address
     )
     if not addr:

--- a/wayfinder_paths/mcp/tools/wallets.py
+++ b/wayfinder_paths/mcp/tools/wallets.py
@@ -9,11 +9,10 @@ from wayfinder_paths.core.utils.wallets import make_random_wallet, write_wallet_
 from wayfinder_paths.mcp.state.profile_store import WalletProfileStore
 from wayfinder_paths.mcp.utils import (
     err,
-    find_wallet_by_label,
     load_wallets,
-    normalize_address,
     ok,
     repo_root,
+    resolve_wallet_address,
 )
 
 PROTOCOL_ADAPTERS: dict[str, dict[str, Any]] = {
@@ -62,24 +61,6 @@ PROTOCOL_ADAPTERS: dict[str, dict[str, Any]] = {
 
 def _public_wallet_view(w: dict[str, Any]) -> dict[str, Any]:
     return {"label": w.get("label"), "address": w.get("address")}
-
-
-def _resolve_wallet_address(
-    *, wallet_label: str | None, wallet_address: str | None
-) -> tuple[str | None, str | None]:
-    waddr = normalize_address(wallet_address)
-    if waddr:
-        return waddr, None
-
-    want = (wallet_label or "").strip()
-    if not want:
-        return None, None
-
-    w = find_wallet_by_label(want)
-    if not w:
-        return None, None
-
-    return normalize_address(w.get("address")), want
 
 
 async def _query_adapter(
@@ -180,7 +161,7 @@ async def wallets(
         )
 
     if action == "annotate":
-        address, lbl = _resolve_wallet_address(
+        address, lbl = resolve_wallet_address(
             wallet_label=wallet_label or label, wallet_address=wallet_address
         )
         if not address:
@@ -218,7 +199,7 @@ async def wallets(
         )
 
     if action == "discover_portfolio":
-        address, lbl = _resolve_wallet_address(
+        address, lbl = resolve_wallet_address(
             wallet_label=wallet_label or label, wallet_address=wallet_address
         )
         if not address:

--- a/wayfinder_paths/mcp/utils.py
+++ b/wayfinder_paths/mcp/utils.py
@@ -73,6 +73,25 @@ def normalize_address(addr: str | None) -> str | None:
     return a if a else None
 
 
+def resolve_wallet_address(
+    *, wallet_label: str | None = None, wallet_address: str | None = None
+) -> tuple[str | None, str | None]:
+    """Return ``(normalized_address, label_used)`` from a label or raw address."""
+    waddr = normalize_address(wallet_address)
+    if waddr:
+        return waddr, None
+
+    want = (wallet_label or "").strip()
+    if not want:
+        return None, None
+
+    w = find_wallet_by_label(want)
+    if not w:
+        return None, None
+
+    return normalize_address(w.get("address")), want
+
+
 def parse_amount_to_raw(amount: str, decimals: int) -> int:
     try:
         d = Decimal(str(amount).strip())

--- a/wayfinder_paths/tests/test_mcp_wallets.py
+++ b/wayfinder_paths/tests/test_mcp_wallets.py
@@ -5,11 +5,12 @@ from unittest.mock import patch
 
 import pytest
 
-from wayfinder_paths.mcp.tools.wallets import _resolve_wallet_address, wallets
+from wayfinder_paths.mcp.tools.wallets import wallets
+from wayfinder_paths.mcp.utils import resolve_wallet_address
 
 
 def test_resolve_wallet_address_prefers_explicit_address():
-    addr, lbl = _resolve_wallet_address(
+    addr, lbl = resolve_wallet_address(
         wallet_label="main", wallet_address="0x000000000000000000000000000000000000dEaD"
     )
     assert addr == "0x000000000000000000000000000000000000dEaD"


### PR DESCRIPTION
## Summary
Consolidate duplicate wallet address resolution logic across multiple modules by extracting it into a single shared utility function in `mcp/utils.py`.

## Key Changes
- **Extracted `resolve_wallet_address()` function** from `mcp/tools/wallets.py` to `mcp/utils.py` as a centralized utility for resolving wallet addresses from either a label or raw address
- **Removed duplicate implementations** of wallet address resolution from:
  - `mcp/tools/wallets.py` (removed `_resolve_wallet_address()`)
  - `mcp/tools/hyperliquid.py` (removed `_resolve_wallet_address()`)
  - `mcp/resources/hyperliquid.py` (removed `_resolve_wallet_address()`)
- **Updated all call sites** to use the shared `resolve_wallet_address()` function from utils
- **Updated imports** across affected modules to reference the new utility location
- **Updated tests** to import `resolve_wallet_address` from the new location in `mcp/utils.py`

## Implementation Details
The shared `resolve_wallet_address()` function:
- Accepts optional `wallet_label` and `wallet_address` parameters
- Returns a tuple of `(normalized_address, label_used)` for consistency across all callers
- Prioritizes explicit wallet addresses over label lookups
- Normalizes addresses using the existing `normalize_address()` utility
- Resolves wallet labels using the existing `find_wallet_by_label()` utility

This refactoring eliminates code duplication and establishes a single source of truth for wallet address resolution logic.

https://claude.ai/code/session_01Ar3HGD6WYdk5Y31SPYFqXF