### PR TITLE
Remove redundant type casts and defensive code patterns

### DIFF
--- a/wayfinder_paths/adapters/moonwell_adapter/adapter.py
+++ b/wayfinder_paths/adapters/moonwell_adapter/adapter.py
@@ -112,12 +112,11 @@ class MoonwellAdapter(BaseAdapter):
 
         self.strategy_wallet_signing_callback = strategy_wallet_signing_callback
 
-        # Chain configuration (Base-only for now)
         self.chain_id = CHAIN_ID_BASE
         self.chain_name = CHAIN_NAME
         self.comptroller_address = MOONWELL_COMPTROLLER
         self.reward_distributor_address = MOONWELL_REWARD_DISTRIBUTOR
-        self.m_usdc = MOONWELL_M_USDC  # Sample mtoken for ABI extraction
+        self.m_usdc = MOONWELL_M_USDC
 
         strategy_wallet = cfg.get("strategy_wallet") or {}
         self.strategy_wallet_address = to_checksum_address(strategy_wallet["address"])

--- a/wayfinder_paths/core/utils/tokens.py
+++ b/wayfinder_paths/core/utils/tokens.py
@@ -24,7 +24,7 @@ NATIVE_TOKEN_ADDRESSES: set = {
 def is_native_token(token_address: str | None) -> bool:
     if token_address is None:
         return True
-    normalized = str(token_address).strip().lower()
+    normalized = token_address.strip().lower()
     if normalized in ("", "native"):
         return True
     return normalized in NATIVE_TOKEN_ADDRESSES

--- a/wayfinder_paths/mcp/tools/hyperliquid.py
+++ b/wayfinder_paths/mcp/tools/hyperliquid.py
@@ -394,7 +394,7 @@ async def hyperliquid_execute(
     def _coin_from_asset_id(aid: int) -> str | None:
         for k, v in (adapter.coin_to_asset or {}).items():
             try:
-                if int(v) == int(aid):
+                if v == aid:
                     return str(k)
             except Exception:
                 continue

--- a/wayfinder_paths/strategies/moonwell_wsteth_loop_strategy/strategy.py
+++ b/wayfinder_paths/strategies/moonwell_wsteth_loop_strategy/strategy.py
@@ -353,7 +353,7 @@ class MoonwellWstethLoopStrategy(Strategy):
         )
 
         gas_keep_wei = int(self._gas_keep_wei())
-        eth_usable_wei = max(0, int(wallet_eth) - int(gas_keep_wei))
+        eth_usable_wei = max(0, wallet_eth - gas_keep_wei)
 
         def _usd(raw: int, price: float, dec: int) -> float:
             if raw <= 0 or not price or price <= 0:
@@ -863,7 +863,7 @@ class MoonwellWstethLoopStrategy(Strategy):
                 wallet_address=addr,
                 block_identifier=pinned_block,
             )
-            amount_to_swap = min(int(wallet_wsteth), int(underlying_raw))
+            amount_to_swap = min(wallet_wsteth, underlying_raw)
             if amount_to_swap <= 0:
                 return (
                     False,
@@ -951,7 +951,7 @@ class MoonwellWstethLoopStrategy(Strategy):
         # 3) Use wallet WETH -> wstETH
         used_any = False
         if snap.wallet_weth > 0 and needed_weth_raw > 0:
-            amt = min(int(snap.wallet_weth), int(needed_weth_raw))
+            amt = min(snap.wallet_weth, needed_weth_raw)
             if amt > 0:
                 wsteth_before = await self._get_balance_raw(
                     token_id=WSTETH_TOKEN_ID, wallet_address=addr
@@ -987,7 +987,7 @@ class MoonwellWstethLoopStrategy(Strategy):
 
         # 4) Use wallet ETH (above reserve) -> wstETH
         if needed_weth_raw > 0 and snap.eth_usable_wei > 0:
-            eth_amt = min(int(snap.eth_usable_wei), int(needed_weth_raw))
+            eth_amt = min(snap.eth_usable_wei, needed_weth_raw)
             if eth_amt > 0:
                 wsteth_before = await self._get_balance_raw(
                     token_id=WSTETH_TOKEN_ID, wallet_address=addr
@@ -1097,7 +1097,7 @@ class MoonwellWstethLoopStrategy(Strategy):
                 attempts=5,
             )
 
-        amount_to_swap = min(int(wsteth_wallet_raw), int(desired_underlying_raw))
+        amount_to_swap = min(wsteth_wallet_raw, desired_underlying_raw)
         if amount_to_swap <= 0:
             return (False, "No wstETH available in wallet after unlend")
 
@@ -1226,7 +1226,7 @@ class MoonwellWstethLoopStrategy(Strategy):
 
             # 1) Wallet WETH -> repay
             if snap.wallet_weth > 0:
-                repay_amt = min(int(snap.wallet_weth), int(batch_weth_raw))
+                repay_amt = min(snap.wallet_weth, batch_weth_raw)
                 if repay_amt > 0:
                     repaid = await self._repay_weth(repay_amt, snap.weth_debt)
                     if repaid > 0:
@@ -1235,7 +1235,7 @@ class MoonwellWstethLoopStrategy(Strategy):
 
             # 2) Wallet ETH (above reserve) -> wrap -> repay
             if snap.eth_usable_wei > 0:
-                wrap_amt = min(int(snap.eth_usable_wei), int(batch_weth_raw))
+                wrap_amt = min(snap.eth_usable_wei, batch_weth_raw)
                 if wrap_amt > 0:
                     wrap_ok, wrap_msg = await self.moonwell_adapter.wrap_eth(
                         amount=wrap_amt
@@ -1273,7 +1273,7 @@ class MoonwellWstethLoopStrategy(Strategy):
                 needed_wsteth_raw = (
                     int(needed_wsteth_usd / snap.wsteth_price * 10**snap.wsteth_dec) + 1
                 )
-                swap_amt = min(int(snap.wallet_wsteth), int(needed_wsteth_raw))
+                swap_amt = min(snap.wallet_wsteth, needed_wsteth_raw)
                 if swap_amt > 0:
                     repaid = await self._swap_to_weth_and_repay(
                         WSTETH_TOKEN_ID, swap_amt, snap.weth_debt
@@ -1298,7 +1298,7 @@ class MoonwellWstethLoopStrategy(Strategy):
                 needed_usdc_raw = (
                     int(needed_usdc_usd / snap.usdc_price * 10**snap.usdc_dec) + 1
                 )
-                swap_amt = min(int(snap.wallet_usdc), int(needed_usdc_raw))
+                swap_amt = min(snap.wallet_usdc, needed_usdc_raw)
                 if swap_amt > 0:
                     repaid = await self._swap_to_weth_and_repay(
                         USDC_TOKEN_ID, swap_amt, snap.weth_debt
@@ -1487,7 +1487,7 @@ class MoonwellWstethLoopStrategy(Strategy):
                         attempts=5,
                     )
 
-                amount_to_swap = min(int(wallet_underlying), int(underlying_raw))
+                amount_to_swap = min(wallet_underlying, underlying_raw)
                 if amount_to_swap <= 0:
                     continue
 
@@ -2363,7 +2363,7 @@ class MoonwellWstethLoopStrategy(Strategy):
         weth_bal = int(weth_after)
 
         if eth_delta > 0 and usable_eth > 0:
-            wrap_amt = min(int(safe_borrow_amt), int(usable_eth))
+            wrap_amt = min(safe_borrow_amt, usable_eth)
             logger.info(
                 f"Borrow arrived as native ETH, wrapping {wrap_amt / 10**18:.6f} ETH to WETH"
             )
@@ -2399,7 +2399,7 @@ class MoonwellWstethLoopStrategy(Strategy):
                     f"Post-wrap WETH balance (calculated): {weth_bal / 10**18:.6f}"
                 )
 
-        amount_to_swap = min(int(safe_borrow_amt), int(weth_bal))
+        amount_to_swap = min(safe_borrow_amt, weth_bal)
 
         if amount_to_swap <= 0:
             raise Exception(

--- a/wayfinder_paths/strategies/projectx_thbill_usdc_strategy/strategy.py
+++ b/wayfinder_paths/strategies/projectx_thbill_usdc_strategy/strategy.py
@@ -189,7 +189,7 @@ class ProjectXThbillUsdcStrategy(Strategy):
         tick_upper = round_tick_to_spacing(current_tick + half, tick_spacing)
         if tick_lower >= tick_upper:
             tick_upper = tick_lower + tick_spacing
-        return int(tick_lower), int(tick_upper)
+        return tick_lower, tick_upper
 
     async def _recent_ticks(
         self, *, window_sec: int, min_swaps: int, max_swaps: int = 500
@@ -221,7 +221,7 @@ class ProjectXThbillUsdcStrategy(Strategy):
         core = ticks[trim : n - trim] if n - 2 * trim > 0 else ticks
 
         center_raw = int(statistics.median(core))
-        center = int(round_tick_to_spacing(center_raw, tick_spacing))
+        center = round_tick_to_spacing(center_raw, tick_spacing)
 
         max_jump = 5 * int(tick_spacing)
         if abs(center - int(fallback_tick)) > max_jump:
@@ -454,9 +454,7 @@ class ProjectXThbillUsdcStrategy(Strategy):
             amount1_raw = int(deposit_usd * price_token1_per_token0 * (10**dec1))
 
         liq_est = int(
-            liq_for_amounts(
-                sqrt_p, sqrt_pl, sqrt_pu, int(amount0_raw), int(amount1_raw)
-            )
+            liq_for_amounts(sqrt_p, sqrt_pl, sqrt_pu, amount0_raw, amount1_raw)
         )
         if liq_est <= 0:
             return out


### PR DESCRIPTION
Cleanup focused on three areas per coding-style.md guidelines:

1. Redundant type casts: Removed double int() casts in min/max operations where variables were already cast to int (moonwell_wsteth_loop_strategy, projectx_thbill_usdc_strategy, hyperliquid.py)

2. Defensive over-engineering: Removed redundant str() cast after None check in is_native_token() (tokens.py)

3. Redundant comments: Removed "what" comments that explain self-documenting code (moonwell_adapter)

All changes align with "fail hard, no excessive guards" philosophy while preserving valuable "why" comments that explain business logic.