### PR TITLE
Shells Jobs - Sync job_type to backend

### DIFF
--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -322,6 +322,7 @@ class RunnerDaemon:
         SCHEDULED_JOBS_CLIENT.sync_job(
             name,
             {
+                "job_type": job.type,
                 "status": state.status,
                 "interval_seconds": job.interval_seconds,
                 "payload": job.payload,


### PR DESCRIPTION
### Summary
- Include `job_type` in the payload sent from `RunnerDaemon._sync_job` so the backend persists the type and the frontend can badge strategy jobs without parsing payload internals