### PR TITLE
path preview: proxy Delta Lab + inject apiBase so applets work in local dev

### DIFF
--- a/wayfinder_paths/paths/cli.py
+++ b/wayfinder_paths/paths/cli.py
@@ -1296,11 +1296,19 @@ def activate_cmd(
 )
 @click.option("--parent-port", default=3333, show_default=True, type=int)
 @click.option("--applet-port", default=3334, show_default=True, type=int)
+@click.option(
+    "--api-base",
+    "api_base",
+    default="https://strategies.wayfinder.ai",
+    show_default=True,
+    help="Upstream proxied by the preview server for Delta Lab public routes (prod or dev Strategies host).",
+)
 def preview_cmd(
     path_dir: str,
     check: bool,
     parent_port: int,
     applet_port: int,
+    api_base: str,
 ) -> None:
     try:
         if check:
@@ -1323,6 +1331,7 @@ def preview_cmd(
             path_dir=Path(path_dir),
             parent_port=parent_port,
             applet_port=applet_port,
+            api_base=api_base,
         )
     except PathPreviewError as exc:
         raise click.ClickException(str(exc)) from exc

--- a/wayfinder_paths/paths/preview.py
+++ b/wayfinder_paths/paths/preview.py
@@ -4,6 +4,9 @@ import contextlib
 import json
 import socket
 import threading
+import urllib.error
+import urllib.parse
+import urllib.request
 from dataclasses import dataclass
 from functools import partial
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
@@ -33,6 +36,82 @@ class PreviewUrls:
     applet_url: str
 
 
+PROXY_PREFIX = "/api/v1/delta-lab/public/"
+PROXY_TIMEOUT = 10.0
+
+
+class ProxyingAppletHandler(SimpleHTTPRequestHandler):
+    """Static file handler that proxies `/api/v1/delta-lab/public/*` to the
+    configured upstream. Proxied through the applet server so the applet's
+    fetches are same-origin (no CORS preflight)."""
+
+    upstream_base: str = ""
+
+    def _send_cors(self) -> None:
+        # The applet iframe is sandboxed without allow-same-origin, giving it
+        # an opaque origin — every fetch becomes cross-origin and requires
+        # CORS headers, even when hitting the iframe's own server.
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+
+    def do_OPTIONS(self) -> None:  # noqa: N802 - http.server naming
+        self.send_response(204)
+        self._send_cors()
+        self.end_headers()
+
+    def end_headers(self) -> None:
+        self._send_cors()
+        super().end_headers()
+
+    def do_GET(self) -> None:  # noqa: N802 - http.server naming
+        if self.upstream_base and self.path.startswith(PROXY_PREFIX):
+            self._proxy()
+            return
+        super().do_GET()
+
+    def _proxy(self) -> None:
+        upstream = self.upstream_base.rstrip("/") + self.path
+        req = urllib.request.Request(
+            upstream,
+            headers={
+                "Accept": "application/json",
+                # Cloudflare blocks the default Python UA with a 1010 signature ban.
+                "User-Agent": (
+                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/120.0.0.0 Safari/537.36"
+                ),
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=PROXY_TIMEOUT) as resp:
+                body = resp.read()
+                self.send_response(resp.status)
+                self.send_header(
+                    "Content-Type",
+                    resp.headers.get("Content-Type", "application/json"),
+                )
+                self.send_header("Content-Length", str(len(body)))
+                self.send_header("Cache-Control", "no-store")
+                self.end_headers()
+                self.wfile.write(body)
+        except urllib.error.HTTPError as exc:
+            body = exc.read() if hasattr(exc, "read") else b""
+            self.send_response(exc.code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        except Exception as exc:
+            msg = json.dumps({"error": "proxy_error", "detail": str(exc)}).encode()
+            self.send_response(502)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(msg)))
+            self.end_headers()
+            self.wfile.write(msg)
+
+
 def _pick_port(port: int) -> int:
     if port:
         return port
@@ -43,6 +122,20 @@ def _pick_port(port: int) -> int:
 
 def _serve_dir(directory: Path, *, port: int) -> tuple[ThreadingHTTPServer, int]:
     handler = partial(SimpleHTTPRequestHandler, directory=str(directory))
+    actual_port = _pick_port(port)
+    server = ThreadingHTTPServer(("127.0.0.1", actual_port), handler)
+    return server, actual_port
+
+
+def _serve_applet(
+    directory: Path, *, port: int, upstream_base: str
+) -> tuple[ThreadingHTTPServer, int]:
+    # Subclass per-call to carry upstream_base; handler classes are per-request.
+    class _Handler(ProxyingAppletHandler):
+        pass
+
+    _Handler.upstream_base = upstream_base
+    handler = partial(_Handler, directory=str(directory))
     actual_port = _pick_port(port)
     server = ThreadingHTTPServer(("127.0.0.1", actual_port), handler)
     return server, actual_port
@@ -100,6 +193,7 @@ def preview_path(
     path_dir: Path,
     parent_port: int = 3333,
     applet_port: int = 3334,
+    api_base: str = "https://strategies.wayfinder.ai",
 ) -> PreviewUrls:
     inspection = inspect_preview_path(path_dir=path_dir)
 
@@ -107,11 +201,16 @@ def preview_path(
         tmp_dir = Path(tmp)
         parent_html = tmp_dir / "index.html"
 
-        applet_server, applet_actual_port = _serve_dir(
+        applet_server, applet_actual_port = _serve_applet(
             inspection.applet_root,
             port=applet_port,
+            upstream_base=api_base,
         )
-        applet_url = f"http://127.0.0.1:{applet_actual_port}/"
+        applet_origin = f"http://127.0.0.1:{applet_actual_port}"
+        applet_url = applet_origin + "/"
+        # The applet fetches apiBase + "/api/v1/delta-lab/public/..." — route that
+        # through the applet server (same-origin, no CORS preflight).
+        applet_api_base_js = json.dumps(applet_origin)
 
         parent_html.write_text(
             "\n".join(
@@ -124,10 +223,12 @@ def preview_path(
                     f"    <title>Path Preview: {inspection.slug}</title>",
                     "    <style>",
                     "      :root { color-scheme: dark; font-family: ui-sans-serif, system-ui; }",
-                    "      body { margin: 0; padding: 16px; background: #0b0f0c; color: #e7f5ea; }",
-                    "      .row { display: flex; gap: 12px; flex-wrap: wrap; }",
+                    "      html, body { margin: 0; padding: 0; background: #0b0f0c; color: #e7f5ea; height: 100%; }",
+                    "      body { display: flex; flex-direction: column; padding: 12px; gap: 12px; box-sizing: border-box; }",
+                    "      .row { display: flex; gap: 12px; flex-wrap: wrap; flex: 0 0 auto; }",
                     "      .card { border: 1px solid rgba(255,255,255,0.12); border-radius: 16px; padding: 12px; background: rgba(255,255,255,0.04); }",
-                    "      iframe { width: 100%; border: 0; }",
+                    "      .applet-card { flex: 1 1 auto; display: flex; min-height: 0; padding: 0; overflow: hidden; }",
+                    "      iframe { width: 100%; height: 100%; min-height: 720px; border: 0; display: block; background: #0b0d10; border-radius: 16px; }",
                     "    </style>",
                     "  </head>",
                     "  <body>",
@@ -136,9 +237,10 @@ def preview_path(
                     "        <div style='opacity:.8'>Parent shell</div>",
                     f"        <div style='font-size:18px;margin-top:6px'>{inspection.name}</div>",
                     "        <div style='opacity:.7;margin-top:10px'>Bridge: <span id='bridge'>pending</span></div>",
+                    f"        <div style='opacity:.6;margin-top:4px;font-size:12px'>Proxying {PROXY_PREFIX}* → {api_base}</div>",
                     "      </div>",
                     "    </div>",
-                    "    <div class='card' style='margin-top:12px'>",
+                    "    <div class='card applet-card'>",
                     f"      <iframe id='applet' sandbox='allow-scripts allow-forms allow-popups' src='{applet_url}{inspection.entry}'></iframe>",
                     "    </div>",
                     "    <script>",
@@ -147,6 +249,7 @@ def preview_path(
                     "      iframe.addEventListener('load', () => {",
                     "        bridge.textContent = 'loading';",
                     "        iframe.contentWindow?.postMessage({ type: 'wf:hello', version: '0.1' }, '*');",
+                    f"        iframe.contentWindow?.postMessage({{ type: 'wf:state', state: {{ apiBase: {applet_api_base_js} }} }}, '*');",
                     "      });",
                     "      window.addEventListener('message', (event) => {",
                     "        const msg = event.data;",
@@ -177,7 +280,7 @@ def preview_path(
 
         try:
             print(
-                f"Path preview running:\n  Parent: {parent_url}\n  Applet: {applet_url}\n(Press Ctrl+C to stop)"
+                f"Path preview running:\n  Parent: {parent_url}\n  Applet: {applet_url}\n  Proxying {PROXY_PREFIX}* → {api_base}\n(Press Ctrl+C to stop)"
             )
             while True:
                 threading.Event().wait(3600)


### PR DESCRIPTION
## Summary

- `wayfinder path preview` now proxies `/api/v1/delta-lab/public/*` to a configurable upstream (`--api-base`, default `https://strategies.wayfinder.ai`) and injects `wf:state.apiBase` into the host shell so applets that fetch Delta Lab's public timeseries route actually work in local dev.
- Published bundles stay prod-URL-free — this is preview-only tooling (SDK, not shipped).
- Fixes a silent fallback where the trailing-hl-orders applet (and any other Delta-Lab-backed applet) fell through to synthetic data whenever run via `wayfinder path preview`.

## What changed

`wayfinder_paths/paths/cli.py`
- New `--api-base` option on `wayfinder path preview`, forwarded to `preview_path`.

`wayfinder_paths/paths/preview.py`
- New `ProxyingAppletHandler` (extends `SimpleHTTPRequestHandler`) that proxies `/api/v1/delta-lab/public/*` upstream.
- Browser-style `User-Agent` on upstream requests so Cloudflare doesn't return a 1010 signature ban.
- `Access-Control-Allow-Origin: *` on all responses so the sandboxed iframe (opaque origin, no `allow-same-origin`) can read response bodies.
- Parent shell postMessages `wf:state { apiBase: <applet_origin> }` right after `wf:hello` so the applet uses the same-origin proxy instead of falling back to the parent origin.
- Parent shell layout: iframe now gets `min-height: 720px` + flex-fill instead of the browser default ~150px.
- Banner under "Bridge: ready" shows which upstream is being proxied.

## Why

Before this change, opening `wayfinder path preview` on an applet that does:

```js
fetch(`${apiBase}/api/v1/delta-lab/public/assets/ETH/timeseries/?...`)
```

…hit `http://localhost:3333/api/v1/...` (404), the applet caught the error, and silently swapped in synthetic demo data. That hid real connectivity problems AND masked bugs in the live-data rendering path.

Three failure modes stacked on top of each other (identified and fixed here): Delta Lab doesn't send CORS headers → Cloudflare bans Python's default UA → the iframe sandbox has an opaque origin so same-origin fetches need CORS. All three are handled in the proxy.

## Test plan

- [ ] `cd examples/paths/trailing-hl-orders && poetry run wayfinder path preview`
- [ ] Parent shell at http://127.0.0.1:3333/index.html loads; iframe fills viewport, not 150px tall
- [ ] DevTools Network: applet's Delta Lab fetches hit `http://127.0.0.1:3334/api/v1/delta-lab/public/assets/ETH/timeseries/...` and return 200 with real price data
- [ ] Try `--api-base https://strategies-dev.wayfinder.ai` — parent shell banner shows the dev host, proxy still returns 200
- [ ] Try `--api-base http://localhost:9999` — proxy fails gracefully (502), applet shows "Data unavailable" warning (no synthetic fallback)
- [ ] Unknown symbol (e.g. `XYZNOTAREAL`) — proxy returns upstream error, applet shows "Data unavailable" warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)