### PR TITLE
Scheduled Jobs - Guard sync behind OPENCODE_INSTANCE_ID

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,16 @@ await INSTANCE_STATE_CLIENT.add_projection(chart_id, {
 
 Projections are scoped per chart — switching markets shows only that chart's projections. The backend is type-agnostic; new projection types only need a frontend renderer.
 
+## Scheduled Jobs (backend sync)
+
+On OpenCode Cloud instances (`OPENCODE_INSTANCE_ID` set), the runner daemon automatically syncs job and run state to vault-backend. This happens transparently — no agent action needed.
+
+- **Job sync**: When a job is added, updated, paused, resumed, or deleted, the daemon pushes the current state to `PUT /instances/{id}/jobs/{name}/`
+- **Run sync**: After each run completes, the daemon pushes the full log output to `POST /instances/{id}/jobs/{name}/runs/`
+- **Local-only**: On non-cloud instances (no `OPENCODE_INSTANCE_ID`), sync is skipped silently
+
+The frontend shows synced jobs and runs in the "Scheduled" tab of the shells sidebar.
+
 ## Project Overview
 
 Wayfinder Paths is a Python 3.12 public SDK for community-contributed DeFi trading strategies and adapters. It provides the building blocks for automated trading: adapters (exchange/protocol integrations), strategies (trading algorithms), and clients (low-level API wrappers). In production it can be integrated with a separate execution service for hosted signing/execution.

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -286,25 +286,32 @@ class RunnerDaemon:
 
         self._notify_session(rp, status=status, error_text=error_text)
 
-        log_output = ""
-        try:
-            log_output = rp.log_path.read_text(errors="replace")
-        except Exception:  # noqa: BLE001
-            pass
-        SCHEDULED_JOBS_CLIENT.report_run(
-            rp.job_name,
-            {
-                "run_id": str(rp.run_id),
-                "status": status,
-                "started_at": datetime.fromtimestamp(rp.started_at, tz=UTC).isoformat(),
-                "finished_at": datetime.fromtimestamp(finished_at, tz=UTC).isoformat(),
-                "exit_code": exit_code,
-                "log_output": log_output,
-            },
-        )
-        self._sync_job(rp.job_name)
+        if os.environ.get("OPENCODE_INSTANCE_ID"):
+            log_output = ""
+            try:
+                log_output = rp.log_path.read_text(errors="replace")
+            except Exception:  # noqa: BLE001
+                pass
+            SCHEDULED_JOBS_CLIENT.report_run(
+                rp.job_name,
+                {
+                    "run_id": str(rp.run_id),
+                    "status": status,
+                    "started_at": datetime.fromtimestamp(
+                        rp.started_at, tz=UTC
+                    ).isoformat(),
+                    "finished_at": datetime.fromtimestamp(
+                        finished_at, tz=UTC
+                    ).isoformat(),
+                    "exit_code": exit_code,
+                    "log_output": log_output,
+                },
+            )
+            self._sync_job(rp.job_name)
 
     def _sync_job(self, name: str) -> None:
+        if not os.environ.get("OPENCODE_INSTANCE_ID"):
+            return
         try:
             job, state = self._db.get_job(name=name)
         except KeyError:
@@ -757,5 +764,6 @@ class RunnerDaemon:
                 return {"ok": False, "error": str(exc)}
             self._running_by_job.pop(job_id, None)
 
-        SCHEDULED_JOBS_CLIENT.delete_job(str(name))
+        if os.environ.get("OPENCODE_INSTANCE_ID"):
+            SCHEDULED_JOBS_CLIENT.delete_job(str(name))
         return {"ok": True, "result": {"name": str(name), "deleted": True}}


### PR DESCRIPTION
### Summary
- Skip job/run sync to vault-backend when `OPENCODE_INSTANCE_ID` is not set (local dev)
- Add AGENTS.md docs for scheduled jobs sync feature