### PR TITLE
Agent Wallets - Sign error logging + session expiry fields

### DIFF
--- a/wayfinder_paths/core/clients/WalletClient.py
+++ b/wayfinder_paths/core/clients/WalletClient.py
@@ -7,8 +7,10 @@ from wayfinder_paths.core.config import get_api_base_url
 
 
 class WalletClient(WayfinderClient):
-    async def list_wallets(self) -> list[dict[str, Any]]:
+    async def list_wallets(self, instance_id: str | None = None) -> list[dict[str, Any]]:
         url = f"{get_api_base_url()}/wallets/"
+        if instance_id:
+            url += f"?instance_id={instance_id}"
         resp = await self._authed_request("GET", url)
         return resp.json()
 

--- a/wayfinder_paths/core/clients/WalletClient.py
+++ b/wayfinder_paths/core/clients/WalletClient.py
@@ -59,7 +59,9 @@ class WalletClient(WayfinderClient):
     async def sign_typed_data(self, wallet_address: str, typed_data: dict) -> str:
         url = f"{get_api_base_url()}/wallets/{wallet_address}/sign-typed-data/"
         try:
-            resp = await self._authed_request("POST", url, json={"typed_data": typed_data})
+            resp = await self._authed_request(
+                "POST", url, json={"typed_data": typed_data}
+            )
             return resp.json()["signature"]
         except Exception as exc:
             logger.error(f"sign_typed_data failed for {wallet_address}: {exc}")

--- a/wayfinder_paths/core/clients/WalletClient.py
+++ b/wayfinder_paths/core/clients/WalletClient.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from loguru import logger
+
 from wayfinder_paths.core.clients.WayfinderClient import WayfinderClient
 from wayfinder_paths.core.config import get_api_base_url
 
@@ -45,25 +47,41 @@ class WalletClient(WayfinderClient):
 
     async def sign_transaction(self, wallet_address: str, transaction: dict) -> str:
         url = f"{get_api_base_url()}/wallets/{wallet_address}/sign-evm-transaction/"
-        resp = await self._authed_request(
-            "POST", url, json={"transaction": transaction}
-        )
-        return resp.json()["signed_transaction"]
+        try:
+            resp = await self._authed_request(
+                "POST", url, json={"transaction": transaction}
+            )
+            return resp.json()["signed_transaction"]
+        except Exception as exc:
+            logger.error(f"sign_transaction failed for {wallet_address}: {exc}")
+            raise
 
     async def sign_typed_data(self, wallet_address: str, typed_data: dict) -> str:
         url = f"{get_api_base_url()}/wallets/{wallet_address}/sign-typed-data/"
-        resp = await self._authed_request("POST", url, json={"typed_data": typed_data})
-        return resp.json()["signature"]
+        try:
+            resp = await self._authed_request("POST", url, json={"typed_data": typed_data})
+            return resp.json()["signature"]
+        except Exception as exc:
+            logger.error(f"sign_typed_data failed for {wallet_address}: {exc}")
+            raise
 
     async def sign_hash(self, wallet_address: str, hash_hex: str) -> str:
         url = f"{get_api_base_url()}/wallets/{wallet_address}/sign-hash/"
-        resp = await self._authed_request("POST", url, json={"hash": hash_hex})
-        return resp.json()["signature"]
+        try:
+            resp = await self._authed_request("POST", url, json={"hash": hash_hex})
+            return resp.json()["signature"]
+        except Exception as exc:
+            logger.error(f"sign_hash failed for {wallet_address}: {exc}")
+            raise
 
     async def personal_sign(self, wallet_address: str, message: str) -> str:
         url = f"{get_api_base_url()}/wallets/{wallet_address}/personal-sign/"
-        resp = await self._authed_request("POST", url, json={"message": message})
-        return resp.json()["signature"]
+        try:
+            resp = await self._authed_request("POST", url, json={"message": message})
+            return resp.json()["signature"]
+        except Exception as exc:
+            logger.error(f"personal_sign failed for {wallet_address}: {exc}")
+            raise
 
 
 WALLET_CLIENT = WalletClient()

--- a/wayfinder_paths/core/clients/WalletClient.py
+++ b/wayfinder_paths/core/clients/WalletClient.py
@@ -7,7 +7,9 @@ from wayfinder_paths.core.config import get_api_base_url
 
 
 class WalletClient(WayfinderClient):
-    async def list_wallets(self, instance_id: str | None = None) -> list[dict[str, Any]]:
+    async def list_wallets(
+        self, instance_id: str | None = None
+    ) -> list[dict[str, Any]]:
         url = f"{get_api_base_url()}/wallets/"
         if instance_id:
             url += f"?instance_id={instance_id}"

--- a/wayfinder_paths/core/utils/wallets.py
+++ b/wayfinder_paths/core/utils/wallets.py
@@ -40,7 +40,8 @@ async def load_remote_wallets() -> list[dict[str, Any]]:
     if not api_key:
         return []
     try:
-        raw = await WALLET_CLIENT.list_wallets()
+        instance_id = get_opencode_instance_id() if OPENCODE_CLIENT.healthy() else None
+        raw = await WALLET_CLIENT.list_wallets(instance_id=instance_id)
         wallets = []
         for i, w in enumerate(raw):
             addr = w.get("wallet_address")


### PR DESCRIPTION
## Summary
- Add error logging to all WalletClient sign methods (sign_transaction, sign_typed_data, sign_hash, personal_sign) — logs wallet address and exception before re-raising
- Surface `session_expires_at` and `session_expires_in` in MCP wallet views and remote wallet loading

## Test plan
- [ ] Trigger a sign failure (e.g. expired session wallet) and verify error is logged with wallet address
- [ ] Create a remote session wallet and verify `session_expires_at`/`session_expires_in` appear in `wayfinder://wallets`

🤖 Generated with [Claude Code](https://claude.com/claude-code)