### PR TITLE
Strategy Automation - SDK Docs and Label Required

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -517,6 +517,21 @@ Strategies extend `wayfinder_paths.core.strategies.Strategy` and must implement:
 
 **On Wayfinder Cloud Instances, ALL wallets MUST be remote. No local wallets — ever.** Remote wallets are managed for you and provide analytics, activity tracking, and session-aware policies. Local wallets are invisible to the rest of the platform and break those guarantees. The `wallets` MCP tool enforces this and will reject local-wallet creation when running on Wayfinder Cloud.
 
+### Session vs strategy wallets
+
+Remote wallets come in two flavours — pick based on how the wallet will be used:
+
+- **Session wallet** (default, recommended for normal trading) — 1-hour TTL, refreshed while the user has the UI open. Use this for day-to-day trading where a human is present and approving actions.
+- **Strategy wallet** — 7-day TTL, intended for longer-running scheduled automation that signs without a human in the loop. Higher blast radius if the wallet leaks, so reach for it only when you actually need unattended signing across many hours; default to a session wallet otherwise.
+
+```bash
+# Session wallet (default)
+poetry run python -m wayfinder_paths.mcp.cli wallets --action create --label main --remote
+
+# Strategy wallet — pair with a strategy job on the runner daemon
+poetry run python -m wayfinder_paths.mcp.cli wallets --action create --label my_strategy --remote --wallet_type strategy
+```
+
 **Always read wallets through the MCP CLI. Never grep `config.json` for `wallets[]` or read wallet files directly.** The MCP wallet resource is the only source of truth — on Wayfinder Cloud the remote wallets are not in `config.json`, so reading the file misses them entirely.
 
 ```bash

--- a/scripts/make_wallets.py
+++ b/scripts/make_wallets.py
@@ -76,6 +76,12 @@ async def main():
         default="[]",
         help="Policies for remote wallet: '[]' for no policies (default), or JSON list",
     )
+    parser.add_argument(
+        "--wallet-type",
+        choices=["session", "policy", "strategy"],
+        default="session",
+        help="Remote wallet type: session (default, 1h TTL), strategy (7d TTL), or policy (custom)",
+    )
     args = parser.parse_args()
 
     # --default means "ensure main wallet exists" (and do nothing otherwise).
@@ -161,7 +167,9 @@ async def main():
     if args.remote:
         for label in labels_to_create:
             policies = json.loads(args.policies)
-            result = await create_remote_wallet(label=label, policies=policies)
+            result = await create_remote_wallet(
+                label=label, wallet_type=args.wallet_type, policies=policies
+            )
             print(
                 f"[remote] {result['wallet_address']}  (label: {result.get('label', label)})"
             )

--- a/wayfinder_paths/core/clients/WalletClient.py
+++ b/wayfinder_paths/core/clients/WalletClient.py
@@ -22,9 +22,9 @@ class WalletClient(WayfinderClient):
         self,
         policies: list[dict],
         wallet_type: str,
+        label: str,
         *,
         chain_type: str = "ethereum",
-        label: str = "",
     ) -> dict[str, Any]:
         url = f"{get_api_base_url()}/wallets/"
         body: dict[str, Any] = {

--- a/wayfinder_paths/core/utils/wallets.py
+++ b/wayfinder_paths/core/utils/wallets.py
@@ -301,22 +301,28 @@ async def get_wallet_sign_hash_callback(label: str):
 # ---------------------------------------------------------------------------
 
 
+VALID_REMOTE_WALLET_TYPES = ("session", "policy", "strategy")
+
+
 async def create_remote_wallet(
     label: str,
+    wallet_type: str,
     chain_type: str = "ethereum",
     policies: list[dict] = [],  # noqa: B006
-    wallet_type: str | None = None,
 ) -> dict[str, Any]:
     if not label.strip():
         raise ValueError("label is required")
-    if wallet_type == "strategy":
-        if not policies:
+    if wallet_type not in VALID_REMOTE_WALLET_TYPES:
+        raise ValueError(
+            f"wallet_type must be one of {VALID_REMOTE_WALLET_TYPES}, got {wallet_type!r}"
+        )
+    if not policies:
+        if wallet_type == "strategy":
             policies = [build_strategy_policy()]
-    elif not policies:
-        wallet_type = "session"
-        policies = [build_session_policy()]
-    else:
-        wallet_type = "policy"
+        elif wallet_type == "session":
+            policies = [build_session_policy()]
+        else:
+            raise ValueError("policies is required when wallet_type=policy")
     result = await WALLET_CLIENT.create_wallet(
         chain_type=chain_type,
         policies=policies,

--- a/wayfinder_paths/core/utils/wallets.py
+++ b/wayfinder_paths/core/utils/wallets.py
@@ -302,11 +302,13 @@ async def get_wallet_sign_hash_callback(label: str):
 
 
 async def create_remote_wallet(
-    label: str = "",
+    label: str,
     chain_type: str = "ethereum",
     policies: list[dict] = [],  # noqa: B006
     wallet_type: str | None = None,
 ) -> dict[str, Any]:
+    if not label.strip():
+        raise ValueError("label is required")
     if wallet_type == "strategy":
         if not policies:
             policies = [build_strategy_policy()]

--- a/wayfinder_paths/mcp/tools/wallets.py
+++ b/wayfinder_paths/mcp/tools/wallets.py
@@ -205,8 +205,13 @@ async def wallets(
                 )
 
         if remote:
+            if not wallet_type:
+                return err(
+                    "invalid_request",
+                    "wallet_type is required for remote wallets (one of: session, policy, strategy)",
+                )
             result = await create_remote_wallet(
-                label=want, policies=policies, wallet_type=wallet_type
+                label=want, wallet_type=wallet_type, policies=policies
             )
             refreshed = await load_wallets()
             return ok(


### PR DESCRIPTION
### Summary
Follow-up to #211. Two small changes the squash-merge missed:

- **Label required on create** — `create_remote_wallet(label, ...)` and `WalletClient.create_wallet(label, ...)` drop the `""` default; the SDK raises `ValueError("label is required")` early instead of round-tripping to the backend and getting a 400. Mirrors the vault-backend serializer which now requires label for all wallet types.
- **AGENTS.md — session vs strategy wallet** — documents when to reach for each:
  - Session wallet (default, recommended for normal trading): 1-hour TTL, human-supervised
  - Strategy wallet: 7-day TTL, unattended automation, higher blast radius
  - Both CLI invocations shown