### PR TITLE
Delta lab update ts

### DIFF
--- a/.claude/skills/using-delta-lab/MCP_INTEGRATION.md
+++ b/.claude/skills/using-delta-lab/MCP_INTEGRATION.md
@@ -160,7 +160,10 @@ ReadMcpResourceTool(
 ```
 
 ### 8. Asset Timeseries (Quick Snapshots)
-**URI:** `wayfinder://delta-lab/{symbol}/timeseries/{series}/{lookback_days}/{limit}`
+**URIs:**
+- `wayfinder://delta-lab/{symbol}/timeseries/{series}/{lookback_days}/{limit}`
+- `wayfinder://delta-lab/{symbol}/timeseries/{series}/{lookback_days}/{limit}/{venue}`
+- `wayfinder://delta-lab/{symbol}/timeseries/{series}/{lookback_days}/{limit}/{venue}/{basis}`
 
 **MCP Philosophy:** SHORT, interpretable results only. For serious analysis, use the client.
 
@@ -169,18 +172,14 @@ ReadMcpResourceTool(
 - `{series}` - Data series: "price" (default), "yield", "lending", "funding", "pendle", "boros", "rates" (all rates), or empty for all
 - `{lookback_days}` - Number of days to look back (default: "7" for quick snapshot)
 - `{limit}` - Maximum data points per series (default: "100", max: "10000")
+- `{venue}` - Venue name prefix to filter on (e.g. "moonwell", "hyperliquid"). Use `_` for no filter (default). Applied to funding, lending, pendle, boros series.
+- `{basis}` - Whether to expand symbol to basis group members for lending (default: "true"). Set to "false" for exact symbol matches only (asset mode). E.g. USDC with basis=true returns sUSDC pools too; basis=false returns only USDC pools.
 
 **Available Series:** `price`, `yield`, `lending`, `funding`, `pendle`, `boros`, `rates` (all rates), or empty string (all series)
 
-**⚠️ Lending Data Limitation:** The `limit` parameter is **global across all venues/markets**, not per-market. For multi-venue assets like BTC (52 lending markets), requesting lending data with a 1000-point limit will return ~20 timestamps (1000 ÷ 52) instead of 1000 timestamps. This can result in large responses (300KB+) with limited time coverage.
+**Venue filter:** The `venue` parameter solves the old limit-vs-lookback conflict. Previously, requesting lending data for a multi-venue asset with a limit of 1000 would return data across ALL venues, cutting off some. With `venue`, you get the full data window for a single venue.
 
-**Workarounds:**
-- Use `price` or `funding` series for longer time ranges (single record per timestamp)
-- For lending data, use the client with post-filtering by venue:
-  ```python
-  data = await DELTA_LAB_CLIENT.get_asset_timeseries("BTC", series="lending", limit=10000)
-  moonwell = data["lending"][data["lending"]["venue"] == "moonwell"]
-  ```
+**Basis vs Asset mode:** By default (`basis=true`), lending series expand the query symbol to all basis group members. E.g. querying "USDC" also returns sUSDC, aUSDC, etc. Set `basis=false` to restrict to exact symbol matches only — useful when you know exactly which asset's pools you want.
 
 **Note:** MCP resource returns JSON arrays. For DataFrame formatting, use the client (see below).
 
@@ -197,6 +196,30 @@ ReadMcpResourceTool(
     server="wayfinder",
     uri="wayfinder://delta-lab/BTC/timeseries/funding/7/100"
 )
+
+# ✅ Moonwell USDC lending rates (venue filter — guarantees full time coverage)
+ReadMcpResourceTool(
+    server="wayfinder",
+    uri="wayfinder://delta-lab/USDC/timeseries/lending/30/800/moonwell"
+)
+
+# ✅ Hyperliquid BTC funding only
+ReadMcpResourceTool(
+    server="wayfinder",
+    uri="wayfinder://delta-lab/BTC/timeseries/funding/14/500/hyperliquid"
+)
+
+# ✅ USDC lending as exact asset (no sUSDC etc.)
+ReadMcpResourceTool(
+    server="wayfinder",
+    uri="wayfinder://delta-lab/USDC/timeseries/lending/30/800/_/false"
+)
+
+# ✅ Moonwell USDC lending, asset mode only
+ReadMcpResourceTool(
+    server="wayfinder",
+    uri="wayfinder://delta-lab/USDC/timeseries/lending/30/800/moonwell/false"
+)
 ```
 
 **Client Examples (Serious Analysis):**
@@ -210,28 +233,38 @@ data = await DELTA_LAB_CLIENT.get_asset_timeseries(
 )
 data["price"]["price_usd"].plot(title="ETH 30-day Price")
 
-# ✅ Analyze lending rates (filter by venue)
+# ✅ Get Moonwell lending rates directly (no post-filtering needed)
 data = await DELTA_LAB_CLIENT.get_asset_timeseries(
-    symbol="BTC",
+    symbol="USDC",
     series="lending",
     lookback_days=30,
-    limit=10000
+    limit=800,
+    venue="moonwell",
 )
-lending_df = data["lending"]
-moonwell = lending_df[lending_df["venue"] == "moonwell"]
-moonwell["supply_apr"].plot(title="BTC Supply APR (Moonwell)")
+lending_df = data["lending"]  # All rows are Moonwell
 
-# ✅ Compare funding across venues
-data = await DELTA_LAB_CLIENT.get_asset_timeseries("BTC", series="funding", lookback_days=14)
-funding_df = data["funding"]
-for venue in funding_df["venue"].unique():
-    venue_data = funding_df[funding_df["venue"] == venue]
-    venue_data["funding_rate"].plot(label=venue)
+# ✅ USDC as exact asset (not basis group)
+data = await DELTA_LAB_CLIENT.get_asset_timeseries(
+    symbol="USDC",
+    series="lending",
+    lookback_days=30,
+    limit=800,
+    venue="moonwell",
+    basis=False,
+)
+
+# ✅ Compare funding across venues (or filter to one)
+data = await DELTA_LAB_CLIENT.get_asset_timeseries(
+    symbol="BTC",
+    series="funding",
+    lookback_days=14,
+    venue="hyperliquid",
+)
 ```
 
 **When to use MCP vs Client:**
-- **MCP:** "Show recent price", "What's the funding rate?", quick sanity checks
-- **Client:** Plotting, filtering, aggregating, multi-day analysis, lending data
+- **MCP:** "Show recent price", "What's the funding rate?", quick sanity checks, venue-filtered snapshots
+- **Client:** Plotting, filtering, aggregating, multi-day analysis, DataFrame operations
 
 ### 9. Screen Price
 **URIs:**

--- a/.claude/skills/using-delta-lab/MCP_INTEGRATION.md
+++ b/.claude/skills/using-delta-lab/MCP_INTEGRATION.md
@@ -160,26 +160,33 @@ ReadMcpResourceTool(
 ```
 
 ### 8. Asset Timeseries (Quick Snapshots)
-**URIs:**
+
+**Asset timeseries (exact symbol, default):**
 - `wayfinder://delta-lab/{symbol}/timeseries/{series}/{lookback_days}/{limit}`
 - `wayfinder://delta-lab/{symbol}/timeseries/{series}/{lookback_days}/{limit}/{venue}`
-- `wayfinder://delta-lab/{symbol}/timeseries/{series}/{lookback_days}/{limit}/{venue}/{basis}`
+
+**Basis timeseries (expands to basis group members):**
+- `wayfinder://delta-lab/basis/{symbol}/timeseries/{series}/{lookback_days}/{limit}`
+- `wayfinder://delta-lab/basis/{symbol}/timeseries/{series}/{lookback_days}/{limit}/{venue}`
 
 **MCP Philosophy:** SHORT, interpretable results only. For serious analysis, use the client.
 
 **Path Parameters:**
-- `{symbol}` - Asset symbol (e.g., "ETH", "BTC")
+- `{symbol}` - Asset symbol (e.g., "USDC", "ETH")
 - `{series}` - Data series: "price" (default), "yield", "lending", "funding", "pendle", "boros", "rates" (all rates), or empty for all
 - `{lookback_days}` - Number of days to look back (default: "7" for quick snapshot)
 - `{limit}` - Maximum data points per series (default: "100", max: "10000")
-- `{venue}` - Venue name prefix to filter on (e.g. "moonwell", "hyperliquid"). Use `_` for no filter (default). Applied to funding, lending, pendle, boros series.
-- `{basis}` - Whether to expand symbol to basis group members for lending (default: "true"). Set to "false" for exact symbol matches only (asset mode). E.g. USDC with basis=true returns sUSDC pools too; basis=false returns only USDC pools.
+- `{venue}` - Venue name prefix to filter on (e.g. "moonwell", "hyperliquid"). Use `_` for no filter.
 
 **Available Series:** `price`, `yield`, `lending`, `funding`, `pendle`, `boros`, `rates` (all rates), or empty string (all series)
 
-**Venue filter:** The `venue` parameter solves the old limit-vs-lookback conflict. Previously, requesting lending data for a multi-venue asset with a limit of 1000 would return data across ALL venues, cutting off some. With `venue`, you get the full data window for a single venue.
+**Asset vs Basis mode:**
+- **Asset (default):** `{symbol}/timeseries/...` — returns data for the exact symbol only. "USDC" returns only USDC pools.
+- **Basis:** `basis/{symbol}/timeseries/...` — expands the symbol to all basis group members. "USDC" returns USDC + sUSDC + aUSDC etc.
 
-**Basis vs Asset mode:** By default (`basis=true`), lending series expand the query symbol to all basis group members. E.g. querying "USDC" also returns sUSDC, aUSDC, etc. Set `basis=false` to restrict to exact symbol matches only — useful when you know exactly which asset's pools you want.
+Use asset mode (the default) when you know what you want. Use basis mode when exploring all related assets.
+
+**Venue filter:** Solves the old limit-vs-lookback conflict. Previously, a limit of 1000 across 50 venues meant ~20 rows per venue. With `venue`, you get the full data window for a single venue.
 
 **Note:** MCP resource returns JSON arrays. For DataFrame formatting, use the client (see below).
 
@@ -191,13 +198,7 @@ ReadMcpResourceTool(
     uri="wayfinder://delta-lab/ETH/timeseries/price/7/100"
 )
 
-# Recent funding rates
-ReadMcpResourceTool(
-    server="wayfinder",
-    uri="wayfinder://delta-lab/BTC/timeseries/funding/7/100"
-)
-
-# ✅ Moonwell USDC lending rates (venue filter — guarantees full time coverage)
+# ✅ Moonwell USDC lending rates (exact asset + venue filter)
 ReadMcpResourceTool(
     server="wayfinder",
     uri="wayfinder://delta-lab/USDC/timeseries/lending/30/800/moonwell"
@@ -209,16 +210,16 @@ ReadMcpResourceTool(
     uri="wayfinder://delta-lab/BTC/timeseries/funding/14/500/hyperliquid"
 )
 
-# ✅ USDC lending as exact asset (no sUSDC etc.)
+# ✅ All USD-basis lending (USDC + sUSDC + aUSDC etc.)
 ReadMcpResourceTool(
     server="wayfinder",
-    uri="wayfinder://delta-lab/USDC/timeseries/lending/30/800/_/false"
+    uri="wayfinder://delta-lab/basis/USDC/timeseries/lending/7/500"
 )
 
-# ✅ Moonwell USDC lending, asset mode only
+# ✅ All USD-basis lending on Moonwell
 ReadMcpResourceTool(
     server="wayfinder",
-    uri="wayfinder://delta-lab/USDC/timeseries/lending/30/800/moonwell/false"
+    uri="wayfinder://delta-lab/basis/USDC/timeseries/lending/7/500/moonwell"
 )
 ```
 
@@ -233,7 +234,7 @@ data = await DELTA_LAB_CLIENT.get_asset_timeseries(
 )
 data["price"]["price_usd"].plot(title="ETH 30-day Price")
 
-# ✅ Get Moonwell lending rates directly (no post-filtering needed)
+# ✅ Moonwell USDC lending (exact asset is the default)
 data = await DELTA_LAB_CLIENT.get_asset_timeseries(
     symbol="USDC",
     series="lending",
@@ -241,19 +242,18 @@ data = await DELTA_LAB_CLIENT.get_asset_timeseries(
     limit=800,
     venue="moonwell",
 )
-lending_df = data["lending"]  # All rows are Moonwell
+lending_df = data["lending"]  # All rows are Moonwell USDC
 
-# ✅ USDC as exact asset (not basis group)
+# ✅ Expand to basis group (USDC + sUSDC + aUSDC etc.)
 data = await DELTA_LAB_CLIENT.get_asset_timeseries(
     symbol="USDC",
     series="lending",
-    lookback_days=30,
-    limit=800,
-    venue="moonwell",
-    basis=False,
+    lookback_days=7,
+    limit=500,
+    basis=True,
 )
 
-# ✅ Compare funding across venues (or filter to one)
+# ✅ Hyperliquid BTC funding only
 data = await DELTA_LAB_CLIENT.get_asset_timeseries(
     symbol="BTC",
     series="funding",

--- a/.claude/skills/using-delta-lab/rules/gotchas.md
+++ b/.claude/skills/using-delta-lab/rules/gotchas.md
@@ -6,6 +6,9 @@ Common mistakes and important considerations when using Delta Lab.
 
 | ❌ Wrong | ✅ Right | Why |
 |---------|---------|-----|
+| `screen_lending(basis="USDC")` | `screen_lending(basis="USD")` | USDC is an asset, not a basis symbol — use `USD` (MCP auto-resolves, client does not) |
+| `get_basis_apy_sources(limit=20)` for lending | Use `screen_lending` or `timeseries(series="lending")` | apy-sources is cross-instrument ranked — low-APY lending gets cut off |
+| `get_lending_timeseries("USDC")` | `get_asset_timeseries(symbol="USDC", series="lending")` | One method for all series, not per-series methods |
 | `ok, data = await DELTA_LAB_CLIENT...` | `data = await DELTA_LAB_CLIENT...` | Clients return data directly, not tuples |
 | `data["opportunities"]` | `data["directions"]["LONG"]` | Lending opps are in LONG direction |
 | `candidate["net_apy"]["value"]` | `candidate["net_apy"]` | net_apy is a float, not a dict |
@@ -14,8 +17,60 @@ Common mistakes and important considerations when using Delta Lab.
 | `max(opps, key=lambda x: x["apy"]["value"])` | `max([o for o in opps if o["apy"]["value"]], ...)` | APY can be null |
 | Using `candidates[0]` for lowest risk | Use `pareto_frontier` | Candidates sorted by APY, not risk |
 | Ignoring `warnings` field | Always check `result["warnings"]` | Data quality issues affect decisions |
+| `get_asset_timeseries(symbol="USDC", series="lending", limit=1000)` (no venue) | Add `venue="moonwell"` when you want one venue | Without venue filter, limit is shared across all venues — data gets cut off |
+| `get_asset_timeseries(symbol="USDC", series="lending")` expecting only USDC pools | Add `basis=False` for exact asset | Default `basis=True` expands to sUSDC, aUSDC, etc. |
 
-## 0. Client Return Pattern
+## 0. Basis Symbol vs Asset Symbol
+
+**Screening, apy-sources, and delta-neutral endpoints use basis symbols, not asset symbols.**
+
+Stablecoins like USDC, USDT, DAI are NOT basis symbols — they belong to the `USD` basis group. Similarly, wstETH → `ETH`, cbBTC → `BTC`.
+
+The MCP layer auto-resolves asset symbols to their root basis (e.g. `USDC` → `USD`), so MCP queries like `screen/lending/.../USDC` will work. But the Python client requires the correct basis symbol directly.
+
+```python
+# WRONG — USDC is not a basis symbol (client will 400)
+await DELTA_LAB_CLIENT.screen_lending(basis="USDC")
+
+# RIGHT — use the root basis symbol
+await DELTA_LAB_CLIENT.screen_lending(basis="USD")
+
+# To find any symbol's root basis:
+info = await DELTA_LAB_CLIENT.get_asset_basis(symbol="USDC")
+# -> {"basis": {"root_symbol": "USD", "role": "STABLE", ...}}
+```
+
+Common mappings: USDC/USDT/DAI → `USD`, wstETH/cbETH → `ETH`, cbBTC/WBTC → `BTC`.
+
+## 0b. apy-sources Is Cross-Instrument, Not Venue-Specific
+
+`get_basis_apy_sources()` returns a **ranked cross-instrument list** (perps, LPs, lending, Pendle, Boros) sorted by APY. A small `limit` (e.g. 20) will only show the highest-APY instruments — standard lending markets at 2-5% get crowded out by perps at 20%+.
+
+**If you want lending rates specifically:**
+- Use `screen_lending(basis="USD")` for a cross-venue snapshot
+- Use `get_asset_timeseries(symbol="USDC", series="lending", venue="moonwell")` for historical data from one venue
+
+**If you need all instrument types:** use a large limit (e.g. 500) with `get_basis_apy_sources()`.
+
+## 0c. One Method for All Timeseries
+
+There is no `get_lending_timeseries()` or `get_funding_timeseries()`. There's one method:
+
+```python
+data = await DELTA_LAB_CLIENT.get_asset_timeseries(
+    symbol="USDC",
+    series="lending",  # or "funding", "price", "pendle", "boros", "rates"
+    lookback_days=30,
+    limit=800,
+    venue="moonwell",  # optional venue filter
+    basis=False,        # optional: exact symbol only (no basis expansion)
+)
+lending_df = data["lending"]  # DataFrame keyed by series name
+```
+
+The `series` parameter selects which data to fetch. The return dict is keyed by series name.
+
+## 1. Client Return Pattern
 
 **CRITICAL: Delta Lab CLIENT returns data directly (not tuples).**
 

--- a/.claude/skills/using-delta-lab/rules/gotchas.md
+++ b/.claude/skills/using-delta-lab/rules/gotchas.md
@@ -18,7 +18,7 @@ Common mistakes and important considerations when using Delta Lab.
 | Using `candidates[0]` for lowest risk | Use `pareto_frontier` | Candidates sorted by APY, not risk |
 | Ignoring `warnings` field | Always check `result["warnings"]` | Data quality issues affect decisions |
 | `get_asset_timeseries(symbol="USDC", series="lending", limit=1000)` (no venue) | Add `venue="moonwell"` when you want one venue | Without venue filter, limit is shared across all venues — data gets cut off |
-| `get_asset_timeseries(symbol="USDC", series="lending")` expecting only USDC pools | Add `basis=False` for exact asset | Default `basis=True` expands to sUSDC, aUSDC, etc. |
+| `get_asset_timeseries(..., basis=True)` when you want one asset | Omit `basis` (defaults to `False`) | Default is exact asset; pass `basis=True` only to expand to basis group |
 
 ## 0. Basis Symbol vs Asset Symbol
 

--- a/.claude/skills/using-delta-lab/rules/high-value-reads.md
+++ b/.claude/skills/using-delta-lab/rules/high-value-reads.md
@@ -22,7 +22,8 @@ These are the core Delta Lab client methods you'll use most often.
 - "Find all WETH assets across chains" → `get_assets_by_address("0xC02a...")`
 - "Is ETH in a basis group?" → `get_asset_basis("ETH")`
 - "Get price history for plotting" → `get_asset_timeseries("ETH", series="price")`
-- "Compare lending rates over time" → `get_asset_timeseries("USDC", series="lending")`
+- "USDC lending over time" → `get_asset_timeseries("USDC", series="lending")` (exact asset, default)
+- "All stablecoin lending over time" → `get_asset_timeseries("USDC", series="lending", basis=True)` (expands to sUSDC etc.)
 
 **Important:** Delta Lab is **read-only** (discovery only, no execution).
 
@@ -441,28 +442,22 @@ if eth_basis["basis"] and weth_basis["basis"]:
 MCP timeseries defaults prioritize SHORT, interpretable results. For serious analysis, use the client.
 
 ```python
-# Quick snapshot: price, 7 days, 100 points (all defaults)
+# Quick snapshot: price, 7 days, 100 points
 ReadMcpResourceTool(
     server="wayfinder",
     uri="wayfinder://delta-lab/ETH/timeseries/price/7/100"
 )
 
-# Recent funding rates
-ReadMcpResourceTool(
-    server="wayfinder",
-    uri="wayfinder://delta-lab/BTC/timeseries/funding/7/100"
-)
-
-# ✅ Moonwell USDC lending (venue filter — full time coverage for one venue)
+# ✅ Moonwell USDC lending (exact asset + venue filter)
 ReadMcpResourceTool(
     server="wayfinder",
     uri="wayfinder://delta-lab/USDC/timeseries/lending/30/800/moonwell"
 )
 
-# ✅ USDC lending, exact asset only (no sUSDC etc.)
+# ✅ All USD-basis lending (USDC + sUSDC + aUSDC etc.)
 ReadMcpResourceTool(
     server="wayfinder",
-    uri="wayfinder://delta-lab/USDC/timeseries/lending/30/800/_/false"
+    uri="wayfinder://delta-lab/basis/USDC/timeseries/lending/7/500"
 )
 ```
 
@@ -478,7 +473,7 @@ data = await DELTA_LAB_CLIENT.get_asset_timeseries(
 )
 data["price"]["price_usd"].plot(title="ETH 30-day Price")
 
-# ✅ Moonwell USDC lending — venue filter guarantees full time window
+# ✅ Moonwell USDC lending (exact asset is the default)
 data = await DELTA_LAB_CLIENT.get_asset_timeseries(
     symbol="USDC",
     series="lending",
@@ -486,15 +481,15 @@ data = await DELTA_LAB_CLIENT.get_asset_timeseries(
     limit=800,
     venue="moonwell",
 )
-lending_df = data["lending"]  # All rows are Moonwell
+lending_df = data["lending"]  # All rows are Moonwell USDC only
 
-# ✅ Exact asset mode (basis=False) — only USDC pools, not sUSDC etc.
+# ✅ Expand to basis group (USDC + sUSDC + aUSDC etc.)
 data = await DELTA_LAB_CLIENT.get_asset_timeseries(
     symbol="USDC",
     series="lending",
-    lookback_days=30,
-    limit=800,
-    basis=False,
+    lookback_days=7,
+    limit=500,
+    basis=True,
 )
 ```
 
@@ -530,7 +525,7 @@ Returns `dict[str, pd.DataFrame]` with each series as a separate DataFrame:
 ### Filtering Parameters
 
 - **`venue`** (str | None): Venue name prefix to filter on (e.g. "moonwell", "hyperliquid"). Applied to series with venue data (funding, lending, pendle, boros). Solves the old limit-vs-lookback conflict — previously a 30-day lookback with 1000-point limit across 50 venues would cut off data; now you can isolate a single venue and get full coverage.
-- **`basis`** (bool, default True): Whether to expand the query symbol to all basis group members for lending series. `True` (default) = "USDC" includes sUSDC, aUSDC etc. `False` = exact symbol matches only. Useful when you know exactly which asset's pools you want.
+- **`basis`** (bool, default **False**): Whether to expand the query symbol to all basis group members for lending series. `False` (default) = exact symbol only ("USDC" returns only USDC pools). `True` = expand to basis group ("USDC" also includes sUSDC, aUSDC etc.). In MCP, use the `basis/{symbol}/timeseries/...` URI for basis mode.
 
 ### Use Cases
 

--- a/.claude/skills/using-delta-lab/rules/high-value-reads.md
+++ b/.claude/skills/using-delta-lab/rules/high-value-reads.md
@@ -10,8 +10,9 @@ These are the core Delta Lab client methods you'll use most often.
 - "What are the absolute best APYs right now?" → `get_top_apy()` (all symbols)
 - "What are the best APYs for BTC/ETH?" → `get_basis_apy_sources(basis_symbol="BTC")`
 - "Find me delta-neutral opportunities" → `get_best_delta_neutral_pairs()`
-- "What lending rates are available for X?" → `screen_lending(basis="ETH")` or `get_basis_apy_sources()` + filter
-- "Compare funding rates across venues" → `screen_perp(basis="BTC")` or `get_basis_apy_sources()` + filter
+- "What lending rates are available for X?" → `screen_lending(basis="ETH")` or `timeseries(series="lending", venue="moonwell")`
+- "USDC lending rates?" → `screen_lending(basis="USD")` (USDC → USD basis group; MCP auto-resolves)
+- "Compare funding rates across venues" → `screen_perp(basis="BTC")` or `timeseries(series="funding", venue="hyperliquid")`
 - "Show me the highest yield with lowest risk" → `get_best_delta_neutral_pairs()` + use `pareto_frontier`
 - "What are the top movers today?" → `screen_price(sort="ret_1d")`
 - "Which perps have highest funding?" → `screen_perp(sort="funding_now")`
@@ -451,11 +452,21 @@ ReadMcpResourceTool(
     server="wayfinder",
     uri="wayfinder://delta-lab/BTC/timeseries/funding/7/100"
 )
+
+# ✅ Moonwell USDC lending (venue filter — full time coverage for one venue)
+ReadMcpResourceTool(
+    server="wayfinder",
+    uri="wayfinder://delta-lab/USDC/timeseries/lending/30/800/moonwell"
+)
+
+# ✅ USDC lending, exact asset only (no sUSDC etc.)
+ReadMcpResourceTool(
+    server="wayfinder",
+    uri="wayfinder://delta-lab/USDC/timeseries/lending/30/800/_/false"
+)
 ```
 
 **Client (Serious Analysis - DataFrames):**
-
-For anything beyond quick snapshots (plotting, filtering, multi-day, multi-venue), use the client:
 
 ```python
 # Plot price history (30 days, 1000 points)
@@ -464,9 +475,27 @@ data = await DELTA_LAB_CLIENT.get_asset_timeseries(
     series="price",
     lookback_days=30,
     limit=1000,
-    as_of=None,  # Optional: query as of a specific time
 )
 data["price"]["price_usd"].plot(title="ETH 30-day Price")
+
+# ✅ Moonwell USDC lending — venue filter guarantees full time window
+data = await DELTA_LAB_CLIENT.get_asset_timeseries(
+    symbol="USDC",
+    series="lending",
+    lookback_days=30,
+    limit=800,
+    venue="moonwell",
+)
+lending_df = data["lending"]  # All rows are Moonwell
+
+# ✅ Exact asset mode (basis=False) — only USDC pools, not sUSDC etc.
+data = await DELTA_LAB_CLIENT.get_asset_timeseries(
+    symbol="USDC",
+    series="lending",
+    lookback_days=30,
+    limit=800,
+    basis=False,
+)
 ```
 
 ### Response Structure
@@ -498,49 +527,52 @@ Returns `dict[str, pd.DataFrame]` with each series as a separate DataFrame:
 - `"rates"` - Alias for all rate series (yield, lending, pendle, boros, funding)
 - `None` - Return all available series (default)
 
+### Filtering Parameters
+
+- **`venue`** (str | None): Venue name prefix to filter on (e.g. "moonwell", "hyperliquid"). Applied to series with venue data (funding, lending, pendle, boros). Solves the old limit-vs-lookback conflict — previously a 30-day lookback with 1000-point limit across 50 venues would cut off data; now you can isolate a single venue and get full coverage.
+- **`basis`** (bool, default True): Whether to expand the query symbol to all basis group members for lending series. `True` (default) = "USDC" includes sUSDC, aUSDC etc. `False` = exact symbol matches only. Useful when you know exactly which asset's pools you want.
+
 ### Use Cases
 
 **Plot price history:**
 ```python
-data = await DELTA_LAB_CLIENT.get_asset_timeseries("ETH", series="price", lookback_days=7)
+data = await DELTA_LAB_CLIENT.get_asset_timeseries(symbol="ETH", series="price", lookback_days=7)
 data["price"]["price_usd"].plot(title="ETH Price (7d)")
 ```
 
-**Compare lending rates across venues:**
+**Get lending rates for a specific venue:**
 ```python
-data = await DELTA_LAB_CLIENT.get_asset_timeseries("USDC", series="lending", lookback_days=30)
-lending_df = data["lending"]
+data = await DELTA_LAB_CLIENT.get_asset_timeseries(
+    symbol="USDC", series="lending", lookback_days=30, limit=800, venue="moonwell"
+)
+data["lending"]["supply_apr"].plot(title="USDC Supply APR (Moonwell)")
+```
 
-# Plot supply APR by venue
-import matplotlib.pyplot as plt
+**Compare lending rates across venues (no venue filter):**
+```python
+data = await DELTA_LAB_CLIENT.get_asset_timeseries(
+    symbol="USDC", series="lending", lookback_days=30, limit=5000
+)
+lending_df = data["lending"]
 for venue in lending_df["venue"].unique():
     venue_data = lending_df[lending_df["venue"] == venue]
-    plt.plot(venue_data.index, venue_data["supply_apr"], label=venue)
-plt.legend()
-plt.title("USDC Supply APR by Venue")
-plt.show()
+    venue_data["supply_apr"].plot(label=venue)
 ```
 
 **Analyze funding rate trends:**
 ```python
-data = await DELTA_LAB_CLIENT.get_asset_timeseries("BTC", series="funding", lookback_days=30)
-funding_df = data["funding"]
-
-# Calculate average funding rate by venue
-avg_funding = funding_df.groupby("venue")["funding_rate"].mean()
-print(avg_funding.sort_values(ascending=False))
+data = await DELTA_LAB_CLIENT.get_asset_timeseries(
+    symbol="BTC", series="funding", lookback_days=30, venue="hyperliquid"
+)
+data["funding"]["funding_rate"].plot(title="BTC Funding (Hyperliquid)")
 ```
 
 **Get all rate series at once:**
 ```python
-# Get price + all rate series
-data = await DELTA_LAB_CLIENT.get_asset_timeseries("ETH", series="price,rates", lookback_days=7)
-
-# Access each series
+data = await DELTA_LAB_CLIENT.get_asset_timeseries(symbol="ETH", series="price,rates", lookback_days=7)
 price_df = data["price"]
 lending_df = data["lending"]
 funding_df = data["funding"]
-# ... etc
 ```
 
 ## 7. Screening (Cross-Venue Feature Snapshots)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,8 @@ Alpha Lab is a **scored alpha insight feed** that surfaces actionable DeFi signa
 - `wayfinder://delta-lab/assets/by-address/{ADDRESS}` - Assets by contract address
 - `wayfinder://delta-lab/{SYMBOL}/basis` - Basis group membership
 - `wayfinder://delta-lab/{SYMBOL}/timeseries/{SERIES}/{LOOKBACK}/{LIMIT}` - Historical data (snapshots only)
+- `wayfinder://delta-lab/{SYMBOL}/timeseries/{SERIES}/{LOOKBACK}/{LIMIT}/{VENUE}` - Timeseries filtered by venue (e.g. "moonwell")
+- `wayfinder://delta-lab/{SYMBOL}/timeseries/{SERIES}/{LOOKBACK}/{LIMIT}/{VENUE}/{BASIS}` - Timeseries with venue + basis/asset mode ("true"/"false")
 - `wayfinder://delta-lab/screen/price/{SORT}/{LIMIT}/{BASIS}` - Screen assets by price features
 - `wayfinder://delta-lab/screen/lending/{SORT}/{LIMIT}/{BASIS}` - Screen lending markets
 - `wayfinder://delta-lab/screen/perp/{SORT}/{LIMIT}/{BASIS}` - Screen perp markets

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,9 +160,10 @@ Alpha Lab is a **scored alpha insight feed** that surfaces actionable DeFi signa
 - `wayfinder://delta-lab/assets/{asset_id}` - Asset metadata by ID
 - `wayfinder://delta-lab/assets/by-address/{ADDRESS}` - Assets by contract address
 - `wayfinder://delta-lab/{SYMBOL}/basis` - Basis group membership
-- `wayfinder://delta-lab/{SYMBOL}/timeseries/{SERIES}/{LOOKBACK}/{LIMIT}` - Historical data (snapshots only)
-- `wayfinder://delta-lab/{SYMBOL}/timeseries/{SERIES}/{LOOKBACK}/{LIMIT}/{VENUE}` - Timeseries filtered by venue (e.g. "moonwell")
-- `wayfinder://delta-lab/{SYMBOL}/timeseries/{SERIES}/{LOOKBACK}/{LIMIT}/{VENUE}/{BASIS}` - Timeseries with venue + basis/asset mode ("true"/"false")
+- `wayfinder://delta-lab/{SYMBOL}/timeseries/{SERIES}/{LOOKBACK}/{LIMIT}` - Timeseries for exact asset (no basis expansion)
+- `wayfinder://delta-lab/{SYMBOL}/timeseries/{SERIES}/{LOOKBACK}/{LIMIT}/{VENUE}` - Timeseries filtered by venue
+- `wayfinder://delta-lab/basis/{SYMBOL}/timeseries/{SERIES}/{LOOKBACK}/{LIMIT}` - Timeseries expanded to basis group (USDC → USDC+sUSDC+aUSDC...)
+- `wayfinder://delta-lab/basis/{SYMBOL}/timeseries/{SERIES}/{LOOKBACK}/{LIMIT}/{VENUE}` - Basis timeseries filtered by venue
 - `wayfinder://delta-lab/screen/price/{SORT}/{LIMIT}/{BASIS}` - Screen assets by price features
 - `wayfinder://delta-lab/screen/lending/{SORT}/{LIMIT}/{BASIS}` - Screen lending markets
 - `wayfinder://delta-lab/screen/perp/{SORT}/{LIMIT}/{BASIS}` - Screen perp markets

--- a/wayfinder_paths/core/backtesting/data.py
+++ b/wayfinder_paths/core/backtesting/data.py
@@ -319,6 +319,7 @@ async def fetch_borrow_rates(
             limit=10000,
             as_of=end,
             series="lending",
+            basis=True,
         )
 
         if "lending" in data:
@@ -467,6 +468,7 @@ async def fetch_supply_rates(
             limit=10000,
             as_of=end,
             series="lending",
+            basis=True,
         )
 
         if "lending" in data:
@@ -532,6 +534,7 @@ async def fetch_lending_rates(
         limit=10000,
         as_of=end,
         series="lending",
+        basis=True,
     )
 
     if "lending" not in data or data["lending"].empty:

--- a/wayfinder_paths/core/clients/DeltaLabClient.py
+++ b/wayfinder_paths/core/clients/DeltaLabClient.py
@@ -216,6 +216,8 @@ class DeltaLabClient(WayfinderClient):
         limit: int = 500,
         as_of: datetime | None = None,
         series: str | None = None,
+        venue: str | None = None,
+        basis: bool = True,
     ) -> dict[str, pd.DataFrame]:
         """
         Get timeseries data for an asset.
@@ -228,6 +230,13 @@ class DeltaLabClient(WayfinderClient):
             series: Comma-separated list of series to fetch (price, yield, lending,
                    funding, pendle, boros) or alias "rates" for all rate series.
                    If None, returns all series.
+            venue: Venue name prefix to filter on. Applied to series that support
+                   venue filtering (funding, lending, pendle, boros).
+                   E.g. "hyperliquid", "moonwell". None means no filter.
+            basis: Whether to expand the symbol to all basis group members for
+                   lending series (default: True). Set to False to restrict lending
+                   to exact symbol matches only (asset mode). E.g. USDC with
+                   basis=True returns sUSDC etc., basis=False returns only USDC pools.
 
         Returns:
             Dict mapping series names to DataFrames:
@@ -251,6 +260,10 @@ class DeltaLabClient(WayfinderClient):
             params["as_of"] = as_of.isoformat()
         if series is not None:
             params["series"] = series
+        if venue is not None:
+            params["venue"] = venue
+        if not basis:
+            params["basis"] = "false"
 
         response = await self._authed_request("GET", url, params=params)
         data = response.json()

--- a/wayfinder_paths/core/clients/DeltaLabClient.py
+++ b/wayfinder_paths/core/clients/DeltaLabClient.py
@@ -217,7 +217,7 @@ class DeltaLabClient(WayfinderClient):
         as_of: datetime | None = None,
         series: str | None = None,
         venue: str | None = None,
-        basis: bool = True,
+        basis: bool = False,
     ) -> dict[str, pd.DataFrame]:
         """
         Get timeseries data for an asset.
@@ -234,9 +234,9 @@ class DeltaLabClient(WayfinderClient):
                    venue filtering (funding, lending, pendle, boros).
                    E.g. "hyperliquid", "moonwell". None means no filter.
             basis: Whether to expand the symbol to all basis group members for
-                   lending series (default: True). Set to False to restrict lending
-                   to exact symbol matches only (asset mode). E.g. USDC with
-                   basis=True returns sUSDC etc., basis=False returns only USDC pools.
+                   lending series (default: False). Set to True to expand — e.g.
+                   USDC with basis=True returns sUSDC, aUSDC etc. in addition
+                   to USDC pools.
 
         Returns:
             Dict mapping series names to DataFrames:

--- a/wayfinder_paths/mcp/resources/delta_lab.py
+++ b/wayfinder_paths/mcp/resources/delta_lab.py
@@ -228,65 +228,120 @@ async def get_top_apy(lookback_days: str = "7", limit: str = "50") -> dict[str, 
         return {"error": str(exc)}
 
 
-async def get_asset_timeseries_data(
+async def _get_asset_timeseries_impl(
     symbol: str,
-    series: str = "price",
-    lookback_days: str = "7",
-    limit: str = "100",
+    series: str,
+    lookback_days: str,
+    limit: str,
     venue: str = "_",
-    basis: str = "true",
+    basis: bool = False,
 ) -> dict[str, Any]:
-    """Get timeseries data for an asset (MCP: quick snapshots only).
-
-    MCP defaults prioritize SHORT, interpretable results. For longer time ranges,
-    multi-venue lending data, or DataFrame-based analysis, use the client directly:
-    DELTA_LAB_CLIENT.get_asset_timeseries() (see /using-delta-lab skill).
-
-    Args:
-        symbol: Asset symbol (e.g., "ETH", "BTC")
-        series: Data series - "price" (default), "funding", "lending", "rates", etc.
-               Empty string = all series (can be large!)
-        lookback_days: Number of days to look back (default: "7" for quick snapshot)
-        limit: Maximum number of data points per series (default: "100", max: "10000")
-        venue: Venue name prefix to filter on (e.g. "moonwell", "hyperliquid").
-               Use "_" for no filter (default). Applied to funding, lending,
-               pendle, boros series.
-        basis: Whether to expand symbol to basis group members for lending
-               (default: "true"). Set to "false" to restrict to exact symbol
-               matches only (asset mode).
-
-    Returns:
-        Dict with series data as JSON arrays (use client for DataFrames)
-    """
+    """Shared implementation for timeseries MCP resources."""
     try:
         lookback_int = int(lookback_days)
         limit_int = int(limit)
         limit_int = min(10000, max(1, limit_int))  # Enforce 1-10000 range
         series_param = series if series else None  # Empty string -> None (all series)
         venue_param = venue.strip() if venue.strip() not in ("_", "") else None
-        basis_param = basis.strip().lower() != "false"
 
-        # Get DataFrames from client
         dataframes = await DELTA_LAB_CLIENT.get_asset_timeseries(
             symbol=symbol.upper(),
             lookback_days=lookback_int,
             limit=limit_int,
             series=series_param,
             venue=venue_param,
-            basis=basis_param,
+            basis=basis,
         )
 
-        # Convert DataFrames back to JSON arrays for MCP
         result: dict[str, Any] = {}
         for series_name, df in dataframes.items():
-            # Reset index to make ts a column again
             df_reset = df.reset_index()
-            # Convert to list of dicts
             result[series_name] = df_reset.to_dict("records")
 
         return result
     except Exception as exc:
         return {"error": str(exc)}
+
+
+async def get_asset_timeseries_data(
+    symbol: str,
+    series: str = "price",
+    lookback_days: str = "7",
+    limit: str = "100",
+) -> dict[str, Any]:
+    """Get timeseries data for an asset (exact symbol, no basis expansion).
+
+    Args:
+        symbol: Asset symbol (e.g., "USDC", "ETH")
+        series: Data series - "price" (default), "funding", "lending", "rates", etc.
+        lookback_days: Number of days to look back (default: "7")
+        limit: Maximum data points per series (default: "100", max: "10000")
+    """
+    return await _get_asset_timeseries_impl(symbol, series, lookback_days, limit)
+
+
+async def get_asset_timeseries_with_venue(
+    symbol: str,
+    series: str,
+    lookback_days: str,
+    limit: str,
+    venue: str,
+) -> dict[str, Any]:
+    """Get timeseries data for an asset filtered by venue (exact symbol, no basis expansion).
+
+    Args:
+        symbol: Asset symbol (e.g., "USDC", "ETH")
+        series: Data series - "price", "funding", "lending", "rates", etc.
+        lookback_days: Number of days to look back
+        limit: Maximum data points per series (max: "10000")
+        venue: Venue name prefix (e.g. "moonwell", "hyperliquid"). Use "_" for no filter.
+    """
+    return await _get_asset_timeseries_impl(
+        symbol, series, lookback_days, limit, venue=venue
+    )
+
+
+async def get_basis_timeseries_data(
+    symbol: str,
+    series: str,
+    lookback_days: str,
+    limit: str,
+) -> dict[str, Any]:
+    """Get timeseries data expanded to all basis group members.
+
+    Use this when you want data for all related assets — e.g. "USDC" returns
+    USDC + sUSDC + aUSDC etc., "ETH" returns ETH + wstETH + cbETH etc.
+
+    Args:
+        symbol: Basis symbol (e.g., "USDC", "ETH")
+        series: Data series - "price", "funding", "lending", "rates", etc.
+        lookback_days: Number of days to look back
+        limit: Maximum data points per series (max: "10000")
+    """
+    return await _get_asset_timeseries_impl(
+        symbol, series, lookback_days, limit, basis=True
+    )
+
+
+async def get_basis_timeseries_with_venue(
+    symbol: str,
+    series: str,
+    lookback_days: str,
+    limit: str,
+    venue: str,
+) -> dict[str, Any]:
+    """Get timeseries data expanded to all basis group members, filtered by venue.
+
+    Args:
+        symbol: Basis symbol (e.g., "USDC", "ETH")
+        series: Data series - "price", "funding", "lending", "rates", etc.
+        lookback_days: Number of days to look back
+        limit: Maximum data points per series (max: "10000")
+        venue: Venue name prefix (e.g. "moonwell", "hyperliquid"). Use "_" for no filter.
+    """
+    return await _get_asset_timeseries_impl(
+        symbol, series, lookback_days, limit, venue=venue, basis=True
+    )
 
 
 async def screen_price(

--- a/wayfinder_paths/mcp/resources/delta_lab.py
+++ b/wayfinder_paths/mcp/resources/delta_lab.py
@@ -1,9 +1,31 @@
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from wayfinder_paths.core.clients.DeltaLabClient import DELTA_LAB_CLIENT
 from wayfinder_paths.core.constants.chains import CHAIN_CODE_TO_ID
+
+logger = logging.getLogger(__name__)
+
+
+async def _resolve_basis_symbol(symbol: str) -> str:
+    """Resolve an asset symbol to its root basis symbol.
+
+    E.g. "USDC" -> "USD", "wstETH" -> "ETH". Returns the input unchanged
+    if it's already a root basis symbol or if resolution fails.
+    """
+    try:
+        result = await DELTA_LAB_CLIENT.get_asset_basis(symbol=symbol)
+        basis = result.get("basis")
+        if basis and basis.get("root_symbol"):
+            root = basis["root_symbol"]
+            if root != symbol:
+                logger.debug("Resolved basis symbol %s -> %s", symbol, root)
+            return root
+    except Exception:
+        pass
+    return symbol
 
 
 async def get_basis_apy_sources(
@@ -25,8 +47,9 @@ async def get_basis_apy_sources(
         limit_int = int(limit)
         limit_int = min(1000, max(1, limit_int))  # Enforce 1-1000 range
 
+        resolved = await _resolve_basis_symbol(basis_symbol.upper())
         result = await DELTA_LAB_CLIENT.get_basis_apy_sources(
-            basis_symbol=basis_symbol.upper(),
+            basis_symbol=resolved,
             lookback_days=lookback_int,
             limit=limit_int,
         )
@@ -54,8 +77,9 @@ async def get_best_delta_neutral_pairs(
         limit_int = int(limit)
         limit_int = min(100, max(1, limit_int))  # Enforce 1-100 range
 
+        resolved = await _resolve_basis_symbol(basis_symbol.upper())
         result = await DELTA_LAB_CLIENT.get_best_delta_neutral_pairs(
-            basis_symbol=basis_symbol.upper(),
+            basis_symbol=resolved,
             lookback_days=lookback_int,
             limit=limit_int,
         )
@@ -209,6 +233,8 @@ async def get_asset_timeseries_data(
     series: str = "price",
     lookback_days: str = "7",
     limit: str = "100",
+    venue: str = "_",
+    basis: str = "true",
 ) -> dict[str, Any]:
     """Get timeseries data for an asset (MCP: quick snapshots only).
 
@@ -222,6 +248,12 @@ async def get_asset_timeseries_data(
                Empty string = all series (can be large!)
         lookback_days: Number of days to look back (default: "7" for quick snapshot)
         limit: Maximum number of data points per series (default: "100", max: "10000")
+        venue: Venue name prefix to filter on (e.g. "moonwell", "hyperliquid").
+               Use "_" for no filter (default). Applied to funding, lending,
+               pendle, boros series.
+        basis: Whether to expand symbol to basis group members for lending
+               (default: "true"). Set to "false" to restrict to exact symbol
+               matches only (asset mode).
 
     Returns:
         Dict with series data as JSON arrays (use client for DataFrames)
@@ -231,6 +263,8 @@ async def get_asset_timeseries_data(
         limit_int = int(limit)
         limit_int = min(10000, max(1, limit_int))  # Enforce 1-10000 range
         series_param = series if series else None  # Empty string -> None (all series)
+        venue_param = venue.strip() if venue.strip() not in ("_", "") else None
+        basis_param = basis.strip().lower() != "false"
 
         # Get DataFrames from client
         dataframes = await DELTA_LAB_CLIENT.get_asset_timeseries(
@@ -238,6 +272,8 @@ async def get_asset_timeseries_data(
             lookback_days=lookback_int,
             limit=limit_int,
             series=series_param,
+            venue=venue_param,
+            basis=basis_param,
         )
 
         # Convert DataFrames back to JSON arrays for MCP
@@ -265,14 +301,18 @@ async def screen_price(
               price_usd, ret_1d, ret_7d, ret_30d, ret_90d,
               vol_7d, vol_30d, vol_90d, mdd_30d, mdd_90d
         limit: Max rows to return (default: "100", max: "1000")
-        basis: Basis symbol to filter by (e.g. "ETH", "BTC"). Use "all" for no filter.
+        basis: Basis symbol or asset symbol to filter by (e.g. "ETH", "USDC").
+               Asset symbols are auto-resolved to their root basis (USDC -> USD).
+               Use "all" for no filter.
 
     Returns:
         Dict with data (list of price feature rows) and count
     """
     try:
         limit_int = min(1000, max(1, int(limit)))
-        basis_param = basis.strip().upper() if basis.strip().lower() != "all" else None
+        basis_param = None
+        if basis.strip().lower() != "all":
+            basis_param = await _resolve_basis_symbol(basis.strip().upper())
         result = await DELTA_LAB_CLIENT.screen_price(
             sort=sort.strip(),
             limit=limit_int,
@@ -335,14 +375,18 @@ async def screen_lending(
               combined_net_supply_apr_now, net_borrow_apr_now,
               supply_tvl_usd, liquidity_usd, util_now, borrow_spike_score
         limit: Max rows to return (default: "100", max: "1000")
-        basis: Basis symbol to filter by (e.g. "ETH", "BTC"). Use "all" for no filter.
+        basis: Basis symbol or asset symbol to filter by (e.g. "ETH", "USDC").
+               Asset symbols are auto-resolved to their root basis (USDC -> USD).
+               Use "all" for no filter.
 
     Returns:
         Dict with data (list of lending surface feature rows) and count
     """
     try:
         limit_int = min(1000, max(1, int(limit)))
-        basis_param = basis.strip().upper() if basis.strip().lower() != "all" else None
+        basis_param = None
+        if basis.strip().lower() != "all":
+            basis_param = await _resolve_basis_symbol(basis.strip().upper())
         result = await DELTA_LAB_CLIENT.screen_lending(
             sort=sort.strip(),
             limit=limit_int,
@@ -407,14 +451,18 @@ async def screen_perp(
               basis_now, basis_mean_7d, basis_mean_30d,
               oi_now, volume_24h, mark_price
         limit: Max rows to return (default: "100", max: "1000")
-        basis: Basis symbol to filter by (e.g. "ETH", "BTC"). Use "all" for no filter.
+        basis: Basis symbol or asset symbol to filter by (e.g. "ETH", "USDC").
+               Asset symbols are auto-resolved to their root basis (USDC -> USD).
+               Use "all" for no filter.
 
     Returns:
         Dict with data (list of perp surface feature rows) and count
     """
     try:
         limit_int = min(1000, max(1, int(limit)))
-        basis_param = basis.strip().upper() if basis.strip().lower() != "all" else None
+        basis_param = None
+        if basis.strip().lower() != "all":
+            basis_param = await _resolve_basis_symbol(basis.strip().upper())
         result = await DELTA_LAB_CLIENT.screen_perp(
             sort=sort.strip(),
             limit=limit_int,
@@ -488,12 +536,14 @@ async def screen_borrow_routes(
     """
     try:
         limit_int = min(1000, max(1, int(limit)))
-        basis_param = basis.strip().upper() if basis.strip().lower() != "all" else None
-        borrow_basis_param = (
-            borrow_basis.strip().upper()
-            if borrow_basis.strip().lower() != "all"
-            else None
-        )
+        basis_param = None
+        if basis.strip().lower() != "all":
+            basis_param = await _resolve_basis_symbol(basis.strip().upper())
+        borrow_basis_param = None
+        if borrow_basis.strip().lower() != "all":
+            borrow_basis_param = await _resolve_basis_symbol(
+                borrow_basis.strip().upper()
+            )
         chain_id_param = None
         chain_value = chain_id.strip().lower()
         if chain_value not in ("all", "_"):

--- a/wayfinder_paths/mcp/server.py
+++ b/wayfinder_paths/mcp/server.py
@@ -121,6 +121,12 @@ mcp.resource("wayfinder://delta-lab/{symbol}/basis")(get_asset_basis_info)
 mcp.resource(
     "wayfinder://delta-lab/{symbol}/timeseries/{series}/{lookback_days}/{limit}"
 )(get_asset_timeseries_data)
+mcp.resource(
+    "wayfinder://delta-lab/{symbol}/timeseries/{series}/{lookback_days}/{limit}/{venue}"
+)(get_asset_timeseries_data)
+mcp.resource(
+    "wayfinder://delta-lab/{symbol}/timeseries/{series}/{lookback_days}/{limit}/{venue}/{basis}"
+)(get_asset_timeseries_data)
 mcp.resource("wayfinder://delta-lab/screen/price/{sort}/{limit}/{basis}")(screen_price)
 mcp.resource(
     "wayfinder://delta-lab/screen/price/by-asset-ids/{sort}/{limit}/{asset_ids}"

--- a/wayfinder_paths/mcp/server.py
+++ b/wayfinder_paths/mcp/server.py
@@ -18,9 +18,12 @@ from wayfinder_paths.mcp.resources.contracts import (
 from wayfinder_paths.mcp.resources.delta_lab import (
     get_asset_basis_info,
     get_asset_timeseries_data,
+    get_asset_timeseries_with_venue,
     get_assets_by_address,
     get_basis_apy_sources,
     get_basis_symbols,
+    get_basis_timeseries_data,
+    get_basis_timeseries_with_venue,
     get_best_delta_neutral_pairs,
     get_delta_lab_asset,
     get_top_apy,
@@ -123,10 +126,13 @@ mcp.resource(
 )(get_asset_timeseries_data)
 mcp.resource(
     "wayfinder://delta-lab/{symbol}/timeseries/{series}/{lookback_days}/{limit}/{venue}"
-)(get_asset_timeseries_data)
+)(get_asset_timeseries_with_venue)
 mcp.resource(
-    "wayfinder://delta-lab/{symbol}/timeseries/{series}/{lookback_days}/{limit}/{venue}/{basis}"
-)(get_asset_timeseries_data)
+    "wayfinder://delta-lab/basis/{symbol}/timeseries/{series}/{lookback_days}/{limit}"
+)(get_basis_timeseries_data)
+mcp.resource(
+    "wayfinder://delta-lab/basis/{symbol}/timeseries/{series}/{lookback_days}/{limit}/{venue}"
+)(get_basis_timeseries_with_venue)
 mcp.resource("wayfinder://delta-lab/screen/price/{sort}/{limit}/{basis}")(screen_price)
 mcp.resource(
     "wayfinder://delta-lab/screen/price/by-asset-ids/{sort}/{limit}/{asset_ids}"


### PR DESCRIPTION
bug: when pulling ts from delta lab we can't specify venue or asset (we pull based on basis for all venues). This leads to too much data and always with cutoff data. Sometimes we want this search but usually we want to be more specific.


This is fixed now in the delta-lab api letting us specify the exact asset and venue we want. This updates the interface to use those now.