### PR TITLE
Agent Wallets - Filter wallet list by instance

### DIFF
--- a/wayfinder_paths/core/clients/WalletClient.py
+++ b/wayfinder_paths/core/clients/WalletClient.py
@@ -7,8 +7,10 @@ from wayfinder_paths.core.config import get_api_base_url
 
 
 class WalletClient(WayfinderClient):
-    async def list_wallets(self) -> list[dict[str, Any]]:
+    async def list_wallets(self, instance_id: str | None = None) -> list[dict[str, Any]]:
         url = f"{get_api_base_url()}/wallets/"
+        if instance_id:
+            url += f"?instance_id={instance_id}"
         resp = await self._authed_request("GET", url)
         return resp.json()
 

--- a/wayfinder_paths/core/clients/WalletClient.py
+++ b/wayfinder_paths/core/clients/WalletClient.py
@@ -7,7 +7,9 @@ from wayfinder_paths.core.config import get_api_base_url
 
 
 class WalletClient(WayfinderClient):
-    async def list_wallets(self, instance_id: str | None = None) -> list[dict[str, Any]]:
+    async def list_wallets(
+        self, instance_id: str | None = None
+    ) -> list[dict[str, Any]]:
         url = f"{get_api_base_url()}/wallets/"
         if instance_id:
             url += f"?instance_id={instance_id}"

--- a/wayfinder_paths/core/utils/wallets.py
+++ b/wayfinder_paths/core/utils/wallets.py
@@ -40,7 +40,8 @@ async def load_remote_wallets() -> list[dict[str, Any]]:
     if not api_key:
         return []
     try:
-        raw = await WALLET_CLIENT.list_wallets()
+        instance_id = get_opencode_instance_id() if OPENCODE_CLIENT.healthy() else None
+        raw = await WALLET_CLIENT.list_wallets(instance_id=instance_id)
         wallets = []
         for i, w in enumerate(raw):
             addr = w.get("wallet_address")


### PR DESCRIPTION
### Summary
- `WalletClient.list_wallets` accepts optional `instance_id` param
- `load_remote_wallets` auto-filters by `OPENCODE_INSTANCE_ID` when on an OpenCode instance
- SDK only sees wallets bound to the current instance session