### PR TITLE
SDK MCP - Require decimal point in human amounts

### DIFF
--- a/wayfinder_paths/mcp/utils.py
+++ b/wayfinder_paths/mcp/utils.py
@@ -133,8 +133,14 @@ async def resolve_wallet_address(
 
 
 def parse_amount_to_raw(amount: str, decimals: int) -> int:
+    s = str(amount).strip()
+    if "." not in s:
+        raise ValueError(
+            "The input amount needs a decimal, as it is a human readable "
+            "amount, and NOT IN WEI. Please input the human readable amount"
+        )
     try:
-        d = Decimal(str(amount).strip())
+        d = Decimal(s)
     except (InvalidOperation, ValueError) as exc:
         raise ValueError(f"Invalid amount: {amount}") from exc
     if d <= 0:

--- a/wayfinder_paths/tests/test_mcp_execute.py
+++ b/wayfinder_paths/tests/test_mcp_execute.py
@@ -96,7 +96,7 @@ async def test_resolve_token_meta_normal_erc20_unchanged():
 @pytest.mark.asyncio
 async def test_execute_validation_error_is_structured():
     # swap requires from_token and to_token
-    out = await execute(kind="swap", wallet_label="main", amount="1")
+    out = await execute(kind="swap", wallet_label="main", amount="1.0")
     assert out["ok"] is False
     assert out["error"]["code"] == "invalid_request"
     assert isinstance(out["error"]["details"], list)
@@ -178,7 +178,7 @@ async def test_execute_swap(tmp_path: Path, monkeypatch):
             wallet_label="main",
             from_token="from",
             to_token="to",
-            amount="1",
+            amount="1.0",
             slippage_bps=50,
         )
         assert out1["ok"] is True

--- a/wayfinder_paths/tests/test_mcp_quote_swap.py
+++ b/wayfinder_paths/tests/test_mcp_quote_swap.py
@@ -220,7 +220,7 @@ async def test_quote_swap_accepts_top_level_brap_shape():
             wallet_label="main",
             from_token="usd-coin-arbitrum",
             to_token="tether-arbitrum",
-            amount="1",
+            amount="1.0",
         )
 
     assert out["ok"] is True

--- a/wayfinder_paths/tests/test_mcp_utils.py
+++ b/wayfinder_paths/tests/test_mcp_utils.py
@@ -11,21 +11,32 @@ def test_repo_root_finds_pyproject():
 
 
 def test_parse_amount_to_raw_scales_and_floors():
-    assert parse_amount_to_raw("1", 6) == 1_000_000
+    assert parse_amount_to_raw("1.0", 6) == 1_000_000
     # Flooring: 1.23456789 with 6 decimals -> 1_234_567
     assert parse_amount_to_raw("1.23456789", 6) == 1_234_567
 
 
 def test_parse_amount_to_raw_rejects_non_positive():
     with pytest.raises(ValueError, match="positive"):
-        parse_amount_to_raw("0", 18)
+        parse_amount_to_raw("0.0", 18)
     with pytest.raises(ValueError, match="positive"):
-        parse_amount_to_raw("-1", 18)
+        parse_amount_to_raw("-1.0", 18)
 
 
 def test_parse_amount_to_raw_rejects_too_small_after_scaling():
     with pytest.raises(ValueError, match="too small"):
         parse_amount_to_raw("0.0000001", 6)
+
+
+def test_parse_amount_to_raw_rejects_integer_strings_as_likely_raw():
+    # The agent has been pasting raw smallest-unit balances (no decimal)
+    # straight into amount fields — reject at the boundary.
+    with pytest.raises(ValueError, match="needs a decimal"):
+        parse_amount_to_raw("10627176835031753880", 18)
+    with pytest.raises(ValueError, match="needs a decimal"):
+        parse_amount_to_raw("13263060", 6)
+    with pytest.raises(ValueError, match="needs a decimal"):
+        parse_amount_to_raw("1", 18)
 
 
 def test_sha256_json_is_stable_for_key_order():

--- a/wayfinder_paths/tests/test_token_resolver_live.py
+++ b/wayfinder_paths/tests/test_token_resolver_live.py
@@ -208,7 +208,7 @@ class TestQuoteSwapLive:
             wallet_label="main",
             from_token="usd-coin-arbitrum",
             to_token="ethereum-arbitrum",
-            amount="1",
+            amount="1.0",
             slippage_bps=100,
         )
 


### PR DESCRIPTION
### Summary
Reject string amounts without a `.` in `parse_amount_to_raw`. Catches the failure where an LLM agent reads a balance's `amount` field (raw smallest-unit int string) and pastes it straight into a tool's human-amount field — the SDK then re-scales by `10^decimals` and produces tx values ~10^36 that revert on `eth_estimateGas`. Applies to every tool that goes through `parse_amount_to_raw` (execute swap/send/hyperliquid_deposit, quote_swap).

Error message:
> The input amount needs a decimal, as it is a human readable amount, and NOT IN WEI. Please input the human readable amount

15 tests pass; existing test cases updated from `"1"` → `"1.0"`, plus a new test asserting the four observed-bad inputs (`"10627176835031753880"`, `"13263060"`, `"112298"`, `"1"`) get rejected.