### PR TITLE
HL Adapter + MCP - Unified coin resolver across perp/spot/HIP-3/HIP-4

### DIFF
--- a/.claude/skills/using-hyperliquid-adapter/SKILL.md
+++ b/.claude/skills/using-hyperliquid-adapter/SKILL.md
@@ -14,6 +14,7 @@ Use this skill when you are:
 
 ## How to use
 
+- [rules/coin-naming.md](rules/coin-naming.md) - Canonical coin-string format per surface (perp / HIP-3 / spot / outcome) and asset-id ranges. **Read first** before any tool that takes `coin` or `asset_id`.
 - [rules/high-value-reads.md](rules/high-value-reads.md) - Data sources + I/O shapes for market data and time series
 - [rules/deposits-withdrawals.md](rules/deposits-withdrawals.md) - Bridge2 deposit/withdraw mechanics (chain, minimums, timing, monitoring)
 - [rules/execution-opportunities.md](rules/execution-opportunities.md) - Order/transfer/withdraw flows and required executor injection

--- a/.claude/skills/using-hyperliquid-adapter/rules/coin-naming.md
+++ b/.claude/skills/using-hyperliquid-adapter/rules/coin-naming.md
@@ -1,0 +1,53 @@
+# Hyperliquid coin names — canonical forms across surfaces
+
+Hyperliquid has four trading surfaces. Each has one canonical coin string. The string itself tells the resolver which surface — there is no `is_spot`/`is_perp` flag to pass alongside (the resolver still accepts `is_spot` for `place_order` as a sanity check, but the format is what dispatches).
+
+| Surface | What you pass as `coin` | Example | API key (l2Book / mids / trades) | asset_id range |
+|---|---|---|---|---|
+| **Default perp** | bare symbol | `BTC`, `ETH`, `HYPE` | same as input (`BTC`) | `0`–`9_999` |
+| **HIP-3 dex perp** | `<dex>:<TICKER>` | `xyz:NVDA`, `hyna:BTC`, `vntl:SPACEX` | same as input (`xyz:NVDA`) | `100_000`+ (per-dex bands of 10k: 110k, 120k, …) |
+| **Spot** | `<BASE>/<QUOTE>` — full pair, never bare | `BTC/USDC`, `BTC/USDH`, `USDH/USDC`, `PURR/USDC` | `@<spot_index>` (or `PURR/USDC` for index 0) | `10_000`–`99_999` |
+| **HIP-4 outcome** (book / mids / trades) | `#<encoding>` | `#20` (YES on outcome 2), `#21` (NO on outcome 2) | `#<encoding>` | `100_000_000`+ |
+| **HIP-4 outcome** (spotClearinghouseState balances) | `+<encoding>` | `+20`, `+21` | priced via `#<encoding>` | n/a (balance entry, not a market id) |
+
+Outcome `encoding = 10 * outcome_id + side`. Asset id = `OUTCOME_ASSET_OFFSET + encoding`.
+
+## Why spot is `BASE/QUOTE`, not just `BASE`
+
+Many tokens trade against multiple quotes — `BTC/USDC` and `BTC/USDH` are both live, with separate orderbooks. Passing just `BTC` is ambiguous. The resolver will not guess.
+
+## Why outcomes have two prefixes
+
+- `#<n>` — the **market** id, used by `l2Book`, `trades`, `allMids`. Always present in mid-price responses.
+- `+<n>` — the **balance entry** id, used by `spotClearinghouseState.balances[].coin`. Read-only — you receive these in user state but never send them in an order.
+
+The resolver accepts either form on input; if you pass `+20` it normalizes to `#20` for pricing/book lookups.
+
+## How `coin` and `asset_id` interact
+
+`hyperliquid_execute(action="place_order", ...)` accepts either `coin` or `asset_id`. Pass one, not both.
+
+- `coin` is preferred for clarity. Use the canonical form for the surface.
+- `asset_id` short-circuits the lookup. Validate the range yourself if you're constructing it.
+- For HIP-4 outcomes, do not use `place_order` — call `place_outcome_order(outcome_id=..., side=..., ...)` instead. Outcome trading has different rules (zero-fee, integer contracts only, USDH collateral, no leverage), so it has its own action.
+
+## Display synonyms (presentation only — not resolved by SDK)
+
+Hyperliquid has wrapped variants of common assets in spot. The UI typically shows the unwrapped ticker; the resolver requires the on-chain name.
+
+| Display name | Canonical spot pair |
+|---|---|
+| `ETH/USDC` | `UETH/USDC` |
+| `BTC/USDC` | `UBTC/USDC` (when "BTC" is shorthand for wrapped) |
+| `SPX` | `SPX6900` |
+
+If the user types `ETH/USDC`, translate to `UETH/USDC` before calling the tool. The resolver does not do this for you — synonym handling is a presentation concern, not a resolution concern.
+
+## Sanity-checklist before placing an order
+
+- Spot order? `coin` contains exactly one `/`.
+- HIP-3 perp? `coin` contains exactly one `:`.
+- Default perp? `coin` is bare symbol with no `/`, `:`, `#`, or `+`.
+- Outcome? You're calling `place_outcome_order`, not `place_order`.
+
+If any of these are wrong, the resolver returns a structured error — see the error `code` field, not just the human message. Codes: `invalid_request` (format wrong / missing field), `not_found` (format ok but coin doesn't exist on this surface).

--- a/.claude/skills/using-hyperliquid-adapter/rules/gotchas.md
+++ b/.claude/skills/using-hyperliquid-adapter/rules/gotchas.md
@@ -22,45 +22,25 @@ Trading on HIP-3 dexes (xyz, flx, vntl, hyna, km, etc.) requires **dex abstracti
 - HIP-3 asset IDs use offsets: first builder dex starts at 110000, then 120000, 130000, etc.
 - HIP-3 coin names are prefixed: `xyz:NVDA`, `vntl:SPACEX`, `hyna:BTC`, etc.
 
-## Asset ID conventions
+## Coin naming + asset id conventions
 
-- Perp assets: `asset_id < 10000`
-- Spot assets: `asset_id >= 10000`
-
-Spot "index" is usually: `spot_index = spot_asset_id - 10000`.
+Canonical coin strings, asset id ranges, and how the resolver dispatches across all four surfaces (default perp, HIP-3 perp, spot, HIP-4 outcome) live in [coin-naming.md](coin-naming.md). Read that first.
 
 ## Spot trading gotchas
-
-**Available spot pairs are limited.** Common assets like BTC and ETH are NOT directly available. Instead:
-
-- Use `UBTC/USDC` for wrapped BTC
-- Use `UETH/USDC` for wrapped ETH
-- `HYPE/USDC` is native and available
-- `PURR/USDC` is the OG spot pair (index 0)
-
-**Spot `coin` must be the explicit pair, not the bare token.** Many tokens trade against multiple quotes (e.g. `BTC/USDC` and `BTC/USDH` both exist). Pass `coin="BTC/USDC"` or `coin="BTC/USDH"` — never `coin="BTC"`. If you already know the asset id, pass `asset_id=` and omit `coin`. The two are interchangeable; `asset_id` short-circuits the pair lookup.
 
 **`is_spot` must be explicit:** When using `hyperliquid_execute(action="place_order", ...)`:
 
 - `is_spot=True` for spot orders
 - `is_spot=False` for perp orders
 - Omitting `is_spot` returns an error
+- The resolver also validates `is_spot` against the coin format — passing `is_spot=True` with `coin="BTC"` is a hard error (use `BTC/USDC` or `BTC/USDH`)
 
 **Spot orders don't use leverage:**
 
 - `usd_amount` is always treated as notional (no `usd_amount_kind` required)
 - `leverage` and `reduce_only` are ignored for spot
 
-**Spot balance location:** Spot tokens live in your spot wallet, separate from perp margin. Use `spot_to_perp_transfer` / `perp_to_spot_transfer` to move USDC between them.
-
-## Spot L2 naming quirks
-
-The adapter implements special naming for spot orderbooks:
-
-- spot_index == 0 uses `"PURR/USDC"`
-- otherwise uses `"@{spot_index}"`
-
-If you request spot data by coin string, prefer the helper mapping from `get_spot_assets()`.
+**Spot balance location:** Spot tokens live in your spot wallet, separate from perp margin. Use `spot_to_perp_transfer` / `perp_to_spot_transfer` to move USDC between them. **USDC perp collateral and USDH spot are not the same asset** — to get USDH from a USDC perp deposit, transfer USDC perp → USDC spot, then trade USDC/USDH (which may be illiquid).
 
 ## Executor wiring
 

--- a/.opencode/plugins/hl-preflight.ts
+++ b/.opencode/plugins/hl-preflight.ts
@@ -1,0 +1,72 @@
+import type { Plugin } from "@opencode-ai/plugin"
+
+// Tools that mutate Hyperliquid state. Before any of these run, the agent
+// gets a forced look at full HL state (perp + spot + outcome positions +
+// asset id maps). Same shape as django's perpetual_agent._tag_user_state —
+// the agent never has to guess what's already on the books.
+const GUARDED_TOOLS = new Set([
+  "wayfinder_hyperliquid_execute",
+  "wayfinder_hyperliquid",
+  "wayfinder_execute", // covers kind="hyperliquid_deposit"
+])
+
+const PREFLIGHT_BASE_URL =
+  process.env.WAYFINDER_MCP_URL ?? "http://127.0.0.1:8000"
+
+function fmt(value: unknown): string {
+  return JSON.stringify(value, null, 2)
+}
+
+export const HLPreflight: Plugin = async () => ({
+  "tool.execute.before": async (input, output) => {
+    if (!GUARDED_TOOLS.has(input.tool)) return
+    // Strip the synthetic `confirmed` flag before the tool sees it — the
+    // underlying MCP tool signatures are strict and would reject an unknown
+    // arg.
+    if (output.args?.confirmed === true) {
+      delete output.args.confirmed
+      return
+    }
+
+    const label = output.args?.wallet_label
+    if (typeof label !== "string" || label.length === 0) {
+      throw new Error(
+        `HL preflight: tool '${input.tool}' requires wallet_label in args.`,
+      )
+    }
+
+    let preflight: unknown
+    try {
+      const res = await fetch(`${PREFLIGHT_BASE_URL}/preflight/${encodeURIComponent(label)}`)
+      if (!res.ok) {
+        throw new Error(
+          `preflight HTTP ${res.status}: ${(await res.text()).slice(0, 500)}`,
+        )
+      }
+      preflight = await res.json()
+    } catch (cause) {
+      throw new Error(
+        `HL preflight: failed to fetch state for '${label}' from ${PREFLIGHT_BASE_URL}. ${
+          cause instanceof Error ? cause.message : String(cause)
+        }`,
+      )
+    }
+
+    throw new Error(
+      [
+        `HL preflight for ${input.tool} (wallet: ${label}):`,
+        "",
+        "Verify the call below against current state before proceeding.",
+        "",
+        `Pending args:`,
+        fmt(output.args),
+        "",
+        `Current state:`,
+        fmt(preflight),
+        "",
+        "If everything checks out, re-call the tool with the same args plus `confirmed: true`.",
+        "If anything looks wrong (insufficient balance, wrong surface, stale asset id), revise args first.",
+      ].join("\n"),
+    )
+  },
+})

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,7 +351,7 @@ Hyperliquid minimums:
 - **Minimum deposit: $5 USD** (deposits below this are **lost**)
 - **Minimum order: $10 USD notional** (applies to both perp and spot)
 
-Hyperliquid surfaces in the adapter/MCP: perp, spot, HIP-3 builder-deployed perp dexes (`xyz`/`flx`/`vntl`/`hyna`/`km`...), and HIP-4 outcome markets (binary/multi-outcome prediction contracts). Outcomes use a separate asset-id space (`100_000_000 + 10*outcome_id + side`) and integer contract sizes; **settle in USDH** (token 360), not USDC; settle daily at 06:00 UTC; written via `hyperliquid_execute(action="place_outcome_order", ...)`. See `/using-hyperliquid-adapter` rules for details.
+Hyperliquid surfaces in the adapter/MCP: perp, spot, HIP-3 builder-deployed perp dexes (`xyz`/`flx`/`vntl`/`hyna`/`km`...), and HIP-4 outcome markets (binary/multi-outcome prediction contracts). Outcomes use a separate asset-id space (`100_000_000 + 10*outcome_id + side`) and integer contract sizes; **settle in USDH** (token 360), not USDC; settle daily at 06:00 UTC; written via `hyperliquid_execute(action="place_outcome_order", ...)`. See `/using-hyperliquid-adapter` rules for details — start with `coin-naming.md` for the canonical coin-string format on each surface (`BTC` perp, `BTC/USDH` spot, `xyz:NVDA` HIP-3, `#20` outcome).
 
 Supported chains:
 

--- a/wayfinder_paths/mcp/resources/hyperliquid.py
+++ b/wayfinder_paths/mcp/resources/hyperliquid.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import json
 import re
 from typing import Any
+from urllib.parse import unquote
 
 from wayfinder_paths.adapters.hyperliquid_adapter.adapter import HyperliquidAdapter
+from wayfinder_paths.mcp.tools.hyperliquid import resolve_coin
 from wayfinder_paths.mcp.utils import resolve_wallet_address
 
 _PERP_SUFFIX_RE = re.compile(r"[-_ ]?perp$", re.IGNORECASE)
@@ -47,24 +49,42 @@ async def get_mid_prices() -> str:
 
 
 async def get_mid_price(coin: str) -> str:
-    adapter = HyperliquidAdapter()
-    success, data = await adapter.get_all_mid_prices()
-
-    want = _PERP_SUFFIX_RE.sub("", coin.strip()).strip()
-    if not want:
+    decoded = unquote(coin or "").strip()
+    if not decoded:
         return json.dumps({"error": "Invalid coin"})
 
+    adapter = HyperliquidAdapter()
+    ok_resolve, resolved = await resolve_coin(adapter, coin=decoded)
+    if not ok_resolve:
+        payload = resolved if isinstance(resolved, dict) else {}
+        return json.dumps(
+            {
+                "coin": decoded,
+                "price": None,
+                "success": False,
+                "error": payload.get("message") or "Could not resolve coin",
+            }
+        )
+
+    success, data = await adapter.get_all_mid_prices()
     price = None
     if success and isinstance(data, dict):
-        for k, v in data.items():
-            if str(k).lower() == want.lower():
-                try:
-                    price = float(v)
-                except (TypeError, ValueError):
-                    pass
-                break
+        raw = data.get(resolved.mid_key)
+        if raw is not None:
+            try:
+                price = float(raw)
+            except (TypeError, ValueError):
+                price = None
 
-    return json.dumps({"coin": want, "price": price, "success": price is not None})
+    return json.dumps(
+        {
+            "coin": decoded,
+            "hl_coin": resolved.hl_coin,
+            "surface": resolved.surface,
+            "price": price,
+            "success": price is not None,
+        }
+    )
 
 
 async def get_markets() -> str:
@@ -80,13 +100,33 @@ async def get_spot_assets() -> str:
 
 
 async def get_orderbook(coin: str) -> str:
-    c = coin.strip()
-    if not c:
+    decoded = unquote(coin or "").strip()
+    if not decoded:
         return json.dumps({"error": "coin is required"})
 
     adapter = HyperliquidAdapter()
-    success, data = await adapter.get_l2_book(c, n_levels=20)
-    return json.dumps({"coin": c, "success": success, "book": data}, indent=2)
+    ok_resolve, resolved = await resolve_coin(adapter, coin=decoded)
+    if not ok_resolve:
+        payload = resolved if isinstance(resolved, dict) else {}
+        return json.dumps(
+            {
+                "coin": decoded,
+                "success": False,
+                "error": payload.get("message") or "Could not resolve coin",
+            },
+            indent=2,
+        )
+    success, data = await adapter.get_l2_book(resolved.hl_coin, n_levels=20)
+    return json.dumps(
+        {
+            "coin": decoded,
+            "hl_coin": resolved.hl_coin,
+            "surface": resolved.surface,
+            "success": success,
+            "book": data,
+        },
+        indent=2,
+    )
 
 
 async def get_outcomes() -> str:

--- a/wayfinder_paths/mcp/resources/hyperliquid.py
+++ b/wayfinder_paths/mcp/resources/hyperliquid.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import re
 from typing import Any
 from urllib.parse import unquote
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse
 
 from wayfinder_paths.adapters.hyperliquid_adapter.adapter import HyperliquidAdapter
 from wayfinder_paths.mcp.tools.hyperliquid import resolve_coin
@@ -142,26 +146,78 @@ async def get_outcome_user_state(label: str) -> str:
 
     adapter = HyperliquidAdapter()
     success, data = await adapter.get_spot_user_state(addr)
-    positions: list[dict[str, Any]] = []
-    if success and isinstance(data, dict):
-        for bal in data.get("balances", []):
-            coin = str(bal.get("coin") or "")
-            if not coin.startswith("+"):
-                continue
-            if float(bal.get("total") or 0) == 0:
-                continue
-            encoding = int(coin[1:])
-            positions.append(
-                {
-                    "coin": coin,
-                    "outcome_id": encoding // 10,
-                    "side": encoding % 10,
-                    "total": bal.get("total"),
-                    "hold": bal.get("hold"),
-                    "entryNtl": bal.get("entryNtl"),
-                }
-            )
+    positions = _outcome_positions_from_spot(data) if success else []
     return json.dumps(
         {"label": label, "address": addr, "success": success, "positions": positions},
         indent=2,
+    )
+
+
+def _outcome_positions_from_spot(spot_state: Any) -> list[dict[str, Any]]:
+    positions: list[dict[str, Any]] = []
+    if not isinstance(spot_state, dict):
+        return positions
+    for bal in spot_state.get("balances", []):
+        coin = str(bal.get("coin") or "")
+        if not coin.startswith("+"):
+            continue
+        if float(bal.get("total") or 0) == 0:
+            continue
+        encoding = int(coin[1:])
+        positions.append(
+            {
+                "coin": coin,
+                "outcome_id": encoding // 10,
+                "side": encoding % 10,
+                "total": bal.get("total"),
+                "hold": bal.get("hold"),
+                "entryNtl": bal.get("entryNtl"),
+            }
+        )
+    return positions
+
+
+async def preflight_route(request: Request) -> JSONResponse:
+    """GET /preflight/{label} — bundled HL state for opencode plugin.
+
+    Returns spot balances, perp clearinghouse state, outcome positions, the
+    live outcome market list, and the spot+perp asset id maps in one call so
+    the hl-preflight plugin can show the agent everything before an HL execute
+    runs (matches django's _tag_user_state pattern).
+    """
+    label = request.path_params["label"]
+    addr, _ = await resolve_wallet_address(wallet_label=label)
+    if not addr:
+        return JSONResponse({"error": f"wallet not found: {label}"}, status_code=404)
+
+    adapter = HyperliquidAdapter()
+    perp_res, spot_res, outcomes_res, spot_assets_res = await asyncio.gather(
+        adapter.get_user_state(addr),
+        adapter.get_spot_user_state(addr),
+        adapter.get_outcome_markets(),
+        adapter.get_spot_assets(),
+        return_exceptions=True,
+    )
+
+    def _ok(res: Any) -> tuple[bool, Any]:
+        if isinstance(res, BaseException):
+            return False, str(res)
+        return res
+
+    perp_ok, perp = _ok(perp_res)
+    spot_ok, spot = _ok(spot_res)
+    outcomes_ok, outcomes = _ok(outcomes_res)
+    spot_assets_ok, spot_assets = _ok(spot_assets_res)
+
+    return JSONResponse(
+        {
+            "wallet_label": label,
+            "address": addr,
+            "perp": perp if perp_ok else None,
+            "spot": spot if spot_ok else None,
+            "outcome_positions": _outcome_positions_from_spot(spot) if spot_ok else [],
+            "outcome_markets": outcomes if outcomes_ok else None,
+            "spot_assets": spot_assets if spot_assets_ok else None,
+            "perp_assets": adapter.coin_to_asset,
+        }
     )

--- a/wayfinder_paths/mcp/server.py
+++ b/wayfinder_paths/mcp/server.py
@@ -55,6 +55,7 @@ from wayfinder_paths.mcp.resources.hyperliquid import (
     get_spot_assets,
     get_spot_user_state,
     get_user_state,
+    preflight_route,
 )
 from wayfinder_paths.mcp.resources.tokens import (
     fuzzy_search_tokens,
@@ -190,6 +191,11 @@ mcp.tool()(get_frontend_context)
 mcp.tool()(add_chart_projection)
 mcp.tool()(remove_chart_projection)
 mcp.tool()(clear_chart_projections)
+
+# Custom HTTP routes (in addition to the standard MCP /mcp endpoint).
+# Used by the .opencode/plugins/hl-preflight.ts plugin to fetch all HL state
+# in one call before any execute MCP tool runs.
+mcp.custom_route("/preflight/{label}", methods=["GET"])(preflight_route)
 
 
 async def read_resource(uri: str) -> dict:

--- a/wayfinder_paths/mcp/tools/hyperliquid.py
+++ b/wayfinder_paths/mcp/tools/hyperliquid.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from typing import Any, Literal
+
+from hyperliquid.utils.types import OUTCOME_ASSET_OFFSET
 
 from wayfinder_paths.adapters.hyperliquid_adapter.adapter import HyperliquidAdapter
 from wayfinder_paths.core.config import CONFIG
@@ -63,36 +66,26 @@ def _resolve_builder_fee(
 def _resolve_perp_asset_id(
     adapter: HyperliquidAdapter, *, coin: str | None, asset_id: int | None
 ) -> tuple[bool, int | dict[str, Any]]:
+    """Thin wrapper that flattens ResolvedCoin → asset_id, scoped to perp.
+
+    Strips the optional `-perp` / `_perp` / ` perp` suffix from the coin string
+    before delegating, and returns just the asset id (not the full ResolvedCoin)
+    so existing call sites stay unchanged.
+    """
     if asset_id is not None:
         try:
             return True, int(asset_id)
         except (TypeError, ValueError):
             return False, {"code": "invalid_request", "message": "asset_id must be int"}
 
-    c = (coin or "").strip()
-    if not c:
-        return False, {
-            "code": "invalid_request",
-            "message": "coin or asset_id is required",
-        }
-
-    c = _PERP_SUFFIX_RE.sub("", c).strip()
+    c = _PERP_SUFFIX_RE.sub("", (coin or "").strip()).strip()
     if not c:
         return False, {"code": "invalid_request", "message": "coin is required"}
 
-    mapping = adapter.coin_to_asset or {}
-    lower = {str(k).lower(): int(v) for k, v in mapping.items()}
-    aid = lower.get(c.lower())
-    if aid is None:
-        return (
-            False,
-            {
-                "code": "not_found",
-                "message": f"Unknown perp coin: {c}",
-                "details": {"coin": c},
-            },
-        )
-    return True, aid
+    ok, res = _resolve_perp_coin(adapter, c)
+    if not ok:
+        return False, res
+    return True, res.asset_id
 
 
 async def _resolve_spot_asset_id(
@@ -101,12 +94,18 @@ async def _resolve_spot_asset_id(
     coin: str | None,
     asset_id: int | None = None,
 ) -> tuple[bool, int | dict[str, Any]]:
+    """Thin wrapper that flattens ResolvedCoin → asset_id, scoped to spot.
+
+    Enforces the 'BASE/QUOTE' contract on `coin` and the `>= 10_000` range on
+    `asset_id` upfront so the error messages are spot-specific, then delegates
+    the actual lookup to resolve_coin.
+    """
     if asset_id is not None:
         try:
             aid = int(asset_id)
         except (TypeError, ValueError):
             return False, {"code": "invalid_request", "message": "asset_id must be int"}
-        if aid < 10000:
+        if aid < _SPOT_ASSET_OFFSET:
             return False, {
                 "code": "invalid_request",
                 "message": (
@@ -132,17 +131,171 @@ async def _resolve_spot_asset_id(
             ),
         }
 
+    ok, res = await resolve_coin(adapter, coin=c)
+    if not ok:
+        return False, res
+    return True, res.asset_id
+
+
+# ---------------------------------------------------------------------------
+# Unified coin resolver
+#
+# Hyperliquid coin strings come in four user-facing forms, each uniquely
+# decodable by syntax:
+#
+#   form               surface           example         hl_coin / mid_key
+#   ----               -------           -------         -----------------
+#   bare              default perp      "BTC"           "BTC"
+#   <dex>:<TICKER>    HIP-3 perp        "xyz:NVDA"      "xyz:NVDA"
+#   <BASE>/<QUOTE>    spot              "BTC/USDH"      "@<index>" (or "PURR/USDC")
+#   #<n>              HIP-4 outcome     "#20"           "#20"
+#   +<n>              HIP-4 outcome     "+20"           "#20"      (priced via book)
+#
+# Asset id ranges:
+#   0      .. 9_999          default perp
+#   10_000 .. 99_999          spot (index = aid - 10_000)
+#   100_000 .. 99_999_999     HIP-3 perp (per-dex bands of 10_000)
+#   100_000_000+              HIP-4 outcome (encoding = aid - OUTCOME_ASSET_OFFSET)
+
+_SPOT_ASSET_OFFSET = 10_000
+_HIP3_ASSET_OFFSET = 100_000
+
+
+@dataclass(frozen=True)
+class ResolvedCoin:
+    asset_id: int
+    surface: Literal["perp", "spot", "outcome"]
+    mid_key: str  # key into adapter.get_all_mid_prices()
+    hl_coin: str  # what to pass to /info l2Book, trades, etc.
+
+
+def _spot_mid_key(spot_index: int) -> str:
+    return "PURR/USDC" if spot_index == 0 else f"@{spot_index}"
+
+
+def _outcome_book_coin(encoding: int) -> str:
+    return f"#{encoding}"
+
+
+def _resolve_outcome_coin(c: str) -> tuple[bool, ResolvedCoin | dict[str, Any]]:
+    body = c[1:]
+    if not body.isdigit():
+        return False, {
+            "code": "invalid_request",
+            "message": f"outcome coin must be '#<n>' or '+<n>' with digits (got '{c}')",
+        }
+    encoding = int(body)
+    book_coin = _outcome_book_coin(encoding)
+    return True, ResolvedCoin(
+        asset_id=OUTCOME_ASSET_OFFSET + encoding,
+        surface="outcome",
+        mid_key=book_coin,
+        hl_coin=book_coin,
+    )
+
+
+async def _resolve_spot_coin(
+    adapter: HyperliquidAdapter, c: str
+) -> tuple[bool, ResolvedCoin | dict[str, Any]]:
+    pair = c.upper()
+    if pair.count("/") != 1 or pair.startswith("/") or pair.endswith("/"):
+        return False, {
+            "code": "invalid_request",
+            "message": (
+                f"spot coin must be 'BASE/QUOTE' (e.g. 'BTC/USDC' or 'BTC/USDH'), got '{c}'"
+            ),
+        }
     ok, assets = await adapter.get_spot_assets()
     if not ok:
         return False, {"code": "error", "message": "Failed to fetch spot assets"}
+    aid = assets.get(pair)
+    if aid is None:
+        return False, {"code": "not_found", "message": f"Unknown spot pair: {pair}"}
+    spot_index = aid - _SPOT_ASSET_OFFSET
+    mid_key = _spot_mid_key(spot_index)
+    return True, ResolvedCoin(
+        asset_id=aid, surface="spot", mid_key=mid_key, hl_coin=mid_key
+    )
 
-    spot_aid = assets.get(c)
-    if spot_aid is None:
+
+def _resolve_perp_coin(
+    adapter: HyperliquidAdapter, c: str
+) -> tuple[bool, ResolvedCoin | dict[str, Any]]:
+    mapping = adapter.coin_to_asset or {}
+    if c in mapping:
+        return True, ResolvedCoin(
+            asset_id=int(mapping[c]), surface="perp", mid_key=c, hl_coin=c
+        )
+    target = c.lower()
+    for k, v in mapping.items():
+        if str(k).lower() == target:
+            canonical = str(k)
+            return True, ResolvedCoin(
+                asset_id=int(v),
+                surface="perp",
+                mid_key=canonical,
+                hl_coin=canonical,
+            )
+    return False, {"code": "not_found", "message": f"Unknown perp coin: {c}"}
+
+
+def _resolve_from_asset_id(
+    adapter: HyperliquidAdapter, aid_raw: int
+) -> tuple[bool, ResolvedCoin | dict[str, Any]]:
+    try:
+        aid = int(aid_raw)
+    except (TypeError, ValueError):
+        return False, {"code": "invalid_request", "message": "asset_id must be int"}
+    if aid < 0:
         return False, {
-            "code": "not_found",
-            "message": f"Unknown spot pair: {c}",
+            "code": "invalid_request",
+            "message": "asset_id must be non-negative",
         }
-    return True, spot_aid
+
+    if aid >= OUTCOME_ASSET_OFFSET:
+        encoding = aid - OUTCOME_ASSET_OFFSET
+        book_coin = _outcome_book_coin(encoding)
+        return True, ResolvedCoin(
+            asset_id=aid, surface="outcome", mid_key=book_coin, hl_coin=book_coin
+        )
+
+    if _SPOT_ASSET_OFFSET <= aid < _HIP3_ASSET_OFFSET:
+        spot_index = aid - _SPOT_ASSET_OFFSET
+        mid_key = _spot_mid_key(spot_index)
+        return True, ResolvedCoin(
+            asset_id=aid, surface="spot", mid_key=mid_key, hl_coin=mid_key
+        )
+
+    # 0-9999 (default perp) or 100_000+ (HIP-3 perp): reverse lookup in coin_to_asset
+    for k, v in (adapter.coin_to_asset or {}).items():
+        if v == aid:
+            return True, ResolvedCoin(
+                asset_id=aid, surface="perp", mid_key=str(k), hl_coin=str(k)
+            )
+    # Asset id is in a perp range but not registered. Caller can still place an
+    # order, but mid-price lookups will fail (mid_key empty).
+    return True, ResolvedCoin(asset_id=aid, surface="perp", mid_key="", hl_coin="")
+
+
+async def resolve_coin(
+    adapter: HyperliquidAdapter,
+    *,
+    coin: str | None = None,
+    asset_id: int | None = None,
+) -> tuple[bool, ResolvedCoin | dict[str, Any]]:
+    if asset_id is not None:
+        return _resolve_from_asset_id(adapter, asset_id)
+    c = (coin or "").strip()
+    if not c:
+        return False, {
+            "code": "invalid_request",
+            "message": "coin or asset_id is required",
+        }
+    if c.startswith("#") or c.startswith("+"):
+        return _resolve_outcome_coin(c)
+    if "/" in c:
+        return await _resolve_spot_coin(adapter, c)
+    return _resolve_perp_coin(adapter, c)
 
 
 async def hyperliquid(
@@ -490,23 +643,33 @@ async def hyperliquid_execute(
                 continue
         return None
 
-    if is_spot:
-        ok_aid, aid_or_err = await _resolve_spot_asset_id(
-            adapter, coin=coin, asset_id=asset_id
-        )
-    else:
-        ok_aid, aid_or_err = _resolve_perp_asset_id(
-            adapter, coin=coin, asset_id=asset_id
-        )
-    if not ok_aid:
-        payload = aid_or_err if isinstance(aid_or_err, dict) else {}
+    ok_resolve, resolved = await resolve_coin(adapter, coin=coin, asset_id=asset_id)
+    if not ok_resolve:
+        payload = resolved if isinstance(resolved, dict) else {}
         response = err(
             payload.get("code") or "invalid_request",
             payload.get("message") or "Invalid asset",
             payload.get("details"),
         )
         return response
-    resolved_asset_id = int(aid_or_err)
+    if resolved.surface == "outcome":
+        response = err(
+            "invalid_request",
+            "outcome orders must use action='place_outcome_order'",
+        )
+        return response
+    expected_surface = "spot" if is_spot else "perp"
+    if resolved.surface != expected_surface:
+        response = err(
+            "invalid_request",
+            (
+                f"is_spot={is_spot} but coin resolved to surface={resolved.surface}. "
+                "Spot uses 'BASE/QUOTE' (e.g. 'BTC/USDC'); perp uses bare symbol "
+                "(e.g. 'BTC') or HIP-3 dex form ('xyz:NVDA')."
+            ),
+        )
+        return response
+    resolved_asset_id = resolved.asset_id
 
     if action == "update_leverage":
         if leverage is None:
@@ -841,31 +1004,41 @@ async def hyperliquid_execute(
                     margin_usd = None
 
         if px_for_sizing is None:
-            coin_name = _PERP_SUFFIX_RE.sub("", str(coin or "").strip()).strip()
-            if not coin_name:
-                coin_name = _coin_from_asset_id(resolved_asset_id) or ""
-            if not coin_name:
+            if not resolved.mid_key:
                 response = err(
                     "invalid_request",
-                    "coin is required when computing size from usd_amount for market orders",
+                    (
+                        "asset_id is in a perp range but not registered in "
+                        "coin_to_asset; cannot price for market sizing"
+                    ),
                 )
                 return response
             ok_mids, mids = await adapter.get_all_mid_prices()
             if not ok_mids or not isinstance(mids, dict):
                 response = err("price_error", "Failed to fetch mid prices")
                 return response
-            mid = None
-            for k, v in mids.items():
-                if str(k).lower() == coin_name.lower():
-                    try:
-                        mid = float(v)
-                    except (TypeError, ValueError):
-                        mid = None
-                    break
-            if mid is None or mid <= 0:
+            raw = mids.get(resolved.mid_key)
+            if raw is None:
                 response = err(
                     "price_error",
-                    f"Could not resolve mid price for {coin_name}",
+                    (
+                        f"No mid price for {resolved.hl_coin} (key={resolved.mid_key}); "
+                        "orderbook may be empty — supply explicit price for a limit order"
+                    ),
+                )
+                return response
+            try:
+                mid = float(raw)
+            except (TypeError, ValueError):
+                response = err(
+                    "price_error",
+                    f"Could not parse mid price for {resolved.hl_coin}: {raw!r}",
+                )
+                return response
+            if mid <= 0:
+                response = err(
+                    "price_error",
+                    f"Mid price for {resolved.hl_coin} is non-positive: {mid}",
                 )
                 return response
             px_for_sizing = mid

--- a/wayfinder_paths/tests/test_mcp_hyperliquid_execute.py
+++ b/wayfinder_paths/tests/test_mcp_hyperliquid_execute.py
@@ -7,10 +7,12 @@ import pytest
 
 from wayfinder_paths.core.constants.hyperliquid import HYPE_FEE_WALLET
 from wayfinder_paths.mcp.tools.hyperliquid import (
+    ResolvedCoin,
     _resolve_builder_fee,
     _resolve_perp_asset_id,
     _resolve_spot_asset_id,
     hyperliquid_execute,
+    resolve_coin,
 )
 
 
@@ -100,6 +102,153 @@ async def test_resolve_spot_asset_id_unknown_pair():
     assert ok is False
     assert err["code"] == "not_found"
     assert "DOGE/USDC" in err["message"]
+
+
+# ---------------------------------------------------------------------------
+# resolve_coin — unified coin resolver across perp / HIP-3 / spot / outcome
+# ---------------------------------------------------------------------------
+
+
+class _ResolveCoinAdapter:
+    """Stub with both spot pair map and perp coin_to_asset map."""
+
+    def __init__(
+        self,
+        *,
+        spot_assets: dict[str, int] | None = None,
+        coin_to_asset: dict[str, int] | None = None,
+    ):
+        self._spot_assets = spot_assets or {}
+        self.coin_to_asset = coin_to_asset or {}
+
+    async def get_spot_assets(self):
+        return True, self._spot_assets
+
+
+@pytest.mark.asyncio
+async def test_resolve_coin_default_perp():
+    adapter = _ResolveCoinAdapter(coin_to_asset={"BTC": 0, "ETH": 1, "HYPE": 159})
+
+    ok, res = await resolve_coin(adapter, coin="BTC")
+    assert ok is True
+    assert res == ResolvedCoin(asset_id=0, surface="perp", mid_key="BTC", hl_coin="BTC")
+
+    ok, res = await resolve_coin(adapter, coin="HYPE")
+    assert ok is True
+    assert res.asset_id == 159
+    assert res.mid_key == "HYPE"
+
+
+@pytest.mark.asyncio
+async def test_resolve_coin_hip3_perp():
+    adapter = _ResolveCoinAdapter(coin_to_asset={"BTC": 0, "xyz:NVDA": 110001})
+
+    ok, res = await resolve_coin(adapter, coin="xyz:NVDA")
+    assert ok is True
+    assert res.asset_id == 110001
+    assert res.surface == "perp"
+    assert res.mid_key == "xyz:NVDA"
+    assert res.hl_coin == "xyz:NVDA"
+
+
+@pytest.mark.asyncio
+async def test_resolve_coin_spot_uses_at_index_for_mid_key():
+    adapter = _ResolveCoinAdapter(
+        spot_assets={"BTC/USDC": 10142, "BTC/USDH": 10999, "PURR/USDC": 10000}
+    )
+
+    ok, res = await resolve_coin(adapter, coin="BTC/USDC")
+    assert ok is True
+    assert res.asset_id == 10142
+    assert res.surface == "spot"
+    assert res.mid_key == "@142"
+    assert res.hl_coin == "@142"
+
+    ok, res = await resolve_coin(adapter, coin="BTC/USDH")
+    assert ok is True
+    assert res.mid_key == "@999"
+
+    ok, res = await resolve_coin(adapter, coin="PURR/USDC")
+    assert ok is True
+    assert res.mid_key == "PURR/USDC"
+    assert res.hl_coin == "PURR/USDC"
+
+
+@pytest.mark.asyncio
+async def test_resolve_coin_spot_rejects_bare_token():
+    adapter = _ResolveCoinAdapter(spot_assets={"BTC/USDC": 10142})
+
+    ok, err = await resolve_coin(adapter, coin="BTC")
+    # "BTC" with no slash falls into perp path; perp dict is empty so not_found
+    assert ok is False
+    assert err["code"] == "not_found"
+
+
+@pytest.mark.asyncio
+async def test_resolve_coin_outcome_book_form():
+    adapter = _ResolveCoinAdapter()
+
+    ok, res = await resolve_coin(adapter, coin="#20")
+    assert ok is True
+    assert res.surface == "outcome"
+    assert res.asset_id == 100_000_020
+    assert res.mid_key == "#20"
+    assert res.hl_coin == "#20"
+
+
+@pytest.mark.asyncio
+async def test_resolve_coin_outcome_balance_form_uses_book_for_pricing():
+    adapter = _ResolveCoinAdapter()
+
+    ok, res = await resolve_coin(adapter, coin="+21")
+    assert ok is True
+    assert res.surface == "outcome"
+    assert res.asset_id == 100_000_021
+    # balance form normalizes to book form for pricing
+    assert res.mid_key == "#21"
+    assert res.hl_coin == "#21"
+
+
+@pytest.mark.asyncio
+async def test_resolve_coin_outcome_rejects_garbage():
+    adapter = _ResolveCoinAdapter()
+
+    ok, err = await resolve_coin(adapter, coin="#abc")
+    assert ok is False
+    assert err["code"] == "invalid_request"
+
+
+@pytest.mark.asyncio
+async def test_resolve_coin_from_asset_id_dispatches_by_range():
+    adapter = _ResolveCoinAdapter(
+        spot_assets={"BTC/USDC": 10142},
+        coin_to_asset={"BTC": 0, "xyz:NVDA": 110001},
+    )
+
+    ok, res = await resolve_coin(adapter, asset_id=0)
+    assert ok is True and res.surface == "perp" and res.hl_coin == "BTC"
+
+    ok, res = await resolve_coin(adapter, asset_id=10142)
+    assert ok is True and res.surface == "spot" and res.mid_key == "@142"
+
+    ok, res = await resolve_coin(adapter, asset_id=110001)
+    assert ok is True and res.surface == "perp" and res.hl_coin == "xyz:NVDA"
+
+    ok, res = await resolve_coin(adapter, asset_id=100_000_020)
+    assert ok is True and res.surface == "outcome" and res.mid_key == "#20"
+
+
+@pytest.mark.asyncio
+async def test_resolve_coin_empty_input():
+    adapter = _ResolveCoinAdapter()
+
+    ok, err = await resolve_coin(adapter, coin=None)
+    assert ok is False
+    assert err["code"] == "invalid_request"
+
+    ok, err = await resolve_coin(adapter, coin="   ")
+    assert ok is False
+    assert err["code"] == "invalid_request"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

Two pieces, in order of layer depth:

**SDK — unified coin resolver.** Single `resolve_coin` that dispatches across all four Hyperliquid surfaces by syntax: bare → default perp, `<dex>:<TICKER>` → HIP-3 perp, `BASE/QUOTE` → spot, `#<n>` / `+<n>` → HIP-4 outcome. Returns a `ResolvedCoin` with `asset_id` plus the right `mid_key`/`hl_coin` per surface — fixes the bug where spot mids (keyed by `@<index>` in HL's `allMids`) were never found because the lookup loop used the bare token name. `place_order` now uses the helper, validates `is_spot` against the resolved surface, and rejects HIP-4 outcomes with a pointer to `place_outcome_order`. Existing `_resolve_perp_asset_id` / `_resolve_spot_asset_id` become thin wrappers around the helper. Resource handlers `wayfinder://hyperliquid/book/{coin}` and `mid/{coin}` URL-decode the input (so `%2320` → `#20`) and route through the resolver. Adds `coin-naming.md` skill rule as the canonical naming reference.

**Harness — `hl-preflight` opencode plugin.** `.opencode/plugins/hl-preflight.ts` hooks `tool.execute.before` for the HL execute MCP tools and throws with full HL state (perp + spot + outcome positions + outcome market list + spot/perp asset id maps) until the agent re-calls with `confirmed=true`. Same shape as django's `perpetual_agent._tag_user_state` — the agent always sees current state before mutating it. Backed by a new `GET /preflight/{label}` HTTP route on the FastMCP server (`mcp.custom_route`) that bundles all reads in one call via `asyncio.gather`, so the plugin pays one round trip per execute. Plugin strips the synthetic `confirmed` arg before letting the underlying MCP tool see it (their signatures are strict).

**Stacked on #244.**