### PR TITLE
SDK Runner - Bind MCP-driven jobs to chat session for notifications

### DIFF
--- a/wayfinder_paths/core/clients/OpenCodeClient.py
+++ b/wayfinder_paths/core/clients/OpenCodeClient.py
@@ -6,7 +6,7 @@ from typing import Any
 import httpx
 from loguru import logger
 
-from wayfinder_paths.runner.constants import ADD_JOB_VERB
+from wayfinder_paths.runner.constants import ADD_JOB_CLI_VERB, ADD_JOB_MCP_ACTION
 
 OPENCODE_DEFAULT_URL = "http://localhost:4096"
 
@@ -36,10 +36,11 @@ class OpenCodeClient:
             return []
 
     def find_runner_session(self) -> str | None:
-        """Find the session that invoked runner add-job (CLI or MCP tool).
+        """Find the session that invoked add-job, via either surface.
 
-        The CLI verb is `add-job` (hyphen); the wayfinder_runner MCP action is
-        `add_job` (underscore). Match either so MCP-driven jobs also bind.
+        The breadcrumb in the chat message blob is surface-specific:
+        Bash + CLI leaves the literal `add-job` (hyphen); the wayfinder_runner
+        MCP tool leaves `add_job` (underscore). Match either.
         """
         for session in self.list_sessions():
             session_id = session["id"]
@@ -50,7 +51,9 @@ class OpenCodeClient:
                         params={"limit": 50},
                     ).json()
                 )
-                if "runner" in raw and (ADD_JOB_VERB in raw or "add_job" in raw):
+                if "runner" in raw and (
+                    ADD_JOB_CLI_VERB in raw or ADD_JOB_MCP_ACTION in raw
+                ):
                     return session_id
             except Exception:
                 continue

--- a/wayfinder_paths/core/clients/OpenCodeClient.py
+++ b/wayfinder_paths/core/clients/OpenCodeClient.py
@@ -36,7 +36,11 @@ class OpenCodeClient:
             return []
 
     def find_runner_session(self) -> str | None:
-        """Find the session that invoked runner add-job."""
+        """Find the session that invoked runner add-job (CLI or MCP tool).
+
+        The CLI verb is `add-job` (hyphen); the wayfinder_runner MCP action is
+        `add_job` (underscore). Match either so MCP-driven jobs also bind.
+        """
         for session in self.list_sessions():
             session_id = session["id"]
             try:
@@ -46,7 +50,7 @@ class OpenCodeClient:
                         params={"limit": 50},
                     ).json()
                 )
-                if "runner" in raw and ADD_JOB_VERB in raw:
+                if "runner" in raw and (ADD_JOB_VERB in raw or "add_job" in raw):
                     return session_id
             except Exception:
                 continue

--- a/wayfinder_paths/runner/cli.py
+++ b/wayfinder_paths/runner/cli.py
@@ -10,7 +10,7 @@ from loguru import logger
 
 from wayfinder_paths.runner.client import RunnerControlClient
 from wayfinder_paths.runner.constants import (
-    ADD_JOB_VERB,
+    ADD_JOB_CLI_VERB,
     JOB_TYPE_SCRIPT,
     JOB_TYPE_STRATEGY,
 )
@@ -95,7 +95,9 @@ def status_cmd() -> None:
     _echo_json(resp)
 
 
-@runner_cli.command(name=ADD_JOB_VERB, help="Add a job without restarting the daemon.")
+@runner_cli.command(
+    name=ADD_JOB_CLI_VERB, help="Add a job without restarting the daemon."
+)
 @click.option("--name", required=True)
 @click.option(
     "--type",

--- a/wayfinder_paths/runner/constants.py
+++ b/wayfinder_paths/runner/constants.py
@@ -22,8 +22,10 @@ class RunStatus(StrEnum):
 JOB_TYPE_STRATEGY: Final[str] = "strategy"
 JOB_TYPE_SCRIPT: Final[str] = "script"
 
-# Command identifier — used in CLI and session discovery
-ADD_JOB_VERB: Final[str] = "add-job"
+# How the "add job" action appears on each surface. Both forms are used by
+# session-message discovery to find the chat that registered a job.
+ADD_JOB_CLI_VERB: Final[str] = "add-job"  # CLI command name (Click convention)
+ADD_JOB_MCP_ACTION: Final[str] = "add_job"  # MCP action key (JSON identifier)
 
 # Control protocol limits
 MAX_LINE_BYTES: Final[int] = 1024 * 1024

--- a/wayfinder_paths/tests/test_opencode_client.py
+++ b/wayfinder_paths/tests/test_opencode_client.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Any
+
+from wayfinder_paths.core.clients.OpenCodeClient import OpenCodeClient
+
+
+class _StubClient:
+    def __init__(
+        self, *, sessions: list[dict[str, Any]], messages_by_id: dict[str, Any]
+    ):
+        self._sessions = sessions
+        self._messages_by_id = messages_by_id
+
+    def get(self, url: str, params: dict[str, Any] | None = None):  # noqa: ARG002
+        class _Resp:
+            def __init__(self, payload: Any):
+                self._payload = payload
+
+            def json(self) -> Any:
+                return self._payload
+
+        if url.endswith("/session"):
+            return _Resp(self._sessions)
+        for session_id, payload in self._messages_by_id.items():
+            if url.endswith(f"/session/{session_id}/message"):
+                return _Resp(payload)
+        return _Resp([])
+
+
+def _client_with(
+    sessions: list[dict[str, Any]], messages: dict[str, Any]
+) -> OpenCodeClient:
+    c = OpenCodeClient()
+    c.client = _StubClient(sessions=sessions, messages_by_id=messages)  # type: ignore[assignment]
+    return c
+
+
+def test_find_runner_session_matches_cli_verb() -> None:
+    c = _client_with(
+        sessions=[{"id": "ses_cli"}],
+        messages={"ses_cli": [{"text": "I ran `runner add-job foo --interval 60`"}]},
+    )
+    assert c.find_runner_session() == "ses_cli"
+
+
+def test_find_runner_session_matches_mcp_action() -> None:
+    """MCP tool calls serialize as `wayfinder_runner` + action `add_job`
+    (underscore). The CLI verb is `add-job` (hyphen). Both must bind."""
+    c = _client_with(
+        sessions=[{"id": "ses_mcp"}],
+        messages={
+            "ses_mcp": [
+                {
+                    "tool": "wayfinder_runner",
+                    "input": {"action": "add_job", "name": "eth-price-check"},
+                }
+            ]
+        },
+    )
+    assert c.find_runner_session() == "ses_mcp"
+
+
+def test_find_runner_session_returns_none_when_no_match() -> None:
+    c = _client_with(
+        sessions=[{"id": "ses_other"}],
+        messages={"ses_other": [{"text": "hello world"}]},
+    )
+    assert c.find_runner_session() is None


### PR DESCRIPTION
### Summary

`OpenCodeClient.find_runner_session()` only matched the CLI verb `add-job` (hyphen). Every chat-driven job goes through the `wayfinder_runner` MCP tool with `action: "add_job"` (underscore), so the heuristic never fired. Result: `notify_session_id=None` on every MCP-added job, and `_notify_session` returned silently after every run — no chat report.

Confirmed live on a dev instance: 8+ runs, 0 chat notifications. After live-patching the job's payload to set `notify_session_id`, both `run_once` and the next 60s interval tick posted `job_result` JSON to chat.

This change matches either form. Three unit tests cover CLI shape, MCP shape, and the no-match branch.