### PR TITLE
Hyperliquid - Split sign_callback and sign_typed_data_callback

### DIFF
--- a/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
+++ b/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
@@ -56,7 +56,8 @@ class HyperliquidAdapter(BaseAdapter):
         self,
         config: dict[str, Any] | None = None,
         *,
-        sign_callback: Callable[[dict], Awaitable[str]] | None = None,
+        sign_callback: Callable[[dict], Awaitable[bytes]] | None = None,
+        sign_typed_data_callback: Callable[[dict | str], Awaitable[str]] | None = None,
         wallet_address: str | None = None,
     ) -> None:
         super().__init__("hyperliquid_adapter", config)
@@ -70,6 +71,9 @@ class HyperliquidAdapter(BaseAdapter):
         )
 
         self._sign_callback: Callable[..., Awaitable[Any]] | None = sign_callback
+        self._sign_typed_data_callback: Callable[..., Awaitable[Any]] | None = (
+            sign_typed_data_callback
+        )
 
     async def _post_across_dexes(
         self,
@@ -153,10 +157,10 @@ class HyperliquidAdapter(BaseAdapter):
     async def _sign(
         self, payload: str, action: dict[str, Any], address: str
     ) -> dict[str, Any] | None:
-        if self._sign_callback is None:
-            raise ValueError("No sign_callback configured")
+        if self._sign_typed_data_callback is None:
+            raise ValueError("No sign_typed_data_callback configured")
 
-        sig_hex = await self._sign_callback(payload)
+        sig_hex = await self._sign_typed_data_callback(payload)
         if not sig_hex:
             return None
         return self._sig_hex_to_hl_signature(sig_hex)

--- a/wayfinder_paths/adapters/hyperliquid_adapter/test_cancel_order.py
+++ b/wayfinder_paths/adapters/hyperliquid_adapter/test_cancel_order.py
@@ -15,7 +15,7 @@ class TestHyperliquidCancelOrder:
         ):
             adapter = HyperliquidAdapter(
                 config={},
-                sign_callback=AsyncMock(return_value="0x" + "00" * 65),
+                sign_typed_data_callback=AsyncMock(return_value="0x" + "00" * 65),
             )
             adapter._sign_and_broadcast_hypecore = AsyncMock(
                 return_value={"status": "ok"}

--- a/wayfinder_paths/adapters/hyperliquid_adapter/test_exchange_mid_prices.py
+++ b/wayfinder_paths/adapters/hyperliquid_adapter/test_exchange_mid_prices.py
@@ -47,7 +47,7 @@ class TestAdapterMidPriceFetch:
         ):
             adapter = HyperliquidAdapter(
                 config={},
-                sign_callback=AsyncMock(return_value="0x" + "00" * 65),
+                sign_typed_data_callback=AsyncMock(return_value="0x" + "00" * 65),
             )
 
             async def _no_broadcast(action, address):

--- a/wayfinder_paths/adapters/hyperliquid_adapter/test_hyperliquid_sdk_live.py
+++ b/wayfinder_paths/adapters/hyperliquid_adapter/test_hyperliquid_sdk_live.py
@@ -24,7 +24,7 @@ class TestAdapterUsesLiveMids:
 
         adapter = HyperliquidAdapter(
             config={},
-            sign_callback=AsyncMock(return_value="0x" + "00" * 65),
+            sign_typed_data_callback=AsyncMock(return_value="0x" + "00" * 65),
         )
 
         async def _no_broadcast(action, address):

--- a/wayfinder_paths/mcp/scripting.py
+++ b/wayfinder_paths/mcp/scripting.py
@@ -6,6 +6,7 @@ from typing import Any
 from wayfinder_paths.core.config import CONFIG
 from wayfinder_paths.core.utils.wallets import (
     get_wallet_sign_hash_callback,
+    get_wallet_sign_typed_data_callback,
     get_wallet_signing_callback,
 )
 
@@ -35,6 +36,9 @@ async def get_adapter[T](
             if "sign_hash_callback" in params:
                 hash_cb, _ = await get_wallet_sign_hash_callback(wallet_label)
                 adapter_kwargs["sign_hash_callback"] = hash_cb
+            if "sign_typed_data_callback" in params:
+                typed_cb, _ = await get_wallet_sign_typed_data_callback(wallet_label)
+                adapter_kwargs["sign_typed_data_callback"] = typed_cb
 
         elif "main_sign_callback" in params:
             adapter_kwargs["main_sign_callback"] = sign_cb

--- a/wayfinder_paths/mcp/tools/hyperliquid.py
+++ b/wayfinder_paths/mcp/tools/hyperliquid.py
@@ -9,8 +9,8 @@ from wayfinder_paths.core.constants.hyperliquid import (
     DEFAULT_HYPERLIQUID_BUILDER_FEE_TENTHS_BP,
     HYPE_FEE_WALLET,
 )
-from wayfinder_paths.core.utils.wallets import get_wallet_sign_typed_data_callback
 from wayfinder_paths.mcp.preview import build_hyperliquid_execute_preview
+from wayfinder_paths.mcp.scripting import get_adapter
 from wayfinder_paths.mcp.state.profile_store import WalletProfileStore
 from wayfinder_paths.mcp.utils import (
     err,
@@ -286,24 +286,17 @@ async def hyperliquid_execute(
     preview_obj = await build_hyperliquid_execute_preview(tool_input)
     preview_text = str(preview_obj.get("summary") or "").strip()
 
-    try:
-        sign_callback, sender = await get_wallet_sign_typed_data_callback(want)
-    except ValueError as e:
-        return err("invalid_wallet", str(e))
-
     strategy_raw = CONFIG.get("strategy")
     strategy_cfg = strategy_raw if isinstance(strategy_raw, dict) else {}
     config: dict[str, Any] = dict(strategy_cfg)
-    config["main_wallet"] = {"address": sender}
-    config["strategy_wallet"] = {"address": sender}
 
     effects: list[dict[str, Any]] = []
 
-    adapter = HyperliquidAdapter(
-        config=config,
-        sign_callback=sign_callback,
-        wallet_address=sender,
-    )
+    try:
+        adapter = await get_adapter(HyperliquidAdapter, want, config_overrides=config)
+    except ValueError as e:
+        return err("invalid_wallet", str(e))
+    sender = adapter.wallet_address
 
     if action == "withdraw":
         if amount_usdc is None:

--- a/wayfinder_paths/strategies/basis_trading_strategy/strategy.py
+++ b/wayfinder_paths/strategies/basis_trading_strategy/strategy.py
@@ -224,7 +224,8 @@ class BasisTradingStrategy(BasisSnapshotMixin, Strategy):
 
             self.hyperliquid_adapter = HyperliquidAdapter(
                 config=adapter_config,
-                sign_callback=strategy_sign_typed_data,
+                sign_callback=strategy_wallet_signing_callback,
+                sign_typed_data_callback=strategy_sign_typed_data,
             )
             strat_addr = (self.config.get("strategy_wallet") or {}).get("address")
             main_addr = (self.config.get("main_wallet") or {}).get("address")

--- a/wayfinder_paths/strategies/boros_hype_strategy/strategy.py
+++ b/wayfinder_paths/strategies/boros_hype_strategy/strategy.py
@@ -276,7 +276,8 @@ class BorosHypeStrategy(
 
         self.hyperliquid_adapter = HyperliquidAdapter(
             config=self._config,
-            sign_callback=self.strategy_sign_typed_data,
+            sign_callback=self._sign_callback,
+            sign_typed_data_callback=self.strategy_sign_typed_data,
         )
 
         strat_addr = (strategy_wallet or {}).get("address")

--- a/wayfinder_paths/strategies/multi_vault_split_strategy/strategy.py
+++ b/wayfinder_paths/strategies/multi_vault_split_strategy/strategy.py
@@ -199,6 +199,7 @@ class MultiVaultSplitStrategy(Strategy):
         self.hyperliquid_adapter = HyperliquidAdapter(
             config=self.config,
             sign_callback=self.strategy_wallet_signing_callback,
+            sign_typed_data_callback=self.strategy_sign_typed_data,
             wallet_address=strat_addr,
         )
 


### PR DESCRIPTION
### Summary

- HL's `_sign()` needs EIP-712 typed-data signing, but the adapter only exposed one `sign_callback` kwarg. Callers stuffed a typed-data callback into it, so `get_adapter()` (which wires plain tx signing) produced a wrong-shape adapter, and `bridge_deposit` (which needs plain tx signing) was using the typed-data callback.
- Split into two kwargs: `sign_callback` (plain tx, for `bridge_deposit`) and `sign_typed_data_callback` (for L1 action signing in `_sign()`).
- `get_adapter()` wires both from the existing `get_wallet_{signing,sign_typed_data}_callback` helpers.
- MCP tool `hyperliquid_execute` switched to `get_adapter(HyperliquidAdapter, ...)` so both callbacks are wired automatically; three strategies (`boros_hype`, `basis_trading`, `multi_vault_split`) pass both too.