### PR TITLE
Base URL - Fix duplicate /v1 in opencode client URLs

### DIFF
--- a/wayfinder_paths/core/clients/InstanceStateClient.py
+++ b/wayfinder_paths/core/clients/InstanceStateClient.py
@@ -8,7 +8,7 @@ from wayfinder_paths.core.config import get_api_base_url, get_opencode_instance_
 
 class InstanceStateClient(WayfinderClient):
     def _base_url(self) -> str:
-        return f"{get_api_base_url()}/v1/opencode/instances/{get_opencode_instance_id()}/context"
+        return f"{get_api_base_url()}/opencode/instances/{get_opencode_instance_id()}/context"
 
     async def get_state(self) -> dict[str, Any]:
         resp = await self._authed_request("GET", f"{self._base_url()}/")

--- a/wayfinder_paths/core/clients/NotifyClient.py
+++ b/wayfinder_paths/core/clients/NotifyClient.py
@@ -8,7 +8,7 @@ from wayfinder_paths.core.config import get_api_base_url
 
 class NotifyClient(WayfinderClient):
     async def notify(self, title: str, message: str) -> dict[str, Any]:
-        url = f"{get_api_base_url()}/v1/opencode/notify/"
+        url = f"{get_api_base_url()}/opencode/notify/"
         response = await self._authed_request(
             "POST", url, json={"title": title, "message": message}
         )


### PR DESCRIPTION
### Summary

- `config.prod.json` / `config.example.json` set `api_base_url` to `https://strategies.wayfinder.ai/api/v1` — the `/v1` is already baked in.
- `InstanceStateClient._base_url()` and `NotifyClient.notify()` prepended another `/v1/`, producing `/api/v1/v1/opencode/...` which 404s.
- Every other client (Token/Balance/Hyperliquid/BRAP/Hyperlend/AlphaLab/DeltaLab/Wallet/Pool/Gorlami) follows `{base}/<resource>/...`. Aligned the two stragglers with that pattern.