### PR TITLE
SDK Polymarket - Rename bridge_withdraw amount_usdce to amount_pusd

### DIFF
--- a/wayfinder_paths/adapters/polymarket_adapter/adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/adapter.py
@@ -1187,7 +1187,7 @@ class PolymarketAdapter(BaseAdapter):
     async def bridge_withdraw(
         self,
         *,
-        amount_usdce: str | float,
+        amount_pusd: str | float,
         to_chain_id: int,
         to_token_address: str,
         recipient_addr: str,
@@ -1204,7 +1204,7 @@ class PolymarketAdapter(BaseAdapter):
         flow.
         """
         from_address, sign_cb = self._require_signer()
-        base_units = to_erc20_raw(amount_usdce, token_decimals)
+        base_units = to_erc20_raw(amount_pusd, token_decimals)
 
         rcpt = to_checksum_address(recipient_addr)
         ok_unwrap, unwrap = await _unwrap_pusd_to_usdce(

--- a/wayfinder_paths/adapters/polymarket_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/test_adapter.py
@@ -971,7 +971,7 @@ class TestPolymarketAdapter:
         )
 
         ok, res = await adapter.bridge_withdraw(
-            amount_usdce=1.0,
+            amount_pusd=1.0,
             to_chain_id=137,
             to_token_address=POLYGON_USDC_ADDRESS,
             recipient_addr=from_address,
@@ -1028,7 +1028,7 @@ class TestPolymarketAdapter:
         )
 
         ok, res = await adapter.bridge_withdraw(
-            amount_usdce=1.0,
+            amount_pusd=1.0,
             to_chain_id=137,
             to_token_address=POLYGON_USDC_E_ADDRESS,
             recipient_addr=from_address,
@@ -1104,7 +1104,7 @@ class TestPolymarketAdapter:
         )
 
         ok, res = await adapter.bridge_withdraw(
-            amount_usdce=1.0,
+            amount_pusd=1.0,
             to_chain_id=137,
             to_token_address=POLYGON_USDC_ADDRESS,
             recipient_addr=from_address,

--- a/wayfinder_paths/mcp/preview.py
+++ b/wayfinder_paths/mcp/preview.py
@@ -263,7 +263,7 @@ async def build_polymarket_execute_preview(
             "route: BRAP swap preferred; Polymarket Bridge fallback\n"
             f"polymarket_collateral_usdce: {POLYGON_USDC_E_ADDRESS}\n"
             f"polygon_native_usdc: {POLYGON_USDC_ADDRESS}\n"
-            f"amount_usdce: {req.get('amount_usdce')}\n"
+            f"amount_pusd: {req.get('amount_pusd')}\n"
             f"to_chain_id: {req.get('to_chain_id')}\n"
             f"to_token_address: {req.get('to_token_address')}\n"
             f"recipient_addr: {req.get('recipient_addr')}"

--- a/wayfinder_paths/mcp/tools/polymarket.py
+++ b/wayfinder_paths/mcp/tools/polymarket.py
@@ -433,7 +433,7 @@ async def polymarket_execute(
     from_token_address: str = POLYGON_USDC_ADDRESS,
     amount: float | None = None,
     recipient_address: str | None = None,
-    amount_usdce: float | None = None,
+    amount_pusd: float | None = None,
     to_chain_id: int = POLYGON_CHAIN_ID,
     to_token_address: str = POLYGON_USDC_ADDRESS,
     recipient_addr: str | None = None,
@@ -470,7 +470,7 @@ async def polymarket_execute(
         "from_token_address": from_token_address,
         "amount": amount,
         "recipient_address": recipient_address,
-        "amount_usdce": amount_usdce,
+        "amount_pusd": amount_pusd,
         "to_chain_id": to_chain_id,
         "to_token_address": to_token_address,
         "recipient_addr": recipient_addr,
@@ -552,13 +552,13 @@ async def polymarket_execute(
             return _done(status)
 
         if action == "bridge_withdraw":
-            if amount_usdce is None:
+            if amount_pusd is None:
                 return err(
-                    "invalid_request", "amount_usdce is required for bridge_withdraw"
+                    "invalid_request", "amount_pusd is required for bridge_withdraw"
                 )
             rcpt = normalize_address(recipient_addr) or sender
             ok_wd, res = await adapter.bridge_withdraw(
-                amount_usdce=float(amount_usdce),
+                amount_pusd=float(amount_pusd),
                 to_chain_id=int(to_chain_id),
                 to_token_address=str(to_token_address),
                 recipient_addr=str(rcpt),
@@ -580,7 +580,7 @@ async def polymarket_execute(
                 status=status,
                 chain_id=int(POLYGON_CHAIN_ID),
                 details={
-                    "amount_usdce": float(amount_usdce),
+                    "amount_pusd": float(amount_pusd),
                     "to_chain_id": int(to_chain_id),
                     "to_token_address": str(to_token_address),
                     "recipient_addr": str(rcpt),


### PR DESCRIPTION
### Summary
The Polymarket V2 collateral is pUSD (`0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB`), not USDC.e. The adapter's own docstring describes the fast path as `pUSD -> USDC.e via the Polymarket CollateralOfframp` — input is in pUSD; the unwrap is internal. Renaming `amount_usdce` → `amount_pusd` on `PolymarketAdapter.bridge_withdraw`, the `polymarket_execute` MCP tool, the preview, and the adapter unit tests.