### PR TITLE
AGENTS.md - Hosted instance wallet rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,20 +6,33 @@ This file provides guidance when working with code in this repository.
 
 **IMPORTANT: On every new conversation, check if setup is needed:**
 
-1. Check if `config.json` exists in the repo root
-2. If it does NOT exist, this is a first-time user. You MUST:
-   - Tell the user: "Welcome to Wayfinder Paths! Let me set things up for you."
+1. **Detect hosted OpenCode first.** Probe `http://localhost:4096/global/health`. If it returns `{ "healthy": true, ... }`, you are running inside a hosted OpenCode instance — the SDK is already installed at `/wf/sdk`, `WAYFINDER_API_KEY` and `OPENCODE_INSTANCE_ID` are already in the environment, and remote wallets are managed by vault-backend. **Do NOT run `setup.py`, do NOT prompt for an API key, do NOT touch `config.json`** — proceed normally.
+
+2. Otherwise (no OpenCode server reachable), this is a local dev environment. Tell the user: "Welcome to Wayfinder Paths! Let me set things up for you."
+
+3. If `config.json` does NOT exist:
    - Run: `python3 scripts/setup.py`
    - After setup completes, ask the user: "Do you have a Wayfinder API key?"
      - If yes: Add it to `config.json` under `system.api_key`
      - If no: Direct them to **https://strategies.wayfinder.ai** to create an account and get one
 
-3. If `config.json` exists but `system.api_key` is empty/missing:
+4. If `config.json` exists but `system.api_key` is empty/missing AND `WAYFINDER_API_KEY` is not set:
    - Ask: "I see you haven't set up your API key yet. Do you have a Wayfinder API key?"
    - If yes: Help them add it to `config.json` under `system.api_key`
    - If no: Direct them to **https://strategies.wayfinder.ai** to get one
 
-4. If everything is configured, proceed normally
+5. If everything is configured, proceed normally
+
+## Hosted instance environment variables
+
+When the SDK runs inside a hosted OpenCode instance, the vault-backend `InstanceService` injects two env vars on the Fly machine at startup:
+
+| Variable              | Source                                        | What it is                                                  |
+| --------------------- | --------------------------------------------- | ----------------------------------------------------------- |
+| `WAYFINDER_API_KEY`   | Optional `wayfinder_api_key` in create request | The user's `wf_…` Wayfinder API key. Picked up automatically by config priority below. |
+| `OPENCODE_INSTANCE_ID` | Always set by the backend                     | The Fly app name (e.g. `cmn387aqk00bu0cl2d6w-7ceb538e5`). Useful for logs/diagnostics. |
+
+Config priority: `Constructor parameter > config.json > WAYFINDER_API_KEY env var`. On hosted instances you do **not** need to write the key into `config.json`.
 
 ## Project Overview
 
@@ -64,6 +77,7 @@ When answering questions about **rates/APYs/funding**:
 Strategy interface — all strategies implement these actions:
 
 **Read-only actions:**
+
 - `status` - Current positions, balances, and state
 - `analyze` - Run strategy analysis with given deposit amount
 - `snapshot` - Build batch snapshot for scoring
@@ -71,12 +85,14 @@ Strategy interface — all strategies implement these actions:
 - `quote` - Get point-in-time expected APY for the strategy
 
 **Fund-moving actions:**
+
 - `deposit` - Add funds to the strategy (requires `main_token_amount`; optional `gas_token_amount`). First deposit should include `gas_token_amount` (e.g. `0.001`).
 - `update` - Rebalance or execute the strategy logic
 - `withdraw` - **Liquidate**: Close all positions and convert to stablecoins (funds stay in strategy wallet)
 - `exit` - **Transfer**: Move funds from strategy wallet to main wallet (call after withdraw)
 
 **Clarify withdraw vs exit** — these are separate steps:
+
 - `withdraw` closes positions → `exit` transfers to main wallet
 - "withdraw all" / "close everything" → run `withdraw` then `exit`
 - "transfer remaining funds" (positions already closed) → just `exit`
@@ -84,6 +100,7 @@ Strategy interface — all strategies implement these actions:
 **Mypy typing** - When adding or modifying Python code, ensure all _new/changed_ code is fully type-annotated and does not introduce new mypy errors.
 
 Run strategies via CLI:
+
 ```bash
 poetry run python -m wayfinder_paths.run_strategy <strategy_name> --action status --config config.json
 ```
@@ -246,6 +263,7 @@ else:
 ### Key domain knowledge
 
 Hyperliquid minimums:
+
 - **Minimum deposit: $5 USD** (deposits below this are **lost**)
 - **Minimum order: $10 USD notional** (applies to both perp and spot)
 
@@ -266,10 +284,12 @@ Supported chains:
 - **HyperEVM**: Hyperliquid's EVM layer. On-chain tokens (HYPE, USDC) live here; perp/spot trading uses the Hyperliquid L1 (off-chain, not EVM).
 
 Gas requirements (critical — assets get stuck without gas):
+
 - **Before any on-chain operation**, check the wallet has native gas on that chain.
 - If bridging to a new chain for the first time: bridge gas first.
 
 Token identifiers (important for quoting/execution/lookups):
+
 - Use **token IDs** (`<coingecko_id>-<chain_code>`) or **address IDs** (`<chain_code>_<address>`).
 
 ### Recurring automation (Runner)
@@ -360,15 +380,19 @@ Strategy → Adapter → Client(s) → Network/API
 **Always use the scaffolding scripts** when creating new strategies or adapters.
 
 **New strategy:**
+
 ```bash
 just create-strategy "My Strategy Name"
 ```
+
 Creates `wayfinder_paths/strategies/<name>/` with strategy.py, manifest.yaml, test, examples.json, README, and a **dedicated wallet** in `config.json`.
 
 **New adapter:**
+
 ```bash
 just create-adapter "my_protocol"
 ```
+
 Creates `wayfinder_paths/adapters/<name>_adapter/` with adapter.py, manifest.yaml, test, examples.json, README.
 
 ### Manifests
@@ -416,11 +440,45 @@ Strategies extend `wayfinder_paths.core.strategies.Strategy` and must implement:
 - `@pytest.mark.requires_wallets` - Tests needing local wallets configured
 - `@pytest.mark.requires_config` - Tests needing config.json
 
+## Wallets
+
+**Always read wallets through the MCP CLI. Never grep `config.json` for `wallets[]` or read wallet files directly.**
+
+The MCP wallet resource is the only source of truth that returns the merged set of local + remote wallets. On a hosted OpenCode instance, remote wallets live in vault-backend (Privy server wallets) and are NOT in `config.json` — reading the file misses them entirely.
+
+```bash
+# List all wallets (local + remote, with labels, addresses, chain types)
+poetry run python -m wayfinder_paths.mcp.cli resource wayfinder://wallets
+
+# Get a single wallet by label (includes profile / tracked protocols)
+poetry run python -m wayfinder_paths.mcp.cli resource wayfinder://wallets/main
+
+# Wallet balances (USD-aggregated, per-chain breakdown, spam-filtered)
+poetry run python -m wayfinder_paths.mcp.cli resource wayfinder://balances/main
+
+# Recent on-chain activity
+poetry run python -m wayfinder_paths.mcp.cli resource wayfinder://activity/main
+```
+
+To create a wallet, use the `wallets` tool (not direct file edits):
+
+```bash
+# Create a remote (Privy) wallet — required on hosted OpenCode instances
+poetry run python -m wayfinder_paths.mcp.cli wallets --action create --label main --remote
+
+# Create a local wallet — only allowed when not running on a hosted instance
+poetry run python -m wayfinder_paths.mcp.cli wallets --action create --label main
+```
+
+In Python scripts, prefer the helpers in `wayfinder_paths.mcp.utils` (`load_wallets`, `find_wallet_by_label`) — they hit the same code path as the resource and merge local + remote.
+
 ## Configuration
 
 Config priority: Constructor parameter > config.json > Environment variable (`WAYFINDER_API_KEY`)
 
 Copy `config.example.json` to `config.json` (or run `python3 scripts/setup.py`) for local development.
+
+On hosted OpenCode instances, the API key comes from the `WAYFINDER_API_KEY` env var (set by vault-backend at machine creation) and `OPENCODE_INSTANCE_ID` identifies the Fly app — see [Hosted instance environment variables](#hosted-instance-environment-variables).
 
 ## CI/CD Pipeline
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,33 +6,31 @@ This file provides guidance when working with code in this repository.
 
 **IMPORTANT: On every new conversation, check if setup is needed:**
 
-1. **Detect hosted OpenCode first.** Probe `http://localhost:4096/global/health`. If it returns `{ "healthy": true, ... }`, you are running inside a hosted OpenCode instance — the SDK is already installed at `/wf/sdk`, `WAYFINDER_API_KEY` and `OPENCODE_INSTANCE_ID` are already in the environment, and remote wallets are managed by vault-backend. **Do NOT run `setup.py`, do NOT prompt for an API key, do NOT touch `config.json`** — proceed normally.
+1. **Detect Wayfinder Cloud first.** Probe `http://localhost:4096/global/health`. If it returns `{ "healthy": true, ... }`, you are running inside Wayfinder Cloud — the SDK is already installed at `/wf/sdk`, the API key is already in the environment, and remote wallets are managed for you. **Do NOT run `setup.py`, do NOT prompt for an API key, do NOT touch `config.json`** — proceed normally.
 
-2. Otherwise (no OpenCode server reachable), this is a local dev environment. Tell the user: "Welcome to Wayfinder Paths! Let me set things up for you."
-
-3. If `config.json` does NOT exist:
+2. If `config.json` does NOT exist:
    - Run: `python3 scripts/setup.py`
    - After setup completes, ask the user: "Do you have a Wayfinder API key?"
      - If yes: Add it to `config.json` under `system.api_key`
      - If no: Direct them to **https://strategies.wayfinder.ai** to create an account and get one
 
-4. If `config.json` exists but `system.api_key` is empty/missing AND `WAYFINDER_API_KEY` is not set:
+3. If `config.json` exists but `system.api_key` is empty/missing AND `WAYFINDER_API_KEY` is not set:
    - Ask: "I see you haven't set up your API key yet. Do you have a Wayfinder API key?"
    - If yes: Help them add it to `config.json` under `system.api_key`
    - If no: Direct them to **https://strategies.wayfinder.ai** to get one
 
-5. If everything is configured, proceed normally
+4. If everything is configured, proceed normally
 
-## Hosted instance environment variables
+## Wayfinder Cloud environment variables
 
-When the SDK runs inside a hosted OpenCode instance, the vault-backend `InstanceService` injects two env vars on the Fly machine at startup:
+When the SDK runs inside Wayfinder Cloud, two env vars are injected at startup:
 
-| Variable              | Source                                        | What it is                                                  |
-| --------------------- | --------------------------------------------- | ----------------------------------------------------------- |
-| `WAYFINDER_API_KEY`   | Optional `wayfinder_api_key` in create request | The user's `wf_…` Wayfinder API key. Picked up automatically by config priority below. |
-| `OPENCODE_INSTANCE_ID` | Always set by the backend                     | The Fly app name (e.g. `cmn387aqk00bu0cl2d6w-7ceb538e5`). Useful for logs/diagnostics. |
+| Variable               | What it is                                                                             |
+| ---------------------- | -------------------------------------------------------------------------------------- |
+| `WAYFINDER_API_KEY`    | The user's `wf_…` Wayfinder API key. Picked up automatically by config priority below. |
+| `OPENCODE_INSTANCE_ID` | The Wayfinder Cloud identifier for this runtime. Useful for logs / diagnostics.        |
 
-Config priority: `Constructor parameter > config.json > WAYFINDER_API_KEY env var`. On hosted instances you do **not** need to write the key into `config.json`.
+Config priority: `Constructor parameter > config.json > WAYFINDER_API_KEY env var`. On Wayfinder Cloud you do **not** need to write the key into `config.json`.
 
 ## Project Overview
 
@@ -442,12 +440,12 @@ Strategies extend `wayfinder_paths.core.strategies.Strategy` and must implement:
 
 ## Wallets
 
-**On a hosted OpenCode instance, ALL wallets MUST be remote. No local wallets — ever.** Remote wallets are Privy server wallets managed by vault-backend, which gives us analytics, activity tracking, and session-aware policies. Local wallets are invisible to the rest of the platform and break those guarantees. The `wallets` MCP tool enforces this and will reject local-wallet creation when an OpenCode server is reachable.
+**On Wayfinder Cloud, ALL wallets MUST be remote. No local wallets — ever.** Remote wallets are managed for you and provide analytics, activity tracking, and session-aware policies. Local wallets are invisible to the rest of the platform and break those guarantees. The `wallets` MCP tool enforces this and will reject local-wallet creation when running on Wayfinder Cloud.
 
-**Always read wallets through the MCP CLI. Never grep `config.json` for `wallets[]` or read wallet files directly.** The MCP wallet resource is the only source of truth — on a hosted instance the remote wallets live in vault-backend (not in `config.json`), so reading the file misses them entirely.
+**Always read wallets through the MCP CLI. Never grep `config.json` for `wallets[]` or read wallet files directly.** The MCP wallet resource is the only source of truth — on Wayfinder Cloud the remote wallets are not in `config.json`, so reading the file misses them entirely.
 
 ```bash
-# List all wallets (returns remote wallets on hosted instances; merged local + remote elsewhere)
+# List all wallets (returns remote wallets on Wayfinder Cloud; merged local + remote elsewhere)
 poetry run python -m wayfinder_paths.mcp.cli resource wayfinder://wallets
 
 # Get a single wallet by label (includes profile / tracked protocols)
@@ -460,13 +458,13 @@ poetry run python -m wayfinder_paths.mcp.cli resource wayfinder://balances/main
 poetry run python -m wayfinder_paths.mcp.cli resource wayfinder://activity/main
 ```
 
-To create a wallet on a hosted instance, always pass `--remote`:
+To create a wallet on Wayfinder Cloud, always pass `--remote`:
 
 ```bash
 poetry run python -m wayfinder_paths.mcp.cli wallets --action create --label main --remote
 ```
 
-(Local wallet creation is only valid in a developer's machine outside of OpenCode — on a hosted instance the same command without `--remote` returns `Local wallets are discouraged for OpenCode instances`.)
+(Local wallet creation is only valid on a developer's local machine — on Wayfinder Cloud the same command without `--remote` returns `Local wallets are discouraged`.)
 
 In Python scripts, prefer the helpers in `wayfinder_paths.mcp.utils` (`load_wallets`, `find_wallet_by_label`) — they hit the same code path as the resource and return remote wallets transparently.
 
@@ -476,7 +474,7 @@ Config priority: Constructor parameter > config.json > Environment variable (`WA
 
 Copy `config.example.json` to `config.json` (or run `python3 scripts/setup.py`) for local development.
 
-On hosted OpenCode instances, the API key comes from the `WAYFINDER_API_KEY` env var (set by vault-backend at machine creation) and `OPENCODE_INSTANCE_ID` identifies the Fly app — see [Hosted instance environment variables](#hosted-instance-environment-variables).
+On Wayfinder Cloud, the API key comes from the `WAYFINDER_API_KEY` env var and `OPENCODE_INSTANCE_ID` identifies the runtime — see [Wayfinder Cloud environment variables](#wayfinder-cloud-environment-variables).
 
 ## CI/CD Pipeline
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This file provides guidance when working with code in this repository.
 
 **IMPORTANT: On every new conversation, check if setup is needed:**
 
-1. **Detect Wayfinder Cloud first.** Probe `http://localhost:4096/global/health`. If it returns `{ "healthy": true, ... }`, you are running inside Wayfinder Cloud — the SDK is already installed at `/wf/sdk`, the API key is already in the environment, and remote wallets are managed for you. **Do NOT run `setup.py`, do NOT prompt for an API key, do NOT touch `config.json`** — proceed normally.
+1. **Detect Cloud Instance first.** Probe `http://localhost:4096/global/health`. If it returns `{ "healthy": true, ... }`, you are running inside a Cloud instance — the SDK is already installed at `/wf/sdk`, the API key is already in the environment, and remote wallets are managed for you. **Do NOT run `setup.py`, do NOT prompt for an API key, do NOT touch `config.json`** — proceed normally.
 
 2. If `config.json` does NOT exist:
    - Run: `python3 scripts/setup.py`
@@ -21,7 +21,7 @@ This file provides guidance when working with code in this repository.
 
 4. If everything is configured, proceed normally
 
-## Wayfinder Cloud environment variables
+## Wayfinder Cloud Instance Environment Variables
 
 When the SDK runs inside Wayfinder Cloud, two env vars are injected at startup:
 
@@ -30,7 +30,7 @@ When the SDK runs inside Wayfinder Cloud, two env vars are injected at startup:
 | `WAYFINDER_API_KEY`    | The user's `wf_…` Wayfinder API key. Picked up automatically by config priority below. |
 | `OPENCODE_INSTANCE_ID` | The Wayfinder Cloud identifier for this runtime. Useful for logs / diagnostics.        |
 
-Config priority: `Constructor parameter > config.json > WAYFINDER_API_KEY env var`. On Wayfinder Cloud you do **not** need to write the key into `config.json`.
+Config priority: `Constructor parameter > config.json > WAYFINDER_API_KEY env var`.
 
 ## Project Overview
 
@@ -440,7 +440,7 @@ Strategies extend `wayfinder_paths.core.strategies.Strategy` and must implement:
 
 ## Wallets
 
-**On Wayfinder Cloud, ALL wallets MUST be remote. No local wallets — ever.** Remote wallets are managed for you and provide analytics, activity tracking, and session-aware policies. Local wallets are invisible to the rest of the platform and break those guarantees. The `wallets` MCP tool enforces this and will reject local-wallet creation when running on Wayfinder Cloud.
+**On Wayfinder Cloud Instances, ALL wallets MUST be remote. No local wallets — ever.** Remote wallets are managed for you and provide analytics, activity tracking, and session-aware policies. Local wallets are invisible to the rest of the platform and break those guarantees. The `wallets` MCP tool enforces this and will reject local-wallet creation when running on Wayfinder Cloud.
 
 **Always read wallets through the MCP CLI. Never grep `config.json` for `wallets[]` or read wallet files directly.** The MCP wallet resource is the only source of truth — on Wayfinder Cloud the remote wallets are not in `config.json`, so reading the file misses them entirely.
 
@@ -449,22 +449,20 @@ Strategies extend `wayfinder_paths.core.strategies.Strategy` and must implement:
 poetry run python -m wayfinder_paths.mcp.cli resource wayfinder://wallets
 
 # Get a single wallet by label (includes profile / tracked protocols)
-poetry run python -m wayfinder_paths.mcp.cli resource wayfinder://wallets/main
+poetry run python -m wayfinder_paths.mcp.cli resource wayfinder://wallets/{label}
 
 # Wallet balances (USD-aggregated, per-chain breakdown, spam-filtered)
-poetry run python -m wayfinder_paths.mcp.cli resource wayfinder://balances/main
+poetry run python -m wayfinder_paths.mcp.cli resource wayfinder://balances/{label}
 
 # Recent on-chain activity
-poetry run python -m wayfinder_paths.mcp.cli resource wayfinder://activity/main
+poetry run python -m wayfinder_paths.mcp.cli resource wayfinder://activity/{label}
 ```
 
-To create a wallet on Wayfinder Cloud, always pass `--remote`:
+To create a wallet on a Wayfinder Cloud Instance, always pass `--remote`:
 
 ```bash
 poetry run python -m wayfinder_paths.mcp.cli wallets --action create --label main --remote
 ```
-
-(Local wallet creation is only valid on a developer's local machine — on Wayfinder Cloud the same command without `--remote` returns `Local wallets are discouraged`.)
 
 In Python scripts, prefer the helpers in `wayfinder_paths.mcp.utils` (`load_wallets`, `find_wallet_by_label`) — they hit the same code path as the resource and return remote wallets transparently.
 
@@ -474,7 +472,7 @@ Config priority: Constructor parameter > config.json > Environment variable (`WA
 
 Copy `config.example.json` to `config.json` (or run `python3 scripts/setup.py`) for local development.
 
-On Wayfinder Cloud, the API key comes from the `WAYFINDER_API_KEY` env var and `OPENCODE_INSTANCE_ID` identifies the runtime — see [Wayfinder Cloud environment variables](#wayfinder-cloud-environment-variables).
+On a Wayfinder Cloud Instance, the API key comes from the `WAYFINDER_API_KEY` env var and `OPENCODE_INSTANCE_ID` identifies the runtime — see [Wayfinder Cloud environment variables](#wayfinder-cloud-environment-variables).
 
 ## CI/CD Pipeline
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -442,12 +442,12 @@ Strategies extend `wayfinder_paths.core.strategies.Strategy` and must implement:
 
 ## Wallets
 
-**Always read wallets through the MCP CLI. Never grep `config.json` for `wallets[]` or read wallet files directly.**
+**On a hosted OpenCode instance, ALL wallets MUST be remote. No local wallets — ever.** Remote wallets are Privy server wallets managed by vault-backend, which gives us analytics, activity tracking, and session-aware policies. Local wallets are invisible to the rest of the platform and break those guarantees. The `wallets` MCP tool enforces this and will reject local-wallet creation when an OpenCode server is reachable.
 
-The MCP wallet resource is the only source of truth that returns the merged set of local + remote wallets. On a hosted OpenCode instance, remote wallets live in vault-backend (Privy server wallets) and are NOT in `config.json` — reading the file misses them entirely.
+**Always read wallets through the MCP CLI. Never grep `config.json` for `wallets[]` or read wallet files directly.** The MCP wallet resource is the only source of truth — on a hosted instance the remote wallets live in vault-backend (not in `config.json`), so reading the file misses them entirely.
 
 ```bash
-# List all wallets (local + remote, with labels, addresses, chain types)
+# List all wallets (returns remote wallets on hosted instances; merged local + remote elsewhere)
 poetry run python -m wayfinder_paths.mcp.cli resource wayfinder://wallets
 
 # Get a single wallet by label (includes profile / tracked protocols)
@@ -460,17 +460,15 @@ poetry run python -m wayfinder_paths.mcp.cli resource wayfinder://balances/main
 poetry run python -m wayfinder_paths.mcp.cli resource wayfinder://activity/main
 ```
 
-To create a wallet, use the `wallets` tool (not direct file edits):
+To create a wallet on a hosted instance, always pass `--remote`:
 
 ```bash
-# Create a remote (Privy) wallet — required on hosted OpenCode instances
 poetry run python -m wayfinder_paths.mcp.cli wallets --action create --label main --remote
-
-# Create a local wallet — only allowed when not running on a hosted instance
-poetry run python -m wayfinder_paths.mcp.cli wallets --action create --label main
 ```
 
-In Python scripts, prefer the helpers in `wayfinder_paths.mcp.utils` (`load_wallets`, `find_wallet_by_label`) — they hit the same code path as the resource and merge local + remote.
+(Local wallet creation is only valid in a developer's machine outside of OpenCode — on a hosted instance the same command without `--remote` returns `Local wallets are discouraged for OpenCode instances`.)
+
+In Python scripts, prefer the helpers in `wayfinder_paths.mcp.utils` (`load_wallets`, `find_wallet_by_label`) — they hit the same code path as the resource and return remote wallets transparently.
 
 ## Configuration
 


### PR DESCRIPTION
### Summary
- First-time setup probes \`http://localhost:4096/global/health\` first; if OpenCode is healthy, skip setup.py / API key prompts.
- New "Hosted instance environment variables" section documenting \`WAYFINDER_API_KEY\` and \`OPENCODE_INSTANCE_ID\` (both injected by vault-backend \`InstanceService\`).
- New "Wallets" section: on hosted instances ALL wallets MUST be remote (Privy server wallets) for analytics, tracking, and session purposes. Read wallets only via the MCP CLI \`resource wayfinder://wallets\` — never grep \`config.json\` since the file misses remote wallets entirely.