### PR TITLE
Adapters - SigningCallbacks migration

### DIFF
--- a/scripts/aave_v3_smoke_test.py
+++ b/scripts/aave_v3_smoke_test.py
@@ -11,8 +11,9 @@ from wayfinder_paths.adapters.aave_v3_adapter import AaveV3Adapter
 from wayfinder_paths.core.config import load_config
 from wayfinder_paths.core.constants.chains import CHAIN_ID_ARBITRUM
 from wayfinder_paths.core.constants.contracts import ARBITRUM_USDC, ZERO_ADDRESS
+from wayfinder_paths.core.utils.signing import build_signing_callbacks
 from wayfinder_paths.core.utils.tokens import get_token_balance
-from wayfinder_paths.run_strategy import create_signing_callback, get_strategy_config
+from wayfinder_paths.run_strategy import get_strategy_config
 
 
 async def main() -> None:
@@ -44,8 +45,8 @@ async def main() -> None:
         raise ValueError(f"No strategy_wallet configured for label={args.wallet_label}")
     addr = to_checksum_address(str(addr))
 
-    signing_cb = create_signing_callback(addr, cfg)
-    adapter = AaveV3Adapter(config=cfg, sign_callback=signing_cb, wallet_address=addr)
+    signing = await build_signing_callbacks(args.wallet_label)
+    adapter = AaveV3Adapter(config=cfg, signing=signing, wallet_address=addr)
 
     chain_id = int(args.chain_id)
     usdc_addr = (

--- a/scripts/morpho_smoke_test.py
+++ b/scripts/morpho_smoke_test.py
@@ -12,9 +12,10 @@ from wayfinder_paths.core.clients.MorphoClient import MORPHO_CLIENT
 from wayfinder_paths.core.config import load_config
 from wayfinder_paths.core.constants.chains import CHAIN_ID_BASE
 from wayfinder_paths.core.constants.hyperlend_abi import WETH_ABI
+from wayfinder_paths.core.utils.signing import build_signing_callbacks
 from wayfinder_paths.core.utils.tokens import get_token_balance
 from wayfinder_paths.core.utils.transaction import encode_call, send_transaction
-from wayfinder_paths.run_strategy import create_signing_callback, get_strategy_config
+from wayfinder_paths.run_strategy import get_strategy_config
 
 
 def _pick_market_by_symbols(
@@ -71,8 +72,8 @@ async def main() -> None:
         raise ValueError(f"No strategy_wallet configured for label={args.wallet_label}")
     addr = to_checksum_address(str(addr))
 
-    signing_cb = create_signing_callback(addr, cfg)
-    adapter = MorphoAdapter(config=cfg, sign_callback=signing_cb, wallet_address=addr)
+    signing = await build_signing_callbacks(args.wallet_label)
+    adapter = MorphoAdapter(config=cfg, signing=signing, wallet_address=addr)
 
     chain_id = int(args.chain_id)
 
@@ -148,7 +149,7 @@ async def main() -> None:
                 chain_id=chain_id,
                 value=int(wrap_total),
             )
-            wrap_hash = await send_transaction(wrap_tx, signing_cb)
+            wrap_hash = await send_transaction(wrap_tx, signing.sign)
             print("wrap_weth_tx", wrap_hash)
 
         ok, tx = await adapter.supply_collateral(
@@ -207,7 +208,7 @@ async def main() -> None:
                 chain_id=chain_id,
                 value=buffer_wei,
             )
-            wrap_hash = await send_transaction(wrap_tx, signing_cb)
+            wrap_hash = await send_transaction(wrap_tx, signing.sign)
             print("wrap_weth_tx", wrap_hash)
 
         ok, tx = await adapter.repay(

--- a/wayfinder_paths/adapters/aave_v3_adapter/adapter.py
+++ b/wayfinder_paths/adapters/aave_v3_adapter/adapter.py
@@ -19,6 +19,7 @@ from wayfinder_paths.core.constants.base import MAX_UINT256, SECONDS_PER_YEAR
 from wayfinder_paths.core.constants.contracts import ZERO_ADDRESS
 from wayfinder_paths.core.utils import web3 as web3_utils
 from wayfinder_paths.core.utils.interest import RAY, apr_to_apy, ray_to_apr
+from wayfinder_paths.core.utils.signing import SigningCallbacks
 from wayfinder_paths.core.utils.symbols import is_stable_symbol, normalize_symbol
 from wayfinder_paths.core.utils.tokens import ensure_allowance, get_token_balance
 from wayfinder_paths.core.utils.transaction import encode_call, send_transaction
@@ -152,11 +153,12 @@ class AaveV3Adapter(BaseAdapter):
     def __init__(
         self,
         config: dict[str, Any] | None = None,
-        sign_callback=None,
+        *,
+        signing: SigningCallbacks | None = None,
         wallet_address: str | None = None,
     ) -> None:
         super().__init__("aave_v3_adapter", config or {})
-        self.sign_callback = sign_callback
+        self.signing = signing
 
         self.wallet_address: str | None = (
             to_checksum_address(wallet_address) if wallet_address else None
@@ -715,7 +717,7 @@ class AaveV3Adapter(BaseAdapter):
                     chain_id=int(chain_id),
                     value=qty,
                 )
-                wrap_hash = await send_transaction(wrap_tx, self.sign_callback)
+                wrap_hash = await send_transaction(wrap_tx, self.signing.sign)
 
                 approved = await ensure_allowance(
                     token_address=wrapped,
@@ -723,7 +725,7 @@ class AaveV3Adapter(BaseAdapter):
                     spender=pool,
                     amount=qty,
                     chain_id=int(chain_id),
-                    signing_callback=self.sign_callback,
+                    signing_callback=self.signing.sign,
                     approval_amount=MAX_UINT256,
                 )
                 if not approved[0]:
@@ -737,7 +739,7 @@ class AaveV3Adapter(BaseAdapter):
                     from_address=strategy,
                     chain_id=int(chain_id),
                 )
-                supply_hash = await send_transaction(supply_tx, self.sign_callback)
+                supply_hash = await send_transaction(supply_tx, self.signing.sign)
                 return True, {"wrap_tx": wrap_hash, "supply_tx": supply_hash}
 
             asset = to_checksum_address(underlying_token)
@@ -747,7 +749,7 @@ class AaveV3Adapter(BaseAdapter):
                 spender=pool,
                 amount=qty,
                 chain_id=int(chain_id),
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=MAX_UINT256,
             )
             if not approved[0]:
@@ -761,7 +763,7 @@ class AaveV3Adapter(BaseAdapter):
                 from_address=strategy,
                 chain_id=int(chain_id),
             )
-            txn_hash = await send_transaction(tx, self.sign_callback)
+            txn_hash = await send_transaction(tx, self.signing.sign)
             return True, txn_hash
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
@@ -798,7 +800,7 @@ class AaveV3Adapter(BaseAdapter):
                     from_address=strategy,
                     chain_id=int(chain_id),
                 )
-                withdraw_hash = await send_transaction(withdraw_tx, self.sign_callback)
+                withdraw_hash = await send_transaction(withdraw_tx, self.signing.sign)
 
                 after = await get_token_balance(
                     wrapped, int(chain_id), strategy, block_identifier="pending"
@@ -815,7 +817,7 @@ class AaveV3Adapter(BaseAdapter):
                     from_address=strategy,
                     chain_id=int(chain_id),
                 )
-                unwrap_hash = await send_transaction(unwrap_tx, self.sign_callback)
+                unwrap_hash = await send_transaction(unwrap_tx, self.signing.sign)
                 return True, {"withdraw_tx": withdraw_hash, "unwrap_tx": unwrap_hash}
 
             asset = to_checksum_address(underlying_token)
@@ -827,7 +829,7 @@ class AaveV3Adapter(BaseAdapter):
                 from_address=strategy,
                 chain_id=int(chain_id),
             )
-            txn_hash = await send_transaction(tx, self.sign_callback)
+            txn_hash = await send_transaction(tx, self.signing.sign)
             return True, txn_hash
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
@@ -858,7 +860,7 @@ class AaveV3Adapter(BaseAdapter):
                     from_address=strategy,
                     chain_id=int(chain_id),
                 )
-                borrow_hash = await send_transaction(borrow_tx, self.sign_callback)
+                borrow_hash = await send_transaction(borrow_tx, self.signing.sign)
 
                 unwrap_tx = await encode_call(
                     target=wrapped,
@@ -868,7 +870,7 @@ class AaveV3Adapter(BaseAdapter):
                     from_address=strategy,
                     chain_id=int(chain_id),
                 )
-                unwrap_hash = await send_transaction(unwrap_tx, self.sign_callback)
+                unwrap_hash = await send_transaction(unwrap_tx, self.signing.sign)
                 return True, {"borrow_tx": borrow_hash, "unwrap_tx": unwrap_hash}
 
             asset = to_checksum_address(underlying_token)
@@ -880,7 +882,7 @@ class AaveV3Adapter(BaseAdapter):
                 from_address=strategy,
                 chain_id=int(chain_id),
             )
-            txn_hash = await send_transaction(tx, self.sign_callback)
+            txn_hash = await send_transaction(tx, self.signing.sign)
             return True, txn_hash
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
@@ -972,7 +974,7 @@ class AaveV3Adapter(BaseAdapter):
                     chain_id=int(chain_id),
                     value=int(value),
                 )
-                wrap_hash = await send_transaction(wrap_tx, self.sign_callback)
+                wrap_hash = await send_transaction(wrap_tx, self.signing.sign)
 
                 approved = await ensure_allowance(
                     token_address=wrapped,
@@ -980,7 +982,7 @@ class AaveV3Adapter(BaseAdapter):
                     spender=pool,
                     amount=MAX_UINT256 if repay_full else int(value),
                     chain_id=int(chain_id),
-                    signing_callback=self.sign_callback,
+                    signing_callback=self.signing.sign,
                     approval_amount=MAX_UINT256,
                 )
                 if not approved[0]:
@@ -994,7 +996,7 @@ class AaveV3Adapter(BaseAdapter):
                     from_address=strategy,
                     chain_id=int(chain_id),
                 )
-                repay_hash = await send_transaction(repay_tx, self.sign_callback)
+                repay_hash = await send_transaction(repay_tx, self.signing.sign)
                 return True, {"wrap_tx": wrap_hash, "repay_tx": repay_hash}
 
             repay_amount = MAX_UINT256 if repay_full else qty
@@ -1006,7 +1008,7 @@ class AaveV3Adapter(BaseAdapter):
                 spender=pool,
                 amount=allowance_target,
                 chain_id=int(chain_id),
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=MAX_UINT256,
             )
             if not approved[0]:
@@ -1020,7 +1022,7 @@ class AaveV3Adapter(BaseAdapter):
                 from_address=strategy,
                 chain_id=int(chain_id),
             )
-            txn_hash = await send_transaction(tx, self.sign_callback)
+            txn_hash = await send_transaction(tx, self.signing.sign)
             return True, txn_hash
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
@@ -1047,7 +1049,7 @@ class AaveV3Adapter(BaseAdapter):
                 from_address=strategy,
                 chain_id=int(chain_id),
             )
-            txn_hash = await send_transaction(tx, self.sign_callback)
+            txn_hash = await send_transaction(tx, self.signing.sign)
             return True, txn_hash
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
@@ -1118,7 +1120,7 @@ class AaveV3Adapter(BaseAdapter):
                 from_address=strategy,
                 chain_id=int(chain_id),
             )
-            txn_hash = await send_transaction(tx, self.sign_callback)
+            txn_hash = await send_transaction(tx, self.signing.sign)
             return True, txn_hash
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)

--- a/wayfinder_paths/adapters/aave_v3_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/aave_v3_adapter/test_adapter.py
@@ -6,6 +6,7 @@ import pytest
 from wayfinder_paths.adapters.aave_v3_adapter.adapter import AaveV3Adapter
 from wayfinder_paths.core.constants.aave_v3_abi import UI_POOL_RESERVE_KEYS
 from wayfinder_paths.core.constants.contracts import ZERO_ADDRESS
+from wayfinder_paths.testing import fake_signing
 
 FAKE_ADDR = "0x1234567890123456789012345678901234567890"
 FAKE_ASSET = "0x0000000000000000000000000000000000000001"
@@ -16,6 +17,7 @@ class TestAaveV3Adapter:
     def adapter(self):
         return AaveV3Adapter(
             config={},
+            signing=fake_signing(address=FAKE_ADDR),
             wallet_address=FAKE_ADDR,
         )
 

--- a/wayfinder_paths/adapters/aave_v3_adapter/test_gorlami_simulation.py
+++ b/wayfinder_paths/adapters/aave_v3_adapter/test_gorlami_simulation.py
@@ -7,6 +7,7 @@ from wayfinder_paths.adapters.aave_v3_adapter.adapter import AaveV3Adapter
 from wayfinder_paths.core.constants.chains import CHAIN_ID_ARBITRUM
 from wayfinder_paths.core.constants.contracts import ARBITRUM_USDC, ZERO_ADDRESS
 from wayfinder_paths.core.utils import web3 as web3_utils
+from wayfinder_paths.testing import fake_signing
 from wayfinder_paths.testing.gorlami import gorlami_configured
 
 pytestmark = pytest.mark.skipif(
@@ -43,7 +44,7 @@ async def test_gorlami_aave_v3_supply_borrow_repay_withdraw_claim(gorlami):
 
     adapter = AaveV3Adapter(
         config={},
-        sign_callback=sign_cb,
+        signing=fake_signing(sign=sign_cb),
         wallet_address=acct.address,
     )
 

--- a/wayfinder_paths/adapters/aerodrome_adapter/adapter.py
+++ b/wayfinder_paths/adapters/aerodrome_adapter/adapter.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import math
 import time
-from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
@@ -31,6 +30,7 @@ from wayfinder_paths.core.utils.multicall import (
     Call,
     read_only_calls_multicall_or_gather,
 )
+from wayfinder_paths.core.utils.signing import SigningCallbacks
 from wayfinder_paths.core.utils.tokens import (
     ensure_allowance,
     get_erc20_metadata,
@@ -141,11 +141,11 @@ class AerodromeAdapter(
         self,
         config: dict[str, Any] | None = None,
         *,
-        sign_callback: Callable | None = None,
+        signing: SigningCallbacks | None = None,
         wallet_address: str | None = None,
     ) -> None:
         super().__init__("aerodrome_adapter", config or {})
-        self.sign_callback = sign_callback
+        self.signing = signing
 
         deployment = AERODROME_BY_CHAIN.get(CHAIN_ID_BASE)
         if not deployment:
@@ -1021,8 +1021,8 @@ class AerodromeAdapter(
         if amountA_desired <= 0 or amountB_desired <= 0:
             return False, "amounts must be positive"
 
-        if self.sign_callback is None:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
 
         try:
             tA_native = is_native_token(tokenA)
@@ -1076,7 +1076,7 @@ class AerodromeAdapter(
                     spender=self.core_contracts["router"],
                     amount=token_amt,
                     chain_id=CHAIN_ID_BASE,
-                    signing_callback=self.sign_callback,
+                    signing_callback=self.signing.sign,
                     approval_amount=MAX_UINT256,
                 )
                 if not approved[0]:
@@ -1099,7 +1099,7 @@ class AerodromeAdapter(
                     chain_id=CHAIN_ID_BASE,
                     value=eth_amt,
                 )
-                tx_hash = await send_transaction(tx, self.sign_callback)
+                tx_hash = await send_transaction(tx, self.signing.sign)
                 return True, tx_hash
 
             # ERC20-ERC20 path
@@ -1136,7 +1136,7 @@ class AerodromeAdapter(
                 spender=self.core_contracts["router"],
                 amount=amountA_desired,
                 chain_id=CHAIN_ID_BASE,
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=MAX_UINT256,
             )
             if not approvedA[0]:
@@ -1148,7 +1148,7 @@ class AerodromeAdapter(
                 spender=self.core_contracts["router"],
                 amount=amountB_desired,
                 chain_id=CHAIN_ID_BASE,
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=MAX_UINT256,
             )
             if not approvedB[0]:
@@ -1172,7 +1172,7 @@ class AerodromeAdapter(
                 from_address=to_checksum_address(self.wallet_address),
                 chain_id=CHAIN_ID_BASE,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)
@@ -1243,8 +1243,8 @@ class AerodromeAdapter(
         """Remove liquidity (wallet-held LP only)."""
         if liquidity <= 0:
             return False, "liquidity must be positive"
-        if self.sign_callback is None:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
 
         try:
             tA_native = is_native_token(tokenA)
@@ -1288,7 +1288,7 @@ class AerodromeAdapter(
                 spender=self.core_contracts["router"],
                 amount=liquidity,
                 chain_id=CHAIN_ID_BASE,
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=MAX_UINT256,
             )
             if not approved[0]:
@@ -1336,7 +1336,7 @@ class AerodromeAdapter(
                     from_address=to_checksum_address(self.wallet_address),
                     chain_id=CHAIN_ID_BASE,
                 )
-                tx_hash = await send_transaction(tx, self.sign_callback)
+                tx_hash = await send_transaction(tx, self.signing.sign)
                 return True, tx_hash
 
             ok_q, q = await self.quote_remove_liquidity(
@@ -1376,7 +1376,7 @@ class AerodromeAdapter(
                 from_address=to_checksum_address(self.wallet_address),
                 chain_id=CHAIN_ID_BASE,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)
@@ -1388,8 +1388,8 @@ class AerodromeAdapter(
         pool: str,
     ) -> tuple[bool, Any]:
         """Claim Pool fees for wallet-held LP (unstaked)."""
-        if self.sign_callback is None:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
         try:
             pool = to_checksum_address(pool)
             acct = to_checksum_address(self.wallet_address)
@@ -1414,7 +1414,7 @@ class AerodromeAdapter(
                 from_address=acct,
                 chain_id=CHAIN_ID_BASE,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, {"tx": tx_hash, "claimable0": c0, "claimable1": c1}
         except Exception as exc:
             return False, str(exc)
@@ -1429,8 +1429,8 @@ class AerodromeAdapter(
     ) -> tuple[bool, Any]:
         if amount <= 0:
             return False, "amount must be positive"
-        if self.sign_callback is None:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
 
         try:
             gauge = to_checksum_address(gauge)
@@ -1458,7 +1458,7 @@ class AerodromeAdapter(
                 spender=gauge,
                 amount=amount,
                 chain_id=CHAIN_ID_BASE,
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=MAX_UINT256,
             )
             if not approved[0]:
@@ -1483,7 +1483,7 @@ class AerodromeAdapter(
                 from_address=to_checksum_address(self.wallet_address),
                 chain_id=CHAIN_ID_BASE,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)
@@ -1506,8 +1506,8 @@ class AerodromeAdapter(
     ) -> tuple[bool, Any]:
         if amount <= 0:
             return False, "amount must be positive"
-        if self.sign_callback is None:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
         try:
             gauge = to_checksum_address(gauge)
             tx = await encode_call(
@@ -1518,7 +1518,7 @@ class AerodromeAdapter(
                 from_address=to_checksum_address(self.wallet_address),
                 chain_id=CHAIN_ID_BASE,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)

--- a/wayfinder_paths/adapters/aerodrome_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/aerodrome_adapter/test_adapter.py
@@ -16,6 +16,7 @@ from wayfinder_paths.adapters.aerodrome_adapter.adapter import (
 from wayfinder_paths.core.constants import ZERO_ADDRESS
 from wayfinder_paths.core.constants.base import SECONDS_PER_YEAR
 from wayfinder_paths.core.constants.chains import CHAIN_ID_BASE
+from wayfinder_paths.testing import fake_signing
 
 EPOCH_SPECIAL_WINDOW_SECONDS = aerodrome_common_module.EPOCH_SPECIAL_WINDOW_SECONDS
 WEEK_SECONDS = aerodrome_common_module.WEEK_SECONDS
@@ -28,7 +29,7 @@ FAKE_GAUGE = "0x0000000000000000000000000000000000000002"
 @pytest.fixture
 def adapter_with_signer():
     return AerodromeAdapter(
-        sign_callback=AsyncMock(return_value="0xsigned"),
+        signing=fake_signing(sign=AsyncMock(return_value="0xsigned")),
         wallet_address=FAKE_WALLET,
     )
 

--- a/wayfinder_paths/adapters/aerodrome_adapter/test_gorlami_simulation.py
+++ b/wayfinder_paths/adapters/aerodrome_adapter/test_gorlami_simulation.py
@@ -18,6 +18,7 @@ from wayfinder_paths.core.constants.aerodrome_contracts import AERODROME_BY_CHAI
 from wayfinder_paths.core.constants.chains import CHAIN_ID_BASE
 from wayfinder_paths.core.constants.contracts import BASE_WETH
 from wayfinder_paths.core.utils import web3 as web3_utils
+from wayfinder_paths.testing import fake_signing
 from wayfinder_paths.testing.gorlami import gorlami_configured
 
 EPOCH_SPECIAL_WINDOW_SECONDS = aerodrome_common_module.EPOCH_SPECIAL_WINDOW_SECONDS
@@ -40,7 +41,7 @@ def _make_adapter(acct: Account) -> AerodromeAdapter:
         return signed.raw_transaction
 
     return AerodromeAdapter(
-        sign_callback=sign_cb,
+        signing=fake_signing(sign=sign_cb),
         wallet_address=acct.address,
     )
 

--- a/wayfinder_paths/adapters/aerodrome_common.py
+++ b/wayfinder_paths/adapters/aerodrome_common.py
@@ -377,8 +377,8 @@ class AerodromeVotingRewardsMixin:
         *,
         gauges: Sequence[str],
     ) -> tuple[bool, Any]:
-        if self.sign_callback is None:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
         if not gauges:
             return False, "gauges cannot be empty"
         try:
@@ -391,7 +391,7 @@ class AerodromeVotingRewardsMixin:
                 from_address=to_checksum_address(self.wallet_address),
                 chain_id=self.chain_id,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)
@@ -450,8 +450,8 @@ class AerodromeVotingRewardsMixin:
             return False, "amount must be positive"
         if lock_duration <= 0:
             return False, "lock_duration must be positive"
-        if self.sign_callback is None:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
 
         try:
             owner = to_checksum_address(self.wallet_address)
@@ -461,7 +461,7 @@ class AerodromeVotingRewardsMixin:
                 spender=self.core_contracts["voting_escrow"],
                 amount=amount,
                 chain_id=self.chain_id,
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=MAX_UINT256,
             )
             if not approved[0]:
@@ -475,7 +475,7 @@ class AerodromeVotingRewardsMixin:
                 from_address=owner,
                 chain_id=self.chain_id,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             token_id = await self._minted_erc721_token_id(
                 nft_contract=self.core_contracts["voting_escrow"],
                 tx_hash=tx_hash,
@@ -497,8 +497,8 @@ class AerodromeVotingRewardsMixin:
             return False, "amount must be positive"
         if lock_duration <= 0:
             return False, "lock_duration must be positive"
-        if self.sign_callback is None:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
 
         try:
             owner = to_checksum_address(self.wallet_address)
@@ -509,7 +509,7 @@ class AerodromeVotingRewardsMixin:
                 spender=self.core_contracts["voting_escrow"],
                 amount=amount,
                 chain_id=self.chain_id,
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=MAX_UINT256,
             )
             if not approved[0]:
@@ -523,7 +523,7 @@ class AerodromeVotingRewardsMixin:
                 from_address=owner,
                 chain_id=self.chain_id,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             token_id = await self._minted_erc721_token_id(
                 nft_contract=self.core_contracts["voting_escrow"],
                 tx_hash=tx_hash,
@@ -542,8 +542,8 @@ class AerodromeVotingRewardsMixin:
     ) -> tuple[bool, Any]:
         if amount <= 0:
             return False, "amount must be positive"
-        if self.sign_callback is None:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
 
         try:
             owner = to_checksum_address(self.wallet_address)
@@ -553,7 +553,7 @@ class AerodromeVotingRewardsMixin:
                 spender=self.core_contracts["voting_escrow"],
                 amount=amount,
                 chain_id=self.chain_id,
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=MAX_UINT256,
             )
             if not approved[0]:
@@ -567,7 +567,7 @@ class AerodromeVotingRewardsMixin:
                 from_address=owner,
                 chain_id=self.chain_id,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)
@@ -581,8 +581,8 @@ class AerodromeVotingRewardsMixin:
     ) -> tuple[bool, Any]:
         if lock_duration <= 0:
             return False, "lock_duration must be positive"
-        if self.sign_callback is None:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
         try:
             tx = await encode_call(
                 target=self.core_contracts["voting_escrow"],
@@ -592,7 +592,7 @@ class AerodromeVotingRewardsMixin:
                 from_address=to_checksum_address(self.wallet_address),
                 chain_id=self.chain_id,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)
@@ -603,8 +603,8 @@ class AerodromeVotingRewardsMixin:
         *,
         token_id: int,
     ) -> tuple[bool, Any]:
-        if self.sign_callback is None:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
         try:
             tx = await encode_call(
                 target=self.core_contracts["voting_escrow"],
@@ -614,7 +614,7 @@ class AerodromeVotingRewardsMixin:
                 from_address=to_checksum_address(self.wallet_address),
                 chain_id=self.chain_id,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)
@@ -625,8 +625,8 @@ class AerodromeVotingRewardsMixin:
         *,
         token_id: int,
     ) -> tuple[bool, Any]:
-        if self.sign_callback is None:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
         try:
             tx = await encode_call(
                 target=self.core_contracts["voting_escrow"],
@@ -636,7 +636,7 @@ class AerodromeVotingRewardsMixin:
                 from_address=to_checksum_address(self.wallet_address),
                 chain_id=self.chain_id,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)
@@ -647,8 +647,8 @@ class AerodromeVotingRewardsMixin:
         *,
         token_id: int,
     ) -> tuple[bool, Any]:
-        if self.sign_callback is None:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
         try:
             tx = await encode_call(
                 target=self.core_contracts["voting_escrow"],
@@ -658,7 +658,7 @@ class AerodromeVotingRewardsMixin:
                 from_address=to_checksum_address(self.wallet_address),
                 chain_id=self.chain_id,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)
@@ -672,8 +672,8 @@ class AerodromeVotingRewardsMixin:
         weights: Sequence[int],
         check_window: bool = True,
     ) -> tuple[bool, Any]:
-        if self.sign_callback is None:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
         if not pools:
             return False, "pools cannot be empty"
         if len(pools) != len(weights):
@@ -697,7 +697,7 @@ class AerodromeVotingRewardsMixin:
                 from_address=to_checksum_address(self.wallet_address),
                 chain_id=self.chain_id,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)
@@ -709,8 +709,8 @@ class AerodromeVotingRewardsMixin:
         token_id: int,
         check_window: bool = True,
     ) -> tuple[bool, Any]:
-        if self.sign_callback is None:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
         try:
             if check_window:
                 ok, reason = await self._can_vote_now(token_id=token_id)
@@ -725,7 +725,7 @@ class AerodromeVotingRewardsMixin:
                 from_address=to_checksum_address(self.wallet_address),
                 chain_id=self.chain_id,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)
@@ -1009,8 +1009,8 @@ class AerodromeVotingRewardsMixin:
         fee_reward_contracts: Sequence[str],
         token_lists: Sequence[Sequence[str]] | None = None,
     ) -> tuple[bool, Any]:
-        if self.sign_callback is None:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
         if not fee_reward_contracts:
             return False, "fee_reward_contracts cannot be empty"
         try:
@@ -1044,7 +1044,7 @@ class AerodromeVotingRewardsMixin:
                 from_address=to_checksum_address(self.wallet_address),
                 chain_id=self.chain_id,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)
@@ -1057,8 +1057,8 @@ class AerodromeVotingRewardsMixin:
         bribe_reward_contracts: Sequence[str],
         token_lists: Sequence[Sequence[str]] | None = None,
     ) -> tuple[bool, Any]:
-        if self.sign_callback is None:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
         if not bribe_reward_contracts:
             return False, "bribe_reward_contracts cannot be empty"
         try:
@@ -1092,7 +1092,7 @@ class AerodromeVotingRewardsMixin:
                 from_address=to_checksum_address(self.wallet_address),
                 chain_id=self.chain_id,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)
@@ -1125,8 +1125,8 @@ class AerodromeVotingRewardsMixin:
         token_id: int,
         skip_if_zero: bool = True,
     ) -> tuple[bool, Any]:
-        if self.sign_callback is None:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
 
         try:
             if skip_if_zero:
@@ -1147,7 +1147,7 @@ class AerodromeVotingRewardsMixin:
                 from_address=to_checksum_address(self.wallet_address),
                 chain_id=self.chain_id,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)
@@ -1158,8 +1158,8 @@ class AerodromeVotingRewardsMixin:
         *,
         token_ids: Sequence[int],
     ) -> tuple[bool, Any]:
-        if self.sign_callback is None:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
         if not token_ids:
             return False, "token_ids cannot be empty"
         try:
@@ -1171,7 +1171,7 @@ class AerodromeVotingRewardsMixin:
                 from_address=to_checksum_address(self.wallet_address),
                 chain_id=self.chain_id,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)

--- a/wayfinder_paths/adapters/aerodrome_slipstream_adapter/adapter.py
+++ b/wayfinder_paths/adapters/aerodrome_slipstream_adapter/adapter.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import math
 import time
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from typing import Any, TypedDict
 
 from eth_utils import keccak, to_checksum_address
@@ -34,6 +34,7 @@ from wayfinder_paths.core.utils.multicall import (
     Call,
     read_only_calls_multicall_or_gather,
 )
+from wayfinder_paths.core.utils.signing import SigningCallbacks
 from wayfinder_paths.core.utils.tokens import ensure_allowance
 from wayfinder_paths.core.utils.transaction import encode_call, send_transaction
 from wayfinder_paths.core.utils.uniswap_v3_math import (
@@ -101,11 +102,11 @@ class AerodromeSlipstreamAdapter(
         self,
         config: AerodromeSlipstreamAdapterConfig | None = None,
         *,
-        sign_callback: Callable | None = None,
+        signing: SigningCallbacks | None = None,
         wallet_address: str | None = None,
     ) -> None:
         super().__init__("aerodrome_slipstream_adapter", config or {})
-        self.sign_callback = sign_callback
+        self.signing = signing
 
         entry = AERODROME_SLIPSTREAM_BY_CHAIN.get(CHAIN_ID_BASE)
         if not entry:
@@ -455,7 +456,7 @@ class AerodromeSlipstreamAdapter(
             from_address=owner,
             chain_id=CHAIN_ID_BASE,
         )
-        tx_hash = await send_transaction(tx, self.sign_callback)
+        tx_hash = await send_transaction(tx, self.signing.sign)
         return True, tx_hash
 
     async def _pool_and_gauge_for_position(
@@ -1738,8 +1739,8 @@ class AerodromeSlipstreamAdapter(
             return False, "amounts must be positive"
         if tick_upper <= tick_lower:
             return False, "tick_upper must be greater than tick_lower"
-        if self.sign_callback is None:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
 
         try:
             _, deployment, npm_address = self._select_write_target(
@@ -1770,7 +1771,7 @@ class AerodromeSlipstreamAdapter(
                 spender=npm_address,
                 amount=amount0_desired,
                 chain_id=CHAIN_ID_BASE,
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=MAX_UINT256,
             )
             if not approved0[0]:
@@ -1782,7 +1783,7 @@ class AerodromeSlipstreamAdapter(
                 spender=npm_address,
                 amount=amount1_desired,
                 chain_id=CHAIN_ID_BASE,
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=MAX_UINT256,
             )
             if not approved1[0]:
@@ -1810,7 +1811,7 @@ class AerodromeSlipstreamAdapter(
                 from_address=owner,
                 chain_id=CHAIN_ID_BASE,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             token_id = await self._minted_erc721_token_id(
                 nft_contract=npm_address,
                 tx_hash=tx_hash,
@@ -1835,8 +1836,8 @@ class AerodromeSlipstreamAdapter(
     ) -> tuple[bool, Any]:
         if amount0_desired <= 0 or amount1_desired <= 0:
             return False, "amounts must be positive"
-        if self.sign_callback is None:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
 
         try:
             variant, deployment, npm_address, owner = await self._resolve_token_manager(
@@ -1884,7 +1885,7 @@ class AerodromeSlipstreamAdapter(
                 spender=npm_address,
                 amount=amount0_desired,
                 chain_id=CHAIN_ID_BASE,
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=MAX_UINT256,
             )
             if not approved0[0]:
@@ -1896,7 +1897,7 @@ class AerodromeSlipstreamAdapter(
                 spender=npm_address,
                 amount=amount1_desired,
                 chain_id=CHAIN_ID_BASE,
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=MAX_UINT256,
             )
             if not approved1[0]:
@@ -1918,7 +1919,7 @@ class AerodromeSlipstreamAdapter(
                 from_address=wallet,
                 chain_id=CHAIN_ID_BASE,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, {
                 "tx": tx_hash,
                 "deployment_variant": variant,
@@ -1941,8 +1942,8 @@ class AerodromeSlipstreamAdapter(
     ) -> tuple[bool, Any]:
         if liquidity <= 0:
             return False, "liquidity must be positive"
-        if self.sign_callback is None:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
 
         try:
             variant, deployment, npm_address, owner = await self._resolve_token_manager(
@@ -1998,7 +1999,7 @@ class AerodromeSlipstreamAdapter(
                 from_address=wallet,
                 chain_id=CHAIN_ID_BASE,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, {
                 "tx": tx_hash,
                 "deployment_variant": variant,
@@ -2017,8 +2018,8 @@ class AerodromeSlipstreamAdapter(
         amount0_max: int = MAX_UINT128,
         amount1_max: int = MAX_UINT128,
     ) -> tuple[bool, Any]:
-        if self.sign_callback is None:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
 
         try:
             variant, _, npm_address, owner = await self._resolve_token_manager(
@@ -2044,7 +2045,7 @@ class AerodromeSlipstreamAdapter(
                 from_address=wallet,
                 chain_id=CHAIN_ID_BASE,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, {
                 "tx": tx_hash,
                 "deployment_variant": variant,
@@ -2060,8 +2061,8 @@ class AerodromeSlipstreamAdapter(
         token_id: int,
         position_manager: str | None = None,
     ) -> tuple[bool, Any]:
-        if self.sign_callback is None:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
 
         try:
             variant, _, npm_address, owner = await self._resolve_token_manager(
@@ -2080,7 +2081,7 @@ class AerodromeSlipstreamAdapter(
                 from_address=wallet,
                 chain_id=CHAIN_ID_BASE,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, {
                 "tx": tx_hash,
                 "deployment_variant": variant,
@@ -2096,8 +2097,8 @@ class AerodromeSlipstreamAdapter(
         gauge: str,
         token_id: int,
     ) -> tuple[bool, Any]:
-        if self.sign_callback is None:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
 
         try:
             wallet = to_checksum_address(self.wallet_address)
@@ -2149,7 +2150,7 @@ class AerodromeSlipstreamAdapter(
                 from_address=wallet,
                 chain_id=CHAIN_ID_BASE,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)
@@ -2161,8 +2162,8 @@ class AerodromeSlipstreamAdapter(
         gauge: str,
         token_id: int,
     ) -> tuple[bool, Any]:
-        if self.sign_callback is None:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
         try:
             tx = await encode_call(
                 target=to_checksum_address(gauge),
@@ -2172,7 +2173,7 @@ class AerodromeSlipstreamAdapter(
                 from_address=to_checksum_address(self.wallet_address),
                 chain_id=CHAIN_ID_BASE,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)
@@ -2184,8 +2185,8 @@ class AerodromeSlipstreamAdapter(
         gauge: str,
         token_id: int,
     ) -> tuple[bool, Any]:
-        if self.sign_callback is None:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
         try:
             tx = await encode_call(
                 target=to_checksum_address(gauge),
@@ -2195,7 +2196,7 @@ class AerodromeSlipstreamAdapter(
                 from_address=to_checksum_address(self.wallet_address),
                 chain_id=CHAIN_ID_BASE,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)

--- a/wayfinder_paths/adapters/aerodrome_slipstream_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/aerodrome_slipstream_adapter/test_adapter.py
@@ -19,6 +19,7 @@ from wayfinder_paths.core.utils.uniswap_v3_math import (
     sqrt_price_x96_from_tick,
     tick_to_price_decimal,
 )
+from wayfinder_paths.testing import fake_signing
 
 EPOCH_SPECIAL_WINDOW_SECONDS = aerodrome_common_module.EPOCH_SPECIAL_WINDOW_SECONDS
 WEEK_SECONDS = aerodrome_common_module.WEEK_SECONDS
@@ -33,7 +34,7 @@ FAKE_NPM = "0x0000000000000000000000000000000000000003"
 def adapter_with_signer():
     return AerodromeSlipstreamAdapter(
         config={"deployments": ("initial",)},
-        sign_callback=AsyncMock(return_value="0xsigned"),
+        signing=fake_signing(sign=AsyncMock(return_value="0xsigned")),
         wallet_address=FAKE_WALLET,
     )
 

--- a/wayfinder_paths/adapters/aerodrome_slipstream_adapter/test_gorlami_simulation.py
+++ b/wayfinder_paths/adapters/aerodrome_slipstream_adapter/test_gorlami_simulation.py
@@ -29,6 +29,7 @@ from wayfinder_paths.core.utils.uniswap_v3_math import (
     round_tick_to_spacing,
     sqrt_price_x96_to_price,
 )
+from wayfinder_paths.testing import fake_signing
 from wayfinder_paths.testing.gorlami import gorlami_configured
 
 pytestmark = pytest.mark.skipif(
@@ -50,7 +51,7 @@ def _make_adapter(acct: Account) -> AerodromeSlipstreamAdapter:
         return signed.raw_transaction
 
     return AerodromeSlipstreamAdapter(
-        sign_callback=sign_cb,
+        signing=fake_signing(sign=sign_cb),
         wallet_address=acct.address,
     )
 

--- a/wayfinder_paths/adapters/avantis_adapter/adapter.py
+++ b/wayfinder_paths/adapters/avantis_adapter/adapter.py
@@ -21,6 +21,7 @@ from wayfinder_paths.core.utils.multicall import (
     Call,
     read_only_calls_multicall_or_gather,
 )
+from wayfinder_paths.core.utils.signing import SigningCallbacks
 from wayfinder_paths.core.utils.tokens import ensure_allowance
 from wayfinder_paths.core.utils.transaction import encode_call, send_transaction
 from wayfinder_paths.core.utils.web3 import web3_from_chain_id
@@ -41,12 +42,12 @@ class AvantisAdapter(BaseAdapter):
     def __init__(
         self,
         config: dict[str, Any] | None = None,
-        sign_callback: Any | None = None,
+        signing: SigningCallbacks | None = None,
         wallet_address: str | None = None,
     ) -> None:
         super().__init__("avantis_adapter", config)
 
-        self.sign_callback = sign_callback
+        self.signing = signing
 
         self.chain_id = CHAIN_ID_BASE
         self.chain_name = CHAIN_NAME
@@ -214,8 +215,8 @@ class AvantisAdapter(BaseAdapter):
         wallet = self.wallet_address
         if not wallet:
             return False, "wallet_address is required"
-        if not self.sign_callback:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
 
         assets = int(amount)
         if assets <= 0:
@@ -235,7 +236,7 @@ class AvantisAdapter(BaseAdapter):
                 spender=vault,
                 amount=assets,
                 chain_id=self.chain_id,
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=MAX_UINT256,
             )
             if not approved[0]:
@@ -249,7 +250,7 @@ class AvantisAdapter(BaseAdapter):
                 from_address=wallet,
                 chain_id=self.chain_id,
             )
-            txn_hash = await send_transaction(transaction, self.sign_callback)
+            txn_hash = await send_transaction(transaction, self.signing.sign)
             return True, txn_hash
         except Exception as exc:
             return False, str(exc)
@@ -264,8 +265,8 @@ class AvantisAdapter(BaseAdapter):
         wallet = self.wallet_address
         if not wallet:
             return False, "wallet_address is required"
-        if not self.sign_callback:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
 
         vault = to_checksum_address(vault_address) if vault_address else self.vault
 
@@ -299,7 +300,7 @@ class AvantisAdapter(BaseAdapter):
                 from_address=wallet,
                 chain_id=self.chain_id,
             )
-            txn_hash = await send_transaction(transaction, self.sign_callback)
+            txn_hash = await send_transaction(transaction, self.signing.sign)
             return True, txn_hash
         except Exception as exc:
             return False, str(exc)

--- a/wayfinder_paths/adapters/avantis_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/avantis_adapter/test_adapter.py
@@ -11,6 +11,7 @@ from wayfinder_paths.core.constants.contracts import (
     AVANTIS_VAULT_MANAGER,
     BASE_USDC,
 )
+from wayfinder_paths.testing import fake_signing
 
 FAKE_WALLET = "0x1234567890123456789012345678901234567890"
 
@@ -23,7 +24,7 @@ def adapter():
 @pytest.fixture
 def adapter_with_signer():
     return AvantisAdapter(
-        sign_callback=AsyncMock(return_value="0xdeadbeef"),
+        signing=fake_signing(sign=AsyncMock(return_value="0xdeadbeef")),
         wallet_address=FAKE_WALLET,
     )
 
@@ -96,7 +97,7 @@ async def test_borrow_and_repay_unsupported(adapter):
 async def test_deposit_requires_signing_callback(adapter):
     ok, msg = await adapter.deposit(amount=1)
     assert ok is False
-    assert "sign_callback" in str(msg).lower()
+    assert "signing" in str(msg).lower()
 
 
 @pytest.mark.asyncio
@@ -131,7 +132,7 @@ async def test_withdraw_requires_wallet(adapter_no_wallet):
 async def test_withdraw_requires_signing_callback(adapter):
     ok, msg = await adapter.withdraw(amount=1)
     assert ok is False
-    assert "sign_callback" in str(msg).lower()
+    assert "signing" in str(msg).lower()
 
 
 @pytest.mark.asyncio

--- a/wayfinder_paths/adapters/avantis_adapter/test_gorlami_simulation.py
+++ b/wayfinder_paths/adapters/avantis_adapter/test_gorlami_simulation.py
@@ -7,6 +7,7 @@ from wayfinder_paths.adapters.avantis_adapter.adapter import AvantisAdapter
 from wayfinder_paths.core.constants.chains import CHAIN_ID_BASE
 from wayfinder_paths.core.constants.contracts import AVANTIS_AVUSDC, BASE_USDC
 from wayfinder_paths.core.utils import web3 as web3_utils
+from wayfinder_paths.testing import fake_signing
 from wayfinder_paths.testing.gorlami import gorlami_configured
 
 pytestmark = pytest.mark.skipif(
@@ -42,7 +43,7 @@ async def test_gorlami_avantis_deposit_withdraw_full(gorlami):
     )
 
     adapter = AvantisAdapter(
-        sign_callback=sign_cb,
+        signing=fake_signing(sign=sign_cb),
         wallet_address=acct.address,
     )
 

--- a/wayfinder_paths/adapters/balance_adapter/adapter.py
+++ b/wayfinder_paths/adapters/balance_adapter/adapter.py
@@ -8,6 +8,7 @@ from wayfinder_paths.core.adapters.BaseAdapter import BaseAdapter
 from wayfinder_paths.core.clients.TokenClient import TOKEN_CLIENT
 from wayfinder_paths.core.constants.erc20_abi import ERC20_ABI
 from wayfinder_paths.core.utils.evm_helpers import resolve_chain_id
+from wayfinder_paths.core.utils.signing import SigningCallbacks
 from wayfinder_paths.core.utils.token_resolver import TokenResolver
 from wayfinder_paths.core.utils.tokens import (
     build_send_transaction,
@@ -26,17 +27,21 @@ class BalanceAdapter(BaseAdapter):
     def __init__(
         self,
         config: dict[str, Any],
-        main_sign_callback=None,
-        strategy_sign_callback=None,
         *,
+        main_signing: SigningCallbacks | None = None,
+        strategy_signing: SigningCallbacks | None = None,
         main_wallet_address: str | None = None,
         strategy_wallet_address: str | None = None,
     ):
         super().__init__("balance", config)
-        self.main_sign_callback = main_sign_callback
-        self.strategy_sign_callback = strategy_sign_callback
-        self.main_wallet_address: str | None = main_wallet_address
-        self.strategy_wallet_address: str | None = strategy_wallet_address
+        self.main_signing = main_signing
+        self.strategy_signing = strategy_signing
+        self.main_wallet_address: str | None = main_wallet_address or (
+            main_signing.address if main_signing else None
+        )
+        self.strategy_wallet_address: str | None = strategy_wallet_address or (
+            strategy_signing.address if strategy_signing else None
+        )
         self.token_adapter = TokenAdapter()
         self.ledger_adapter = LedgerAdapter()
 
@@ -248,13 +253,15 @@ class BalanceAdapter(BaseAdapter):
             amount=raw_amount,
         )
 
-        callback = (
-            self.main_sign_callback
+        bundle = (
+            self.main_signing
             if self.main_wallet_address
             and from_address.lower() == self.main_wallet_address.lower()
-            else self.strategy_sign_callback
+            else self.strategy_signing
         )
-        tx_hash = await send_transaction(transaction, callback)
+        if bundle is None:
+            return False, "signing is required"
+        tx_hash = await send_transaction(transaction, bundle.sign)
 
         if ledger_method:
             wallet_for_ledger = from_address if ledger_wallet == "from" else to_address

--- a/wayfinder_paths/adapters/boros_adapter/adapter.py
+++ b/wayfinder_paths/adapters/boros_adapter/adapter.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import time
-from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import Any
 
@@ -29,6 +28,7 @@ from wayfinder_paths.core.utils.multicall import (
     Call,
     read_only_calls_multicall_or_gather,
 )
+from wayfinder_paths.core.utils.signing import SigningCallbacks
 from wayfinder_paths.core.utils.tokens import (
     build_approve_transaction,
     get_token_balance,
@@ -90,13 +90,13 @@ class BorosAdapter(BaseAdapter):
         self,
         config: dict[str, Any] | None = None,
         *,
-        sign_callback: Callable | None = None,
+        signing: SigningCallbacks | None = None,
         wallet_address: str | None = None,
         account_id: int = 0,
         **kwargs: Any,
     ) -> None:
         super().__init__("boros_adapter", config)
-        self.sign_callback = sign_callback
+        self.signing = signing
         self._scaling_factor_cache: dict[int, int] = {}
         self._amm_address_cache: dict[int, str | None] = {}
         self._amm_id_by_market_cache: dict[int, int] = {}
@@ -492,9 +492,9 @@ class BorosAdapter(BaseAdapter):
             timeout: Transaction timeout in seconds.
             max_retries: Number of retry attempts for failed transactions.
         """
-        if not self.sign_callback:
+        if self.signing is None:
             return False, {
-                "error": "sign_callback not configured",
+                "error": "signing not configured",
                 "calldata": calldata,
             }
         if not self.wallet_address:
@@ -514,7 +514,7 @@ class BorosAdapter(BaseAdapter):
                 )
                 try:
                     tx_hash = await send_transaction(
-                        tx, self.sign_callback, wait_for_receipt=True
+                        tx, self.signing.sign, wait_for_receipt=True
                     )
                     results.append({"ok": True, "res": {"tx_hash": tx_hash}})
                 except Exception as e:
@@ -541,7 +541,7 @@ class BorosAdapter(BaseAdapter):
             )
             try:
                 tx_hash = await send_transaction(
-                    tx, self.sign_callback, wait_for_receipt=True
+                    tx, self.signing.sign, wait_for_receipt=True
                 )
                 return True, {
                     "status": "ok",
@@ -3007,9 +3007,9 @@ class BorosAdapter(BaseAdapter):
                 account_id=0,
             )
 
-            if not self.sign_callback or not self.wallet_address:
+            if self.signing is None or not self.wallet_address:
                 return False, {
-                    "error": "sign_callback or user_address not configured",
+                    "error": "signing or wallet_address not configured",
                     "calldata": calldata,
                 }
 
@@ -3031,7 +3031,7 @@ class BorosAdapter(BaseAdapter):
                     amount=int(amount_wei),
                 )
                 approve_hash = await send_transaction(
-                    approve_tx, self.sign_callback, wait_for_receipt=True
+                    approve_tx, self.signing.sign, wait_for_receipt=True
                 )
                 approve_res = {"tx_hash": approve_hash}
             except Exception as e:
@@ -3281,8 +3281,8 @@ class BorosAdapter(BaseAdapter):
     ) -> tuple[bool, dict[str, Any]]:
         if not self.wallet_address:
             return False, {"error": "wallet_address is required"}
-        if not self.sign_callback:
-            return False, {"error": "sign_callback is required"}
+        if self.signing is None:
+            return False, {"error": "signing is required"}
 
         net_cash = int(net_cash_in_wei)
         if net_cash <= 0:
@@ -3332,7 +3332,7 @@ class BorosAdapter(BaseAdapter):
                     chain_id=self.chain_id,
                 )
                 tx_hash = await send_transaction(
-                    tx, self.sign_callback, wait_for_receipt=True
+                    tx, self.signing.sign, wait_for_receipt=True
                 )
                 self._invalidate_lp_cache()
                 return True, {
@@ -3365,8 +3365,8 @@ class BorosAdapter(BaseAdapter):
     ) -> tuple[bool, dict[str, Any]]:
         if not self.wallet_address:
             return False, {"error": "wallet_address is required"}
-        if not self.sign_callback:
-            return False, {"error": "sign_callback is required"}
+        if self.signing is None:
+            return False, {"error": "signing is required"}
 
         context = None
         if market_id is None or is_isolated_only is None:
@@ -3403,7 +3403,7 @@ class BorosAdapter(BaseAdapter):
                 chain_id=self.chain_id,
             )
             tx_hash = await send_transaction(
-                tx, self.sign_callback, wait_for_receipt=True
+                tx, self.signing.sign, wait_for_receipt=True
             )
             self._invalidate_lp_cache()
             return True, {
@@ -3562,8 +3562,8 @@ class BorosAdapter(BaseAdapter):
     async def claim_rewards(self) -> tuple[bool, dict[str, Any]]:
         if not self.wallet_address:
             return False, {"error": "wallet_address is required"}
-        if not self.sign_callback:
-            return False, {"error": "sign_callback is required"}
+        if self.signing is None:
+            return False, {"error": "signing is required"}
 
         ok, proof = await self.get_claim_proof()
         if not ok:
@@ -3587,7 +3587,7 @@ class BorosAdapter(BaseAdapter):
 
         try:
             tx_hash = await send_transaction(
-                tx, self.sign_callback, wait_for_receipt=True
+                tx, self.signing.sign, wait_for_receipt=True
             )
             return True, {
                 "status": "claimed",
@@ -3619,8 +3619,8 @@ class BorosAdapter(BaseAdapter):
         if amount_wei <= 0:
             return True, {"status": "no_op", "amount_wei": 0}
 
-        if not self.sign_callback:
-            return False, {"error": "sign_callback not configured"}
+        if self.signing is None:
+            return False, {"error": "signing not configured"}
 
         sender = from_address or self.wallet_address
         recipient = to_address or self.wallet_address
@@ -3708,7 +3708,7 @@ class BorosAdapter(BaseAdapter):
                 value=int(total_value_wei),
             )
             tx_hash = await send_transaction(
-                tx, self.sign_callback, wait_for_receipt=True
+                tx, self.signing.sign, wait_for_receipt=True
             )
             return True, {
                 "status": "ok",
@@ -3746,8 +3746,8 @@ class BorosAdapter(BaseAdapter):
         if amount_wei <= 0:
             return True, {"status": "no_op", "amount_wei": 0}
 
-        if not self.sign_callback:
-            return False, {"error": "sign_callback not configured"}
+        if self.signing is None:
+            return False, {"error": "signing not configured"}
 
         sender = from_address or self.wallet_address
         recipient = to_address or self.wallet_address
@@ -3816,7 +3816,7 @@ class BorosAdapter(BaseAdapter):
                 value=int(native_fee_wei),
             )
             tx_hash = await send_transaction(
-                tx, self.sign_callback, wait_for_receipt=True
+                tx, self.signing.sign, wait_for_receipt=True
             )
             return True, {
                 "status": "ok",
@@ -4017,9 +4017,9 @@ class BorosAdapter(BaseAdapter):
                 slippage=slippage,
             )
 
-            if not self.sign_callback:
+            if self.signing is None:
                 return False, {
-                    "error": "sign_callback not configured",
+                    "error": "signing not configured",
                     "calldata": calldata,
                 }
 
@@ -4079,9 +4079,9 @@ class BorosAdapter(BaseAdapter):
                 tif=1,  # IOC
             )
 
-            if not self.sign_callback:
+            if self.signing is None:
                 return False, {
-                    "error": "sign_callback not configured",
+                    "error": "signing not configured",
                     "calldata": calldata,
                 }
 
@@ -4111,9 +4111,9 @@ class BorosAdapter(BaseAdapter):
                 cancel_all=cancel_all,
             )
 
-            if not self.sign_callback:
+            if self.signing is None:
                 return False, {
-                    "error": "sign_callback not configured",
+                    "error": "signing not configured",
                     "calldata": calldata,
                 }
 
@@ -4147,8 +4147,8 @@ class BorosAdapter(BaseAdapter):
             if not dest_address:
                 return False, {"error": "No destination address configured"}
 
-            if not self.sign_callback:
-                return False, {"error": "sign_callback not configured"}
+            if self.signing is None:
+                return False, {"error": "signing not configured"}
 
             # Encode finalizeVaultWithdrawal(address root, uint16 tokenId) directly
             # Function selector: keccak256("finalizeVaultWithdrawal(address,uint16)")[:4]
@@ -4170,7 +4170,7 @@ class BorosAdapter(BaseAdapter):
 
             try:
                 tx_hash = await send_transaction(
-                    tx, self.sign_callback, wait_for_receipt=True
+                    tx, self.signing.sign, wait_for_receipt=True
                 )
                 self._invalidate_lp_cache()
                 return True, {"status": "ok", "tx": {"tx_hash": tx_hash}}

--- a/wayfinder_paths/adapters/boros_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/boros_adapter/test_adapter.py
@@ -14,6 +14,7 @@ from wayfinder_paths.adapters.boros_adapter.adapter import (
     BorosMarketQuote,
     BorosVault,
 )
+from wayfinder_paths.testing import fake_signing
 
 
 class TestBorosAdapter:
@@ -873,7 +874,7 @@ class TestBorosAdapter:
         self, adapter, mock_boros_client
     ):
         """Test deposit falls back to direct isolated->cross transfer when sweep is empty."""
-        adapter.sign_callback = object()
+        adapter.signing = fake_signing(sign=object())
 
         mock_boros_client.build_deposit_calldata = AsyncMock(
             return_value={
@@ -954,7 +955,7 @@ class TestBorosAdapter:
     async def test_deposit_to_isolated_margin_skips_cross_sweep(
         self, adapter, mock_boros_client
     ):
-        adapter.sign_callback = object()
+        adapter.signing = fake_signing(sign=object())
 
         mock_boros_client.build_deposit_calldata = AsyncMock(
             return_value={
@@ -1159,7 +1160,7 @@ class TestBorosAdapter:
     async def test_deposit_to_vault_direct_uses_isolated_router_mode(
         self, adapter, mock_boros_client
     ):
-        adapter.sign_callback = object()
+        adapter.signing = fake_signing(sign=object())
         adapter._get_vault_context_for_amm = AsyncMock(
             return_value={"market_id": 73, "is_isolated_only": True}
         )
@@ -1198,7 +1199,7 @@ class TestBorosAdapter:
     async def test_withdraw_from_vault_direct_uses_isolated_router_mode(
         self, adapter, mock_boros_client
     ):
-        adapter.sign_callback = object()
+        adapter.signing = fake_signing(sign=object())
         adapter._get_vault_context_for_amm = AsyncMock(
             return_value={"market_id": 73, "is_isolated_only": True}
         )
@@ -1287,7 +1288,7 @@ class TestBorosAdapter:
 
     @pytest.mark.asyncio
     async def test_bridge_hype_oft_rounds_amount_and_builds_tx(self, adapter):
-        adapter.sign_callback = object()
+        adapter.signing = fake_signing(sign=object())
 
         mock_contract = SimpleNamespace()
         mock_dec_fn = SimpleNamespace(call=AsyncMock(return_value=10))
@@ -1345,7 +1346,7 @@ class TestBorosAdapter:
     async def test_bridge_hype_oft_arbitrum_to_hyperevm_rounds_amount_and_builds_tx(
         self, adapter
     ):
-        adapter.sign_callback = object()
+        adapter.signing = fake_signing(sign=object())
 
         mock_contract = SimpleNamespace()
         mock_dec_fn = SimpleNamespace(call=AsyncMock(return_value=10))

--- a/wayfinder_paths/adapters/boros_adapter/test_gorlami_simulation.py
+++ b/wayfinder_paths/adapters/boros_adapter/test_gorlami_simulation.py
@@ -6,6 +6,7 @@ from eth_account import Account
 from wayfinder_paths.adapters.boros_adapter import BorosAdapter
 from wayfinder_paths.core.constants.chains import CHAIN_ID_ARBITRUM
 from wayfinder_paths.core.utils import web3 as web3_utils
+from wayfinder_paths.testing import fake_signing
 from wayfinder_paths.testing.gorlami import gorlami_configured
 
 ARBITRUM_USDT = "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9"
@@ -41,7 +42,7 @@ async def _make_funded_boros_adapter(gorlami) -> tuple[BorosAdapter, str]:
 
     return (
         BorosAdapter(
-            sign_callback=sign_cb,
+            signing=fake_signing(sign=sign_cb),
             wallet_address=acct.address,
         ),
         acct.address,

--- a/wayfinder_paths/adapters/brap_adapter/adapter.py
+++ b/wayfinder_paths/adapters/brap_adapter/adapter.py
@@ -11,6 +11,7 @@ from wayfinder_paths.core.adapters.models import SWAP
 from wayfinder_paths.core.clients.BRAPClient import BRAP_CLIENT
 from wayfinder_paths.core.clients.LedgerClient import TransactionRecord
 from wayfinder_paths.core.clients.TokenClient import TOKEN_CLIENT
+from wayfinder_paths.core.utils.signing import SigningCallbacks
 from wayfinder_paths.core.utils.tokens import (
     ensure_allowance,
     is_native_token,
@@ -24,11 +25,11 @@ class BRAPAdapter(BaseAdapter):
     def __init__(
         self,
         config: dict[str, Any] | None = None,
-        sign_callback=None,
+        signing: SigningCallbacks | None = None,
         wallet_address: str | None = None,
     ):
         super().__init__("brap_adapter", config)
-        self.sign_callback = sign_callback
+        self.signing = signing
         self.wallet_address: str | None = wallet_address
         self.token_adapter = TokenAdapter()
         self.ledger_adapter = LedgerAdapter()
@@ -192,10 +193,10 @@ class BRAPAdapter(BaseAdapter):
                 spender=spender,
                 amount=int(approve_amount),
                 chain_id=chain_id,
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
             )
 
-        txn_hash = await send_transaction(transaction, self.sign_callback)
+        txn_hash = await send_transaction(transaction, self.signing.sign)
         self.logger.info(f"Swap broadcast: tx={txn_hash}")
 
         try:

--- a/wayfinder_paths/adapters/eigencloud_adapter/adapter.py
+++ b/wayfinder_paths/adapters/eigencloud_adapter/adapter.py
@@ -27,6 +27,7 @@ from wayfinder_paths.core.constants.eigencloud_abi import (
     ISTRATEGY_ABI,
     ISTRATEGY_MANAGER_ABI,
 )
+from wayfinder_paths.core.utils.signing import SigningCallbacks
 from wayfinder_paths.core.utils.tokens import ensure_allowance, get_erc20_metadata
 from wayfinder_paths.core.utils.transaction import encode_call, send_transaction
 from wayfinder_paths.core.utils.web3 import web3_from_chain_id
@@ -91,11 +92,11 @@ class EigenCloudAdapter(BaseAdapter):
     def __init__(
         self,
         config: dict[str, Any] | None = None,
-        sign_callback: Any | None = None,
+        signing: SigningCallbacks | None = None,
         wallet_address: str | None = None,
     ) -> None:
         super().__init__("eigencloud_adapter", config)
-        self.sign_callback = sign_callback
+        self.signing = signing
 
         self.wallet_address: str | None = (
             to_checksum_address(wallet_address) if wallet_address else None
@@ -198,8 +199,8 @@ class EigenCloudAdapter(BaseAdapter):
         check_whitelist: bool = True,
         block_identifier: int | str = "pending",
     ) -> tuple[bool, Any]:
-        if not self.sign_callback:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
 
         if amount <= 0:
             return False, "amount must be positive"
@@ -243,7 +244,7 @@ class EigenCloudAdapter(BaseAdapter):
                 spender=EIGENCLOUD_STRATEGY_MANAGER,
                 amount=amount,
                 chain_id=CHAIN_ID_ETHEREUM,
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=MAX_UINT256,
             )
             if not ok_appr:
@@ -260,7 +261,7 @@ class EigenCloudAdapter(BaseAdapter):
                 from_address=self.wallet_address,
                 chain_id=CHAIN_ID_ETHEREUM,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, {
                 "tx_hash": tx_hash,
                 "approve_tx_hash": approve_tx_hash,
@@ -325,8 +326,8 @@ class EigenCloudAdapter(BaseAdapter):
         approver_expiry: int = 0,
         approver_salt: Any = None,
     ) -> tuple[bool, Any]:
-        if not self.sign_callback:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
 
         op = to_checksum_address(operator)
         sig = _as_bytes(approver_signature)
@@ -341,7 +342,7 @@ class EigenCloudAdapter(BaseAdapter):
                 from_address=self.wallet_address,
                 chain_id=CHAIN_ID_ETHEREUM,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)
@@ -354,8 +355,8 @@ class EigenCloudAdapter(BaseAdapter):
         include_withdrawal_roots: bool = True,
         block_identifier: int | str = "pending",
     ) -> tuple[bool, Any]:
-        if not self.sign_callback:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
 
         stk = to_checksum_address(staker) if staker else self.wallet_address
 
@@ -368,7 +369,7 @@ class EigenCloudAdapter(BaseAdapter):
                 from_address=self.wallet_address,
                 chain_id=CHAIN_ID_ETHEREUM,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             payload: dict[str, Any] = {"tx_hash": tx_hash}
             if include_withdrawal_roots:
                 ok, roots = await self.get_withdrawal_roots_from_tx_hash(
@@ -391,8 +392,8 @@ class EigenCloudAdapter(BaseAdapter):
         include_withdrawal_roots: bool = True,
         block_identifier: int | str = "pending",
     ) -> tuple[bool, Any]:
-        if not self.sign_callback:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
 
         op = to_checksum_address(new_operator)
         sig = _as_bytes(approver_signature)
@@ -407,7 +408,7 @@ class EigenCloudAdapter(BaseAdapter):
                 from_address=self.wallet_address,
                 chain_id=CHAIN_ID_ETHEREUM,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             payload: dict[str, Any] = {"tx_hash": tx_hash}
             if include_withdrawal_roots:
                 ok, roots = await self.get_withdrawal_roots_from_tx_hash(
@@ -428,8 +429,8 @@ class EigenCloudAdapter(BaseAdapter):
         include_withdrawal_roots: bool = True,
         block_identifier: int | str = "pending",
     ) -> tuple[bool, Any]:
-        if not self.sign_callback:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
 
         if not strategies:
             return False, "strategies is required"
@@ -451,7 +452,7 @@ class EigenCloudAdapter(BaseAdapter):
                 from_address=self.wallet_address,
                 chain_id=CHAIN_ID_ETHEREUM,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             payload: dict[str, Any] = {"tx_hash": tx_hash}
             if include_withdrawal_roots:
                 ok, roots = await self.get_withdrawal_roots_from_tx_hash(
@@ -557,8 +558,8 @@ class EigenCloudAdapter(BaseAdapter):
         tokens_override: list[str] | None = None,
         block_identifier: int | str = "pending",
     ) -> tuple[bool, Any]:
-        if not self.sign_callback:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
 
         root_hex = _as_bytes32_hex(withdrawal_root)
 
@@ -622,7 +623,7 @@ class EigenCloudAdapter(BaseAdapter):
                     from_address=self.wallet_address,
                     chain_id=CHAIN_ID_ETHEREUM,
                 )
-                tx_hash = await send_transaction(tx, self.sign_callback)
+                tx_hash = await send_transaction(tx, self.signing.sign)
                 return True, {
                     "tx_hash": tx_hash,
                     "withdrawal_root": root_hex,
@@ -684,8 +685,8 @@ class EigenCloudAdapter(BaseAdapter):
         *,
         claimer: str,
     ) -> tuple[bool, Any]:
-        if not self.sign_callback:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
 
         c = to_checksum_address(claimer)
         try:
@@ -697,7 +698,7 @@ class EigenCloudAdapter(BaseAdapter):
                 from_address=self.wallet_address,
                 chain_id=CHAIN_ID_ETHEREUM,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)
@@ -727,8 +728,8 @@ class EigenCloudAdapter(BaseAdapter):
         claim: Any,
         recipient: str,
     ) -> tuple[bool, Any]:
-        if not self.sign_callback:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
 
         rcpt = to_checksum_address(recipient)
         try:
@@ -740,7 +741,7 @@ class EigenCloudAdapter(BaseAdapter):
                 from_address=self.wallet_address,
                 chain_id=CHAIN_ID_ETHEREUM,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)
@@ -752,8 +753,8 @@ class EigenCloudAdapter(BaseAdapter):
         claims: list[Any],
         recipient: str,
     ) -> tuple[bool, Any]:
-        if not self.sign_callback:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
 
         if not claims:
             return False, "claims is required"
@@ -768,7 +769,7 @@ class EigenCloudAdapter(BaseAdapter):
                 from_address=self.wallet_address,
                 chain_id=CHAIN_ID_ETHEREUM,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)
@@ -781,8 +782,8 @@ class EigenCloudAdapter(BaseAdapter):
         value: int = 0,
     ) -> tuple[bool, Any]:
         """Raw-calldata fallback for rewards claiming (e.g., from EigenLayer CLI/app)."""
-        if not self.sign_callback:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing is required"
 
         try:
             raw_data = (
@@ -802,7 +803,7 @@ class EigenCloudAdapter(BaseAdapter):
                 "data": "0x" + data.hex(),
                 "value": value,
             }
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)

--- a/wayfinder_paths/adapters/eigencloud_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/eigencloud_adapter/test_adapter.py
@@ -17,6 +17,7 @@ from wayfinder_paths.core.constants.contracts import (
     ZERO_ADDRESS,
 )
 from wayfinder_paths.core.constants.eigencloud_abi import IDELEGATION_MANAGER_ABI
+from wayfinder_paths.testing import fake_signing
 
 FAKE_WALLET = "0x1234567890123456789012345678901234567890"
 FAKE_STRATEGY = "0x1111111111111111111111111111111111111111"
@@ -79,7 +80,8 @@ def adapter():
 @pytest.fixture
 def adapter_with_signer():
     return EigenCloudAdapter(
-        sign_callback=AsyncMock(return_value="0xdeadbeef"), wallet_address=FAKE_WALLET
+        signing=fake_signing(sign=AsyncMock(return_value="0xdeadbeef")),
+        wallet_address=FAKE_WALLET,
     )
 
 
@@ -103,7 +105,7 @@ async def test_deposit_requires_wallet(adapter_no_wallet):
 async def test_deposit_requires_sign_callback(adapter):
     ok, msg = await adapter.deposit(strategy=FAKE_STRATEGY, amount=1)
     assert ok is False
-    assert "sign_callback" in str(msg).lower()
+    assert "signing" in str(msg).lower()
 
 
 @pytest.mark.asyncio

--- a/wayfinder_paths/adapters/eigencloud_adapter/test_gorlami_simulation.py
+++ b/wayfinder_paths/adapters/eigencloud_adapter/test_gorlami_simulation.py
@@ -7,6 +7,7 @@ from wayfinder_paths.adapters.eigencloud_adapter.adapter import EigenCloudAdapte
 from wayfinder_paths.core.constants.chains import CHAIN_ID_ETHEREUM
 from wayfinder_paths.core.constants.contracts import EIGENCLOUD_STRATEGIES
 from wayfinder_paths.core.utils import web3 as web3_utils
+from wayfinder_paths.testing import fake_signing
 from wayfinder_paths.testing.gorlami import gorlami_configured
 
 pytestmark = pytest.mark.skipif(
@@ -47,7 +48,7 @@ async def test_gorlami_eigencloud_deposit_queue_withdraw(gorlami):
 
     adapter = EigenCloudAdapter(
         config={},
-        sign_callback=sign_cb,
+        signing=fake_signing(sign=sign_cb),
         wallet_address=acct.address,
     )
 

--- a/wayfinder_paths/adapters/ethena_vault_adapter/adapter.py
+++ b/wayfinder_paths/adapters/ethena_vault_adapter/adapter.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
 from typing import Any
 
 from eth_utils import to_checksum_address
@@ -21,6 +20,7 @@ from wayfinder_paths.core.utils.multicall import (
     Call,
     read_only_calls_multicall_or_gather,
 )
+from wayfinder_paths.core.utils.signing import SigningCallbacks
 from wayfinder_paths.core.utils.tokens import ensure_allowance
 from wayfinder_paths.core.utils.transaction import encode_call, send_transaction
 from wayfinder_paths.core.utils.web3 import web3_from_chain_id
@@ -41,11 +41,11 @@ class EthenaVaultAdapter(BaseAdapter):
     def __init__(
         self,
         config: dict[str, Any] | None = None,
-        sign_callback: Callable | None = None,
+        signing: SigningCallbacks | None = None,
         wallet_address: str | None = None,
     ) -> None:
         super().__init__("ethena_vault_adapter", config)
-        self.sign_callback = sign_callback
+        self.signing = signing
         self.wallet_address: str | None = (
             to_checksum_address(wallet_address) if wallet_address else None
         )
@@ -337,7 +337,7 @@ class EthenaVaultAdapter(BaseAdapter):
                 spender=ETHENA_SUSDE_VAULT_MAINNET,
                 amount=amount_assets,
                 chain_id=CHAIN_ID_ETHEREUM,
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=MAX_UINT256,
             )
             if not approved[0]:
@@ -351,7 +351,7 @@ class EthenaVaultAdapter(BaseAdapter):
                 from_address=self.wallet_address,
                 chain_id=CHAIN_ID_ETHEREUM,
             )
-            txn_hash = await send_transaction(tx, self.sign_callback)
+            txn_hash = await send_transaction(tx, self.signing.sign)
             return True, txn_hash
         except Exception as exc:
             return False, str(exc)
@@ -374,7 +374,7 @@ class EthenaVaultAdapter(BaseAdapter):
                 from_address=self.wallet_address,
                 chain_id=CHAIN_ID_ETHEREUM,
             )
-            txn_hash = await send_transaction(tx, self.sign_callback)
+            txn_hash = await send_transaction(tx, self.signing.sign)
             return True, txn_hash
         except Exception as exc:
             return False, str(exc)
@@ -397,7 +397,7 @@ class EthenaVaultAdapter(BaseAdapter):
                 from_address=self.wallet_address,
                 chain_id=CHAIN_ID_ETHEREUM,
             )
-            txn_hash = await send_transaction(tx, self.sign_callback)
+            txn_hash = await send_transaction(tx, self.signing.sign)
             return True, txn_hash
         except Exception as exc:
             return False, str(exc)
@@ -441,7 +441,7 @@ class EthenaVaultAdapter(BaseAdapter):
                 from_address=self.wallet_address,
                 chain_id=CHAIN_ID_ETHEREUM,
             )
-            txn_hash = await send_transaction(tx, self.sign_callback)
+            txn_hash = await send_transaction(tx, self.signing.sign)
             return True, txn_hash
         except Exception as exc:
             return False, str(exc)

--- a/wayfinder_paths/adapters/ethena_vault_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/ethena_vault_adapter/test_adapter.py
@@ -16,6 +16,7 @@ from wayfinder_paths.core.constants.ethena_contracts import (
     ETHENA_USDE_MAINNET,
     ethena_tokens_by_chain_id,
 )
+from wayfinder_paths.testing import fake_signing
 
 MOCK_WALLET = "0x1234567890123456789012345678901234567890"
 ADAPTER_MODULE = "wayfinder_paths.adapters.ethena_vault_adapter.adapter"
@@ -26,7 +27,7 @@ class TestEthenaVaultAdapter:
     def adapter(self):
         return EthenaVaultAdapter(
             config={},
-            sign_callback=AsyncMock(return_value=b"\x00" * 32),
+            signing=fake_signing(sign=AsyncMock(return_value=b"\x00" * 32)),
             wallet_address=MOCK_WALLET,
         )
 
@@ -43,7 +44,7 @@ class TestEthenaVaultAdapter:
 
     def test_no_wallet(self, readonly_adapter):
         assert readonly_adapter.wallet_address is None
-        assert readonly_adapter.sign_callback is None
+        assert readonly_adapter.signing is None
 
     # -- get_apy ---------------------------------------------------------------
 

--- a/wayfinder_paths/adapters/ethena_vault_adapter/test_gorlami_simulation.py
+++ b/wayfinder_paths/adapters/ethena_vault_adapter/test_gorlami_simulation.py
@@ -12,6 +12,7 @@ from wayfinder_paths.core.constants.ethena_contracts import (
 )
 from wayfinder_paths.core.utils import web3 as web3_utils
 from wayfinder_paths.core.utils.tokens import get_token_balance, get_token_decimals
+from wayfinder_paths.testing import fake_signing
 from wayfinder_paths.testing.gorlami import gorlami_configured
 
 pytestmark = pytest.mark.skipif(
@@ -95,7 +96,7 @@ async def test_gorlami_ethena_deposit_cooldown_and_claim(gorlami):
 
     adapter = EthenaVaultAdapter(
         config={},
-        sign_callback=sign_cb,
+        signing=fake_signing(sign=sign_cb),
         wallet_address=acct.address,
     )
 

--- a/wayfinder_paths/adapters/etherfi_adapter/adapter.py
+++ b/wayfinder_paths/adapters/etherfi_adapter/adapter.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import Any
 
 from eth_utils import to_checksum_address
@@ -25,6 +24,7 @@ from wayfinder_paths.core.utils.multicall import (
     Call,
     read_only_calls_multicall_or_gather,
 )
+from wayfinder_paths.core.utils.signing import SigningCallbacks
 from wayfinder_paths.core.utils.tokens import ensure_allowance
 from wayfinder_paths.core.utils.transaction import encode_call, send_transaction
 from wayfinder_paths.core.utils.web3 import web3_from_chain_id
@@ -108,11 +108,11 @@ class EtherfiAdapter(BaseAdapter):
         self,
         config: dict[str, Any] | None = None,
         *,
-        sign_callback: Callable | None = None,
+        signing: SigningCallbacks | None = None,
         wallet_address: str | None = None,
     ) -> None:
         super().__init__("etherfi_adapter", config or {})
-        self.sign_callback = sign_callback
+        self.signing = signing
         self.wallet_address: str | None = (
             to_checksum_address(wallet_address) if wallet_address else None
         )
@@ -241,7 +241,7 @@ class EtherfiAdapter(BaseAdapter):
                 chain_id=chain_id,
                 value=amount_wei,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)
@@ -267,7 +267,7 @@ class EtherfiAdapter(BaseAdapter):
                 spender=entry["weeth"],
                 amount=amount_eeth,
                 chain_id=chain_id,
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=approval_amount,
             )
             if not approved[0]:
@@ -281,7 +281,7 @@ class EtherfiAdapter(BaseAdapter):
                 from_address=self.wallet_address,
                 chain_id=chain_id,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)
@@ -310,7 +310,7 @@ class EtherfiAdapter(BaseAdapter):
                 from_address=self.wallet_address,
                 chain_id=chain_id,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)
@@ -336,7 +336,7 @@ class EtherfiAdapter(BaseAdapter):
                 from_address=self.wallet_address,
                 chain_id=chain_id,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)
@@ -369,7 +369,7 @@ class EtherfiAdapter(BaseAdapter):
                 spender=entry["liquidity_pool"],
                 amount=amount_eeth,
                 chain_id=chain_id,
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=approval_amount,
             )
             if not approved[0]:
@@ -383,7 +383,7 @@ class EtherfiAdapter(BaseAdapter):
                 from_address=self.wallet_address,
                 chain_id=chain_id,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
 
             request_id: int | None = None
             if include_request_id:
@@ -438,7 +438,7 @@ class EtherfiAdapter(BaseAdapter):
                 from_address=self.wallet_address,
                 chain_id=chain_id,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
 
             request_id: int | None = None
             if include_request_id:
@@ -481,7 +481,7 @@ class EtherfiAdapter(BaseAdapter):
                 from_address=self.wallet_address,
                 chain_id=chain_id,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)

--- a/wayfinder_paths/adapters/etherfi_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/etherfi_adapter/test_adapter.py
@@ -19,6 +19,7 @@ from wayfinder_paths.core.constants.etherfi_contracts import (
     ETHERFI_BY_CHAIN,
     weeth_token_by_chain_id,
 )
+from wayfinder_paths.testing import fake_signing
 
 WALLET = "0x1234567890123456789012345678901234567890"
 ENTRY = ETHERFI_BY_CHAIN[CHAIN_ID_ETHEREUM]
@@ -30,7 +31,7 @@ PATCH_PREFIX = "wayfinder_paths.adapters.etherfi_adapter.adapter"
 def adapter():
     return EtherfiAdapter(
         config={},
-        sign_callback=AsyncMock(return_value=b"\x00" * 32),
+        signing=fake_signing(sign=AsyncMock(return_value=b"\x00" * 32)),
         wallet_address=WALLET,
     )
 

--- a/wayfinder_paths/adapters/etherfi_adapter/test_gorlami_simulation.py
+++ b/wayfinder_paths/adapters/etherfi_adapter/test_gorlami_simulation.py
@@ -17,6 +17,7 @@ from wayfinder_paths.core.constants.etherfi_abi import (
 from wayfinder_paths.core.constants.etherfi_contracts import ETHERFI_BY_CHAIN
 from wayfinder_paths.core.utils import web3 as web3_utils
 from wayfinder_paths.core.utils.tokens import get_token_balance
+from wayfinder_paths.testing import fake_signing
 from wayfinder_paths.testing.gorlami import gorlami_configured
 
 pytestmark = pytest.mark.skipif(
@@ -35,7 +36,7 @@ def _make_adapter(acct) -> EtherfiAdapter:
 
     return EtherfiAdapter(
         config={},
-        sign_callback=sign_cb,
+        signing=fake_signing(sign=sign_cb),
         wallet_address=acct.address,
     )
 

--- a/wayfinder_paths/adapters/hyperlend_adapter/adapter.py
+++ b/wayfinder_paths/adapters/hyperlend_adapter/adapter.py
@@ -32,6 +32,7 @@ from wayfinder_paths.core.constants.hyperlend_abi import (
     WRAPPED_TOKEN_GATEWAY_ABI,
 )
 from wayfinder_paths.core.utils.interest import RAY, apr_to_apy, ray_to_apr
+from wayfinder_paths.core.utils.signing import SigningCallbacks
 from wayfinder_paths.core.utils.symbols import is_stable_symbol, normalize_symbol
 from wayfinder_paths.core.utils.tokens import ensure_allowance, get_token_balance
 from wayfinder_paths.core.utils.transaction import encode_call, send_transaction
@@ -76,11 +77,11 @@ class HyperlendAdapter(BaseAdapter):
     def __init__(
         self,
         config: dict[str, Any] | None = None,
-        sign_callback=None,
+        signing: SigningCallbacks | None = None,
         wallet_address: str | None = None,
     ) -> None:
         super().__init__("hyperlend_adapter", config)
-        self.sign_callback = sign_callback
+        self.signing = signing
 
         self.ledger_adapter = LedgerAdapter()
         self.token_adapter = TokenAdapter()
@@ -343,7 +344,7 @@ class HyperlendAdapter(BaseAdapter):
                 spender=HYPERLEND_POOL,
                 amount=qty,
                 chain_id=chain_id,
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
             )
             if not approved[0]:
                 return approved
@@ -356,7 +357,7 @@ class HyperlendAdapter(BaseAdapter):
                 chain_id=chain_id,
             )
 
-        txn_hash = await send_transaction(transaction, self.sign_callback)
+        txn_hash = await send_transaction(transaction, self.signing.sign)
 
         await self._record_pool_op(
             token_address=token_addr,
@@ -406,7 +407,7 @@ class HyperlendAdapter(BaseAdapter):
                 chain_id=chain_id,
             )
 
-        txn_hash = await send_transaction(transaction, self.sign_callback)
+        txn_hash = await send_transaction(transaction, self.signing.sign)
         await self._record_pool_op(
             token_address=token_addr,
             amount=qty,
@@ -443,7 +444,7 @@ class HyperlendAdapter(BaseAdapter):
                 from_address=strategy,
                 chain_id=chain_id,
             )
-            borrow_tx_hash = await send_transaction(borrow_tx, self.sign_callback)
+            borrow_tx_hash = await send_transaction(borrow_tx, self.signing.sign)
 
             unwrap_tx = await encode_call(
                 target=asset,
@@ -453,7 +454,7 @@ class HyperlendAdapter(BaseAdapter):
                 from_address=strategy,
                 chain_id=chain_id,
             )
-            unwrap_tx_hash = await send_transaction(unwrap_tx, self.sign_callback)
+            unwrap_tx_hash = await send_transaction(unwrap_tx, self.signing.sign)
             return True, {"borrow_tx": borrow_tx_hash, "unwrap_tx": unwrap_tx_hash}
         else:
             asset = to_checksum_address(underlying_token)
@@ -466,7 +467,7 @@ class HyperlendAdapter(BaseAdapter):
                 chain_id=chain_id,
             )
 
-        txn_hash = await send_transaction(transaction, self.sign_callback)
+        txn_hash = await send_transaction(transaction, self.signing.sign)
         return True, txn_hash
 
     async def repay(
@@ -580,7 +581,7 @@ class HyperlendAdapter(BaseAdapter):
                 spender=HYPERLEND_POOL,
                 amount=allowance_target,
                 chain_id=chain_id,
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=MAX_UINT256,
             )
             if not approved[0]:
@@ -595,7 +596,7 @@ class HyperlendAdapter(BaseAdapter):
                 chain_id=chain_id,
             )
 
-        txn_hash = await send_transaction(transaction, self.sign_callback)
+        txn_hash = await send_transaction(transaction, self.signing.sign)
         return True, txn_hash
 
     async def set_collateral(
@@ -617,7 +618,7 @@ class HyperlendAdapter(BaseAdapter):
             from_address=strategy,
             chain_id=chain_id,
         )
-        txn_hash = await send_transaction(transaction, self.sign_callback)
+        txn_hash = await send_transaction(transaction, self.signing.sign)
         return True, txn_hash
 
     async def remove_collateral(
@@ -639,7 +640,7 @@ class HyperlendAdapter(BaseAdapter):
             from_address=strategy,
             chain_id=chain_id,
         )
-        txn_hash = await send_transaction(transaction, self.sign_callback)
+        txn_hash = await send_transaction(transaction, self.signing.sign)
         return True, txn_hash
 
     async def _record_pool_op(

--- a/wayfinder_paths/adapters/hyperlend_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/hyperlend_adapter/test_adapter.py
@@ -11,6 +11,7 @@ from wayfinder_paths.core.constants.contracts import (
     HYPERLEND_WRAPPED_TOKEN_GATEWAY,
 )
 from wayfinder_paths.core.constants.hyperlend_abi import UI_POOL_RESERVE_KEYS
+from wayfinder_paths.testing import fake_signing
 
 
 class TestHyperlendAdapter:
@@ -22,6 +23,7 @@ class TestHyperlendAdapter:
     def adapter(self):
         return HyperlendAdapter(
             config={},
+            signing=fake_signing(),
             wallet_address="0x1234567890123456789012345678901234567890",
         )
 
@@ -545,7 +547,7 @@ class TestHyperlendAdapter:
             mock_encode.return_value = {"tx": "data"}
             mock_send.return_value = "0xabc"
             mock_record.return_value = None
-            adapter.sign_callback = AsyncMock()
+            adapter.signing = fake_signing(sign=AsyncMock())
 
             ok, txn = await adapter.lend(
                 underlying_token="0x0000000000000000000000000000000000000000",
@@ -581,7 +583,7 @@ class TestHyperlendAdapter:
             mock_encode.return_value = {"tx": "data"}
             mock_send.return_value = "0xabc"
             mock_record.return_value = None
-            adapter.sign_callback = AsyncMock()
+            adapter.signing = fake_signing(sign=AsyncMock())
 
             ok, txn = await adapter.unlend(
                 underlying_token="0x0000000000000000000000000000000000000000",
@@ -613,7 +615,7 @@ class TestHyperlendAdapter:
         ):
             mock_encode.return_value = {"tx": "data"}
             mock_send.return_value = "0xabc"
-            adapter.sign_callback = AsyncMock()
+            adapter.signing = fake_signing(sign=AsyncMock())
 
             ok, txn = await adapter.borrow(
                 underlying_token=token,
@@ -646,7 +648,7 @@ class TestHyperlendAdapter:
         ):
             mock_encode.side_effect = [{"tx": "borrow"}, {"tx": "unwrap"}]
             mock_send.side_effect = ["0xborrow", "0xunwrap"]
-            adapter.sign_callback = AsyncMock()
+            adapter.signing = fake_signing(sign=AsyncMock())
 
             ok, res = await adapter.borrow(
                 underlying_token="0x0000000000000000000000000000000000000000",
@@ -693,7 +695,7 @@ class TestHyperlendAdapter:
             mock_allow.return_value = (True, "ok")
             mock_encode.return_value = {"tx": "data"}
             mock_send.return_value = "0xabc"
-            adapter.sign_callback = AsyncMock()
+            adapter.signing = fake_signing(sign=AsyncMock())
 
             ok, txn = await adapter.repay(
                 underlying_token=token,
@@ -731,7 +733,7 @@ class TestHyperlendAdapter:
         ):
             mock_encode.return_value = {"tx": "data"}
             mock_send.return_value = "0xabc"
-            adapter.sign_callback = AsyncMock()
+            adapter.signing = fake_signing(sign=AsyncMock())
 
             ok, txn = await adapter.repay(
                 underlying_token="0x0000000000000000000000000000000000000000",
@@ -795,7 +797,7 @@ class TestHyperlendAdapter:
             mock_bal.side_effect = [1000, 10000]  # debt, native balance
             mock_encode.return_value = {"tx": "data"}
             mock_send.return_value = "0xabc"
-            adapter.sign_callback = AsyncMock()
+            adapter.signing = fake_signing(sign=AsyncMock())
 
             ok, txn = await adapter.repay(
                 underlying_token="0x0000000000000000000000000000000000000000",

--- a/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
+++ b/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 from decimal import ROUND_DOWN, Decimal, getcontext
 from typing import Any, Literal
 
@@ -38,6 +38,7 @@ from wayfinder_paths.core.constants.hyperliquid import (
     DEFAULT_HYPERLIQUID_BUILDER_FEE_TENTHS_BP,
     HYPE_FEE_WALLET,
 )
+from wayfinder_paths.core.utils.signing import SigningCallbacks
 from wayfinder_paths.core.utils.tokens import build_send_transaction
 from wayfinder_paths.core.utils.transaction import send_transaction
 
@@ -56,20 +57,16 @@ class HyperliquidAdapter(BaseAdapter):
         self,
         config: dict[str, Any] | None = None,
         *,
-        sign_callback: Callable[[dict], Awaitable[str]] | None = None,
+        signing: SigningCallbacks | None = None,
         wallet_address: str | None = None,
     ) -> None:
         super().__init__("hyperliquid_adapter", config)
 
         self._cache = Cache(Cache.MEMORY)
+        self.signing = signing
         self.wallet_address = to_checksum_address(
-            wallet_address
-            or ((config or {}).get("strategy_wallet") or {}).get("address")
-            or ((config or {}).get("main_wallet") or {}).get("address")
-            or ZERO_ADDRESS
+            wallet_address or (signing.address if signing else None) or ZERO_ADDRESS
         )
-
-        self._sign_callback: Callable[..., Awaitable[Any]] | None = sign_callback
 
     async def _post_across_dexes(
         self,
@@ -153,10 +150,10 @@ class HyperliquidAdapter(BaseAdapter):
     async def _sign(
         self, payload: str, action: dict[str, Any], address: str
     ) -> dict[str, Any] | None:
-        if self._sign_callback is None:
-            raise ValueError("No sign_callback configured")
+        if self.signing is None:
+            raise ValueError("No signing callbacks configured")
 
-        sig_hex = await self._sign_callback(payload)
+        sig_hex = await self.signing.sign_typed_data(payload)
         if not sig_hex:
             return None
         return self._sig_hex_to_hl_signature(sig_hex)
@@ -1316,8 +1313,8 @@ class HyperliquidAdapter(BaseAdapter):
         *,
         address: str | None = None,
     ) -> tuple[bool, str]:
-        if not self._sign_callback:
-            return False, "sign_callback is required"
+        if self.signing is None:
+            return False, "signing callbacks are required"
 
         sender = to_checksum_address(address or self.wallet_address)
         raw_amount = float_to_usd_int(float(amount))
@@ -1348,7 +1345,7 @@ class HyperliquidAdapter(BaseAdapter):
 
         try:
             tx_hash = await send_transaction(
-                tx, self._sign_callback, wait_for_receipt=True
+                tx, self.signing.sign, wait_for_receipt=True
             )
             return True, tx_hash
         except Exception as exc:  # noqa: BLE001

--- a/wayfinder_paths/adapters/hyperliquid_adapter/test_cancel_order.py
+++ b/wayfinder_paths/adapters/hyperliquid_adapter/test_cancel_order.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from wayfinder_paths.adapters.hyperliquid_adapter.adapter import HyperliquidAdapter
+from wayfinder_paths.testing import fake_signing
 
 
 class TestHyperliquidCancelOrder:
@@ -15,7 +16,7 @@ class TestHyperliquidCancelOrder:
         ):
             adapter = HyperliquidAdapter(
                 config={},
-                sign_callback=AsyncMock(return_value="0x" + "00" * 65),
+                signing=fake_signing(sign=AsyncMock(return_value="0x" + "00" * 65)),
             )
             adapter._sign_and_broadcast_hypecore = AsyncMock(
                 return_value={"status": "ok"}

--- a/wayfinder_paths/adapters/hyperliquid_adapter/test_exchange_mid_prices.py
+++ b/wayfinder_paths/adapters/hyperliquid_adapter/test_exchange_mid_prices.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from wayfinder_paths.adapters.hyperliquid_adapter.adapter import HyperliquidAdapter
+from wayfinder_paths.testing import fake_signing
 
 
 class _InfoStub(SimpleNamespace):
@@ -47,7 +48,7 @@ class TestAdapterMidPriceFetch:
         ):
             adapter = HyperliquidAdapter(
                 config={},
-                sign_callback=AsyncMock(return_value="0x" + "00" * 65),
+                signing=fake_signing(sign=AsyncMock(return_value="0x" + "00" * 65)),
             )
 
             async def _no_broadcast(action, address):

--- a/wayfinder_paths/adapters/hyperliquid_adapter/test_hyperliquid_sdk_live.py
+++ b/wayfinder_paths/adapters/hyperliquid_adapter/test_hyperliquid_sdk_live.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from wayfinder_paths.adapters.hyperliquid_adapter.adapter import HyperliquidAdapter
+from wayfinder_paths.testing import fake_signing
 
 if os.getenv("RUN_HYPERLIQUID_LIVE_TESTS", "").lower() not in ("1", "true", "yes"):
     pytest.skip(
@@ -24,7 +25,7 @@ class TestAdapterUsesLiveMids:
 
         adapter = HyperliquidAdapter(
             config={},
-            sign_callback=AsyncMock(return_value="0x" + "00" * 65),
+            signing=fake_signing(sign=AsyncMock(return_value="0x" + "00" * 65)),
         )
 
         async def _no_broadcast(action, address):

--- a/wayfinder_paths/adapters/lido_adapter/adapter.py
+++ b/wayfinder_paths/adapters/lido_adapter/adapter.py
@@ -21,6 +21,7 @@ from wayfinder_paths.core.utils.multicall import (
     Call,
     read_only_calls_multicall_or_gather,
 )
+from wayfinder_paths.core.utils.signing import SigningCallbacks
 from wayfinder_paths.core.utils.tokens import ensure_allowance, get_token_balance
 from wayfinder_paths.core.utils.transaction import encode_call, send_transaction
 from wayfinder_paths.core.utils.web3 import web3_from_chain_id
@@ -74,11 +75,11 @@ class LidoAdapter(BaseAdapter):
         self,
         config: dict[str, Any] | None = None,
         *,
-        sign_callback=None,
+        signing: SigningCallbacks | None = None,
         wallet_address: str | None = None,
     ) -> None:
         super().__init__("lido_adapter", config or {})
-        self.sign_callback = sign_callback
+        self.signing = signing
         self.wallet_address: str | None = (
             to_checksum_address(wallet_address) if wallet_address else None
         )
@@ -151,7 +152,7 @@ class LidoAdapter(BaseAdapter):
                     chain_id=chain_id,
                     value=amount_wei,
                 )
-                tx_hash = await send_transaction(tx, self.sign_callback)
+                tx_hash = await send_transaction(tx, self.signing.sign)
                 return True, tx_hash
 
             if receive != "wstETH":
@@ -173,7 +174,7 @@ class LidoAdapter(BaseAdapter):
                 chain_id=chain_id,
                 value=amount_wei,
             )
-            stake_hash = await send_transaction(stake_tx, self.sign_callback)
+            stake_hash = await send_transaction(stake_tx, self.signing.sign)
 
             try:
                 after = await get_token_balance(
@@ -192,7 +193,7 @@ class LidoAdapter(BaseAdapter):
                     spender=entry["wsteth"],
                     amount=wrap_amount,
                     chain_id=chain_id,
-                    signing_callback=self.sign_callback,
+                    signing_callback=self.signing.sign,
                     approval_amount=MAX_UINT256,
                 )
                 if not approved[0]:
@@ -209,7 +210,7 @@ class LidoAdapter(BaseAdapter):
                     from_address=self.wallet_address,
                     chain_id=chain_id,
                 )
-                wrap_hash = await send_transaction(wrap_tx, self.sign_callback)
+                wrap_hash = await send_transaction(wrap_tx, self.signing.sign)
                 return True, {
                     "stake_tx": stake_hash,
                     "wrap_tx": wrap_hash,
@@ -241,7 +242,7 @@ class LidoAdapter(BaseAdapter):
                 spender=entry["wsteth"],
                 amount=amount_steth_wei,
                 chain_id=chain_id,
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=MAX_UINT256,
             )
             if not approved[0]:
@@ -255,7 +256,7 @@ class LidoAdapter(BaseAdapter):
                 from_address=self.wallet_address,
                 chain_id=chain_id,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)
@@ -280,7 +281,7 @@ class LidoAdapter(BaseAdapter):
                 from_address=self.wallet_address,
                 chain_id=chain_id,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)
@@ -325,7 +326,7 @@ class LidoAdapter(BaseAdapter):
                 spender=entry["withdrawal_queue"],
                 amount=amount_wei,
                 chain_id=chain_id,
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=MAX_UINT256,
             )
             if not approved[0]:
@@ -339,7 +340,7 @@ class LidoAdapter(BaseAdapter):
                 from_address=self.wallet_address,
                 chain_id=chain_id,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, {
                 "tx": tx_hash,
                 "asset": asset,
@@ -418,7 +419,7 @@ class LidoAdapter(BaseAdapter):
                 from_address=self.wallet_address,
                 chain_id=chain_id,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:
             return False, str(exc)

--- a/wayfinder_paths/adapters/lido_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/lido_adapter/test_adapter.py
@@ -12,6 +12,7 @@ from wayfinder_paths.core.constants.base import MAX_UINT256
 from wayfinder_paths.core.constants.chains import CHAIN_ID_ETHEREUM
 from wayfinder_paths.core.constants.contracts import ZERO_ADDRESS
 from wayfinder_paths.core.constants.lido_contracts import LIDO_BY_CHAIN
+from wayfinder_paths.testing import fake_signing
 
 
 def test_adapter_type():
@@ -67,7 +68,7 @@ def test_split_withdrawal_amount_multi_chunk_adjusts_small_tail():
 async def test_stake_eth_receive_steth_calls_submit():
     adapter = LidoAdapter(
         config={},
-        sign_callback=AsyncMock(),
+        signing=fake_signing(sign=AsyncMock()),
         wallet_address="0x1111111111111111111111111111111111111111",
     )
     entry = LIDO_BY_CHAIN[CHAIN_ID_ETHEREUM]
@@ -101,7 +102,7 @@ async def test_stake_eth_receive_steth_calls_submit():
     assert kwargs["args"] == [ZERO_ADDRESS]
     assert kwargs["value"] == 123
     mock_send.assert_awaited_once_with(
-        {"to": entry["steth"], "data": "0x"}, adapter.sign_callback
+        {"to": entry["steth"], "data": "0x"}, adapter.signing.sign
     )
 
 
@@ -109,7 +110,7 @@ async def test_stake_eth_receive_steth_calls_submit():
 async def test_stake_eth_receive_wsteth_stakes_then_wraps_delta():
     adapter = LidoAdapter(
         config={},
-        sign_callback=AsyncMock(),
+        signing=fake_signing(sign=AsyncMock()),
         wallet_address="0x1111111111111111111111111111111111111111",
     )
     entry = LIDO_BY_CHAIN[CHAIN_ID_ETHEREUM]
@@ -165,7 +166,7 @@ async def test_stake_eth_receive_wsteth_stakes_then_wraps_delta():
 async def test_request_withdrawal_steth_splits_and_calls_queue():
     adapter = LidoAdapter(
         config={},
-        sign_callback=AsyncMock(),
+        signing=fake_signing(sign=AsyncMock()),
         wallet_address="0x1111111111111111111111111111111111111111",
     )
     entry = LIDO_BY_CHAIN[CHAIN_ID_ETHEREUM]
@@ -213,7 +214,7 @@ async def test_request_withdrawal_steth_splits_and_calls_queue():
 async def test_claim_withdrawals_sorts_and_dedupes_ids():
     adapter = LidoAdapter(
         config={},
-        sign_callback=AsyncMock(),
+        signing=fake_signing(sign=AsyncMock()),
         wallet_address="0x1111111111111111111111111111111111111111",
     )
     entry = LIDO_BY_CHAIN[CHAIN_ID_ETHEREUM]

--- a/wayfinder_paths/adapters/lido_adapter/test_gorlami_simulation.py
+++ b/wayfinder_paths/adapters/lido_adapter/test_gorlami_simulation.py
@@ -8,6 +8,7 @@ from wayfinder_paths.core.constants.chains import CHAIN_ID_ETHEREUM
 from wayfinder_paths.core.constants.lido_contracts import LIDO_BY_CHAIN
 from wayfinder_paths.core.utils import web3 as web3_utils
 from wayfinder_paths.core.utils.tokens import get_token_balance
+from wayfinder_paths.testing import fake_signing
 from wayfinder_paths.testing.gorlami import gorlami_configured
 
 pytestmark = pytest.mark.skipif(
@@ -27,7 +28,7 @@ def _make_adapter(acct: Account) -> tuple[LidoAdapter, Account]:
 
     adapter = LidoAdapter(
         config={},
-        sign_callback=sign_cb,
+        signing=fake_signing(sign=sign_cb),
         wallet_address=acct.address,
     )
     return adapter, acct

--- a/wayfinder_paths/adapters/moonwell_adapter/adapter.py
+++ b/wayfinder_paths/adapters/moonwell_adapter/adapter.py
@@ -31,6 +31,7 @@ from wayfinder_paths.core.utils.multicall import (
     Call,
     read_only_calls_multicall_or_gather,
 )
+from wayfinder_paths.core.utils.signing import SigningCallbacks
 from wayfinder_paths.core.utils.tokens import ensure_allowance
 from wayfinder_paths.core.utils.transaction import encode_call, send_transaction
 from wayfinder_paths.core.utils.web3 import web3_from_chain_id
@@ -111,11 +112,11 @@ class MoonwellAdapter(BaseAdapter):
     def __init__(
         self,
         config: dict[str, Any] | None = None,
-        sign_callback=None,
+        signing: SigningCallbacks | None = None,
         wallet_address: str | None = None,
     ) -> None:
         super().__init__("moonwell_adapter", config)
-        self.sign_callback = sign_callback
+        self.signing = signing
 
         self.chain_id = CHAIN_ID_BASE
         self.chain_name = CHAIN_NAME
@@ -151,7 +152,7 @@ class MoonwellAdapter(BaseAdapter):
             spender=mtoken,
             amount=amount,
             chain_id=CHAIN_ID_BASE,
-            signing_callback=self.sign_callback,
+            signing_callback=self.signing.sign,
             approval_amount=MAX_UINT256,
         )
         if not approved[0]:
@@ -165,7 +166,7 @@ class MoonwellAdapter(BaseAdapter):
             from_address=strategy,
             chain_id=CHAIN_ID_BASE,
         )
-        txn_hash = await send_transaction(transaction, self.sign_callback)
+        txn_hash = await send_transaction(transaction, self.signing.sign)
         return (True, txn_hash)
 
     async def unlend(
@@ -191,7 +192,7 @@ class MoonwellAdapter(BaseAdapter):
             from_address=strategy,
             chain_id=CHAIN_ID_BASE,
         )
-        txn_hash = await send_transaction(transaction, self.sign_callback)
+        txn_hash = await send_transaction(transaction, self.signing.sign)
         return (True, txn_hash)
 
     async def borrow(
@@ -217,7 +218,7 @@ class MoonwellAdapter(BaseAdapter):
             from_address=strategy,
             chain_id=CHAIN_ID_BASE,
         )
-        txn_hash = await send_transaction(transaction, self.sign_callback)
+        txn_hash = await send_transaction(transaction, self.signing.sign)
         return (True, txn_hash)
 
     async def repay(
@@ -244,7 +245,7 @@ class MoonwellAdapter(BaseAdapter):
             spender=mtoken,
             amount=amount,
             chain_id=CHAIN_ID_BASE,
-            signing_callback=self.sign_callback,
+            signing_callback=self.signing.sign,
             approval_amount=MAX_UINT256,
         )
         if not approved[0]:
@@ -261,7 +262,7 @@ class MoonwellAdapter(BaseAdapter):
             from_address=strategy,
             chain_id=CHAIN_ID_BASE,
         )
-        txn_hash = await send_transaction(transaction, self.sign_callback)
+        txn_hash = await send_transaction(transaction, self.signing.sign)
         return (True, txn_hash)
 
     async def set_collateral(
@@ -282,7 +283,7 @@ class MoonwellAdapter(BaseAdapter):
             from_address=strategy,
             chain_id=CHAIN_ID_BASE,
         )
-        txn_hash = await send_transaction(transaction, self.sign_callback)
+        txn_hash = await send_transaction(transaction, self.signing.sign)
 
         try:
             async with web3_from_chain_id(CHAIN_ID_BASE) as web3:
@@ -348,7 +349,7 @@ class MoonwellAdapter(BaseAdapter):
             from_address=strategy,
             chain_id=CHAIN_ID_BASE,
         )
-        txn_hash = await send_transaction(transaction, self.sign_callback)
+        txn_hash = await send_transaction(transaction, self.signing.sign)
         return (True, txn_hash)
 
     async def claim_rewards(
@@ -378,7 +379,7 @@ class MoonwellAdapter(BaseAdapter):
             from_address=strategy,
             chain_id=CHAIN_ID_BASE,
         )
-        await send_transaction(transaction, self.sign_callback)
+        await send_transaction(transaction, self.signing.sign)
         return True, rewards
 
     async def _get_outstanding_rewards(self, account: str) -> dict[str, int]:
@@ -1468,5 +1469,5 @@ class MoonwellAdapter(BaseAdapter):
             chain_id=CHAIN_ID_BASE,
             value=amount,
         )
-        txn_hash = await send_transaction(transaction, self.sign_callback)
+        txn_hash = await send_transaction(transaction, self.signing.sign)
         return (True, txn_hash)

--- a/wayfinder_paths/adapters/moonwell_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/moonwell_adapter/test_adapter.py
@@ -20,6 +20,7 @@ from wayfinder_paths.core.constants.contracts import (
     MOONWELL_VIEWS,
     MOONWELL_WELL_TOKEN,
 )
+from wayfinder_paths.testing import fake_signing
 
 
 class TestMoonwellAdapter:
@@ -27,6 +28,7 @@ class TestMoonwellAdapter:
     def adapter(self):
         return MoonwellAdapter(
             config={},
+            signing=fake_signing(),
             wallet_address="0x1234567890123456789012345678901234567890",
         )
 

--- a/wayfinder_paths/adapters/morpho_adapter/adapter.py
+++ b/wayfinder_paths/adapters/morpho_adapter/adapter.py
@@ -21,6 +21,7 @@ from wayfinder_paths.core.constants.morpho_contracts import MORPHO_BY_CHAIN
 from wayfinder_paths.core.constants.public_allocator_abi import PUBLIC_ALLOCATOR_ABI
 from wayfinder_paths.core.constants.rewards_abi import MERKL_DISTRIBUTOR_ABI
 from wayfinder_paths.core.utils import web3 as web3_utils
+from wayfinder_paths.core.utils.signing import SigningCallbacks
 from wayfinder_paths.core.utils.tokens import ensure_allowance
 from wayfinder_paths.core.utils.transaction import encode_call, send_transaction
 
@@ -33,11 +34,11 @@ class MorphoAdapter(BaseAdapter):
     def __init__(
         self,
         config: dict[str, Any] | None = None,
-        sign_callback=None,
+        signing: SigningCallbacks | None = None,
         wallet_address: str | None = None,
     ) -> None:
         super().__init__("morpho_adapter", config or {})
-        self.sign_callback = sign_callback
+        self.signing = signing
 
         self.wallet_address: str | None = (
             to_checksum_address(wallet_address) if wallet_address else None
@@ -148,7 +149,7 @@ class MorphoAdapter(BaseAdapter):
                 from_address=strategy,
                 chain_id=int(chain_id),
             )
-            txn_hash = await send_transaction(tx, self.sign_callback)
+            txn_hash = await send_transaction(tx, self.signing.sign)
             return True, txn_hash
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
@@ -195,7 +196,7 @@ class MorphoAdapter(BaseAdapter):
                 from_address=strategy,
                 chain_id=int(chain_id),
             )
-            txn_hash = await send_transaction(tx, self.sign_callback)
+            txn_hash = await send_transaction(tx, self.signing.sign)
             return True, txn_hash
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
@@ -677,7 +678,7 @@ class MorphoAdapter(BaseAdapter):
                 spender=vault,
                 amount=int(assets),
                 chain_id=int(chain_id),
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=MAX_UINT256,
             )
             if not approved[0]:
@@ -691,7 +692,7 @@ class MorphoAdapter(BaseAdapter):
                 from_address=strategy,
                 chain_id=int(chain_id),
             )
-            txn_hash = await send_transaction(tx, self.sign_callback)
+            txn_hash = await send_transaction(tx, self.signing.sign)
             return True, txn_hash
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
@@ -720,7 +721,7 @@ class MorphoAdapter(BaseAdapter):
                 from_address=strategy,
                 chain_id=int(chain_id),
             )
-            txn_hash = await send_transaction(tx, self.sign_callback)
+            txn_hash = await send_transaction(tx, self.signing.sign)
             return True, txn_hash
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
@@ -749,7 +750,7 @@ class MorphoAdapter(BaseAdapter):
                 spender=vault,
                 amount=MAX_UINT256,
                 chain_id=int(chain_id),
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=MAX_UINT256,
             )
             if not approved[0]:
@@ -763,7 +764,7 @@ class MorphoAdapter(BaseAdapter):
                 from_address=strategy,
                 chain_id=int(chain_id),
             )
-            txn_hash = await send_transaction(tx, self.sign_callback)
+            txn_hash = await send_transaction(tx, self.signing.sign)
             return True, txn_hash
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
@@ -792,7 +793,7 @@ class MorphoAdapter(BaseAdapter):
                 from_address=strategy,
                 chain_id=int(chain_id),
             )
-            txn_hash = await send_transaction(tx, self.sign_callback)
+            txn_hash = await send_transaction(tx, self.signing.sign)
             return True, txn_hash
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
@@ -1039,7 +1040,7 @@ class MorphoAdapter(BaseAdapter):
                 from_address=acct,
                 chain_id=int(chain_id),
             )
-            txn_hash = await send_transaction(tx, self.sign_callback)
+            txn_hash = await send_transaction(tx, self.signing.sign)
             return True, txn_hash
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
@@ -1089,7 +1090,7 @@ class MorphoAdapter(BaseAdapter):
                     "data": str(tx_data),
                     "value": 0,
                 }
-                txn_hash = await send_transaction(tx, self.sign_callback)
+                txn_hash = await send_transaction(tx, self.signing.sign)
                 tx_hashes.append(str(txn_hash))
 
             return True, tx_hashes
@@ -1345,7 +1346,7 @@ class MorphoAdapter(BaseAdapter):
                 spender=morpho,
                 amount=qty,
                 chain_id=int(chain_id),
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=MAX_UINT256,
             )
             if not approved[0]:
@@ -1359,7 +1360,7 @@ class MorphoAdapter(BaseAdapter):
                 from_address=strategy,
                 chain_id=int(chain_id),
             )
-            txn_hash = await send_transaction(tx, self.sign_callback)
+            txn_hash = await send_transaction(tx, self.signing.sign)
             return True, txn_hash
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
@@ -1393,7 +1394,7 @@ class MorphoAdapter(BaseAdapter):
                 from_address=strategy,
                 chain_id=int(chain_id),
             )
-            txn_hash = await send_transaction(tx, self.sign_callback)
+            txn_hash = await send_transaction(tx, self.signing.sign)
             return True, txn_hash
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
@@ -1426,7 +1427,7 @@ class MorphoAdapter(BaseAdapter):
                 spender=morpho,
                 amount=qty,
                 chain_id=int(chain_id),
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=MAX_UINT256,
             )
             if not approved[0]:
@@ -1440,7 +1441,7 @@ class MorphoAdapter(BaseAdapter):
                 from_address=strategy,
                 chain_id=int(chain_id),
             )
-            txn_hash = await send_transaction(tx, self.sign_callback)
+            txn_hash = await send_transaction(tx, self.signing.sign)
             return True, txn_hash
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
@@ -1494,7 +1495,7 @@ class MorphoAdapter(BaseAdapter):
                 from_address=strategy,
                 chain_id=int(chain_id),
             )
-            txn_hash = await send_transaction(tx, self.sign_callback)
+            txn_hash = await send_transaction(tx, self.signing.sign)
             return True, txn_hash
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
@@ -1528,7 +1529,7 @@ class MorphoAdapter(BaseAdapter):
                 from_address=strategy,
                 chain_id=int(chain_id),
             )
-            txn_hash = await send_transaction(tx, self.sign_callback)
+            txn_hash = await send_transaction(tx, self.signing.sign)
             return True, txn_hash
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
@@ -1629,7 +1630,7 @@ class MorphoAdapter(BaseAdapter):
                 chain_id=int(chain_id),
                 value=int(fee_value),
             )
-            txn_hash = await send_transaction(tx, self.sign_callback)
+            txn_hash = await send_transaction(tx, self.signing.sign)
             return True, txn_hash
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
@@ -1688,7 +1689,7 @@ class MorphoAdapter(BaseAdapter):
                 chain_id=int(chain_id),
                 value=int(value),
             )
-            txn_hash = await send_transaction(tx, self.sign_callback)
+            txn_hash = await send_transaction(tx, self.signing.sign)
             return True, txn_hash
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
@@ -1870,7 +1871,7 @@ class MorphoAdapter(BaseAdapter):
                 chain_id=int(chain_id),
                 value=int(fee_value),
             )
-            realloc_hash = await send_transaction(tx, self.sign_callback)
+            realloc_hash = await send_transaction(tx, self.signing.sign)
 
             ok2, borrow_tx = await self.borrow(
                 chain_id=int(chain_id),
@@ -1974,7 +1975,7 @@ class MorphoAdapter(BaseAdapter):
                 spender=morpho,
                 amount=allowance_target,
                 chain_id=int(chain_id),
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=MAX_UINT256,
             )
             if not approved[0]:
@@ -1994,7 +1995,7 @@ class MorphoAdapter(BaseAdapter):
                 from_address=strategy,
                 chain_id=int(chain_id),
             )
-            txn_hash = await send_transaction(tx, self.sign_callback)
+            txn_hash = await send_transaction(tx, self.signing.sign)
             return True, txn_hash
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)

--- a/wayfinder_paths/adapters/morpho_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/morpho_adapter/test_adapter.py
@@ -8,13 +8,14 @@ from wayfinder_paths.adapters.morpho_adapter.adapter import MorphoAdapter
 from wayfinder_paths.core.constants.base import MAX_UINT256
 from wayfinder_paths.core.constants.chains import CHAIN_ID_BASE
 from wayfinder_paths.core.constants.morpho_constants import MERKL_DISTRIBUTOR_ADDRESS
+from wayfinder_paths.testing import fake_signing
 
 
 @pytest.fixture
 def adapter():
     return MorphoAdapter(
         config={},
-        sign_callback=AsyncMock(return_value=b"\x00" * 65),
+        signing=fake_signing(sign=AsyncMock(return_value=b"\x00" * 65)),
         wallet_address="0x81830bC5f811aF86fF6f17Fb9a619088B09Dff43",
     )
 

--- a/wayfinder_paths/adapters/morpho_adapter/test_gorlami_simulation.py
+++ b/wayfinder_paths/adapters/morpho_adapter/test_gorlami_simulation.py
@@ -14,6 +14,7 @@ from wayfinder_paths.core.constants.contracts import (
 )
 from wayfinder_paths.core.constants.morpho_abi import MORPHO_BLUE_ABI
 from wayfinder_paths.core.utils import web3 as web3_utils
+from wayfinder_paths.testing import fake_signing
 from wayfinder_paths.testing.gorlami import gorlami_configured
 
 pytestmark = pytest.mark.skipif(
@@ -78,7 +79,7 @@ async def test_gorlami_morpho_markets_and_borrow(gorlami):
 
     adapter = MorphoAdapter(
         config={},
-        sign_callback=sign_cb,
+        signing=fake_signing(sign=sign_cb),
         wallet_address=acct.address,
     )
 
@@ -273,7 +274,7 @@ async def test_gorlami_morpho_bridge_base_to_arbitrum_then_borrow(gorlami):
 
     adapter = MorphoAdapter(
         config={},
-        sign_callback=sign_cb,
+        signing=fake_signing(sign=sign_cb),
         wallet_address=acct.address,
     )
 

--- a/wayfinder_paths/adapters/pendle_adapter/adapter.py
+++ b/wayfinder_paths/adapters/pendle_adapter/adapter.py
@@ -11,6 +11,7 @@ from eth_utils import to_checksum_address
 from wayfinder_paths.adapters.multicall_adapter.adapter import MulticallAdapter
 from wayfinder_paths.core.adapters.BaseAdapter import BaseAdapter
 from wayfinder_paths.core.constants.erc20_abi import ERC20_ABI
+from wayfinder_paths.core.utils.signing import SigningCallbacks
 from wayfinder_paths.core.utils.tokens import (
     ensure_allowance,
     get_token_balance,
@@ -179,7 +180,7 @@ class PendleAdapter(BaseAdapter):
         base_url: str | None = None,
         client: httpx.AsyncClient | None = None,
         timeout: float = 30.0,
-        sign_callback: Callable | None = None,
+        signing: SigningCallbacks | None = None,
         wallet_address: str | None = None,
     ) -> None:
         super().__init__("pendle_adapter", config)
@@ -193,7 +194,7 @@ class PendleAdapter(BaseAdapter):
         self.timeout = float(adapter_cfg.get("timeout", timeout))
 
         self._owns_client = False
-        self.sign_callback = sign_callback
+        self.signing = signing
         self.wallet_address: str | None = (
             to_checksum_address(wallet_address) if wallet_address else None
         )
@@ -223,9 +224,9 @@ class PendleAdapter(BaseAdapter):
         return self.wallet_address
 
     async def _send_tx(self, tx: dict[str, Any]) -> tuple[bool, Any]:
-        if self.sign_callback is None:
+        if self.signing is None:
             raise ValueError("sign_callback is required for tx execution")
-        txn_hash = await send_transaction(tx, self.sign_callback)
+        txn_hash = await send_transaction(tx, self.signing.sign)
         return True, txn_hash
 
     # ---------------------------
@@ -1766,11 +1767,11 @@ class PendleAdapter(BaseAdapter):
             amount = approval.get("amount")
             if not token or not amount:
                 continue
-            if not self.sign_callback:
+            if self.signing is None:
                 return False, {
-                    "error": "sign_callback is required",
+                    "error": "signing is required",
                     "stage": "approval",
-                    "details": {"error": "sign_callback is required"},
+                    "details": {"error": "signing is required"},
                 }
             approved, result = await ensure_allowance(
                 chain_id=chain_id,
@@ -1778,7 +1779,7 @@ class PendleAdapter(BaseAdapter):
                 owner=sender,
                 spender=spender,
                 amount=int(amount),
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
             )
             if not approved:
                 return False, {
@@ -1899,10 +1900,10 @@ class PendleAdapter(BaseAdapter):
             amount = approval.get("amount")
             if not (isinstance(token, str) and token and amount is not None):
                 continue
-            if not self.sign_callback:
+            if self.signing is None:
                 return False, {
                     "stage": "approval",
-                    "error": "sign_callback is required",
+                    "error": "signing is required",
                     "token": token,
                 }
             try:
@@ -1912,7 +1913,7 @@ class PendleAdapter(BaseAdapter):
                     owner=sender,
                     spender=spender,
                     amount=int(str(amount)),
-                    signing_callback=self.sign_callback,
+                    signing_callback=self.signing.sign,
                 )
             except Exception as exc:  # noqa: BLE001
                 return False, {

--- a/wayfinder_paths/adapters/pendle_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/pendle_adapter/test_adapter.py
@@ -10,6 +10,7 @@ import pytest
 from web3 import Web3
 
 from wayfinder_paths.adapters.pendle_adapter.adapter import PendleAdapter
+from wayfinder_paths.testing import fake_signing
 
 
 class TestPendleAdapter:
@@ -285,7 +286,7 @@ class TestPendleAdapter:
         adapter = PendleAdapter(
             config={},
             wallet_address="0x" + "a" * 40,
-            sign_callback=signing_callback,
+            signing=fake_signing(sign=signing_callback),
         )
 
         adapter.sdk_convert_v2 = AsyncMock(
@@ -488,7 +489,7 @@ class TestPendleAdapter:
         adapter = PendleAdapter(
             config={},
             wallet_address="0x" + "a" * 40,
-            sign_callback=signing_callback,
+            signing=fake_signing(sign=signing_callback),
         )
 
         # Mock sdk_swap_v2 to return a valid quote
@@ -534,7 +535,7 @@ class TestPendleAdapter:
         adapter = PendleAdapter(
             config={},
             wallet_address="0x" + "a" * 40,
-            sign_callback=AsyncMock(),
+            signing=fake_signing(sign=AsyncMock()),
         )
 
         adapter.sdk_swap_v2 = AsyncMock(
@@ -562,7 +563,7 @@ class TestPendleAdapter:
         adapter = PendleAdapter(
             config={},
             wallet_address="0x" + "a" * 40,
-            sign_callback=AsyncMock(return_value=b"\x00" * 65),
+            signing=fake_signing(sign=AsyncMock(return_value=b"\x00" * 65)),
         )
 
         adapter.sdk_swap_v2 = AsyncMock(
@@ -622,14 +623,14 @@ class TestPendleAdapter:
 
         assert success is False
         assert result["stage"] == "approval"
-        assert "sign_callback" in result["details"]["error"]
+        assert "signing" in result["details"]["error"]
 
     @pytest.mark.asyncio
     async def test_execute_swap_requires_strategy_wallet(self):
         """Test swap fails without strategy_wallet address."""
         adapter = PendleAdapter(
             config={},  # No strategy_wallet
-            sign_callback=AsyncMock(),
+            signing=fake_signing(sign=AsyncMock()),
         )
 
         with pytest.raises(ValueError, match="wallet_address is required"):

--- a/wayfinder_paths/adapters/polymarket_adapter/adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/adapter.py
@@ -42,6 +42,7 @@ from wayfinder_paths.core.utils.multicall import (
     Call,
     read_only_calls_multicall_or_gather,
 )
+from wayfinder_paths.core.utils.signing import SigningCallbacks
 from wayfinder_paths.core.utils.tokens import (
     build_send_transaction,
     ensure_allowance,
@@ -147,8 +148,7 @@ class PolymarketAdapter(BaseAdapter):
         self,
         config: dict[str, Any] | None = None,
         *,
-        sign_callback=None,
-        sign_hash_callback=None,
+        signing: SigningCallbacks | None = None,
         wallet_address: str | None = None,
         funder: str | None = None,
         signature_type: int | None = None,
@@ -163,8 +163,7 @@ class PolymarketAdapter(BaseAdapter):
         self.wallet_address: str | None = (
             to_checksum_address(wallet_address) if wallet_address else None
         )
-        self.sign_callback = sign_callback
-        self.sign_hash_callback = sign_hash_callback
+        self.signing = signing
         self._funder_override = funder
         self._signature_type = signature_type
 
@@ -1084,11 +1083,11 @@ class PolymarketAdapter(BaseAdapter):
 
     def _require_signer(self) -> tuple[str, Any]:
         addr = self._require_wallet_address()
-        if not self.sign_callback:
+        if self.signing is None:
             raise ValueError(
-                "sign_callback is required. Use get_adapter(PolymarketAdapter, wallet_label)."
+                "signing is required. Use get_adapter(PolymarketAdapter, wallet_label)."
             )
-        return addr, self.sign_callback
+        return addr, self.signing.sign
 
     def _contract_addrs(self, *, neg_risk: bool = False) -> dict[str, str]:
         cfg = get_contract_config(POLYGON_CHAIN_ID, neg_risk=neg_risk)
@@ -1110,7 +1109,9 @@ class PolymarketAdapter(BaseAdapter):
                 signature_type=self._signature_type,
                 funder=funder,
                 address_override=addr,
-                sign_callback_override=self.sign_hash_callback,
+                sign_callback_override=(
+                    self.signing.sign_hash if self.signing else None
+                ),
             )
         return self._clob_client  # type: ignore[return-value]
 

--- a/wayfinder_paths/adapters/projectx_adapter/adapter.py
+++ b/wayfinder_paths/adapters/projectx_adapter/adapter.py
@@ -32,6 +32,7 @@ from wayfinder_paths.core.utils.multicall import (
     Call,
     read_only_calls_multicall_or_gather,
 )
+from wayfinder_paths.core.utils.signing import SigningCallbacks
 from wayfinder_paths.core.utils.tokens import (
     ensure_allowance,
     get_token_balance,
@@ -206,7 +207,7 @@ class ProjectXLiquidityAdapter(UniswapV3BaseAdapter):
         self,
         config: dict[str, Any],
         *,
-        sign_callback=None,
+        signing: SigningCallbacks | None = None,
         wallet_address: str | None = None,
     ) -> None:
         if not wallet_address:
@@ -225,7 +226,7 @@ class ProjectXLiquidityAdapter(UniswapV3BaseAdapter):
             npm_address=PRJX_NPM,
             factory_address=PRJX_FACTORY,
             owner=owner,
-            sign_callback=sign_callback,
+            signing=signing,
             factory_abi=PROJECTX_FACTORY_ABI,
         )
 
@@ -775,7 +776,7 @@ class ProjectXLiquidityAdapter(UniswapV3BaseAdapter):
                 spender=PRJX_ROUTER,
                 amount=int(amount_in),
                 chain_id=PROJECTX_CHAIN_ID,
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=int(amount_in * 2),
             )
 
@@ -859,7 +860,7 @@ class ProjectXLiquidityAdapter(UniswapV3BaseAdapter):
                 from_address=self.owner,
                 chain_id=PROJECTX_CHAIN_ID,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, str(tx_hash)
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)

--- a/wayfinder_paths/adapters/projectx_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/projectx_adapter/test_adapter.py
@@ -9,6 +9,7 @@ import wayfinder_paths.adapters.uniswap_adapter.base as uniswap_base_module
 from wayfinder_paths.adapters.projectx_adapter.adapter import ProjectXLiquidityAdapter
 from wayfinder_paths.core.constants import ZERO_ADDRESS
 from wayfinder_paths.core.constants.projectx import PRJX_FACTORY, THBILL_USDC_POOL
+from wayfinder_paths.testing import fake_signing
 
 
 def test_init_requires_strategy_wallet():
@@ -143,7 +144,7 @@ class _FakeNpmContract:
 async def test_mint_from_balances_adjusts_ticks_and_uses_int_min_amounts(monkeypatch):
     adapter = ProjectXLiquidityAdapter(
         {"pool_address": THBILL_USDC_POOL},
-        sign_callback=AsyncMock(return_value="0xsigned"),
+        signing=fake_signing(sign=AsyncMock(return_value="0xsigned")),
         wallet_address="0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     )
     adapter._balance_for_band = AsyncMock(return_value=None)
@@ -223,7 +224,7 @@ async def test_mint_from_balances_adjusts_ticks_and_uses_int_min_amounts(monkeyp
 async def test_burn_position_calls_remove_liquidity():
     adapter = ProjectXLiquidityAdapter(
         {"pool_address": THBILL_USDC_POOL},
-        sign_callback=AsyncMock(return_value="0xsigned"),
+        signing=fake_signing(sign=AsyncMock(return_value="0xsigned")),
         wallet_address="0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     )
     adapter.remove_liquidity = AsyncMock(return_value=(True, "0xtx_burn"))

--- a/wayfinder_paths/adapters/sparklend_adapter/adapter.py
+++ b/wayfinder_paths/adapters/sparklend_adapter/adapter.py
@@ -22,6 +22,7 @@ from wayfinder_paths.core.utils.multicall import (
     Call,
     read_only_calls_multicall_or_gather,
 )
+from wayfinder_paths.core.utils.signing import SigningCallbacks
 from wayfinder_paths.core.utils.tokens import ensure_allowance, get_token_balance
 from wayfinder_paths.core.utils.transaction import encode_call, send_transaction
 
@@ -36,14 +37,12 @@ class SparkLendAdapter(AaveV3Adapter):
     def __init__(
         self,
         config: dict[str, Any] | None = None,
-        sign_callback=None,
+        signing: SigningCallbacks | None = None,
         wallet_address: str | None = None,
     ) -> None:
         # SparkLend is Aave v3-based. We inherit common pool interactions from
         # AaveV3Adapter and keep Spark-specific reads/rate modes here.
-        super().__init__(
-            config=config, sign_callback=sign_callback, wallet_address=wallet_address
-        )
+        super().__init__(config=config, signing=signing, wallet_address=wallet_address)
         self.name = "sparklend_adapter"
 
         # Cache: (chain_id, underlying.lower()) -> reserve config dict
@@ -182,7 +181,7 @@ class SparkLendAdapter(AaveV3Adapter):
                 from_address=self.wallet_address,
                 chain_id=chain_id,
             )
-            txn_hash = await send_transaction(tx, self.sign_callback)
+            txn_hash = await send_transaction(tx, self.signing.sign)
             return True, txn_hash
         except Exception as exc:
             return False, str(exc)
@@ -226,7 +225,7 @@ class SparkLendAdapter(AaveV3Adapter):
                 spender=pool,
                 amount=allowance_target,
                 chain_id=chain_id,
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=MAX_UINT256,
             )
             if not approved[0]:
@@ -240,7 +239,7 @@ class SparkLendAdapter(AaveV3Adapter):
                 from_address=self.wallet_address,
                 chain_id=chain_id,
             )
-            txn_hash = await send_transaction(tx, self.sign_callback)
+            txn_hash = await send_transaction(tx, self.signing.sign)
             return True, txn_hash
         except Exception as exc:
             return False, str(exc)
@@ -325,7 +324,7 @@ class SparkLendAdapter(AaveV3Adapter):
                 from_address=self.wallet_address,
                 chain_id=chain_id,
             )
-            txn_hash = await send_transaction(tx, self.sign_callback)
+            txn_hash = await send_transaction(tx, self.signing.sign)
             return True, txn_hash
         except Exception as exc:
             return False, str(exc)
@@ -717,7 +716,7 @@ class SparkLendAdapter(AaveV3Adapter):
                 from_address=self.wallet_address,
                 chain_id=chain_id,
             )
-            txn_hash = await send_transaction(tx, self.sign_callback)
+            txn_hash = await send_transaction(tx, self.signing.sign)
             return True, txn_hash
         except Exception as exc:
             return False, str(exc)
@@ -803,7 +802,7 @@ class SparkLendAdapter(AaveV3Adapter):
                 chain_id=chain_id,
                 value=value,
             )
-            txn_hash = await send_transaction(tx, self.sign_callback)
+            txn_hash = await send_transaction(tx, self.signing.sign)
             return True, txn_hash
         except Exception as exc:
             return False, str(exc)

--- a/wayfinder_paths/adapters/sparklend_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/sparklend_adapter/test_adapter.py
@@ -10,6 +10,7 @@ from wayfinder_paths.adapters.sparklend_adapter.adapter import (
     SparkLendAdapter,
 )
 from wayfinder_paths.core.constants.contracts import ZERO_ADDRESS
+from wayfinder_paths.testing import fake_signing
 
 FAKE_ADDR = "0x1234567890123456789012345678901234567890"
 FAKE_ASSET = "0x0000000000000000000000000000000000000001"
@@ -20,6 +21,7 @@ class TestSparkLendAdapter:
     def adapter(self):
         return SparkLendAdapter(
             config={},
+            signing=fake_signing(address=FAKE_ADDR),
             wallet_address=FAKE_ADDR,
         )
 

--- a/wayfinder_paths/adapters/sparklend_adapter/test_gorlami_simulation.py
+++ b/wayfinder_paths/adapters/sparklend_adapter/test_gorlami_simulation.py
@@ -8,6 +8,7 @@ from wayfinder_paths.adapters.sparklend_adapter.adapter import SparkLendAdapter
 from wayfinder_paths.core.constants.chains import CHAIN_ID_ETHEREUM
 from wayfinder_paths.core.constants.contracts import ZERO_ADDRESS
 from wayfinder_paths.core.utils import web3 as web3_utils
+from wayfinder_paths.testing import fake_signing
 from wayfinder_paths.testing.gorlami import gorlami_configured
 
 pytestmark = pytest.mark.skipif(
@@ -69,7 +70,7 @@ async def test_gorlami_sparklend_supply_borrow_repay_withdraw_claim(
 
     adapter = SparkLendAdapter(
         config={},
-        sign_callback=sign_cb,
+        signing=fake_signing(sign=sign_cb),
         wallet_address=acct.address,
     )
 

--- a/wayfinder_paths/adapters/uniswap_adapter/adapter.py
+++ b/wayfinder_paths/adapters/uniswap_adapter/adapter.py
@@ -6,6 +6,7 @@ from eth_utils import to_checksum_address
 
 from wayfinder_paths.adapters.uniswap_adapter.base import UniswapV3BaseAdapter
 from wayfinder_paths.core.constants.contracts import UNISWAP_V3_FACTORY, UNISWAP_V3_NPM
+from wayfinder_paths.core.utils.signing import SigningCallbacks
 
 SUPPORTED_CHAIN_IDS = set(UNISWAP_V3_NPM.keys())
 
@@ -17,7 +18,7 @@ class UniswapAdapter(UniswapV3BaseAdapter):
         self,
         config: dict[str, Any],
         *,
-        sign_callback=None,
+        signing: SigningCallbacks | None = None,
         wallet_address: str | None = None,
     ) -> None:
         chain_id = int(config.get("chain_id", 8453))
@@ -38,5 +39,5 @@ class UniswapAdapter(UniswapV3BaseAdapter):
             npm_address=UNISWAP_V3_NPM[chain_id],
             factory_address=UNISWAP_V3_FACTORY[chain_id],
             owner=owner,
-            sign_callback=sign_callback,
+            signing=signing,
         )

--- a/wayfinder_paths/adapters/uniswap_adapter/base.py
+++ b/wayfinder_paths/adapters/uniswap_adapter/base.py
@@ -9,6 +9,7 @@ from wayfinder_paths.core.constants.uniswap_v3_abi import (
     NONFUNGIBLE_POSITION_MANAGER_ABI,
     UNISWAP_V3_FACTORY_ABI,
 )
+from wayfinder_paths.core.utils.signing import SigningCallbacks
 from wayfinder_paths.core.utils.tokens import ensure_allowance
 from wayfinder_paths.core.utils.transaction import encode_call, send_transaction
 from wayfinder_paths.core.utils.uniswap_v3_math import (
@@ -36,11 +37,11 @@ class UniswapV3BaseAdapter(BaseAdapter):
         npm_address: str,
         factory_address: str,
         owner: str,
-        sign_callback=None,
+        signing: SigningCallbacks | None = None,
         factory_abi: list[dict[str, Any]] | None = None,
     ) -> None:
         super().__init__(adapter_name, config)
-        self.sign_callback = sign_callback
+        self.signing = signing
         self.chain_id = int(chain_id)
         self.npm_address = to_checksum_address(str(npm_address))
         self.factory_address = to_checksum_address(str(factory_address))
@@ -90,7 +91,7 @@ class UniswapV3BaseAdapter(BaseAdapter):
                 spender=to_checksum_address(self.npm_address),
                 amount=int(amount0_desired),
                 chain_id=self.chain_id,
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=int(amount0_desired * 2),
             )
             await ensure_allowance(
@@ -99,7 +100,7 @@ class UniswapV3BaseAdapter(BaseAdapter):
                 spender=to_checksum_address(self.npm_address),
                 amount=int(amount1_desired),
                 chain_id=self.chain_id,
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=int(amount1_desired * 2),
             )
 
@@ -125,7 +126,7 @@ class UniswapV3BaseAdapter(BaseAdapter):
                 from_address=self.owner,
                 chain_id=self.chain_id,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
@@ -152,7 +153,7 @@ class UniswapV3BaseAdapter(BaseAdapter):
                 spender=to_checksum_address(self.npm_address),
                 amount=int(amount0_desired),
                 chain_id=self.chain_id,
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=int(amount0_desired * 2),
             )
             await ensure_allowance(
@@ -161,7 +162,7 @@ class UniswapV3BaseAdapter(BaseAdapter):
                 spender=to_checksum_address(self.npm_address),
                 amount=int(amount1_desired),
                 chain_id=self.chain_id,
-                signing_callback=self.sign_callback,
+                signing_callback=self.signing.sign,
                 approval_amount=int(amount1_desired * 2),
             )
 
@@ -182,7 +183,7 @@ class UniswapV3BaseAdapter(BaseAdapter):
                 from_address=self.owner,
                 chain_id=self.chain_id,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
@@ -241,7 +242,7 @@ class UniswapV3BaseAdapter(BaseAdapter):
                 from_address=self.owner,
                 chain_id=self.chain_id,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
@@ -256,7 +257,7 @@ class UniswapV3BaseAdapter(BaseAdapter):
                 from_address=self.owner,
                 chain_id=self.chain_id,
             )
-            tx_hash = await send_transaction(tx, self.sign_callback)
+            tx_hash = await send_transaction(tx, self.signing.sign)
             return True, tx_hash
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)

--- a/wayfinder_paths/adapters/uniswap_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/uniswap_adapter/test_adapter.py
@@ -6,6 +6,7 @@ import pytest
 
 from wayfinder_paths.adapters.uniswap_adapter.adapter import UniswapAdapter
 from wayfinder_paths.core.utils.uniswap_v3_math import tick_to_price, ticks_for_range
+from wayfinder_paths.testing import fake_signing
 
 OWNER = "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"
 TOKEN_A = "0x1111111111111111111111111111111111111111"
@@ -18,7 +19,7 @@ FAKE_POS_RAW = (0, OWNER, TOKEN_A, TOKEN_B, 3000, -120, 120, 5000, 0, 0, 10, 20)
 def _make_adapter(chain_id: int = 8453) -> UniswapAdapter:
     return UniswapAdapter(
         {"chain_id": chain_id},
-        sign_callback=AsyncMock(return_value=b"signed"),
+        signing=fake_signing(sign=AsyncMock(return_value=b"signed")),
         wallet_address=OWNER,
     )
 

--- a/wayfinder_paths/core/strategies/Strategy.py
+++ b/wayfinder_paths/core/strategies/Strategy.py
@@ -9,6 +9,7 @@ from loguru import logger
 from wayfinder_paths.adapters.ledger_adapter.adapter import LedgerAdapter
 from wayfinder_paths.core.clients.TokenClient import TokenDetails
 from wayfinder_paths.core.strategies.descriptors import StratDescriptor
+from wayfinder_paths.core.utils.signing import SigningCallbacks
 
 
 class StatusDict(TypedDict):
@@ -72,6 +73,35 @@ class Strategy(ABC):
         self.main_wallet_signing_callback = main_wallet_signing_callback
         self.strategy_wallet_signing_callback = strategy_wallet_signing_callback
         self.strategy_sign_typed_data = strategy_sign_typed_data
+
+        main_wallet = self.config.get("main_wallet")
+        main_addr = (
+            main_wallet["address"]
+            if isinstance(main_wallet, dict) and main_wallet.get("address")
+            else None
+        )
+        strategy_wallet = self.config.get("strategy_wallet")
+        strat_addr = (
+            strategy_wallet["address"]
+            if isinstance(strategy_wallet, dict) and strategy_wallet.get("address")
+            else None
+        )
+
+        self.main_signing: SigningCallbacks | None = (
+            SigningCallbacks(address=main_addr, sign=main_wallet_signing_callback)
+            if main_addr and main_wallet_signing_callback
+            else None
+        )
+        self.strategy_signing: SigningCallbacks | None = (
+            SigningCallbacks(
+                address=strat_addr,
+                sign=strategy_wallet_signing_callback,
+                sign_typed_data=strategy_sign_typed_data,
+            )
+            if strat_addr
+            and (strategy_wallet_signing_callback or strategy_sign_typed_data)
+            else None
+        )
 
     async def setup(self) -> None:
         pass

--- a/wayfinder_paths/core/utils/signing.py
+++ b/wayfinder_paths/core/utils/signing.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from wayfinder_paths.core.utils.wallets import (
+    _build_sign_hash_callback,
+    _build_signing_callback,
+    _build_typed_data_callback,
+    find_wallet_by_label,
+    get_local_sign_callback,
+    get_local_sign_hash_callback,
+    get_local_sign_typed_data_callback,
+)
+
+SignTx = Callable[[dict[str, Any]], Awaitable[bytes]]
+SignHash = Callable[[str], Awaitable[str]]
+SignTypedData = Callable[[str | dict[str, Any]], Awaitable[str]]
+
+
+@dataclass(frozen=True, slots=True)
+class SigningCallbacks:
+    address: str
+    sign: SignTx | None = None
+    sign_typed_data: SignTypedData | None = None
+    sign_hash: SignHash | None = None
+
+
+async def build_signing_callbacks(label: str) -> SigningCallbacks:
+    wallet = await find_wallet_by_label(label)
+    if not wallet:
+        raise ValueError(f"Wallet '{label}' not found.")
+    sign, address = _build_signing_callback(wallet, label)
+    sign_hash, _ = _build_sign_hash_callback(wallet, label)
+    sign_typed_data, _ = _build_typed_data_callback(wallet, label)
+    return SigningCallbacks(
+        address=address,
+        sign=sign,
+        sign_hash=sign_hash,
+        sign_typed_data=sign_typed_data,
+    )
+
+
+def signing_from_private_key(private_key: str, address: str) -> SigningCallbacks:
+    return SigningCallbacks(
+        address=address,
+        sign=get_local_sign_callback(private_key),
+        sign_hash=get_local_sign_hash_callback(private_key),
+        sign_typed_data=get_local_sign_typed_data_callback(private_key),
+    )

--- a/wayfinder_paths/mcp/scripting.py
+++ b/wayfinder_paths/mcp/scripting.py
@@ -4,10 +4,7 @@ import inspect
 from typing import Any
 
 from wayfinder_paths.core.config import CONFIG
-from wayfinder_paths.core.utils.wallets import (
-    get_wallet_sign_hash_callback,
-    get_wallet_signing_callback,
-)
+from wayfinder_paths.core.utils.signing import build_signing_callbacks
 
 
 async def get_adapter[T](
@@ -25,38 +22,33 @@ async def get_adapter[T](
     adapter_kwargs: dict[str, Any] = {"config": config}
 
     if wallet_label:
-        sign_cb, address = await get_wallet_signing_callback(wallet_label)
         params = set(inspect.signature(adapter_class.__init__).parameters)
+        signing = await build_signing_callbacks(wallet_label)
 
-        if "sign_callback" in params:
-            adapter_kwargs["sign_callback"] = sign_cb
+        if "signing" in params:
+            adapter_kwargs["signing"] = signing
             if "wallet_address" in params:
-                adapter_kwargs["wallet_address"] = address
-            if "sign_hash_callback" in params:
-                hash_cb, _ = await get_wallet_sign_hash_callback(wallet_label)
-                adapter_kwargs["sign_hash_callback"] = hash_cb
+                adapter_kwargs["wallet_address"] = signing.address
 
-        elif "main_sign_callback" in params:
-            adapter_kwargs["main_sign_callback"] = sign_cb
+        elif "main_signing" in params:
+            adapter_kwargs["main_signing"] = signing
             if "main_wallet_address" in params:
-                adapter_kwargs["main_wallet_address"] = address
+                adapter_kwargs["main_wallet_address"] = signing.address
 
-            if "strategy_sign_callback" not in kwargs:
+            if "strategy_signing" not in kwargs:
                 if not strategy_wallet_label:
                     raise ValueError(
                         f"{adapter_class.__name__} requires a strategy wallet. "
                         "Pass strategy_wallet_label."
                     )
-                strategy_cb, strategy_addr = await get_wallet_signing_callback(
-                    strategy_wallet_label
-                )
-                adapter_kwargs["strategy_sign_callback"] = strategy_cb
+                strategy_signing = await build_signing_callbacks(strategy_wallet_label)
+                adapter_kwargs["strategy_signing"] = strategy_signing
                 if "strategy_wallet_address" in params:
-                    adapter_kwargs["strategy_wallet_address"] = strategy_addr
+                    adapter_kwargs["strategy_wallet_address"] = strategy_signing.address
 
         else:
             raise ValueError(
-                f"{adapter_class.__name__} does not accept a signing callback."
+                f"{adapter_class.__name__} does not accept signing callbacks."
             )
 
     adapter_kwargs.update(kwargs)

--- a/wayfinder_paths/mcp/test_scripting.py
+++ b/wayfinder_paths/mcp/test_scripting.py
@@ -8,6 +8,7 @@ import pytest
 
 from wayfinder_paths.adapters.balance_adapter.adapter import BalanceAdapter
 from wayfinder_paths.adapters.moonwell_adapter import MoonwellAdapter
+from wayfinder_paths.core.utils.signing import SigningCallbacks
 from wayfinder_paths.core.utils.wallets import get_local_sign_callback
 from wayfinder_paths.mcp.scripting import get_adapter
 
@@ -30,7 +31,7 @@ def _mock_find(wallets: dict[str, dict]):
         return wallets.get(label)
 
     return patch(
-        "wayfinder_paths.core.utils.wallets.find_wallet_by_label",
+        "wayfinder_paths.core.utils.signing.find_wallet_by_label",
         side_effect=find,
     )
 
@@ -70,7 +71,7 @@ class TestGetAdapter:
     @pytest.mark.asyncio
     async def test_raises_when_wallet_missing_private_key(self):
         class MockAdapter:
-            def __init__(self, config=None):
+            def __init__(self, config=None, *, signing: SigningCallbacks | None = None):
                 pass
 
         wallet = {"label": "test", "address": "0x" + "11" * 20}
@@ -89,16 +90,17 @@ class TestGetAdapter:
             assert adapter.config == {"foo": "bar"}
 
     @pytest.mark.asyncio
-    async def test_wires_sign_callback_and_wallet(self):
+    async def test_wires_signing_and_wallet(self):
         class MockAdapter:
-            def __init__(self, config=None, sign_callback=None, wallet_address=None):
+            def __init__(self, config=None, signing=None, wallet_address=None):
                 self.config = config
-                self.callback = sign_callback
+                self.signing = signing
                 self.wallet_address = wallet_address
 
         with _mock_find({"main": MAIN_WALLET}), _mock_config():
             adapter = await get_adapter(MockAdapter, "main")
-            assert adapter.callback is not None
+            assert adapter.signing is not None
+            assert adapter.signing.sign is not None
             assert adapter.wallet_address == MAIN_WALLET["address"]
 
     @pytest.mark.asyncio
@@ -126,26 +128,24 @@ class TestGetAdapter:
             assert adapter.custom_arg == "my_value"
 
     @pytest.mark.asyncio
-    async def test_caller_kwargs_override_auto_wired_callback(self):
+    async def test_caller_kwargs_override_auto_wired_signing(self):
         class MockAdapter:
-            def __init__(self, config=None, sign_callback=None):
-                self.callback = sign_callback
+            def __init__(self, config=None, signing=None):
+                self.signing = signing
 
-        custom_callback = MagicMock()
+        custom = MagicMock()
         with _mock_find({"main": MAIN_WALLET}), _mock_config():
-            adapter = await get_adapter(
-                MockAdapter, "main", sign_callback=custom_callback
-            )
-            assert adapter.callback is custom_callback
+            adapter = await get_adapter(MockAdapter, "main", signing=custom)
+            assert adapter.signing is custom
 
     @pytest.mark.asyncio
-    async def test_raises_when_adapter_has_no_callback_param(self):
+    async def test_raises_when_adapter_has_no_signing_param(self):
         class MockAdapter:
             def __init__(self, config=None):
                 pass
 
         with _mock_find({"main": MAIN_WALLET}), _mock_config():
-            with pytest.raises(ValueError, match="does not accept a signing callback"):
+            with pytest.raises(ValueError, match="does not accept signing callbacks"):
                 await get_adapter(MockAdapter, "main")
 
     @pytest.mark.asyncio
@@ -153,7 +153,7 @@ class TestGetAdapter:
         with _mock_find({"main": MAIN_WALLET}), _mock_config():
             adapter = await get_adapter(MoonwellAdapter, "main")
             assert isinstance(adapter, MoonwellAdapter)
-            assert adapter.sign_callback is not None
+            assert adapter.signing is not None
             assert adapter.wallet_address == MAIN_WALLET["address"]
 
     @pytest.mark.asyncio
@@ -162,25 +162,25 @@ class TestGetAdapter:
             def __init__(
                 self,
                 config=None,
-                main_sign_callback=None,
-                strategy_sign_callback=None,
                 *,
+                main_signing=None,
+                strategy_signing=None,
                 main_wallet_address=None,
                 strategy_wallet_address=None,
             ):
-                self.main_cb = main_sign_callback
-                self.strategy_cb = strategy_sign_callback
+                self.main_signing = main_signing
+                self.strategy_signing = strategy_signing
                 self.main_addr = main_wallet_address
                 self.strategy_addr = strategy_wallet_address
 
         wallets = {"main": MAIN_WALLET, "strat": STRATEGY_WALLET}
         with _mock_find(wallets), _mock_config():
             adapter = await get_adapter(DualAdapter, "main", "strat")
-            assert adapter.main_cb is not None
-            assert adapter.strategy_cb is not None
+            assert adapter.main_signing is not None
+            assert adapter.strategy_signing is not None
             assert adapter.main_addr == MAIN_WALLET["address"]
             assert adapter.strategy_addr == STRATEGY_WALLET["address"]
-            assert adapter.main_cb is not adapter.strategy_cb
+            assert adapter.main_signing is not adapter.strategy_signing
 
     @pytest.mark.asyncio
     async def test_dual_wallet_raises_without_strategy_label(self):
@@ -188,8 +188,9 @@ class TestGetAdapter:
             def __init__(
                 self,
                 config=None,
-                main_sign_callback=None,
-                strategy_sign_callback=None,
+                *,
+                main_signing=None,
+                strategy_signing=None,
             ):
                 pass
 
@@ -203,17 +204,16 @@ class TestGetAdapter:
             def __init__(
                 self,
                 config=None,
-                main_sign_callback=None,
-                strategy_sign_callback=None,
+                *,
+                main_signing=None,
+                strategy_signing=None,
             ):
-                self.strategy_cb = strategy_sign_callback
+                self.strategy_signing = strategy_signing
 
         custom = MagicMock()
         with _mock_find({"main": MAIN_WALLET}), _mock_config():
-            adapter = await get_adapter(
-                DualAdapter, "main", strategy_sign_callback=custom
-            )
-            assert adapter.strategy_cb is custom
+            adapter = await get_adapter(DualAdapter, "main", strategy_signing=custom)
+            assert adapter.strategy_signing is custom
 
     @pytest.mark.asyncio
     async def test_integration_balance_adapter(self):
@@ -221,7 +221,7 @@ class TestGetAdapter:
         with _mock_find(wallets), _mock_config():
             adapter = await get_adapter(BalanceAdapter, "main", "strat")
             assert isinstance(adapter, BalanceAdapter)
-            assert adapter.main_sign_callback is not None
-            assert adapter.strategy_sign_callback is not None
+            assert adapter.main_signing is not None
+            assert adapter.strategy_signing is not None
             assert adapter.main_wallet_address == MAIN_WALLET["address"]
             assert adapter.strategy_wallet_address == STRATEGY_WALLET["address"]

--- a/wayfinder_paths/mcp/tools/hyperliquid.py
+++ b/wayfinder_paths/mcp/tools/hyperliquid.py
@@ -9,8 +9,8 @@ from wayfinder_paths.core.constants.hyperliquid import (
     DEFAULT_HYPERLIQUID_BUILDER_FEE_TENTHS_BP,
     HYPE_FEE_WALLET,
 )
-from wayfinder_paths.core.utils.wallets import get_wallet_sign_typed_data_callback
 from wayfinder_paths.mcp.preview import build_hyperliquid_execute_preview
+from wayfinder_paths.mcp.scripting import get_adapter
 from wayfinder_paths.mcp.state.profile_store import WalletProfileStore
 from wayfinder_paths.mcp.utils import (
     err,
@@ -286,24 +286,17 @@ async def hyperliquid_execute(
     preview_obj = await build_hyperliquid_execute_preview(tool_input)
     preview_text = str(preview_obj.get("summary") or "").strip()
 
-    try:
-        sign_callback, sender = await get_wallet_sign_typed_data_callback(want)
-    except ValueError as e:
-        return err("invalid_wallet", str(e))
-
     strategy_raw = CONFIG.get("strategy")
     strategy_cfg = strategy_raw if isinstance(strategy_raw, dict) else {}
     config: dict[str, Any] = dict(strategy_cfg)
-    config["main_wallet"] = {"address": sender}
-    config["strategy_wallet"] = {"address": sender}
 
     effects: list[dict[str, Any]] = []
 
-    adapter = HyperliquidAdapter(
-        config=config,
-        sign_callback=sign_callback,
-        wallet_address=sender,
-    )
+    try:
+        adapter = await get_adapter(HyperliquidAdapter, want, config_overrides=config)
+    except ValueError as e:
+        return err("invalid_wallet", str(e))
+    sender = adapter.wallet_address
 
     if action == "withdraw":
         if amount_usdc is None:

--- a/wayfinder_paths/mcp/tools/polymarket.py
+++ b/wayfinder_paths/mcp/tools/polymarket.py
@@ -9,10 +9,7 @@ from wayfinder_paths.core.constants.polymarket import (
     POLYGON_CHAIN_ID,
     POLYGON_USDC_ADDRESS,
 )
-from wayfinder_paths.core.utils.wallets import (
-    get_wallet_sign_hash_callback,
-    get_wallet_signing_callback,
-)
+from wayfinder_paths.core.utils.signing import build_signing_callbacks
 from wayfinder_paths.mcp.preview import build_polymarket_execute_preview
 from wayfinder_paths.mcp.state.profile_store import WalletProfileStore
 from wayfinder_paths.mcp.utils import (
@@ -194,15 +191,10 @@ async def polymarket(
         return err("invalid_request", "wallet_label is required for open_orders")
 
     config: dict[str, Any] | None = None
-    sign_cb = None
-    sign_hash_cb = None
+    signing = None
     if want and waddr:
         try:
-            sign_cb, _ = await get_wallet_signing_callback(want)
-        except ValueError:
-            pass
-        try:
-            sign_hash_cb, _ = await get_wallet_sign_hash_callback(want)
+            signing = await build_signing_callbacks(want)
         except ValueError:
             pass
         config = dict(CONFIG)
@@ -210,8 +202,7 @@ async def polymarket(
 
     adapter = PolymarketAdapter(
         config=config,
-        sign_callback=sign_cb,
-        sign_hash_callback=sign_hash_cb,
+        signing=signing,
         wallet_address=waddr,
     )
     try:
@@ -390,7 +381,7 @@ async def polymarket(
         if action == "open_orders":
             if not want or not waddr:
                 return err("not_found", f"Unknown wallet_label: {wallet_label}")
-            if not sign_cb:
+            if signing is None:
                 return err(
                     "invalid_wallet",
                     "Wallet must include private_key_hex in config.json to fetch open orders",
@@ -453,13 +444,10 @@ async def polymarket_execute(
     condition_id: str | None = None,
 ) -> dict[str, Any]:
     try:
-        sign_callback, sender = await get_wallet_signing_callback(wallet_label or "")
+        signing = await build_signing_callbacks(wallet_label or "")
     except ValueError as e:
         return err("invalid_wallet", str(e))
-    try:
-        sign_hash_cb, _ = await get_wallet_sign_hash_callback(wallet_label or "")
-    except ValueError:
-        sign_hash_cb = None
+    sender = signing.address
     want = wallet_label
 
     tool_input = {
@@ -498,8 +486,7 @@ async def polymarket_execute(
     effects: list[dict[str, Any]] = []
     adapter = PolymarketAdapter(
         config=cfg,
-        sign_callback=sign_callback,
-        sign_hash_callback=sign_hash_cb,
+        signing=signing,
         wallet_address=sender,
     )
     try:

--- a/wayfinder_paths/strategies/basis_trading_strategy/strategy.py
+++ b/wayfinder_paths/strategies/basis_trading_strategy/strategy.py
@@ -224,15 +224,15 @@ class BasisTradingStrategy(BasisSnapshotMixin, Strategy):
 
             self.hyperliquid_adapter = HyperliquidAdapter(
                 config=adapter_config,
-                sign_callback=strategy_sign_typed_data,
+                signing=self.strategy_signing,
             )
             strat_addr = (self.config.get("strategy_wallet") or {}).get("address")
             main_addr = (self.config.get("main_wallet") or {}).get("address")
 
             self.balance_adapter = BalanceAdapter(
                 adapter_config,
-                main_sign_callback=self.main_wallet_signing_callback,
-                strategy_sign_callback=self.strategy_wallet_signing_callback,
+                main_signing=self.main_signing,
+                strategy_signing=self.strategy_signing,
                 main_wallet_address=main_addr,
                 strategy_wallet_address=strat_addr,
             )

--- a/wayfinder_paths/strategies/boros_hype_strategy/strategy.py
+++ b/wayfinder_paths/strategies/boros_hype_strategy/strategy.py
@@ -39,6 +39,7 @@ from wayfinder_paths.core.strategies.descriptors import (
     TokenExposure,
     Volatility,
 )
+from wayfinder_paths.core.utils.signing import signing_from_private_key
 
 from .boros_ops_mixin import BorosHypeBorosOpsMixin
 from .constants import (
@@ -263,20 +264,25 @@ class BorosHypeStrategy(
             else None
         )
 
-        self._sign_callback = (
-            self._make_sign_callback(strategy_pk) if strategy_pk else None
-        )
-        main_sign_callback = self._make_sign_callback(main_pk) if main_pk else None
+        if strategy_pk and user_address:
+            self.strategy_signing = signing_from_private_key(strategy_pk, user_address)
+            self._sign_callback = self.strategy_signing.sign
+        else:
+            self._sign_callback = None
+
+        main_addr_pk = main_wallet.get("address") if main_wallet else None
+        if main_pk and main_addr_pk:
+            self.main_signing = signing_from_private_key(main_pk, main_addr_pk)
 
         self.boros_adapter = BorosAdapter(
             config=self._config,
-            sign_callback=self._sign_callback,
+            signing=self.strategy_signing,
             wallet_address=user_address,
         )
 
         self.hyperliquid_adapter = HyperliquidAdapter(
             config=self._config,
-            sign_callback=self.strategy_sign_typed_data,
+            signing=self.strategy_signing,
         )
 
         strat_addr = (strategy_wallet or {}).get("address")
@@ -284,14 +290,14 @@ class BorosHypeStrategy(
 
         self.balance_adapter = BalanceAdapter(
             config=self._config,
-            main_sign_callback=main_sign_callback,
-            strategy_sign_callback=self._sign_callback,
+            main_signing=self.main_signing,
+            strategy_signing=self.strategy_signing,
             main_wallet_address=main_addr,
             strategy_wallet_address=strat_addr,
         )
         self.brap_adapter = BRAPAdapter(
             config=self._config,
-            sign_callback=self._sign_callback,
+            signing=self.strategy_signing,
             wallet_address=strat_addr,
         )
 

--- a/wayfinder_paths/strategies/hyperlend_stable_yield_strategy/strategy.py
+++ b/wayfinder_paths/strategies/hyperlend_stable_yield_strategy/strategy.py
@@ -223,20 +223,20 @@ class HyperlendStableYieldStrategy(Strategy):
 
             self.balance_adapter = BalanceAdapter(
                 adapter_config,
-                main_sign_callback=self.main_wallet_signing_callback,
-                strategy_sign_callback=self.strategy_wallet_signing_callback,
+                main_signing=self.main_signing,
+                strategy_signing=self.strategy_signing,
                 main_wallet_address=main_addr,
                 strategy_wallet_address=strat_addr,
             )
             self.token_adapter = TokenAdapter()
             self.brap_adapter = BRAPAdapter(
                 adapter_config,
-                sign_callback=self.strategy_wallet_signing_callback,
+                signing=self.strategy_signing,
                 wallet_address=strat_addr,
             )
             self.hyperlend_adapter = HyperlendAdapter(
                 adapter_config,
-                sign_callback=self.strategy_wallet_signing_callback,
+                signing=self.strategy_signing,
                 wallet_address=strat_addr,
             )
 

--- a/wayfinder_paths/strategies/moonwell_wsteth_loop_strategy/strategy.py
+++ b/wayfinder_paths/strategies/moonwell_wsteth_loop_strategy/strategy.py
@@ -219,20 +219,20 @@ class MoonwellWstethLoopStrategy(Strategy):
 
             self.balance_adapter = BalanceAdapter(
                 adapter_config,
-                main_sign_callback=self.main_wallet_signing_callback,
-                strategy_sign_callback=self.strategy_wallet_signing_callback,
+                main_signing=self.main_signing,
+                strategy_signing=self.strategy_signing,
                 main_wallet_address=main_addr,
                 strategy_wallet_address=strat_addr,
             )
             self.token_adapter = TokenAdapter()
             self.brap_adapter = BRAPAdapter(
                 adapter_config,
-                sign_callback=self.strategy_wallet_signing_callback,
+                signing=self.strategy_signing,
                 wallet_address=strat_addr,
             )
             self.moonwell_adapter = MoonwellAdapter(
                 adapter_config,
-                sign_callback=self.strategy_wallet_signing_callback,
+                signing=self.strategy_signing,
                 wallet_address=strat_addr,
             )
         except Exception as e:

--- a/wayfinder_paths/strategies/multi_vault_split_strategy/strategy.py
+++ b/wayfinder_paths/strategies/multi_vault_split_strategy/strategy.py
@@ -176,29 +176,29 @@ class MultiVaultSplitStrategy(Strategy):
 
         self.balance_adapter = BalanceAdapter(
             adapter_config,
-            main_sign_callback=self.main_wallet_signing_callback,
-            strategy_sign_callback=self.strategy_wallet_signing_callback,
+            main_signing=self.main_signing,
+            strategy_signing=self.strategy_signing,
             main_wallet_address=main_addr,
             strategy_wallet_address=strat_addr,
         )
         self.brap_adapter = BRAPAdapter(
             adapter_config,
-            sign_callback=self.strategy_wallet_signing_callback,
+            signing=self.strategy_signing,
             wallet_address=strat_addr,
         )
         self.boros_adapter = BorosAdapter(
             config=adapter_config,
-            sign_callback=self.strategy_wallet_signing_callback,
+            signing=self.strategy_signing,
             wallet_address=strat_addr,
         )
         self.avantis_adapter = AvantisAdapter(
             config=adapter_config,
-            sign_callback=self.strategy_wallet_signing_callback,
+            signing=self.strategy_signing,
             wallet_address=strat_addr,
         )
         self.hyperliquid_adapter = HyperliquidAdapter(
             config=self.config,
-            sign_callback=self.strategy_wallet_signing_callback,
+            signing=self.strategy_signing,
             wallet_address=strat_addr,
         )
 

--- a/wayfinder_paths/strategies/projectx_thbill_usdc_strategy/strategy.py
+++ b/wayfinder_paths/strategies/projectx_thbill_usdc_strategy/strategy.py
@@ -160,15 +160,15 @@ class ProjectXThbillUsdcStrategy(Strategy):
 
         self.balance_adapter = BalanceAdapter(
             adapter_config,
-            main_sign_callback=self.main_wallet_signing_callback,
-            strategy_sign_callback=self.strategy_wallet_signing_callback,
+            main_signing=self.main_signing,
+            strategy_signing=self.strategy_signing,
             main_wallet_address=main_addr,
             strategy_wallet_address=strat_addr,
         )
         self.token_adapter = TokenAdapter()
         self.projectx = ProjectXLiquidityAdapter(
             adapter_config,
-            sign_callback=self.strategy_wallet_signing_callback,
+            signing=self.strategy_signing,
             wallet_address=strat_addr,
         )
 

--- a/wayfinder_paths/strategies/stablecoin_yield_strategy/strategy.py
+++ b/wayfinder_paths/strategies/stablecoin_yield_strategy/strategy.py
@@ -193,8 +193,8 @@ class StablecoinYieldStrategy(Strategy):
 
             self.balance_adapter = BalanceAdapter(
                 adapter_config,
-                main_sign_callback=self.main_wallet_signing_callback,
-                strategy_sign_callback=self.strategy_wallet_signing_callback,
+                main_signing=self.main_signing,
+                strategy_signing=self.strategy_signing,
                 main_wallet_address=main_addr,
                 strategy_wallet_address=strat_addr,
             )
@@ -202,7 +202,7 @@ class StablecoinYieldStrategy(Strategy):
             self.pool_adapter = PoolAdapter()
             self.brap_adapter = BRAPAdapter(
                 adapter_config,
-                sign_callback=self.strategy_wallet_signing_callback,
+                signing=self.strategy_signing,
                 wallet_address=strat_addr,
             )
         except Exception as e:

--- a/wayfinder_paths/testing/__init__.py
+++ b/wayfinder_paths/testing/__init__.py
@@ -1,3 +1,4 @@
 from wayfinder_paths.testing.gorlami import gorlami
+from wayfinder_paths.testing.signing import fake_signing
 
-__all__ = ["gorlami"]
+__all__ = ["fake_signing", "gorlami"]

--- a/wayfinder_paths/testing/signing.py
+++ b/wayfinder_paths/testing/signing.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+from unittest.mock import AsyncMock
+
+from wayfinder_paths.core.utils.signing import SigningCallbacks
+
+FAKE_ADDR = "0x1234567890123456789012345678901234567890"
+
+
+def fake_signing(
+    *,
+    sign: Callable[[dict[str, Any]], Awaitable[bytes]] | None = None,
+    sign_typed_data: Callable[..., Awaitable[str]] | None = None,
+    sign_hash: Callable[[str], Awaitable[str]] | None = None,
+    address: str = FAKE_ADDR,
+) -> SigningCallbacks:
+    return SigningCallbacks(
+        address=address,
+        sign=sign if sign is not None else AsyncMock(return_value=b"\x00" * 32),
+        sign_typed_data=(
+            sign_typed_data
+            if sign_typed_data is not None
+            else AsyncMock(return_value="0x" + "00" * 65)
+        ),
+        sign_hash=(
+            sign_hash
+            if sign_hash is not None
+            else AsyncMock(return_value="0x" + "00" * 65)
+        ),
+    )

--- a/wayfinder_paths/tests/test_mcp_polymarket_tool.py
+++ b/wayfinder_paths/tests/test_mcp_polymarket_tool.py
@@ -6,23 +6,21 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from wayfinder_paths.mcp.tools.polymarket import polymarket, polymarket_execute
+from wayfinder_paths.testing import fake_signing
 
 _FIND_WALLET = "wayfinder_paths.mcp.utils.find_wallet_by_label"
-_GET_SIGN_CB = "wayfinder_paths.mcp.tools.polymarket.get_wallet_signing_callback"
-_GET_HASH_CB = "wayfinder_paths.mcp.tools.polymarket.get_wallet_sign_hash_callback"
+_BUILD_SIGNING = "wayfinder_paths.mcp.tools.polymarket.build_signing_callbacks"
 
 _ADDR = "0x000000000000000000000000000000000000dEaD"
 _WALLET = {"address": _ADDR, "private_key_hex": "0x" + "11" * 32}
-_SIGN_CB = AsyncMock(return_value=b"\x00" * 65)
-_HASH_CB = AsyncMock(return_value="0x" + "00" * 65)
+_FAKE_SIGNING = fake_signing(address=_ADDR)
 
 
 @pytest.mark.asyncio
 async def test_polymarket_status_uses_adapter_full_state():
     with (
         patch(_FIND_WALLET, AsyncMock(return_value=_WALLET)),
-        patch(_GET_SIGN_CB, AsyncMock(return_value=(_SIGN_CB, _ADDR))),
-        patch(_GET_HASH_CB, AsyncMock(return_value=(_HASH_CB, _ADDR))),
+        patch(_BUILD_SIGNING, AsyncMock(return_value=_FAKE_SIGNING)),
         patch("wayfinder_paths.mcp.tools.polymarket.CONFIG", {}),
         patch(
             "wayfinder_paths.mcp.tools.polymarket.PolymarketAdapter.get_full_user_state",
@@ -146,8 +144,7 @@ async def test_polymarket_execute_bridge_deposit(tmp_path: Path, monkeypatch):
 
     with (
         patch(_FIND_WALLET, AsyncMock(return_value=_WALLET)),
-        patch(_GET_SIGN_CB, AsyncMock(return_value=(_SIGN_CB, _ADDR))),
-        patch(_GET_HASH_CB, AsyncMock(return_value=(_HASH_CB, _ADDR))),
+        patch(_BUILD_SIGNING, AsyncMock(return_value=_FAKE_SIGNING)),
         patch("wayfinder_paths.mcp.tools.polymarket.CONFIG", {}),
         patch(
             "wayfinder_paths.mcp.tools.polymarket.PolymarketAdapter.bridge_deposit",
@@ -172,8 +169,7 @@ async def test_polymarket_execute_buy_market_order(tmp_path: Path, monkeypatch):
 
     with (
         patch(_FIND_WALLET, AsyncMock(return_value=_WALLET)),
-        patch(_GET_SIGN_CB, AsyncMock(return_value=(_SIGN_CB, _ADDR))),
-        patch(_GET_HASH_CB, AsyncMock(return_value=(_HASH_CB, _ADDR))),
+        patch(_BUILD_SIGNING, AsyncMock(return_value=_FAKE_SIGNING)),
         patch("wayfinder_paths.mcp.tools.polymarket.CONFIG", {}),
         patch(
             "wayfinder_paths.mcp.tools.polymarket.PolymarketAdapter.place_prediction",


### PR DESCRIPTION
### Summary

- New `SigningCallbacks` dataclass bundles `address` + `sign` + `sign_typed_data` + `sign_hash`; `get_adapter()` builds it once and passes `signing=` (or `main_signing`/`strategy_signing` for BalanceAdapter) — no more parameter-name sniffing for multiple callback shapes.
- Every adapter migrated to `signing=`; Strategy base constructs bundles centrally from the existing callback kwargs so strategies and their mixins keep working.
- Hyperliquid squash: the adapter now holds both primitives separately (`signing.sign_typed_data` for L1 actions, `signing.sign` for `bridge_deposit`). The previous single `sign_callback` slot couldn't carry both, which was silently breaking `get_adapter(HyperliquidAdapter, ...)`.
- Tests use a new `wayfinder_paths.testing.fake_signing()` helper for fixtures.