### PR TITLE
Scheduled Jobs - Push job/run state to vault-backend

### DIFF
--- a/wayfinder_paths/core/clients/ScheduledJobsClient.py
+++ b/wayfinder_paths/core/clients/ScheduledJobsClient.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+from loguru import logger
+
+from wayfinder_paths.core.config import (
+    get_api_base_url,
+    get_api_key,
+    get_opencode_instance_id,
+)
+
+
+class ScheduledJobsClient:
+    """Sync client for pushing job/run data to vault-backend. Used by the runner daemon."""
+
+    def __init__(self) -> None:
+        self._client = httpx.Client(timeout=httpx.Timeout(10), follow_redirects=True)
+
+    def _base_url(self) -> str:
+        return (
+            f"{get_api_base_url()}/opencode/instances/{get_opencode_instance_id()}/jobs"
+        )
+
+    def _headers(self) -> dict[str, str]:
+        hdrs: dict[str, str] = {"Content-Type": "application/json"}
+        api_key = get_api_key()
+        if api_key:
+            hdrs["X-API-KEY"] = api_key
+        return hdrs
+
+    def sync_job(self, job_name: str, data: dict[str, Any]) -> None:
+        try:
+            self._client.put(
+                f"{self._base_url()}/{job_name}/", json=data, headers=self._headers()
+            )
+        except Exception:
+            logger.opt(exception=True).warning(
+                f"Failed to sync job {job_name} to backend"
+            )
+
+    def delete_job(self, job_name: str) -> None:
+        try:
+            self._client.delete(
+                f"{self._base_url()}/{job_name}/", headers=self._headers()
+            )
+        except Exception:
+            logger.opt(exception=True).warning(
+                f"Failed to delete job {job_name} from backend"
+            )
+
+    def report_run(self, job_name: str, run_data: dict[str, Any]) -> None:
+        try:
+            self._client.post(
+                f"{self._base_url()}/{job_name}/runs/",
+                json=run_data,
+                headers=self._headers(),
+            )
+        except Exception:
+            logger.opt(exception=True).warning(
+                f"Failed to report run for {job_name} to backend"
+            )
+
+
+SCHEDULED_JOBS_CLIENT = ScheduledJobsClient()

--- a/wayfinder_paths/core/clients/ScheduledJobsClient.py
+++ b/wayfinder_paths/core/clients/ScheduledJobsClient.py
@@ -30,29 +30,23 @@ class ScheduledJobsClient:
             hdrs["X-API-KEY"] = api_key
         return hdrs
 
-    def sync_job(self, job_name: str, data: dict[str, Any]) -> None:
-        try:
-            self._client.put(
-                f"{self._base_url()}/{job_name}/", json=data, headers=self._headers()
-            )
-        except Exception:
-            logger.opt(exception=True).warning(
-                f"Failed to sync job {job_name} to backend"
-            )
-
     def sync_job_from_db(self, db: Any, name: str) -> None:
         try:
             job, state = db.get_job(name=name)
         except KeyError:
             return
-        self.sync_job(
-            name,
-            {
-                "status": state.status,
-                "interval_seconds": job.interval_seconds,
-                "payload": job.payload,
-            },
-        )
+        try:
+            self._client.put(
+                f"{self._base_url()}/{name}/",
+                json={
+                    "status": state.status,
+                    "interval_seconds": job.interval_seconds,
+                    "payload": job.payload,
+                },
+                headers=self._headers(),
+            )
+        except Exception:
+            logger.opt(exception=True).warning(f"Failed to sync job {name} to backend")
 
     def delete_job(self, job_name: str) -> None:
         try:

--- a/wayfinder_paths/core/clients/ScheduledJobsClient.py
+++ b/wayfinder_paths/core/clients/ScheduledJobsClient.py
@@ -13,7 +13,7 @@ from wayfinder_paths.core.config import (
 
 
 class ScheduledJobsClient:
-    """Sync client for pushing job/run data to vault-backend. Used by the runner daemon."""
+    """Sync HTTP client for pushing job/run data to vault-backend."""
 
     def __init__(self) -> None:
         self._client = httpx.Client(timeout=httpx.Timeout(10), follow_redirects=True)
@@ -30,23 +30,17 @@ class ScheduledJobsClient:
             hdrs["X-API-KEY"] = api_key
         return hdrs
 
-    def sync_job_from_db(self, db: Any, name: str) -> None:
-        try:
-            job, state = db.get_job(name=name)
-        except KeyError:
-            return
+    def sync_job(self, job_name: str, data: dict[str, Any]) -> None:
         try:
             self._client.put(
-                f"{self._base_url()}/{name}/",
-                json={
-                    "status": state.status,
-                    "interval_seconds": job.interval_seconds,
-                    "payload": job.payload,
-                },
+                f"{self._base_url()}/{job_name}/",
+                json=data,
                 headers=self._headers(),
             )
         except Exception:
-            logger.opt(exception=True).warning(f"Failed to sync job {name} to backend")
+            logger.opt(exception=True).warning(
+                f"Failed to sync job {job_name} to backend"
+            )
 
     def delete_job(self, job_name: str) -> None:
         try:

--- a/wayfinder_paths/core/clients/ScheduledJobsClient.py
+++ b/wayfinder_paths/core/clients/ScheduledJobsClient.py
@@ -40,6 +40,20 @@ class ScheduledJobsClient:
                 f"Failed to sync job {job_name} to backend"
             )
 
+    def sync_job_from_db(self, db: Any, name: str) -> None:
+        try:
+            job, state = db.get_job(name=name)
+        except KeyError:
+            return
+        self.sync_job(
+            name,
+            {
+                "status": state.status,
+                "interval_seconds": job.interval_seconds,
+                "payload": job.payload,
+            },
+        )
+
     def delete_job(self, job_name: str) -> None:
         try:
             self._client.delete(

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -8,7 +8,7 @@ import sys
 import threading
 import time
 from dataclasses import dataclass
-from datetime import UTC
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -31,22 +31,6 @@ from wayfinder_paths.runner.script_resolver import resolve_script_path
 
 def _utc_epoch_s() -> int:
     return int(time.time())
-
-
-def _sync_job_to_backend(db: RunnerDB, name: str) -> None:
-    """Fire-and-forget push of job state to vault-backend."""
-    try:
-        job, state = db.get_job(name=name)
-    except KeyError:
-        return
-    SCHEDULED_JOBS_CLIENT.sync_job(
-        name,
-        {
-            "status": state.status,
-            "interval_seconds": job.interval_seconds,
-            "payload": job.payload,
-        },
-    )
 
 
 def _safe_job_dirname(name: str) -> str:
@@ -301,9 +285,24 @@ class RunnerDaemon:
         )
 
         self._notify_session(rp, status=status, error_text=error_text)
-        self._report_run_to_backend(
-            rp, status=status, exit_code=exit_code, finished_at=finished_at
+
+        log_tail = ""
+        try:
+            log_tail = rp.log_path.read_text(errors="replace")[-4096:]
+        except Exception:  # noqa: BLE001
+            pass
+        SCHEDULED_JOBS_CLIENT.report_run(
+            rp.job_name,
+            {
+                "run_id": str(rp.run_id),
+                "status": status,
+                "started_at": datetime.fromtimestamp(rp.started_at, tz=UTC).isoformat(),
+                "finished_at": datetime.fromtimestamp(finished_at, tz=UTC).isoformat(),
+                "exit_code": exit_code,
+                "log_tail": log_tail,
+            },
         )
+        SCHEDULED_JOBS_CLIENT.sync_job_from_db(self._db, rp.job_name)
 
     def _notify_session(
         self,
@@ -329,38 +328,6 @@ class RunnerDaemon:
             }
         )
         OPENCODE_CLIENT.send_message(session_id, notification)
-
-    def _report_run_to_backend(
-        self,
-        rp: RunningProcess,
-        *,
-        status: str,
-        exit_code: int | None,
-        finished_at: int,
-    ) -> None:
-        from datetime import datetime
-
-        def _ts(epoch: int) -> str:
-            return datetime.fromtimestamp(epoch, tz=UTC).isoformat()
-
-        log_tail = ""
-        try:
-            log_tail = rp.log_path.read_text(errors="replace")[-4096:]
-        except Exception:  # noqa: BLE001
-            pass
-
-        SCHEDULED_JOBS_CLIENT.report_run(
-            rp.job_name,
-            {
-                "run_id": str(rp.run_id),
-                "status": status,
-                "started_at": _ts(rp.started_at),
-                "finished_at": _ts(finished_at),
-                "exit_code": exit_code,
-                "log_tail": log_tail,
-            },
-        )
-        _sync_job_to_backend(self._db, rp.job_name)
 
     def _shutdown_running_processes(self) -> None:
         with self._lock:
@@ -700,7 +667,7 @@ class RunnerDaemon:
             )
         except Exception as exc:  # noqa: BLE001
             return {"ok": False, "error": str(exc)}
-        _sync_job_to_backend(self._db, name)
+        SCHEDULED_JOBS_CLIENT.sync_job_from_db(self._db, name)
         return {"ok": True, "result": {"job_id": job_id, "name": name}}
 
     def ctl_update_job(
@@ -712,7 +679,7 @@ class RunnerDaemon:
             self._db.update_job(
                 name=name, payload=payload, interval_seconds=interval_seconds
             )
-            _sync_job_to_backend(self._db, name)
+            SCHEDULED_JOBS_CLIENT.sync_job_from_db(self._db, name)
             return {"ok": True, "result": {"name": name}}
         except KeyError as exc:
             return {"ok": False, "error": str(exc)}
@@ -720,7 +687,7 @@ class RunnerDaemon:
     def ctl_pause_job(self, *, name: str) -> dict[str, Any]:
         try:
             self._db.set_job_status(name=name, status=JobStatus.PAUSED)
-            _sync_job_to_backend(self._db, name)
+            SCHEDULED_JOBS_CLIENT.sync_job_from_db(self._db, name)
             return {"ok": True, "result": {"name": name, "status": JobStatus.PAUSED}}
         except KeyError as exc:
             return {"ok": False, "error": str(exc)}
@@ -730,7 +697,7 @@ class RunnerDaemon:
             job, _ = self._db.get_job(name=name)
             self._db.set_job_status(name=name, status=JobStatus.ACTIVE)
             self._db.set_next_run_at(job_id=job.id, next_run_at=_utc_epoch_s())
-            _sync_job_to_backend(self._db, name)
+            SCHEDULED_JOBS_CLIENT.sync_job_from_db(self._db, name)
             return {"ok": True, "result": {"name": name, "status": JobStatus.ACTIVE}}
         except KeyError as exc:
             return {"ok": False, "error": str(exc)}

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -8,6 +8,7 @@ import sys
 import threading
 import time
 from dataclasses import dataclass
+from datetime import UTC
 from pathlib import Path
 from typing import Any
 
@@ -15,6 +16,7 @@ from loguru import logger
 
 from wayfinder_paths import __version__
 from wayfinder_paths.core.clients.OpenCodeClient import OPENCODE_CLIENT
+from wayfinder_paths.core.clients.ScheduledJobsClient import SCHEDULED_JOBS_CLIENT
 from wayfinder_paths.runner.constants import (
     JOB_TYPE_SCRIPT,
     JOB_TYPE_STRATEGY,
@@ -29,6 +31,32 @@ from wayfinder_paths.runner.script_resolver import resolve_script_path
 
 def _utc_epoch_s() -> int:
     return int(time.time())
+
+
+def _sync_job_to_backend(db: RunnerDB, name: str) -> None:
+    """Fire-and-forget push of job state to vault-backend."""
+    try:
+        job, state = db.get_job(name=name)
+    except KeyError:
+        return
+    from datetime import datetime
+
+    def _ts(epoch: int | None) -> str | None:
+        return datetime.fromtimestamp(epoch, tz=UTC).isoformat() if epoch else None
+
+    SCHEDULED_JOBS_CLIENT.sync_job(
+        name,
+        {
+            "job_type": job.type,
+            "status": state.status,
+            "interval_seconds": job.interval_seconds,
+            "payload": job.payload,
+            "last_run_at": _ts(state.last_run_at),
+            "next_run_at": _ts(state.next_run_at),
+            "consecutive_failures": state.consecutive_failures,
+            "last_error": state.last_error or "",
+        },
+    )
 
 
 def _safe_job_dirname(name: str) -> str:
@@ -283,6 +311,9 @@ class RunnerDaemon:
         )
 
         self._notify_session(rp, status=status, error_text=error_text)
+        self._report_run_to_backend(
+            rp, status=status, exit_code=exit_code, finished_at=finished_at
+        )
 
     def _notify_session(
         self,
@@ -308,6 +339,38 @@ class RunnerDaemon:
             }
         )
         OPENCODE_CLIENT.send_message(session_id, notification)
+
+    def _report_run_to_backend(
+        self,
+        rp: RunningProcess,
+        *,
+        status: str,
+        exit_code: int | None,
+        finished_at: int,
+    ) -> None:
+        from datetime import datetime
+
+        def _ts(epoch: int) -> str:
+            return datetime.fromtimestamp(epoch, tz=UTC).isoformat()
+
+        log_tail = ""
+        try:
+            log_tail = rp.log_path.read_text(errors="replace")[-4096:]
+        except Exception:  # noqa: BLE001
+            pass
+
+        SCHEDULED_JOBS_CLIENT.report_run(
+            rp.job_name,
+            {
+                "run_id": str(rp.run_id),
+                "status": status,
+                "started_at": _ts(rp.started_at),
+                "finished_at": _ts(finished_at),
+                "exit_code": exit_code,
+                "log_tail": log_tail,
+            },
+        )
+        _sync_job_to_backend(self._db, rp.job_name)
 
     def _shutdown_running_processes(self) -> None:
         with self._lock:
@@ -647,6 +710,7 @@ class RunnerDaemon:
             )
         except Exception as exc:  # noqa: BLE001
             return {"ok": False, "error": str(exc)}
+        _sync_job_to_backend(self._db, name)
         return {"ok": True, "result": {"job_id": job_id, "name": name}}
 
     def ctl_update_job(
@@ -658,6 +722,7 @@ class RunnerDaemon:
             self._db.update_job(
                 name=name, payload=payload, interval_seconds=interval_seconds
             )
+            _sync_job_to_backend(self._db, name)
             return {"ok": True, "result": {"name": name}}
         except KeyError as exc:
             return {"ok": False, "error": str(exc)}
@@ -665,6 +730,7 @@ class RunnerDaemon:
     def ctl_pause_job(self, *, name: str) -> dict[str, Any]:
         try:
             self._db.set_job_status(name=name, status=JobStatus.PAUSED)
+            _sync_job_to_backend(self._db, name)
             return {"ok": True, "result": {"name": name, "status": JobStatus.PAUSED}}
         except KeyError as exc:
             return {"ok": False, "error": str(exc)}
@@ -674,6 +740,7 @@ class RunnerDaemon:
             job, _ = self._db.get_job(name=name)
             self._db.set_job_status(name=name, status=JobStatus.ACTIVE)
             self._db.set_next_run_at(job_id=job.id, next_run_at=_utc_epoch_s())
+            _sync_job_to_backend(self._db, name)
             return {"ok": True, "result": {"name": name, "status": JobStatus.ACTIVE}}
         except KeyError as exc:
             return {"ok": False, "error": str(exc)}
@@ -719,4 +786,5 @@ class RunnerDaemon:
                 return {"ok": False, "error": str(exc)}
             self._running_by_job.pop(job_id, None)
 
+        SCHEDULED_JOBS_CLIENT.delete_job(str(name))
         return {"ok": True, "result": {"name": str(name), "deleted": True}}

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -286,9 +286,9 @@ class RunnerDaemon:
 
         self._notify_session(rp, status=status, error_text=error_text)
 
-        log_tail = ""
+        log_output = ""
         try:
-            log_tail = rp.log_path.read_text(errors="replace")[-4096:]
+            log_output = rp.log_path.read_text(errors="replace")
         except Exception:  # noqa: BLE001
             pass
         SCHEDULED_JOBS_CLIENT.report_run(
@@ -299,7 +299,7 @@ class RunnerDaemon:
                 "started_at": datetime.fromtimestamp(rp.started_at, tz=UTC).isoformat(),
                 "finished_at": datetime.fromtimestamp(finished_at, tz=UTC).isoformat(),
                 "exit_code": exit_code,
-                "log_tail": log_tail,
+                "log_output": log_output,
             },
         )
         SCHEDULED_JOBS_CLIENT.sync_job_from_db(self._db, rp.job_name)

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -39,22 +39,12 @@ def _sync_job_to_backend(db: RunnerDB, name: str) -> None:
         job, state = db.get_job(name=name)
     except KeyError:
         return
-    from datetime import datetime
-
-    def _ts(epoch: int | None) -> str | None:
-        return datetime.fromtimestamp(epoch, tz=UTC).isoformat() if epoch else None
-
     SCHEDULED_JOBS_CLIENT.sync_job(
         name,
         {
-            "job_type": job.type,
             "status": state.status,
             "interval_seconds": job.interval_seconds,
             "payload": job.payload,
-            "last_run_at": _ts(state.last_run_at),
-            "next_run_at": _ts(state.next_run_at),
-            "consecutive_failures": state.consecutive_failures,
-            "last_error": state.last_error or "",
         },
     )
 

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -302,7 +302,21 @@ class RunnerDaemon:
                 "log_output": log_output,
             },
         )
-        SCHEDULED_JOBS_CLIENT.sync_job_from_db(self._db, rp.job_name)
+        self._sync_job(rp.job_name)
+
+    def _sync_job(self, name: str) -> None:
+        try:
+            job, state = self._db.get_job(name=name)
+        except KeyError:
+            return
+        SCHEDULED_JOBS_CLIENT.sync_job(
+            name,
+            {
+                "status": state.status,
+                "interval_seconds": job.interval_seconds,
+                "payload": job.payload,
+            },
+        )
 
     def _notify_session(
         self,
@@ -667,7 +681,7 @@ class RunnerDaemon:
             )
         except Exception as exc:  # noqa: BLE001
             return {"ok": False, "error": str(exc)}
-        SCHEDULED_JOBS_CLIENT.sync_job_from_db(self._db, name)
+        self._sync_job(name)
         return {"ok": True, "result": {"job_id": job_id, "name": name}}
 
     def ctl_update_job(
@@ -679,7 +693,7 @@ class RunnerDaemon:
             self._db.update_job(
                 name=name, payload=payload, interval_seconds=interval_seconds
             )
-            SCHEDULED_JOBS_CLIENT.sync_job_from_db(self._db, name)
+            self._sync_job(name)
             return {"ok": True, "result": {"name": name}}
         except KeyError as exc:
             return {"ok": False, "error": str(exc)}
@@ -687,7 +701,7 @@ class RunnerDaemon:
     def ctl_pause_job(self, *, name: str) -> dict[str, Any]:
         try:
             self._db.set_job_status(name=name, status=JobStatus.PAUSED)
-            SCHEDULED_JOBS_CLIENT.sync_job_from_db(self._db, name)
+            self._sync_job(name)
             return {"ok": True, "result": {"name": name, "status": JobStatus.PAUSED}}
         except KeyError as exc:
             return {"ok": False, "error": str(exc)}
@@ -697,7 +711,7 @@ class RunnerDaemon:
             job, _ = self._db.get_job(name=name)
             self._db.set_job_status(name=name, status=JobStatus.ACTIVE)
             self._db.set_next_run_at(job_id=job.id, next_run_at=_utc_epoch_s())
-            SCHEDULED_JOBS_CLIENT.sync_job_from_db(self._db, name)
+            self._sync_job(name)
             return {"ok": True, "result": {"name": name, "status": JobStatus.ACTIVE}}
         except KeyError as exc:
             return {"ok": False, "error": str(exc)}


### PR DESCRIPTION
### Summary
- `ScheduledJobsClient` (sync) for fire-and-forget pushes from the runner daemon
- Hooks into add/update/delete/pause/resume job lifecycle + run completion
- Reports run data (status, timestamps, exit code, log tail) after each run