### PR TITLE
Runner - Notify OpenCode session on job completion

### DIFF
--- a/wayfinder_paths/core/clients/OpenCodeClient.py
+++ b/wayfinder_paths/core/clients/OpenCodeClient.py
@@ -37,10 +37,14 @@ class OpenCodeClient:
             return []
         return resp.json()
 
-    def latest_session_id(self) -> str | None:
+    def active_session_id(self) -> str | None:
+        """Return the busy session (mid-tool-call), or the most recently updated one."""
         sessions = self.list_sessions()
         if not sessions:
             return None
+        for s in sessions:
+            if s.get("status") == "busy":
+                return s.get("id")
         return sessions[0].get("id")
 
     def send_message(self, session_id: str, text: str) -> bool:

--- a/wayfinder_paths/core/clients/OpenCodeClient.py
+++ b/wayfinder_paths/core/clients/OpenCodeClient.py
@@ -17,54 +17,52 @@ class OpenCodeClient:
             headers={"Content-Type": "application/json"},
         )
 
-    def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response | None:
-        url = f"{self.base_url}{path}"
-        try:
-            return self.client.request(method, url, **kwargs)
-        except Exception as error:
-            logger.debug(f"OpenCode {method} {url} failed: {error}")
-            return None
+    def get(self, path: str, **kwargs: Any) -> httpx.Response:
+        return self.client.get(f"{self.base_url}{path}", **kwargs)
+
+    def post(self, path: str, **kwargs: Any) -> httpx.Response:
+        return self.client.post(f"{self.base_url}{path}", **kwargs)
 
     def healthy(self) -> bool:
-        response = self._request("GET", "/global/health")
-        if response is None or response.status_code != 200:
+        try:
+            return self.get("/global/health").json().get("healthy", False)
+        except Exception:
             return False
-        return response.json().get("healthy", False)
 
     def list_sessions(self) -> list[dict[str, Any]]:
-        response = self._request("GET", "/session")
-        if response is None or response.status_code != 200:
+        try:
+            return self.get("/session").json()
+        except Exception:
             return []
-        return response.json()
 
-    def active_session_id(self) -> str | None:
+    def find_runner_session(self) -> str | None:
         """Find the session that invoked runner add-job."""
         for session in self.list_sessions():
             session_id = session.get("id")
-            if session_id and self._session_has_runner_job(session_id):
-                return session_id
+            if not session_id:
+                continue
+            try:
+                raw = json.dumps(
+                    self.get(
+                        f"/session/{session_id}/message", params={"limit": 50}
+                    ).json()
+                )
+                if "runner" in raw and ("add-job" in raw or "add_job" in raw):
+                    return session_id
+            except Exception:
+                continue
         return None
 
-    def _session_has_runner_job(self, session_id: str) -> bool:
-        response = self._request(
-            "GET", f"/session/{session_id}/message", params={"limit": 50}
-        )
-        if response is None or response.status_code != 200:
-            return False
-        raw_messages = json.dumps(response.json())
-        return "runner" in raw_messages and (
-            "add-job" in raw_messages or "add_job" in raw_messages
-        )
-
     def send_message(self, session_id: str, text: str) -> bool:
-        response = self._request(
-            "POST",
-            f"/session/{session_id}/message",
-            json={"parts": [{"type": "text", "text": text}]},
-        )
-        if response is None or response.status_code != 200:
+        try:
+            response = self.post(
+                f"/session/{session_id}/message",
+                json={"parts": [{"type": "text", "text": text}]},
+            )
+            return response.is_success
+        except Exception as error:
+            logger.debug(f"Failed to send message to session {session_id}: {error}")
             return False
-        return True
 
 
 OPENCODE_CLIENT = OpenCodeClient()

--- a/wayfinder_paths/core/clients/OpenCodeClient.py
+++ b/wayfinder_paths/core/clients/OpenCodeClient.py
@@ -38,14 +38,29 @@ class OpenCodeClient:
         return resp.json()
 
     def active_session_id(self) -> str | None:
-        """Return the busy session (mid-tool-call), or the most recently updated one."""
+        """Find the session that invoked 'runner add-job' or 'runner add_job'."""
         sessions = self.list_sessions()
         if not sessions:
             return None
         for s in sessions:
-            if s.get("status") == "busy":
-                return s.get("id")
-        return sessions[0].get("id")
+            sid = s.get("id")
+            if not sid:
+                continue
+            resp = self._request("GET", f"/session/{sid}/message", params={"limit": 50})
+            if resp is None or resp.status_code != 200:
+                continue
+            for msg in resp.json():
+                for part in msg.get("parts", []):
+                    if part.get("type") != "tool":
+                        continue
+                    inp = part.get("state", {}).get("input", {})
+                    cmd = str(inp.get("command", ""))
+                    action = str(inp.get("action", ""))
+                    if "runner" in cmd and "add-job" in cmd:
+                        return sid
+                    if action == "add_job":
+                        return sid
+        return None
 
     def send_message(self, session_id: str, text: str) -> bool:
         resp = self._request(

--- a/wayfinder_paths/core/clients/OpenCodeClient.py
+++ b/wayfinder_paths/core/clients/OpenCodeClient.py
@@ -36,9 +36,7 @@ class OpenCodeClient:
     def find_runner_session(self) -> str | None:
         """Find the session that invoked runner add-job."""
         for session in self.list_sessions():
-            session_id = session.get("id")
-            if not session_id:
-                continue
+            session_id = session["id"]
             try:
                 raw = json.dumps(
                     self.client.get(

--- a/wayfinder_paths/core/clients/OpenCodeClient.py
+++ b/wayfinder_paths/core/clients/OpenCodeClient.py
@@ -21,46 +21,48 @@ class OpenCodeClient:
         url = f"{self.base_url}{path}"
         try:
             return self.client.request(method, url, **kwargs)
-        except Exception as exc:
-            logger.debug(f"OpenCode {method} {url} failed: {exc}")
+        except Exception as error:
+            logger.debug(f"OpenCode {method} {url} failed: {error}")
             return None
 
     def healthy(self) -> bool:
-        resp = self._request("GET", "/global/health")
-        if resp is None or resp.status_code != 200:
+        response = self._request("GET", "/global/health")
+        if response is None or response.status_code != 200:
             return False
-        return resp.json().get("healthy", False)
+        return response.json().get("healthy", False)
 
     def list_sessions(self) -> list[dict[str, Any]]:
-        resp = self._request("GET", "/session")
-        if resp is None or resp.status_code != 200:
+        response = self._request("GET", "/session")
+        if response is None or response.status_code != 200:
             return []
-        return resp.json()
+        return response.json()
 
     def active_session_id(self) -> str | None:
         """Find the session that invoked runner add-job."""
-        for s in self.list_sessions():
-            sid = s.get("id")
-            if sid and self._session_has_runner_job(sid):
-                return sid
+        for session in self.list_sessions():
+            session_id = session.get("id")
+            if session_id and self._session_has_runner_job(session_id):
+                return session_id
         return None
 
     def _session_has_runner_job(self, session_id: str) -> bool:
-        resp = self._request(
+        response = self._request(
             "GET", f"/session/{session_id}/message", params={"limit": 50}
         )
-        if resp is None or resp.status_code != 200:
+        if response is None or response.status_code != 200:
             return False
-        raw = json.dumps(resp.json())
-        return "runner" in raw and ("add-job" in raw or "add_job" in raw)
+        raw_messages = json.dumps(response.json())
+        return "runner" in raw_messages and (
+            "add-job" in raw_messages or "add_job" in raw_messages
+        )
 
     def send_message(self, session_id: str, text: str) -> bool:
-        resp = self._request(
+        response = self._request(
             "POST",
             f"/session/{session_id}/message",
             json={"parts": [{"type": "text", "text": text}]},
         )
-        if resp is None or resp.status_code != 200:
+        if response is None or response.status_code != 200:
             return False
         return True
 

--- a/wayfinder_paths/core/clients/OpenCodeClient.py
+++ b/wayfinder_paths/core/clients/OpenCodeClient.py
@@ -6,6 +6,8 @@ from typing import Any
 import httpx
 from loguru import logger
 
+from wayfinder_paths.runner.constants import ADD_JOB_CLI_VERB, ADD_JOB_MCP_ACTION
+
 OPENCODE_DEFAULT_URL = "http://localhost:4096"
 
 
@@ -44,7 +46,9 @@ class OpenCodeClient:
                         params={"limit": 50},
                     ).json()
                 )
-                if "runner" in raw and ("add-job" in raw or "add_job" in raw):
+                if "runner" in raw and (
+                    ADD_JOB_CLI_VERB in raw or ADD_JOB_MCP_ACTION in raw
+                ):
                     return session_id
             except Exception:
                 continue

--- a/wayfinder_paths/core/clients/OpenCodeClient.py
+++ b/wayfinder_paths/core/clients/OpenCodeClient.py
@@ -12,42 +12,43 @@ OPENCODE_DEFAULT_URL = "http://localhost:4096"
 class OpenCodeClient:
     def __init__(self, base_url: str = OPENCODE_DEFAULT_URL):
         self.base_url = base_url.rstrip("/")
-        self.client = httpx.Client(
+        self.client = httpx.AsyncClient(
             timeout=httpx.Timeout(10),
             headers={"Content-Type": "application/json"},
         )
 
-    def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response | None:
+    async def _request(
+        self, method: str, path: str, **kwargs: Any
+    ) -> httpx.Response | None:
         url = f"{self.base_url}{path}"
         try:
-            resp = self.client.request(method, url, **kwargs)
-            return resp
+            return await self.client.request(method, url, **kwargs)
         except Exception as exc:
             logger.debug(f"OpenCode {method} {url} failed: {exc}")
             return None
 
-    def healthy(self) -> bool:
-        resp = self._request("GET", "/global/health")
+    async def healthy(self) -> bool:
+        resp = await self._request("GET", "/global/health")
         if resp is None or resp.status_code != 200:
             return False
         return resp.json().get("healthy", False)
 
-    def list_sessions(self) -> list[dict[str, Any]]:
-        resp = self._request("GET", "/session")
+    async def list_sessions(self) -> list[dict[str, Any]]:
+        resp = await self._request("GET", "/session")
         if resp is None or resp.status_code != 200:
             return []
         return resp.json()
 
-    def active_session_id(self) -> str | None:
+    async def active_session_id(self) -> str | None:
         """Find the session that invoked runner add-job."""
-        for s in self.list_sessions():
+        for s in await self.list_sessions():
             sid = s.get("id")
-            if sid and self._session_has_runner_job(sid):
+            if sid and await self._session_has_runner_job(sid):
                 return sid
         return None
 
-    def _session_has_runner_job(self, session_id: str) -> bool:
-        resp = self._request(
+    async def _session_has_runner_job(self, session_id: str) -> bool:
+        resp = await self._request(
             "GET", f"/session/{session_id}/message", params={"limit": 50}
         )
         if resp is None or resp.status_code != 200:
@@ -55,8 +56,8 @@ class OpenCodeClient:
         raw = json.dumps(resp.json())
         return "runner" in raw and ("add-job" in raw or "add_job" in raw)
 
-    def send_message(self, session_id: str, text: str) -> bool:
-        resp = self._request(
+    async def send_message(self, session_id: str, text: str) -> bool:
+        resp = await self._request(
             "POST",
             f"/session/{session_id}/message",
             json={"parts": [{"type": "text", "text": text}]},

--- a/wayfinder_paths/core/clients/OpenCodeClient.py
+++ b/wayfinder_paths/core/clients/OpenCodeClient.py
@@ -12,43 +12,41 @@ OPENCODE_DEFAULT_URL = "http://localhost:4096"
 class OpenCodeClient:
     def __init__(self, base_url: str = OPENCODE_DEFAULT_URL):
         self.base_url = base_url.rstrip("/")
-        self.client = httpx.AsyncClient(
+        self.client = httpx.Client(
             timeout=httpx.Timeout(10),
             headers={"Content-Type": "application/json"},
         )
 
-    async def _request(
-        self, method: str, path: str, **kwargs: Any
-    ) -> httpx.Response | None:
+    def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response | None:
         url = f"{self.base_url}{path}"
         try:
-            return await self.client.request(method, url, **kwargs)
+            return self.client.request(method, url, **kwargs)
         except Exception as exc:
             logger.debug(f"OpenCode {method} {url} failed: {exc}")
             return None
 
-    async def healthy(self) -> bool:
-        resp = await self._request("GET", "/global/health")
+    def healthy(self) -> bool:
+        resp = self._request("GET", "/global/health")
         if resp is None or resp.status_code != 200:
             return False
         return resp.json().get("healthy", False)
 
-    async def list_sessions(self) -> list[dict[str, Any]]:
-        resp = await self._request("GET", "/session")
+    def list_sessions(self) -> list[dict[str, Any]]:
+        resp = self._request("GET", "/session")
         if resp is None or resp.status_code != 200:
             return []
         return resp.json()
 
-    async def active_session_id(self) -> str | None:
+    def active_session_id(self) -> str | None:
         """Find the session that invoked runner add-job."""
-        for s in await self.list_sessions():
+        for s in self.list_sessions():
             sid = s.get("id")
-            if sid and await self._session_has_runner_job(sid):
+            if sid and self._session_has_runner_job(sid):
                 return sid
         return None
 
-    async def _session_has_runner_job(self, session_id: str) -> bool:
-        resp = await self._request(
+    def _session_has_runner_job(self, session_id: str) -> bool:
+        resp = self._request(
             "GET", f"/session/{session_id}/message", params={"limit": 50}
         )
         if resp is None or resp.status_code != 200:
@@ -56,8 +54,8 @@ class OpenCodeClient:
         raw = json.dumps(resp.json())
         return "runner" in raw and ("add-job" in raw or "add_job" in raw)
 
-    async def send_message(self, session_id: str, text: str) -> bool:
-        resp = await self._request(
+    def send_message(self, session_id: str, text: str) -> bool:
+        resp = self._request(
             "POST",
             f"/session/{session_id}/message",
             json={"parts": [{"type": "text", "text": text}]},

--- a/wayfinder_paths/core/clients/OpenCodeClient.py
+++ b/wayfinder_paths/core/clients/OpenCodeClient.py
@@ -1,0 +1,40 @@
+import httpx
+from loguru import logger
+
+OPENCODE_DEFAULT_URL = "http://localhost:4096"
+
+
+class OpenCodeClient:
+    def __init__(self, base_url: str = OPENCODE_DEFAULT_URL):
+        self.base_url = base_url.rstrip("/")
+        self._client = httpx.Client(timeout=10)
+
+    def healthy(self) -> bool:
+        try:
+            r = self._client.get(f"{self.base_url}/global/health")
+            return r.status_code == 200 and r.json().get("healthy", False)
+        except Exception:
+            return False
+
+    def latest_session_id(self) -> str | None:
+        try:
+            r = self._client.get(f"{self.base_url}/session")
+            if r.status_code != 200:
+                return None
+            sessions = r.json()
+            if not sessions:
+                return None
+            return sessions[0].get("id")
+        except Exception:
+            return None
+
+    def send_message(self, session_id: str, text: str) -> bool:
+        try:
+            r = self._client.post(
+                f"{self.base_url}/session/{session_id}/message",
+                json={"parts": [{"type": "text", "text": text}]},
+            )
+            return r.status_code == 200
+        except Exception as exc:
+            logger.debug(f"Failed to send message to session {session_id}: {exc}")
+            return False

--- a/wayfinder_paths/core/clients/OpenCodeClient.py
+++ b/wayfinder_paths/core/clients/OpenCodeClient.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Any
+
 import httpx
 from loguru import logger
 
@@ -7,34 +11,47 @@ OPENCODE_DEFAULT_URL = "http://localhost:4096"
 class OpenCodeClient:
     def __init__(self, base_url: str = OPENCODE_DEFAULT_URL):
         self.base_url = base_url.rstrip("/")
-        self._client = httpx.Client(timeout=10)
+        self.client = httpx.Client(
+            timeout=httpx.Timeout(10),
+            headers={"Content-Type": "application/json"},
+        )
 
-    def healthy(self) -> bool:
+    def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response | None:
+        url = f"{self.base_url}{path}"
         try:
-            r = self._client.get(f"{self.base_url}/global/health")
-            return r.status_code == 200 and r.json().get("healthy", False)
-        except Exception:
-            return False
-
-    def latest_session_id(self) -> str | None:
-        try:
-            r = self._client.get(f"{self.base_url}/session")
-            if r.status_code != 200:
-                return None
-            sessions = r.json()
-            if not sessions:
-                return None
-            return sessions[0].get("id")
-        except Exception:
+            resp = self.client.request(method, url, **kwargs)
+            return resp
+        except Exception as exc:
+            logger.debug(f"OpenCode {method} {url} failed: {exc}")
             return None
 
-    def send_message(self, session_id: str, text: str) -> bool:
-        try:
-            r = self._client.post(
-                f"{self.base_url}/session/{session_id}/message",
-                json={"parts": [{"type": "text", "text": text}]},
-            )
-            return r.status_code == 200
-        except Exception as exc:
-            logger.debug(f"Failed to send message to session {session_id}: {exc}")
+    def healthy(self) -> bool:
+        resp = self._request("GET", "/global/health")
+        if resp is None or resp.status_code != 200:
             return False
+        return resp.json().get("healthy", False)
+
+    def list_sessions(self) -> list[dict[str, Any]]:
+        resp = self._request("GET", "/session")
+        if resp is None or resp.status_code != 200:
+            return []
+        return resp.json()
+
+    def latest_session_id(self) -> str | None:
+        sessions = self.list_sessions()
+        if not sessions:
+            return None
+        return sessions[0].get("id")
+
+    def send_message(self, session_id: str, text: str) -> bool:
+        resp = self._request(
+            "POST",
+            f"/session/{session_id}/message",
+            json={"parts": [{"type": "text", "text": text}]},
+        )
+        if resp is None or resp.status_code != 200:
+            return False
+        return True
+
+
+OPENCODE_CLIENT = OpenCodeClient()

--- a/wayfinder_paths/core/clients/OpenCodeClient.py
+++ b/wayfinder_paths/core/clients/OpenCodeClient.py
@@ -17,21 +17,19 @@ class OpenCodeClient:
             headers={"Content-Type": "application/json"},
         )
 
-    def get(self, path: str, **kwargs: Any) -> httpx.Response:
-        return self.client.get(f"{self.base_url}{path}", **kwargs)
-
-    def post(self, path: str, **kwargs: Any) -> httpx.Response:
-        return self.client.post(f"{self.base_url}{path}", **kwargs)
-
     def healthy(self) -> bool:
         try:
-            return self.get("/global/health").json().get("healthy", False)
+            return (
+                self.client.get(f"{self.base_url}/global/health")
+                .json()
+                .get("healthy", False)
+            )
         except Exception:
             return False
 
     def list_sessions(self) -> list[dict[str, Any]]:
         try:
-            return self.get("/session").json()
+            return self.client.get(f"{self.base_url}/session").json()
         except Exception:
             return []
 
@@ -43,8 +41,9 @@ class OpenCodeClient:
                 continue
             try:
                 raw = json.dumps(
-                    self.get(
-                        f"/session/{session_id}/message", params={"limit": 50}
+                    self.client.get(
+                        f"{self.base_url}/session/{session_id}/message",
+                        params={"limit": 50},
                     ).json()
                 )
                 if "runner" in raw and ("add-job" in raw or "add_job" in raw):
@@ -55,11 +54,10 @@ class OpenCodeClient:
 
     def send_message(self, session_id: str, text: str) -> bool:
         try:
-            response = self.post(
-                f"/session/{session_id}/message",
+            return self.client.post(
+                f"{self.base_url}/session/{session_id}/message",
                 json={"parts": [{"type": "text", "text": text}]},
-            )
-            return response.is_success
+            ).is_success
         except Exception as error:
             logger.debug(f"Failed to send message to session {session_id}: {error}")
             return False

--- a/wayfinder_paths/core/clients/OpenCodeClient.py
+++ b/wayfinder_paths/core/clients/OpenCodeClient.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import httpx
@@ -38,29 +39,21 @@ class OpenCodeClient:
         return resp.json()
 
     def active_session_id(self) -> str | None:
-        """Find the session that invoked 'runner add-job' or 'runner add_job'."""
-        sessions = self.list_sessions()
-        if not sessions:
-            return None
-        for s in sessions:
+        """Find the session that invoked runner add-job."""
+        for s in self.list_sessions():
             sid = s.get("id")
-            if not sid:
-                continue
-            resp = self._request("GET", f"/session/{sid}/message", params={"limit": 50})
-            if resp is None or resp.status_code != 200:
-                continue
-            for msg in resp.json():
-                for part in msg.get("parts", []):
-                    if part.get("type") != "tool":
-                        continue
-                    inp = part.get("state", {}).get("input", {})
-                    cmd = str(inp.get("command", ""))
-                    action = str(inp.get("action", ""))
-                    if "runner" in cmd and "add-job" in cmd:
-                        return sid
-                    if action == "add_job":
-                        return sid
+            if sid and self._session_has_runner_job(sid):
+                return sid
         return None
+
+    def _session_has_runner_job(self, session_id: str) -> bool:
+        resp = self._request(
+            "GET", f"/session/{session_id}/message", params={"limit": 50}
+        )
+        if resp is None or resp.status_code != 200:
+            return False
+        raw = json.dumps(resp.json())
+        return "runner" in raw and ("add-job" in raw or "add_job" in raw)
 
     def send_message(self, session_id: str, text: str) -> bool:
         resp = self._request(

--- a/wayfinder_paths/core/clients/OpenCodeClient.py
+++ b/wayfinder_paths/core/clients/OpenCodeClient.py
@@ -6,7 +6,7 @@ from typing import Any
 import httpx
 from loguru import logger
 
-from wayfinder_paths.runner.constants import ADD_JOB_CLI_VERB, ADD_JOB_MCP_ACTION
+from wayfinder_paths.runner.constants import ADD_JOB_VERB
 
 OPENCODE_DEFAULT_URL = "http://localhost:4096"
 
@@ -46,9 +46,7 @@ class OpenCodeClient:
                         params={"limit": 50},
                     ).json()
                 )
-                if "runner" in raw and (
-                    ADD_JOB_CLI_VERB in raw or ADD_JOB_MCP_ACTION in raw
-                ):
+                if "runner" in raw and ADD_JOB_VERB in raw:
                     return session_id
             except Exception:
                 continue

--- a/wayfinder_paths/mcp/tools/runner.py
+++ b/wayfinder_paths/mcp/tools/runner.py
@@ -5,7 +5,6 @@ import time
 from pathlib import Path
 from typing import Any, Literal
 
-from wayfinder_paths.core.clients.OpenCodeClient import OPENCODE_CLIENT
 from wayfinder_paths.mcp.utils import err, ok, read_text_excerpt, repo_root
 from wayfinder_paths.runner.client import RunnerControlClient
 from wayfinder_paths.runner.constants import JOB_TYPE_SCRIPT, JOB_TYPE_STRATEGY
@@ -77,8 +76,6 @@ async def runner(
     args: list[str] | None = None,
     env: dict[str, str] | None = None,
     debug: bool = False,
-    # Notification
-    notify_session: str | None = None,
 ) -> dict[str, Any]:
     """Control the local runner daemon via its Unix socket.
 
@@ -328,15 +325,6 @@ async def runner(
                         "args": argv,
                     }
                 )
-
-            resolved_session_id = None
-            if notify_session == "auto":
-                if OPENCODE_CLIENT.healthy():
-                    resolved_session_id = OPENCODE_CLIENT.latest_session_id()
-            elif notify_session:
-                resolved_session_id = notify_session
-            if resolved_session_id:
-                job_payload["notify_session_id"] = resolved_session_id
 
             resp = client.call(
                 "add_job",

--- a/wayfinder_paths/mcp/tools/runner.py
+++ b/wayfinder_paths/mcp/tools/runner.py
@@ -5,6 +5,7 @@ import time
 from pathlib import Path
 from typing import Any, Literal
 
+from wayfinder_paths.core.clients.OpenCodeClient import OpenCodeClient
 from wayfinder_paths.mcp.utils import err, ok, read_text_excerpt, repo_root
 from wayfinder_paths.runner.client import RunnerControlClient
 from wayfinder_paths.runner.constants import JOB_TYPE_SCRIPT, JOB_TYPE_STRATEGY
@@ -76,6 +77,8 @@ async def runner(
     args: list[str] | None = None,
     env: dict[str, str] | None = None,
     debug: bool = False,
+    # Notification
+    notify_session: str | None = None,
 ) -> dict[str, Any]:
     """Control the local runner daemon via its Unix socket.
 
@@ -325,6 +328,16 @@ async def runner(
                         "args": argv,
                     }
                 )
+
+            resolved_session_id = None
+            if notify_session == "auto":
+                oc = OpenCodeClient()
+                if oc.healthy():
+                    resolved_session_id = oc.latest_session_id()
+            elif notify_session:
+                resolved_session_id = notify_session
+            if resolved_session_id:
+                job_payload["notify_session_id"] = resolved_session_id
 
             resp = client.call(
                 "add_job",

--- a/wayfinder_paths/mcp/tools/runner.py
+++ b/wayfinder_paths/mcp/tools/runner.py
@@ -5,7 +5,7 @@ import time
 from pathlib import Path
 from typing import Any, Literal
 
-from wayfinder_paths.core.clients.OpenCodeClient import OpenCodeClient
+from wayfinder_paths.core.clients.OpenCodeClient import OPENCODE_CLIENT
 from wayfinder_paths.mcp.utils import err, ok, read_text_excerpt, repo_root
 from wayfinder_paths.runner.client import RunnerControlClient
 from wayfinder_paths.runner.constants import JOB_TYPE_SCRIPT, JOB_TYPE_STRATEGY
@@ -331,9 +331,8 @@ async def runner(
 
             resolved_session_id = None
             if notify_session == "auto":
-                oc = OpenCodeClient()
-                if oc.healthy():
-                    resolved_session_id = oc.latest_session_id()
+                if OPENCODE_CLIENT.healthy():
+                    resolved_session_id = OPENCODE_CLIENT.latest_session_id()
             elif notify_session:
                 resolved_session_id = notify_session
             if resolved_session_id:

--- a/wayfinder_paths/runner/cli.py
+++ b/wayfinder_paths/runner/cli.py
@@ -8,6 +8,7 @@ from typing import Any
 import click
 from loguru import logger
 
+from wayfinder_paths.core.clients.OpenCodeClient import OpenCodeClient
 from wayfinder_paths.runner.client import RunnerControlClient
 from wayfinder_paths.runner.constants import JOB_TYPE_SCRIPT, JOB_TYPE_STRATEGY
 from wayfinder_paths.runner.daemon import RunnerDaemon
@@ -187,6 +188,11 @@ def status_cmd() -> None:
     "--env-json", default=None, help="JSON object of env vars for the worker."
 )
 @click.option("--debug/--no-debug", default=False, show_default=True)
+@click.option(
+    "--notify-session",
+    default=None,
+    help="OpenCode session ID to post job results to. Use 'auto' to discover the latest session.",
+)
 def add_job_cmd(
     name: str,
     job_type: str,
@@ -200,6 +206,7 @@ def add_job_cmd(
     timeout_seconds: int | None,
     env_json: str | None,
     debug: bool,
+    notify_session: str | None,
 ) -> None:
     paths = get_runner_paths()
     jt = str(job_type).lower().strip()
@@ -210,6 +217,20 @@ def add_job_cmd(
         if not isinstance(decoded, dict):
             raise click.UsageError("--env-json must decode to an object")
         env_payload = {str(k): str(v) for k, v in decoded.items()}
+
+    resolved_session_id = None
+    if notify_session == "auto":
+        oc = OpenCodeClient()
+        if oc.healthy():
+            resolved_session_id = oc.latest_session_id()
+            if resolved_session_id:
+                click.echo(f"Auto-discovered session: {resolved_session_id}")
+            else:
+                click.echo("Warning: no active sessions found", err=True)
+        else:
+            click.echo("Warning: OpenCode server not reachable, skipping notify", err=True)
+    elif notify_session:
+        resolved_session_id = notify_session
 
     payload: dict[str, Any]
     if jt == JOB_TYPE_STRATEGY:
@@ -244,6 +265,9 @@ def add_job_cmd(
             payload["env"] = env_payload
     else:
         raise click.UsageError(f"Unsupported type: {job_type}")
+
+    if resolved_session_id:
+        payload["notify_session_id"] = resolved_session_id
 
     resp = _client(paths.sock_path).call(
         "add_job",

--- a/wayfinder_paths/runner/cli.py
+++ b/wayfinder_paths/runner/cli.py
@@ -10,7 +10,7 @@ from loguru import logger
 
 from wayfinder_paths.runner.client import RunnerControlClient
 from wayfinder_paths.runner.constants import (
-    ADD_JOB_CLI_VERB,
+    ADD_JOB_VERB,
     JOB_TYPE_SCRIPT,
     JOB_TYPE_STRATEGY,
 )
@@ -149,9 +149,7 @@ def status_cmd() -> None:
     _echo_json(resp)
 
 
-@runner_cli.command(
-    name=ADD_JOB_CLI_VERB, help="Add a job without restarting the daemon."
-)
+@runner_cli.command(name=ADD_JOB_VERB, help="Add a job without restarting the daemon.")
 @click.option("--name", required=True)
 @click.option(
     "--type",

--- a/wayfinder_paths/runner/cli.py
+++ b/wayfinder_paths/runner/cli.py
@@ -8,7 +8,6 @@ from typing import Any
 import click
 from loguru import logger
 
-from wayfinder_paths.core.clients.OpenCodeClient import OPENCODE_CLIENT
 from wayfinder_paths.runner.client import RunnerControlClient
 from wayfinder_paths.runner.constants import JOB_TYPE_SCRIPT, JOB_TYPE_STRATEGY
 from wayfinder_paths.runner.daemon import RunnerDaemon
@@ -188,11 +187,6 @@ def status_cmd() -> None:
     "--env-json", default=None, help="JSON object of env vars for the worker."
 )
 @click.option("--debug/--no-debug", default=False, show_default=True)
-@click.option(
-    "--notify-session",
-    default=None,
-    help="OpenCode session ID to post job results to. Use 'auto' to discover the latest session.",
-)
 def add_job_cmd(
     name: str,
     job_type: str,
@@ -206,7 +200,6 @@ def add_job_cmd(
     timeout_seconds: int | None,
     env_json: str | None,
     debug: bool,
-    notify_session: str | None,
 ) -> None:
     paths = get_runner_paths()
     jt = str(job_type).lower().strip()
@@ -217,21 +210,6 @@ def add_job_cmd(
         if not isinstance(decoded, dict):
             raise click.UsageError("--env-json must decode to an object")
         env_payload = {str(k): str(v) for k, v in decoded.items()}
-
-    resolved_session_id = None
-    if notify_session == "auto":
-        if OPENCODE_CLIENT.healthy():
-            resolved_session_id = OPENCODE_CLIENT.latest_session_id()
-            if resolved_session_id:
-                click.echo(f"Auto-discovered session: {resolved_session_id}")
-            else:
-                click.echo("Warning: no active sessions found", err=True)
-        else:
-            click.echo(
-                "Warning: OpenCode server not reachable, skipping notify", err=True
-            )
-    elif notify_session:
-        resolved_session_id = notify_session
 
     payload: dict[str, Any]
     if jt == JOB_TYPE_STRATEGY:
@@ -266,9 +244,6 @@ def add_job_cmd(
             payload["env"] = env_payload
     else:
         raise click.UsageError(f"Unsupported type: {job_type}")
-
-    if resolved_session_id:
-        payload["notify_session_id"] = resolved_session_id
 
     resp = _client(paths.sock_path).call(
         "add_job",

--- a/wayfinder_paths/runner/cli.py
+++ b/wayfinder_paths/runner/cli.py
@@ -8,7 +8,7 @@ from typing import Any
 import click
 from loguru import logger
 
-from wayfinder_paths.core.clients.OpenCodeClient import OpenCodeClient
+from wayfinder_paths.core.clients.OpenCodeClient import OPENCODE_CLIENT
 from wayfinder_paths.runner.client import RunnerControlClient
 from wayfinder_paths.runner.constants import JOB_TYPE_SCRIPT, JOB_TYPE_STRATEGY
 from wayfinder_paths.runner.daemon import RunnerDaemon
@@ -220,9 +220,8 @@ def add_job_cmd(
 
     resolved_session_id = None
     if notify_session == "auto":
-        oc = OpenCodeClient()
-        if oc.healthy():
-            resolved_session_id = oc.latest_session_id()
+        if OPENCODE_CLIENT.healthy():
+            resolved_session_id = OPENCODE_CLIENT.latest_session_id()
             if resolved_session_id:
                 click.echo(f"Auto-discovered session: {resolved_session_id}")
             else:

--- a/wayfinder_paths/runner/cli.py
+++ b/wayfinder_paths/runner/cli.py
@@ -9,7 +9,11 @@ import click
 from loguru import logger
 
 from wayfinder_paths.runner.client import RunnerControlClient
-from wayfinder_paths.runner.constants import JOB_TYPE_SCRIPT, JOB_TYPE_STRATEGY
+from wayfinder_paths.runner.constants import (
+    ADD_JOB_CLI_VERB,
+    JOB_TYPE_SCRIPT,
+    JOB_TYPE_STRATEGY,
+)
 from wayfinder_paths.runner.daemon import RunnerDaemon
 from wayfinder_paths.runner.lifecycle import ensure_daemon_started, try_status
 from wayfinder_paths.runner.paths import get_runner_paths
@@ -145,7 +149,9 @@ def status_cmd() -> None:
     _echo_json(resp)
 
 
-@runner_cli.command(name="add-job", help="Add a job without restarting the daemon.")
+@runner_cli.command(
+    name=ADD_JOB_CLI_VERB, help="Add a job without restarting the daemon."
+)
 @click.option("--name", required=True)
 @click.option(
     "--type",

--- a/wayfinder_paths/runner/cli.py
+++ b/wayfinder_paths/runner/cli.py
@@ -227,7 +227,9 @@ def add_job_cmd(
             else:
                 click.echo("Warning: no active sessions found", err=True)
         else:
-            click.echo("Warning: OpenCode server not reachable, skipping notify", err=True)
+            click.echo(
+                "Warning: OpenCode server not reachable, skipping notify", err=True
+            )
     elif notify_session:
         resolved_session_id = notify_session
 

--- a/wayfinder_paths/runner/constants.py
+++ b/wayfinder_paths/runner/constants.py
@@ -22,9 +22,8 @@ class RunStatus(StrEnum):
 JOB_TYPE_STRATEGY: Final[str] = "strategy"
 JOB_TYPE_SCRIPT: Final[str] = "script"
 
-# Command identifiers — used in CLI, MCP, and session discovery
-ADD_JOB_CLI_VERB: Final[str] = "add-job"
-ADD_JOB_MCP_ACTION: Final[str] = "add_job"
+# Command identifier — used in CLI and session discovery
+ADD_JOB_VERB: Final[str] = "add-job"
 
 # Control protocol limits
 MAX_LINE_BYTES: Final[int] = 1024 * 1024

--- a/wayfinder_paths/runner/constants.py
+++ b/wayfinder_paths/runner/constants.py
@@ -22,5 +22,9 @@ class RunStatus(StrEnum):
 JOB_TYPE_STRATEGY: Final[str] = "strategy"
 JOB_TYPE_SCRIPT: Final[str] = "script"
 
+# Command identifiers — used in CLI, MCP, and session discovery
+ADD_JOB_CLI_VERB: Final[str] = "add-job"
+ADD_JOB_MCP_ACTION: Final[str] = "add_job"
+
 # Control protocol limits
 MAX_LINE_BYTES: Final[int] = 1024 * 1024

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import signal
@@ -298,19 +299,22 @@ class RunnerDaemon:
         session_id = (job.payload or {}).get("notify_session_id")
         if not session_id:
             return
-        if not OPENCODE_CLIENT.healthy():
-            logger.debug("OpenCode server not reachable, skipping notification")
-            return
-        log_tail = _tail_text(rp.log_path, max_bytes=2000) or "(no output)"
-        msg = json.dumps(
-            {
-                "type": "job",
-                "name": rp.job_name,
-                "status": status,
-                "message": log_tail,
-            }
-        )
-        OPENCODE_CLIENT.send_message(session_id, msg)
+        try:
+            if not asyncio.run(OPENCODE_CLIENT.healthy()):
+                logger.debug("OpenCode server not reachable, skipping notification")
+                return
+            log_tail = _tail_text(rp.log_path, max_bytes=2000) or "(no output)"
+            msg = json.dumps(
+                {
+                    "type": "job",
+                    "name": rp.job_name,
+                    "status": status,
+                    "message": log_tail,
+                }
+            )
+            asyncio.run(OPENCODE_CLIENT.send_message(session_id, msg))
+        except Exception as exc:
+            logger.debug(f"Notification failed: {exc}")
 
     def _shutdown_running_processes(self) -> None:
         with self._lock:
@@ -635,11 +639,15 @@ class RunnerDaemon:
             env = payload_norm.get("env")
             if env is not None and not isinstance(env, dict):
                 return {"ok": False, "error": "payload.env must be an object"}
-        if "notify_session_id" not in payload_norm and OPENCODE_CLIENT.healthy():
-            sid = OPENCODE_CLIENT.active_session_id()
-            if sid:
-                payload_norm["notify_session_id"] = sid
-                logger.info(f"Auto-bound job {name} to session {sid}")
+        if "notify_session_id" not in payload_norm:
+            try:
+                if asyncio.run(OPENCODE_CLIENT.healthy()):
+                    sid = asyncio.run(OPENCODE_CLIENT.active_session_id())
+                    if sid:
+                        payload_norm["notify_session_id"] = sid
+                        logger.info(f"Auto-bound job {name} to session {sid}")
+            except Exception:
+                pass
 
         try:
             job_id = self._db.add_job(

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -14,6 +14,7 @@ from typing import Any
 from loguru import logger
 
 from wayfinder_paths import __version__
+from wayfinder_paths.core.clients.OpenCodeClient import OPENCODE_CLIENT
 from wayfinder_paths.runner.constants import (
     JOB_TYPE_SCRIPT,
     JOB_TYPE_STRATEGY,
@@ -22,7 +23,6 @@ from wayfinder_paths.runner.constants import (
 )
 from wayfinder_paths.runner.control import RunnerControlServer
 from wayfinder_paths.runner.db import RunnerDB
-from wayfinder_paths.core.clients.OpenCodeClient import OPENCODE_CLIENT
 from wayfinder_paths.runner.paths import RunnerPaths
 from wayfinder_paths.runner.script_resolver import resolve_script_path
 
@@ -302,12 +302,14 @@ class RunnerDaemon:
             logger.debug("OpenCode server not reachable, skipping notification")
             return
         log_tail = _tail_text(rp.log_path, max_bytes=2000) or "(no output)"
-        msg = json.dumps({
-            "type": "job",
-            "name": rp.job_name,
-            "status": status,
-            "message": log_tail,
-        })
+        msg = json.dumps(
+            {
+                "type": "job",
+                "name": rp.job_name,
+                "status": status,
+                "message": log_tail,
+            }
+        )
         OPENCODE_CLIENT.send_message(session_id, msg)
 
     def _shutdown_running_processes(self) -> None:

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import signal
 import subprocess
@@ -21,6 +22,7 @@ from wayfinder_paths.runner.constants import (
 )
 from wayfinder_paths.runner.control import RunnerControlServer
 from wayfinder_paths.runner.db import RunnerDB
+from wayfinder_paths.core.clients.OpenCodeClient import OpenCodeClient
 from wayfinder_paths.runner.paths import RunnerPaths
 from wayfinder_paths.runner.script_resolver import resolve_script_path
 
@@ -279,6 +281,35 @@ class RunnerDaemon:
         self._running_by_job[rp.job_id] = max(
             0, self._running_by_job.get(rp.job_id, 1) - 1
         )
+
+        self._notify_session(rp, status=status, error_text=error_text)
+
+    def _notify_session(
+        self,
+        rp: RunningProcess,
+        *,
+        status: str,
+        error_text: str | None,
+    ) -> None:
+        try:
+            job, _ = self._db.get_job(name=rp.job_name)
+        except Exception:
+            return
+        session_id = (job.payload or {}).get("notify_session_id")
+        if not session_id:
+            return
+        oc = OpenCodeClient()
+        if not oc.healthy():
+            logger.debug("OpenCode server not reachable, skipping notification")
+            return
+        log_tail = _tail_text(rp.log_path, max_bytes=2000) or "(no output)"
+        msg = json.dumps({
+            "type": "job",
+            "name": rp.job_name,
+            "status": status,
+            "message": log_tail,
+        })
+        oc.send_message(session_id, msg)
 
     def _shutdown_running_processes(self) -> None:
         with self._lock:

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -32,7 +32,8 @@ def _utc_epoch_s() -> int:
 
 
 def _safe_job_dirname(name: str) -> str:
-    cleaned = "".join(ch if ch.isalnum() or ch in ("-", "_") else "_" for ch in name)
+    cleaned = "".join(ch if ch.isalnum() or ch in (
+        "-", "_") else "_" for ch in name)
     return cleaned.strip("_") or "job"
 
 
@@ -139,7 +140,8 @@ class RunnerDaemon:
                 f"Failed to configure daemon log file {daemon_log_path}: {exc}"
             )
 
-        aborted = self._db.mark_stale_running_runs_aborted(note="runner restarted")
+        aborted = self._db.mark_stale_running_runs_aborted(
+            note="runner restarted")
         if aborted:
             logger.warning(f"Marked {aborted} stale RUNNING runs as ABORTED")
 
@@ -237,7 +239,8 @@ class RunnerDaemon:
             status = RunStatus.OK if int(exit_code) == 0 else RunStatus.FAILED
             error_text = None
             if status != RunStatus.OK:
-                error_text = _tail_text(rp.log_path) or f"exit_code={exit_code}"
+                error_text = _tail_text(
+                    rp.log_path) or f"exit_code={exit_code}"
             self._finish_run(
                 rp,
                 finished_at=now,
@@ -296,9 +299,10 @@ class RunnerDaemon:
 
         if session_id is None or not OPENCODE_CLIENT.healthy():
             return
+
         notification = json.dumps(
             {
-                "type": "job",
+                "type": "job_result",
                 "name": running_process.job_name,
                 "status": status,
                 "error": error_text,
@@ -445,7 +449,8 @@ class RunnerDaemon:
             strategy = str(payload.get("strategy") or "").strip()
             action = str(payload.get("action") or "update").strip()
             config_path = str(payload.get("config") or "config.json")
-            wallet_label = payload.get("wallet_label") or payload.get("wallet") or None
+            wallet_label = payload.get(
+                "wallet_label") or payload.get("wallet") or None
             debug = bool(payload.get("debug") or False)
 
             cmd = [
@@ -472,7 +477,8 @@ class RunnerDaemon:
                 or payload.get("path")
             )
             if not sp:
-                raise ValueError("payload.script_path is required for script jobs")
+                raise ValueError(
+                    "payload.script_path is required for script jobs")
 
             script = resolve_script_path(self._paths, str(sp))
             args = payload.get("args") or []
@@ -539,7 +545,8 @@ class RunnerDaemon:
         except (TypeError, ValueError):
             return {"ok": False, "error": "run_id must be an integer"}
 
-        tbytes = _clamp_int(tail_bytes, min_value=200, max_value=200_000, default=4000)
+        tbytes = _clamp_int(tail_bytes, min_value=200,
+                            max_value=200_000, default=4000)
 
         run = self._db.get_run(run_id=rid)
         if run is None:
@@ -547,7 +554,8 @@ class RunnerDaemon:
 
         duration_s = None
         if run.get("finished_at") is not None:
-            duration_s = max(0, int(run["finished_at"]) - int(run["started_at"]))
+            duration_s = max(
+                0, int(run["finished_at"]) - int(run["started_at"]))
 
         log_tail = None
         log_path_s = run.get("log_path")
@@ -694,7 +702,8 @@ class RunnerDaemon:
             "interval_seconds": job.interval_seconds,
         }
         with self._lock:
-            run_id = self._maybe_start_job(job=job_dict, now=now, reason="run_once")
+            run_id = self._maybe_start_job(
+                job=job_dict, now=now, reason="run_once")
         if run_id is None:
             return {
                 "ok": False,

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -32,8 +32,7 @@ def _utc_epoch_s() -> int:
 
 
 def _safe_job_dirname(name: str) -> str:
-    cleaned = "".join(ch if ch.isalnum() or ch in (
-        "-", "_") else "_" for ch in name)
+    cleaned = "".join(ch if ch.isalnum() or ch in ("-", "_") else "_" for ch in name)
     return cleaned.strip("_") or "job"
 
 
@@ -140,8 +139,7 @@ class RunnerDaemon:
                 f"Failed to configure daemon log file {daemon_log_path}: {exc}"
             )
 
-        aborted = self._db.mark_stale_running_runs_aborted(
-            note="runner restarted")
+        aborted = self._db.mark_stale_running_runs_aborted(note="runner restarted")
         if aborted:
             logger.warning(f"Marked {aborted} stale RUNNING runs as ABORTED")
 
@@ -239,8 +237,7 @@ class RunnerDaemon:
             status = RunStatus.OK if int(exit_code) == 0 else RunStatus.FAILED
             error_text = None
             if status != RunStatus.OK:
-                error_text = _tail_text(
-                    rp.log_path) or f"exit_code={exit_code}"
+                error_text = _tail_text(rp.log_path) or f"exit_code={exit_code}"
             self._finish_run(
                 rp,
                 finished_at=now,
@@ -449,8 +446,7 @@ class RunnerDaemon:
             strategy = str(payload.get("strategy") or "").strip()
             action = str(payload.get("action") or "update").strip()
             config_path = str(payload.get("config") or "config.json")
-            wallet_label = payload.get(
-                "wallet_label") or payload.get("wallet") or None
+            wallet_label = payload.get("wallet_label") or payload.get("wallet") or None
             debug = bool(payload.get("debug") or False)
 
             cmd = [
@@ -477,8 +473,7 @@ class RunnerDaemon:
                 or payload.get("path")
             )
             if not sp:
-                raise ValueError(
-                    "payload.script_path is required for script jobs")
+                raise ValueError("payload.script_path is required for script jobs")
 
             script = resolve_script_path(self._paths, str(sp))
             args = payload.get("args") or []
@@ -545,8 +540,7 @@ class RunnerDaemon:
         except (TypeError, ValueError):
             return {"ok": False, "error": "run_id must be an integer"}
 
-        tbytes = _clamp_int(tail_bytes, min_value=200,
-                            max_value=200_000, default=4000)
+        tbytes = _clamp_int(tail_bytes, min_value=200, max_value=200_000, default=4000)
 
         run = self._db.get_run(run_id=rid)
         if run is None:
@@ -554,8 +548,7 @@ class RunnerDaemon:
 
         duration_s = None
         if run.get("finished_at") is not None:
-            duration_s = max(
-                0, int(run["finished_at"]) - int(run["started_at"]))
+            duration_s = max(0, int(run["finished_at"]) - int(run["started_at"]))
 
         log_tail = None
         log_path_s = run.get("log_path")
@@ -702,8 +695,7 @@ class RunnerDaemon:
             "interval_seconds": job.interval_seconds,
         }
         with self._lock:
-            run_id = self._maybe_start_job(
-                job=job_dict, now=now, reason="run_once")
+            run_id = self._maybe_start_job(job=job_dict, now=now, reason="run_once")
         if run_id is None:
             return {
                 "ok": False,

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -632,7 +632,7 @@ class RunnerDaemon:
             env = payload_norm.get("env")
             if env is not None and not isinstance(env, dict):
                 return {"ok": False, "error": "payload.env must be an object"}
-        session_id = OPENCODE_CLIENT.active_session_id()
+        session_id = OPENCODE_CLIENT.find_runner_session()
         if session_id:
             payload_norm["notify_session_id"] = session_id
             logger.info(f"Auto-bound job {name} to session {session_id}")

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -292,29 +292,24 @@ class RunnerDaemon:
         status: str,
         error_text: str | None,
     ) -> None:
-        try:
-            job, _ = self._db.get_job(name=rp.job_name)
-        except Exception:
-            return
+        job, _ = self._db.get_job(name=rp.job_name)
         session_id = (job.payload or {}).get("notify_session_id")
-        if not session_id:
+
+        if not session_id or not asyncio.run(OPENCODE_CLIENT.healthy()):
+            logger.debug("OpenCode server not reachable, skipping notification")
             return
-        try:
-            if not asyncio.run(OPENCODE_CLIENT.healthy()):
-                logger.debug("OpenCode server not reachable, skipping notification")
-                return
-            log_tail = _tail_text(rp.log_path, max_bytes=2000) or "(no output)"
-            msg = json.dumps(
-                {
-                    "type": "job",
-                    "name": rp.job_name,
-                    "status": status,
-                    "message": log_tail,
-                }
-            )
-            asyncio.run(OPENCODE_CLIENT.send_message(session_id, msg))
-        except Exception as exc:
-            logger.debug(f"Notification failed: {exc}")
+
+        log_tail = _tail_text(rp.log_path, max_bytes=2000) or "(no output)"
+        msg = json.dumps(
+            {
+                "type": "job",
+                "name": rp.job_name,
+                "status": status,
+                "error": error_text,
+                "message": log_tail,
+            }
+        )
+        asyncio.run(OPENCODE_CLIENT.send_message(session_id, msg))
 
     def _shutdown_running_processes(self) -> None:
         with self._lock:

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -283,9 +283,9 @@ class RunnerDaemon:
             0, self._running_by_job.get(rp.job_id, 1) - 1
         )
 
-        self._notify_session(rp, status=status, error_text=error_text)
+        asyncio.run(self._notify_session(rp, status=status, error_text=error_text))
 
-    def _notify_session(
+    async def _notify_session(
         self,
         rp: RunningProcess,
         *,
@@ -295,8 +295,7 @@ class RunnerDaemon:
         job, _ = self._db.get_job(name=rp.job_name)
         session_id = (job.payload or {}).get("notify_session_id")
 
-        if not session_id or not asyncio.run(OPENCODE_CLIENT.healthy()):
-            logger.debug("OpenCode server not reachable, skipping notification")
+        if not session_id or not await OPENCODE_CLIENT.healthy():
             return
 
         log_tail = _tail_text(rp.log_path, max_bytes=2000) or "(no output)"
@@ -309,7 +308,7 @@ class RunnerDaemon:
                 "message": log_tail,
             }
         )
-        asyncio.run(OPENCODE_CLIENT.send_message(session_id, msg))
+        await OPENCODE_CLIENT.send_message(session_id, msg)
 
     def _shutdown_running_processes(self) -> None:
         with self._lock:

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -292,19 +292,18 @@ class RunnerDaemon:
         error_text: str | None,
     ) -> None:
         job, _ = self._db.get_job(name=running_process.job_name)
-        session_id = (job.payload or {}).get("notify_session_id")
+        session_id = job.payload["notify_session_id"]
 
-        if not session_id or not OPENCODE_CLIENT.healthy():
+        if session_id is None or not OPENCODE_CLIENT.healthy():
             return
-
-        log_tail = _tail_text(running_process.log_path, max_bytes=2000) or "(no output)"
         notification = json.dumps(
             {
                 "type": "job",
                 "name": running_process.job_name,
                 "status": status,
                 "error": error_text,
-                "message": log_tail,
+                "message": running_process.log_path.read_text(errors="replace").strip()
+                or "(no output)",
             }
         )
         OPENCODE_CLIENT.send_message(session_id, notification)
@@ -633,9 +632,8 @@ class RunnerDaemon:
             if env is not None and not isinstance(env, dict):
                 return {"ok": False, "error": "payload.env must be an object"}
         session_id = OPENCODE_CLIENT.find_runner_session()
-        if session_id:
-            payload_norm["notify_session_id"] = session_id
-            logger.info(f"Auto-bound job {name} to session {session_id}")
+        payload_norm["notify_session_id"] = session_id
+        logger.info(f"Auto-bound job {name} to session {session_id}")
 
         try:
             job_id = self._db.add_job(

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -635,6 +635,12 @@ class RunnerDaemon:
             env = payload_norm.get("env")
             if env is not None and not isinstance(env, dict):
                 return {"ok": False, "error": "payload.env must be an object"}
+        if "notify_session_id" not in payload_norm and OPENCODE_CLIENT.healthy():
+            sid = OPENCODE_CLIENT.latest_session_id()
+            if sid:
+                payload_norm["notify_session_id"] = sid
+                logger.info(f"Auto-bound job {name} to session {sid}")
+
         try:
             job_id = self._db.add_job(
                 name=name,

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -286,28 +286,28 @@ class RunnerDaemon:
 
     def _notify_session(
         self,
-        rp: RunningProcess,
+        running_process: RunningProcess,
         *,
         status: str,
         error_text: str | None,
     ) -> None:
-        job, _ = self._db.get_job(name=rp.job_name)
+        job, _ = self._db.get_job(name=running_process.job_name)
         session_id = (job.payload or {}).get("notify_session_id")
 
         if not session_id or not OPENCODE_CLIENT.healthy():
             return
 
-        log_tail = _tail_text(rp.log_path, max_bytes=2000) or "(no output)"
-        msg = json.dumps(
+        log_tail = _tail_text(running_process.log_path, max_bytes=2000) or "(no output)"
+        notification = json.dumps(
             {
                 "type": "job",
-                "name": rp.job_name,
+                "name": running_process.job_name,
                 "status": status,
                 "error": error_text,
                 "message": log_tail,
             }
         )
-        OPENCODE_CLIENT.send_message(session_id, msg)
+        OPENCODE_CLIENT.send_message(session_id, notification)
 
     def _shutdown_running_processes(self) -> None:
         with self._lock:

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import json
 import os
 import signal
@@ -283,9 +282,9 @@ class RunnerDaemon:
             0, self._running_by_job.get(rp.job_id, 1) - 1
         )
 
-        asyncio.run(self._notify_session(rp, status=status, error_text=error_text))
+        self._notify_session(rp, status=status, error_text=error_text)
 
-    async def _notify_session(
+    def _notify_session(
         self,
         rp: RunningProcess,
         *,
@@ -295,7 +294,7 @@ class RunnerDaemon:
         job, _ = self._db.get_job(name=rp.job_name)
         session_id = (job.payload or {}).get("notify_session_id")
 
-        if not session_id or not await OPENCODE_CLIENT.healthy():
+        if not session_id or not OPENCODE_CLIENT.healthy():
             return
 
         log_tail = _tail_text(rp.log_path, max_bytes=2000) or "(no output)"
@@ -308,7 +307,7 @@ class RunnerDaemon:
                 "message": log_tail,
             }
         )
-        await OPENCODE_CLIENT.send_message(session_id, msg)
+        OPENCODE_CLIENT.send_message(session_id, msg)
 
     def _shutdown_running_processes(self) -> None:
         with self._lock:
@@ -633,15 +632,10 @@ class RunnerDaemon:
             env = payload_norm.get("env")
             if env is not None and not isinstance(env, dict):
                 return {"ok": False, "error": "payload.env must be an object"}
-        if "notify_session_id" not in payload_norm:
-            try:
-                if asyncio.run(OPENCODE_CLIENT.healthy()):
-                    sid = asyncio.run(OPENCODE_CLIENT.active_session_id())
-                    if sid:
-                        payload_norm["notify_session_id"] = sid
-                        logger.info(f"Auto-bound job {name} to session {sid}")
-            except Exception:
-                pass
+        session_id = OPENCODE_CLIENT.active_session_id()
+        if session_id:
+            payload_norm["notify_session_id"] = session_id
+            logger.info(f"Auto-bound job {name} to session {session_id}")
 
         try:
             job_id = self._db.add_job(

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -636,7 +636,7 @@ class RunnerDaemon:
             if env is not None and not isinstance(env, dict):
                 return {"ok": False, "error": "payload.env must be an object"}
         if "notify_session_id" not in payload_norm and OPENCODE_CLIENT.healthy():
-            sid = OPENCODE_CLIENT.latest_session_id()
+            sid = OPENCODE_CLIENT.active_session_id()
             if sid:
                 payload_norm["notify_session_id"] = sid
                 logger.info(f"Auto-bound job {name} to session {sid}")

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -22,7 +22,7 @@ from wayfinder_paths.runner.constants import (
 )
 from wayfinder_paths.runner.control import RunnerControlServer
 from wayfinder_paths.runner.db import RunnerDB
-from wayfinder_paths.core.clients.OpenCodeClient import OpenCodeClient
+from wayfinder_paths.core.clients.OpenCodeClient import OPENCODE_CLIENT
 from wayfinder_paths.runner.paths import RunnerPaths
 from wayfinder_paths.runner.script_resolver import resolve_script_path
 
@@ -298,8 +298,7 @@ class RunnerDaemon:
         session_id = (job.payload or {}).get("notify_session_id")
         if not session_id:
             return
-        oc = OpenCodeClient()
-        if not oc.healthy():
+        if not OPENCODE_CLIENT.healthy():
             logger.debug("OpenCode server not reachable, skipping notification")
             return
         log_tail = _tail_text(rp.log_path, max_bytes=2000) or "(no output)"
@@ -309,7 +308,7 @@ class RunnerDaemon:
             "status": status,
             "message": log_tail,
         })
-        oc.send_message(session_id, msg)
+        OPENCODE_CLIENT.send_message(session_id, msg)
 
     def _shutdown_running_processes(self) -> None:
         with self._lock:


### PR DESCRIPTION
## Summary
- New `OpenCodeClient` — health check, session discovery, send message (soft-fail if server unreachable)
- Runner daemon posts job results as JSON `{"type": "job", "name": "...", "status": "...", "message": "..."}` to the originating OpenCode session when a job completes
- CLI: `--notify-session <session_id>` or `--notify-session auto` to discover the latest session
- MCP: `notify_session` param with same auto-discover support
- Session ID stored in job payload at creation time, used at notification time

## Test plan
- [ ] `wayfinder runner add-job --name test --type script --script-path .wayfinder_runs/test.py --interval 60 --notify-session auto`
- [ ] Verify job completion posts to the OpenCode chat session
- [ ] Verify graceful skip when OpenCode server is not running

🤖 Generated with [Claude Code](https://claude.com/claude-code)