### PR TITLE
Remote Setup - Add --skip-poetry-install flag

### DIFF
--- a/scripts/remote_setup_stage1.py
+++ b/scripts/remote_setup_stage1.py
@@ -12,6 +12,12 @@ def main() -> int:
         description="Remote bootstrap (stage 1): poetry install + write config.json."
     )
     parser.add_argument("--api-key", help="Wayfinder API key (wk_...)")
+    parser.add_argument(
+        "--skip-poetry-install",
+        action="store_true",
+        default=False,
+        help="Skip poetry install (use when venv is pre-built).",
+    )
     args = parser.parse_args()
 
     os.chdir(REPO_ROOT)
@@ -21,7 +27,8 @@ def main() -> int:
         raise SystemExit("Missing API key. Pass --api-key or set WAYFINDER_API_KEY.")
 
     ensure_config(api_key=api_key)
-    run_cmd(["poetry", "install"])
+    if not args.skip_poetry_install:
+        run_cmd(["poetry", "install"])
     return 0
 
 


### PR DESCRIPTION
## Summary
- Add `--skip-poetry-install` flag to `remote_setup_stage1.py` (defaults to `False`)
- OpenCode image sets this flag since venv is pre-built in the Docker image

## Test plan
- [ ] `python scripts/remote_setup_stage1.py --api-key wk_...` → runs poetry install (default)
- [ ] `python scripts/remote_setup_stage1.py --api-key wk_... --skip-poetry-install` → skips poetry install
- [ ] OpenCode container boots without running poetry install

🤖 Generated with [Claude Code](https://claude.com/claude-code)