### PR TITLE
Add live data, user params, and chart tooltip docs to applet skill

### DIFF
--- a/.claude/skills/developing-wayfinder-paths/SKILL.md
+++ b/.claude/skills/developing-wayfinder-paths/SKILL.md
@@ -14,6 +14,7 @@ Use this skill when you are:
 - Emitting signals/receipts to make a path page feel “alive”
 - Defining canonical path skill source in `wfpath.yaml` + `skill/instructions.md`
 - Generating host-specific skill exports for Claude Code, Codex, OpenClaw, and portable use
+- Adding live data fetching or interactive controls to a path applet
 
 ## How to use
 

--- a/.claude/skills/developing-wayfinder-paths/rules/applet.md
+++ b/.claude/skills/developing-wayfinder-paths/rules/applet.md
@@ -83,6 +83,89 @@ if (parentOrigin) {
 }
 ```
 
+## Fetching live data at runtime
+
+Applets embedded on the Strategies host can fetch Delta Lab data via the
+public timeseries endpoint — no API key needed. The endpoint is same-origin
+when the applet is served from the path page.
+
+### Pattern
+
+1. Capture the API base from the host bridge: prefer `wf:state.apiBase`,
+   then the `wf:hello` event origin.
+2. Fetch: `${apiBase}/api/v1/delta-lab/public/assets/${SYMBOL}/timeseries/?series=price,funding,pendle&lookback_days=60&limit=2000`
+3. Treat non-200 as "data unavailable" — render a fallback UI, don't crash.
+
+Available series: `price`, `funding`, `lending`, `yield`, `pendle`, `boros`.
+Not all series exist for all symbols. Degrade gracefully.
+
+### Static fallback for local development
+
+On localhost the public endpoint is cross-origin and will be blocked.
+Bundle pre-computed data under `data/` and attempt live fetch first:
+
+```js
+async function loadData(apiBase) {
+  try {
+    var r = await fetch(apiBase +
+      "/api/v1/delta-lab/public/assets/SYMBOL/timeseries/?series=price,funding&lookback_days=30&limit=2000");
+    if (!r.ok) throw new Error(r.status);
+    return { live: true, data: await r.json() };
+  } catch {
+    var fb = await fetch("./data/fallback.json");
+    return fb.ok ? { live: false, data: await fb.json() } : null;
+  }
+}
+```
+
+When displaying fallback data, show the date it was generated so the viewer
+knows they are looking at stale data (e.g. "Showing cached data from
+2026-04-01").
+
+### External APIs (Pendle, Hyperliquid, etc.)
+
+Direct browser fetch to third-party APIs will fail due to CORS.
+Use only data available through the Delta Lab public endpoint.
+If a needed series isn't available for your symbol, fall back to
+static bundled data or request the series be added to Delta Lab.
+
+## User-configurable parameters
+
+When an applet runs a computation (e.g. backtest), expose key inputs
+so the viewer can explore scenarios without republishing:
+
+- **Investment amount (USD):** number input, sensible default (e.g. $100,000)
+- **Lookback period (days):** number input, default 30, range 7–90
+
+Wire inputs to re-run the computation and re-render on change (debounce
+~400ms). If a parameter requires a live data re-fetch (e.g. lookback
+changes the API query), refetch then recompute. If a parameter only
+affects the computation (e.g. notional), recompute on cached data.
+
+Disable controls that have no effect in the current mode (e.g. lookback
+is meaningless when using static fallback data — disable the input and
+add a title tooltip explaining why).
+
+## Chart hover tooltips
+
+All canvas-based charts should include hover interaction by default.
+
+### Pattern
+
+1. Maintain a `chartRegistry` array. After drawing each chart, register:
+   canvas element, series array (`[{data, mapped?, color, label, lineWidth?}]`),
+   timestamps array, value formatter, y-bounds, and optional transform threshold.
+2. Create one shared tooltip div (`position:fixed`, `pointer-events:none`,
+   dark background, `z-index:100`).
+3. On each canvas `mousemove`:
+   - Resolve nearest data index from cursor x
+   - Redraw chart with a dashed vertical crosshair + filled dots at intersections
+   - Populate tooltip: timestamp line + one color-coded value per series
+4. On `mouseleave`: hide tooltip, redraw chart without crosshair.
+5. For transformed scales (e.g. symlog), store both raw data and mapped
+   on the series entry. Tooltip shows raw values; crosshair renders in
+   transformed space.
+
 ## MVP constraints
 
 For now:


### PR DESCRIPTION
## Summary
- Add **Fetching live data at runtime** section: Delta Lab public timeseries endpoint pattern, static fallback with date display, CORS guidance
- Add **User-configurable parameters** section: exposing computation inputs (investment amount, lookback), debounced re-render, disabled-control guidance
- Add **Chart hover tooltips** section: chartRegistry pattern, shared tooltip div, crosshair rendering, transformed-scale handling
- Update SKILL.md "When to use" with new bullet for live data / interactive controls

## Test plan
- [x] Review applet.md renders correctly in GitHub markdown
- [x] Confirm Delta Lab `limit=2000` matches API max
- [x] Verify new sections sit between "Wayfinder Bridge" and "MVP constraints"

🤖 Generated with [Claude Code](https://claude.com/claude-code)