### PR TITLE
HL Adapter + MCP - Spot resolver requires explicit pair

### DIFF
--- a/.claude/skills/using-hyperliquid-adapter/rules/gotchas.md
+++ b/.claude/skills/using-hyperliquid-adapter/rules/gotchas.md
@@ -38,7 +38,7 @@ Spot "index" is usually: `spot_index = spot_asset_id - 10000`.
 - `HYPE/USDC` is native and available
 - `PURR/USDC` is the OG spot pair (index 0)
 
-**Coin name resolution:** The MCP tool resolves `coin="HYPE"` to `HYPE/USDC`. If you need a different quote (e.g., `HYPE/USDH`), use `asset_id` directly.
+**Spot `coin` must be the explicit pair, not the bare token.** Many tokens trade against multiple quotes (e.g. `BTC/USDC` and `BTC/USDH` both exist). Pass `coin="BTC/USDC"` or `coin="BTC/USDH"` — never `coin="BTC"`. If you already know the asset id, pass `asset_id=` and omit `coin`. The two are interchangeable; `asset_id` short-circuits the pair lookup.
 
 **`is_spot` must be explicit:** When using `hyperliquid_execute(action="place_order", ...)`:
 

--- a/wayfinder_paths/mcp/tools/hyperliquid.py
+++ b/wayfinder_paths/mcp/tools/hyperliquid.py
@@ -96,26 +96,51 @@ def _resolve_perp_asset_id(
 
 
 async def _resolve_spot_asset_id(
-    adapter: HyperliquidAdapter, *, coin: str | None
+    adapter: HyperliquidAdapter,
+    *,
+    coin: str | None,
+    asset_id: int | None = None,
 ) -> tuple[bool, int | dict[str, Any]]:
-    c = _PERP_SUFFIX_RE.sub("", (coin or "").strip()).strip().upper()
+    if asset_id is not None:
+        try:
+            aid = int(asset_id)
+        except (TypeError, ValueError):
+            return False, {"code": "invalid_request", "message": "asset_id must be int"}
+        if aid < 10000:
+            return False, {
+                "code": "invalid_request",
+                "message": (
+                    f"spot asset_id must be >= 10000 (got {aid}); "
+                    "use is_spot=False for perp asset ids"
+                ),
+            }
+        return True, aid
+
+    c = (coin or "").strip().upper()
     if not c:
         return False, {
             "code": "invalid_request",
-            "message": "coin is required for spot orders",
+            "message": "coin or asset_id is required for spot orders",
+        }
+    if "/" not in c:
+        return False, {
+            "code": "invalid_request",
+            "message": (
+                f"spot coin must be the full pair, e.g. 'BTC/USDC' or 'BTC/USDH' (got '{c}'). "
+                "USDC and USDH are separate spot quotes — pass the explicit pair, "
+                "or pass asset_id."
+            ),
         }
 
-    # get_spot_assets populates cache, then we look up
     ok, assets = await adapter.get_spot_assets()
     if not ok:
         return False, {"code": "error", "message": "Failed to fetch spot assets"}
 
-    pair_name = f"{c}/USDC"
-    spot_aid = assets.get(pair_name)
+    spot_aid = assets.get(c)
     if spot_aid is None:
         return False, {
             "code": "not_found",
-            "message": f"Unknown spot pair: {pair_name}",
+            "message": f"Unknown spot pair: {c}",
         }
     return True, spot_aid
 
@@ -466,7 +491,9 @@ async def hyperliquid_execute(
         return None
 
     if is_spot:
-        ok_aid, aid_or_err = await _resolve_spot_asset_id(adapter, coin=coin)
+        ok_aid, aid_or_err = await _resolve_spot_asset_id(
+            adapter, coin=coin, asset_id=asset_id
+        )
     else:
         ok_aid, aid_or_err = _resolve_perp_asset_id(
             adapter, coin=coin, asset_id=asset_id

--- a/wayfinder_paths/tests/test_mcp_hyperliquid_execute.py
+++ b/wayfinder_paths/tests/test_mcp_hyperliquid_execute.py
@@ -9,6 +9,7 @@ from wayfinder_paths.core.constants.hyperliquid import HYPE_FEE_WALLET
 from wayfinder_paths.mcp.tools.hyperliquid import (
     _resolve_builder_fee,
     _resolve_perp_asset_id,
+    _resolve_spot_asset_id,
     hyperliquid_execute,
 )
 
@@ -33,6 +34,72 @@ def test_resolve_perp_asset_id_accepts_coin_and_strips_perp_suffix():
     ok, res = _resolve_perp_asset_id(StubAdapter(), coin="HYPE-perp", asset_id=None)
     assert ok is True
     assert res == 7
+
+
+class _SpotStubAdapter:
+    def __init__(self, assets: dict[str, int]):
+        self._assets = assets
+
+    async def get_spot_assets(self):
+        return True, self._assets
+
+
+@pytest.mark.asyncio
+async def test_resolve_spot_asset_id_accepts_explicit_pair():
+    adapter = _SpotStubAdapter(
+        {"BTC/USDC": 10142, "BTC/USDH": 10999, "USDH/USDC": 10230}
+    )
+
+    ok, res = await _resolve_spot_asset_id(adapter, coin="BTC/USDC")
+    assert ok is True
+    assert res == 10142
+
+    ok, res = await _resolve_spot_asset_id(adapter, coin="BTC/USDH")
+    assert ok is True
+    assert res == 10999
+
+    ok, res = await _resolve_spot_asset_id(adapter, coin="usdh/usdc")
+    assert ok is True
+    assert res == 10230
+
+
+@pytest.mark.asyncio
+async def test_resolve_spot_asset_id_rejects_bare_token():
+    adapter = _SpotStubAdapter({"BTC/USDC": 10142, "BTC/USDH": 10999})
+
+    ok, err = await _resolve_spot_asset_id(adapter, coin="BTC")
+    assert ok is False
+    assert err["code"] == "invalid_request"
+    assert "BTC/USDC" in err["message"] or "full pair" in err["message"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_spot_asset_id_accepts_asset_id():
+    adapter = _SpotStubAdapter({})
+
+    ok, res = await _resolve_spot_asset_id(adapter, coin=None, asset_id=10230)
+    assert ok is True
+    assert res == 10230
+
+
+@pytest.mark.asyncio
+async def test_resolve_spot_asset_id_rejects_perp_asset_id():
+    adapter = _SpotStubAdapter({})
+
+    ok, err = await _resolve_spot_asset_id(adapter, coin=None, asset_id=7)
+    assert ok is False
+    assert err["code"] == "invalid_request"
+    assert ">= 10000" in err["message"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_spot_asset_id_unknown_pair():
+    adapter = _SpotStubAdapter({"BTC/USDC": 10142})
+
+    ok, err = await _resolve_spot_asset_id(adapter, coin="DOGE/USDC")
+    assert ok is False
+    assert err["code"] == "not_found"
+    assert "DOGE/USDC" in err["message"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

`_resolve_spot_asset_id` blindly appended `/USDC` to the input `coin`, dropped the `asset_id` arg even though the call site forwarded it (perp path took both, spot path took only `coin`), and stripped a `-perp` suffix on the spot path. Fallout in a recent shells session: passing `coin="USDH/USDC"` produced `Unknown spot pair: USDH/USDC/USDC`, and passing `asset_id=10230` produced `coin is required for spot orders`. With three different misleading errors the agent gave up and told the user that USDC and USDH were "interchangeable" on Hyperliquid.

Now: spot orders require the full pair (`BTC/USDC` or `BTC/USDH`) or an `asset_id >= 10000`; perp asset ids passed to the spot path are rejected; `-perp` suffix stripping is gone from the spot path. Skill rule + tests updated.