### PR TITLE
Scheduled Jobs - Surface HTTP errors and reconcile on startup

### DIFF
--- a/wayfinder_paths/core/clients/ScheduledJobsClient.py
+++ b/wayfinder_paths/core/clients/ScheduledJobsClient.py
@@ -30,13 +30,23 @@ class ScheduledJobsClient:
             hdrs["X-API-KEY"] = api_key
         return hdrs
 
+    def list_jobs(self) -> list[dict[str, Any]]:
+        try:
+            resp = self._client.get(f"{self._base_url()}/", headers=self._headers())
+            resp.raise_for_status()
+            return resp.json()
+        except Exception:
+            logger.opt(exception=True).warning("Failed to list jobs from backend")
+            return []
+
     def sync_job(self, job_name: str, data: dict[str, Any]) -> None:
         try:
-            self._client.put(
+            resp = self._client.put(
                 f"{self._base_url()}/{job_name}/",
                 json=data,
                 headers=self._headers(),
             )
+            resp.raise_for_status()
         except Exception:
             logger.opt(exception=True).warning(
                 f"Failed to sync job {job_name} to backend"
@@ -44,9 +54,10 @@ class ScheduledJobsClient:
 
     def delete_job(self, job_name: str) -> None:
         try:
-            self._client.delete(
+            resp = self._client.delete(
                 f"{self._base_url()}/{job_name}/", headers=self._headers()
             )
+            resp.raise_for_status()
         except Exception:
             logger.opt(exception=True).warning(
                 f"Failed to delete job {job_name} from backend"
@@ -54,11 +65,12 @@ class ScheduledJobsClient:
 
     def report_run(self, job_name: str, run_data: dict[str, Any]) -> None:
         try:
-            self._client.post(
+            resp = self._client.post(
                 f"{self._base_url()}/{job_name}/runs/",
                 json=run_data,
                 headers=self._headers(),
             )
+            resp.raise_for_status()
         except Exception:
             logger.opt(exception=True).warning(
                 f"Failed to report run for {job_name} to backend"

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -146,6 +146,8 @@ class RunnerDaemon:
         if aborted:
             logger.warning(f"Marked {aborted} stale RUNNING runs as ABORTED")
 
+        self._reconcile_with_backend()
+
         self._control = RunnerControlServer(
             sock_path=self._paths.sock_path, daemon=self
         )
@@ -325,6 +327,18 @@ class RunnerDaemon:
                 "payload": job.payload,
             },
         )
+
+    def _reconcile_with_backend(self) -> None:
+        if not is_opencode_instance():
+            return
+        local_names = {str(j["name"]) for j in self._db.list_jobs()}
+        remote = SCHEDULED_JOBS_CLIENT.list_jobs()
+        remote_names = {str(j["job_name"]) for j in remote}
+        for orphan in remote_names - local_names:
+            logger.info(f"Reconcile: deleting remote-only job {orphan}")
+            SCHEDULED_JOBS_CLIENT.delete_job(orphan)
+        for name in local_names:
+            self._sync_job(name)
 
     def _notify_session(
         self,

--- a/wayfinder_paths/tests/test_runner_reconcile.py
+++ b/wayfinder_paths/tests/test_runner_reconcile.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from wayfinder_paths.core.clients.ScheduledJobsClient import SCHEDULED_JOBS_CLIENT
+from wayfinder_paths.runner.constants import JOB_TYPE_SCRIPT, JobStatus
+from wayfinder_paths.runner.daemon import RunnerDaemon
+from wayfinder_paths.runner.paths import RunnerPaths
+
+
+def _paths(tmp_path: Path) -> RunnerPaths:
+    runner_dir = tmp_path / "runner"
+    runner_dir.mkdir()
+    (tmp_path / "pyproject.toml").write_text("[tool.x]\n")
+    return RunnerPaths(
+        repo_root=tmp_path,
+        runner_dir=runner_dir,
+        db_path=runner_dir / "state.db",
+        logs_dir=runner_dir / "logs",
+        sock_path=runner_dir / "runner.sock",
+    )
+
+
+def _add_local(daemon: RunnerDaemon, name: str) -> None:
+    daemon._db.add_job(
+        name=name,
+        job_type=JOB_TYPE_SCRIPT,
+        payload={"script_path": "x.py"},
+        interval_seconds=60,
+        status=JobStatus.ACTIVE,
+        next_run_at=0,
+    )
+
+
+def test_reconcile_deletes_remote_only_and_syncs_local(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OPENCODE_INSTANCE_ID", "inst-xyz")
+
+    daemon = RunnerDaemon(paths=_paths(tmp_path))
+    _add_local(daemon, "local-a")
+    _add_local(daemon, "local-b")
+
+    deleted: list[str] = []
+    synced: list[str] = []
+
+    monkeypatch.setattr(
+        SCHEDULED_JOBS_CLIENT,
+        "list_jobs",
+        lambda: [
+            {"job_name": "local-a"},
+            {"job_name": "orphan-1"},
+            {"job_name": "orphan-2"},
+        ],
+    )
+    monkeypatch.setattr(
+        SCHEDULED_JOBS_CLIENT, "delete_job", lambda name: deleted.append(name)
+    )
+    monkeypatch.setattr(
+        SCHEDULED_JOBS_CLIENT,
+        "sync_job",
+        lambda name, _data: synced.append(name),
+    )
+
+    daemon._reconcile_with_backend()
+
+    assert set(deleted) == {"orphan-1", "orphan-2"}
+    assert set(synced) == {"local-a", "local-b"}
+
+
+def test_reconcile_noop_when_not_opencode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("OPENCODE_INSTANCE_ID", raising=False)
+
+    daemon = RunnerDaemon(paths=_paths(tmp_path))
+    _add_local(daemon, "local-a")
+
+    called = {"list": 0, "delete": 0, "sync": 0}
+    monkeypatch.setattr(
+        SCHEDULED_JOBS_CLIENT,
+        "list_jobs",
+        lambda: (called.__setitem__("list", called["list"] + 1), [])[1],
+    )
+    monkeypatch.setattr(
+        SCHEDULED_JOBS_CLIENT,
+        "delete_job",
+        lambda _name: called.__setitem__("delete", called["delete"] + 1),
+    )
+    monkeypatch.setattr(
+        SCHEDULED_JOBS_CLIENT,
+        "sync_job",
+        lambda _n, _d: called.__setitem__("sync", called["sync"] + 1),
+    )
+
+    daemon._reconcile_with_backend()
+
+    assert called == {"list": 0, "delete": 0, "sync": 0}
+
+
+def test_reconcile_empty_remote_just_syncs_local(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OPENCODE_INSTANCE_ID", "inst-xyz")
+
+    daemon = RunnerDaemon(paths=_paths(tmp_path))
+    _add_local(daemon, "only-local")
+
+    deleted: list[str] = []
+    synced: list[str] = []
+    monkeypatch.setattr(SCHEDULED_JOBS_CLIENT, "list_jobs", lambda: [])
+    monkeypatch.setattr(
+        SCHEDULED_JOBS_CLIENT, "delete_job", lambda name: deleted.append(name)
+    )
+    monkeypatch.setattr(
+        SCHEDULED_JOBS_CLIENT,
+        "sync_job",
+        lambda name, _data: synced.append(name),
+    )
+
+    daemon._reconcile_with_backend()
+
+    assert deleted == []
+    assert synced == ["only-local"]

--- a/wayfinder_paths/tests/test_scheduled_jobs_client.py
+++ b/wayfinder_paths/tests/test_scheduled_jobs_client.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from wayfinder_paths.core.clients.ScheduledJobsClient import ScheduledJobsClient
+
+
+@pytest.fixture
+def cloud_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENCODE_INSTANCE_ID", "inst-xyz")
+    monkeypatch.setattr(
+        "wayfinder_paths.core.clients.ScheduledJobsClient.get_api_base_url",
+        lambda: "https://api.test",
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.core.clients.ScheduledJobsClient.get_api_key",
+        lambda: "wk_test",
+    )
+
+
+def _make_client(handler) -> ScheduledJobsClient:
+    c = ScheduledJobsClient()
+    c._client = httpx.Client(transport=httpx.MockTransport(handler), timeout=5)
+    return c
+
+
+def test_list_jobs_returns_rows(cloud_env) -> None:
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["url"] = str(request.url)
+        captured["api_key"] = request.headers.get("X-API-KEY")
+        return httpx.Response(
+            200, json=[{"job_name": "a", "status": "active", "interval_seconds": 60}]
+        )
+
+    c = _make_client(handler)
+    rows = c.list_jobs()
+
+    assert rows == [{"job_name": "a", "status": "active", "interval_seconds": 60}]
+    assert captured["method"] == "GET"
+    assert captured["url"] == "https://api.test/opencode/instances/inst-xyz/jobs/"
+    assert captured["api_key"] == "wk_test"
+
+
+def test_list_jobs_http_error_returns_empty(cloud_env) -> None:
+    c = _make_client(lambda _req: httpx.Response(500))
+    assert c.list_jobs() == []
+
+
+def test_sync_job_puts_with_payload(cloud_env) -> None:
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["url"] = str(request.url)
+        captured["body"] = request.read()
+        return httpx.Response(200, json={})
+
+    c = _make_client(handler)
+    c.sync_job("my-job", {"status": "active", "interval_seconds": 60, "payload": {}})
+
+    assert captured["method"] == "PUT"
+    assert (
+        captured["url"] == "https://api.test/opencode/instances/inst-xyz/jobs/my-job/"
+    )
+    assert b"active" in captured["body"]
+
+
+def test_sync_job_swallows_4xx(cloud_env) -> None:
+    c = _make_client(lambda _req: httpx.Response(404))
+    c.sync_job("my-job", {"status": "active", "interval_seconds": 60, "payload": {}})
+
+
+def test_delete_job_issues_delete(cloud_env) -> None:
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["url"] = str(request.url)
+        return httpx.Response(204)
+
+    c = _make_client(handler)
+    c.delete_job("my-job")
+
+    assert captured["method"] == "DELETE"
+    assert (
+        captured["url"] == "https://api.test/opencode/instances/inst-xyz/jobs/my-job/"
+    )
+
+
+def test_delete_job_swallows_5xx(cloud_env) -> None:
+    c = _make_client(lambda _req: httpx.Response(500))
+    c.delete_job("my-job")
+
+
+def test_report_run_posts_run_data(cloud_env) -> None:
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["url"] = str(request.url)
+        captured["body"] = request.read()
+        return httpx.Response(201)
+
+    c = _make_client(handler)
+    c.report_run("my-job", {"run_id": "1", "status": "OK"})
+
+    assert captured["method"] == "POST"
+    assert (
+        captured["url"]
+        == "https://api.test/opencode/instances/inst-xyz/jobs/my-job/runs/"
+    )
+    assert b"run_id" in captured["body"]
+
+
+def test_report_run_swallows_4xx(cloud_env) -> None:
+    c = _make_client(lambda _req: httpx.Response(403))
+    c.report_run("my-job", {"run_id": "1", "status": "OK"})


### PR DESCRIPTION
### Summary
- Adds `raise_for_status()` to all `ScheduledJobsClient` methods so 4xx/5xx responses from vault-backend are logged instead of silently passing as success.
- Adds `ScheduledJobsClient.list_jobs()` so the daemon can read the remote job list.
- On `RunnerDaemon.start()`, reconcile against backend: `DELETE` any remote job not in the local SQLite, then `sync_job` every local job. Fixes orphan rows that survive a volume wipe / snapshot restore / earlier silent-DELETE failure.
- Covered by 11 new unit tests (`test_scheduled_jobs_client.py`, `test_runner_reconcile.py`) using `httpx.MockTransport` and monkeypatched `SCHEDULED_JOBS_CLIENT`.