### PR TITLE
MCP - Fill missing docstrings on tool surfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,20 @@ Discover names via the `wayfinder://strategies` resource. Fund-moving actions (`
 
 ## Execution modes (one-off vs recurring)
 
+### MCP vs scripting — pick the right tool
+
+Prefer **MCP tools** for simple, one-shot actions: a single quote, a single swap, reading a
+balance, placing one order, querying a strategy. They're already wired up, validated, and
+return structured results.
+
+Reach for **scripts under `.wayfinder_runs/`** when the work is complex or repetitive: stitching
+multiple adapter calls together, fan-out across many wallets/chains, multi-step flows with
+conditional branches, or anything you'll want to re-run. Scripts can be scheduled via
+`runner(action="add_job", type="script", ...)` once they're stable.
+
+Rough cut: if you can express it as one MCP call, use the MCP call. If you find yourself
+chaining three or more, write a script.
+
 ### Scripting helper for adapters
 
 When writing scripts under `.wayfinder_runs/`, use `get_adapter()` to simplify setup:

--- a/wayfinder_paths/mcp/tools/execute.py
+++ b/wayfinder_paths/mcp/tools/execute.py
@@ -261,6 +261,35 @@ async def core_execute(
     token: str | None = None,
     chain_id: int | None = None,
 ) -> dict[str, Any]:
+    """Broadcast on-chain transactions: cross-chain swap, token send, or Hyperliquid bridge deposit.
+
+    **Always quote before swapping** — call `onchain_quote_swap` first, confirm route + output
+    with the user, then run this. The tool waits for the receipt and returns `status="confirmed"`
+    only on `status=1`.
+
+    Kinds:
+      - `swap`: BRAP cross-chain/cross-DEX swap. Requires `from_token`, `to_token`, `amount`
+        (human units string). `slippage_bps` (50 = 0.5%, default), `recipient` defaults to sender.
+        Resolves token symbols/IDs via `TokenResolver`, ensures ERC-20 allowance, then broadcasts.
+      - `send`: ERC-20 or native transfer. Requires `token`, `recipient`, `amount`. Pass
+        `chain_id` when `token="native"`.
+      - `hyperliquid_deposit`: hardcoded Arbitrum USDC → HL Bridge2 deposit. Only `amount`
+        (≥ 5 USDC; below is lost) is required; `token`/`recipient`/`chain_id` if provided
+        must match the bridge constants.
+
+    Args:
+        kind: "swap" | "send" | "hyperliquid_deposit".
+        wallet_label: Required — config.json wallet label.
+        amount: Human-units string (e.g. "1000" or "0.5").
+        recipient: Destination address (defaults to sender for swap; required for send).
+        from_token / to_token: Swap inputs (token id, address-id, or symbol query).
+        slippage_bps: Swap slippage cap in basis points.
+        deadline_seconds: Best-effort quote TTL.
+        token / chain_id: Send inputs (chain_id only required for `token="native"`).
+
+    Returns:
+        `{status: "confirmed"|"failed", sender, recipient, effects: {approval?, swap|send_*|deposit}, ...}`
+    """
     request_data = {
         "kind": kind,
         "wallet_label": wallet_label,

--- a/wayfinder_paths/mcp/tools/hyperliquid.py
+++ b/wayfinder_paths/mcp/tools/hyperliquid.py
@@ -131,6 +131,24 @@ async def hyperliquid_wait(
     lookback_s: int = 5,
     max_poll_time_s: int = 15 * 60,
 ) -> dict[str, Any]:
+    """Block until a Hyperliquid deposit credits or a withdrawal lands on Arbitrum.
+
+    Use after `core_execute(kind="hyperliquid_deposit", ...)` or `hyperliquid_execute(action="withdraw")`
+    to confirm before chaining dependent steps.
+
+    Actions:
+      - `wait_for_deposit`: poll perp clearinghouse balance until it grows by `expected_increase` USDC.
+      - `wait_for_withdrawal`: poll until a recent withdrawal record appears within `lookback_s` window.
+
+    Args:
+        action: Which event to wait on.
+        wallet_label / wallet_address: Resolve target account; one is required.
+        expected_increase: USDC delta to confirm deposit (required for `wait_for_deposit`).
+        timeout_s: Hard ceiling for `wait_for_deposit` polling.
+        poll_interval_s: Seconds between polls.
+        lookback_s: For withdrawals, how far back to scan recent records.
+        max_poll_time_s: Hard ceiling for `wait_for_withdrawal` polling (default 15 min).
+    """
     adapter = HyperliquidAdapter()
 
     addr, _ = await resolve_wallet_address(
@@ -256,6 +274,37 @@ async def hyperliquid_execute(
     tpsl: Literal["tp", "sl"] | None = None,
     is_market_trigger: bool = True,
 ) -> dict[str, Any]:
+    """Place orders, transfer collateral, or adjust leverage on Hyperliquid.
+
+    Builder attribution is mandatory — every order routes through the Wayfinder builder wallet
+    and the tool auto-approves the builder fee on first use.
+
+    Actions:
+      - `place_order`: spot or perp market/limit. Set `is_spot` explicitly. Size by either `size`
+        (coin units) or `usd_amount` (with `usd_amount_kind="notional"|"margin"` for perps).
+      - `place_outcome_order`: HIP-4 prediction outcome (settles in USDH). Requires `outcome_id`,
+        `side`, `is_buy`, integer `size`.
+      - `place_trigger_order`: TP/SL trigger. `tpsl="tp"|"sl"`, `trigger_price`, `is_buy` set to
+        the side that closes the position (long → False, short → True).
+      - `cancel_order`: by `order_id` or `cancel_cloid`.
+      - `update_leverage`: set `leverage` and `is_cross` for an asset.
+      - `withdraw`: bridge `amount_usdc` from perp account back to Arbitrum.
+      - `spot_to_perp_transfer` / `perp_to_spot_transfer`: shift `usd_amount` between sub-accounts.
+
+    Args:
+        wallet_label: Required — config.json wallet label.
+        coin / asset_id: Symbol (e.g. "BTC", "@107" spot, "xyz:SP500" HIP-3) or numeric asset id.
+        is_spot: Required for `place_order`; routes coin to the spot vs perp asset-id space.
+        side: HIP-4 outcome side (0 or 1).
+        order_type: "market" or "limit"; `price` required for limit.
+        size / usd_amount: Pick one. `usd_amount_kind` disambiguates perp notional vs margin.
+        slippage: Market-order slippage cap (0.01 = 1%, max 0.25).
+        reduce_only / cloid / order_id / cancel_cloid: Standard HL order flags / IDs.
+        leverage / is_cross: Used by `update_leverage` and (optionally) pre-order leverage adjust.
+        amount_usdc: USDC amount for `withdraw`.
+        builder_fee_tenths_bp: Override builder fee (default from config or hardcoded constant).
+        trigger_price / tpsl / is_market_trigger / price: Trigger-order parameters.
+    """
     want = str(wallet_label or "").strip()
     if not want:
         return err("invalid_request", "wallet_label is required")

--- a/wayfinder_paths/mcp/tools/polymarket.py
+++ b/wayfinder_paths/mcp/tools/polymarket.py
@@ -172,6 +172,31 @@ async def polymarket_read(
     end_ts: int | None = None,
     fidelity: int | None = None,
 ) -> dict[str, Any]:
+    """Read-only Polymarket queries: account state, market discovery, prices, books, history.
+
+    Actions:
+      - `status`: full user state — positions, optional `include_orders` / `include_activity`
+        / `include_trades` with their respective `*_limit`s. Requires a wallet/account.
+      - `search`: fuzzy market search by `query`. `events_status` filters active/closed/archived;
+        `end_date_min` (YYYY-MM-DD) filters out resolved markets; `rerank` re-scores results.
+      - `trending`: list markets sorted by 24h volume (`limit`, `offset`).
+      - `get_market` / `get_event`: fetch by `market_slug` / `event_slug`.
+      - `quote`: market-order quote. BUY needs `amount_collateral` (USDC), SELL needs `shares`.
+        Provide `market_slug`+`outcome` OR `token_id`.
+      - `price`: best `BUY`/`SELL` price for a `token_id`.
+      - `order_book`: full book for a `token_id`.
+      - `price_history`: time series. `interval` ("1h"/"6h"/"1d"/"1w"/"max"), `start_ts`/`end_ts`
+        (unix sec), `fidelity` (denser sampling for tight buckets).
+      - `bridge_status`: pUSD bridge state for an account.
+      - `open_orders`: requires Level-2 auth — wallet must have `private_key_hex` in config.
+
+    Args:
+        wallet_label / wallet_address / account: Target account; precedence is account >
+            wallet_address > wallet_label-resolved address.
+        outcome: "YES"/"NO" or numeric outcome index.
+        side: "BUY" or "SELL".
+        Other args: see action-specific descriptions above.
+    """
     waddr, want = await resolve_wallet_address(wallet_label=wallet_label)
 
     acct = normalize_address(account) or normalize_address(wallet_address) or waddr
@@ -453,6 +478,30 @@ async def polymarket_execute(
     # redeem
     condition_id: str | None = None,
 ) -> dict[str, Any]:
+    """Execute Polymarket trades, bridge collateral, cancel/redeem.
+
+    Polymarket settles on Polygon in pUSD (post-V2 rollover). Bridging in/out goes through
+    the official bridge; trading uses the CLOB.
+
+    Actions:
+      - `bridge_deposit`: bridge `amount` of `from_token_address` from `from_chain_id` into
+        Polymarket pUSD. `recipient_address` defaults to sender. `token_decimals` defaults to 6.
+      - `bridge_withdraw`: bridge `amount_pusd` out to `to_chain_id` / `to_token_address`.
+      - `buy` / `sell`: market order. Specify `market_slug`+`outcome` OR `token_id`. BUY needs
+        `amount_collateral` (USDC); SELL needs `shares`.
+      - `close_position`: SELL the full holding. Resolves token via `token_id`, or
+        `market_slug`+`outcome`, or `condition_id` (looks up holding via positions API).
+        Pass `shares` to partially close.
+      - `place_limit_order`: requires `token_id`, `side`, `price`, `size`. `post_only` = maker-only.
+      - `cancel_order`: by `order_id`.
+      - `redeem_positions`: claim winnings on a resolved market by `condition_id`.
+
+    Args:
+        wallet_label: Required.
+        outcome: "YES"/"NO" or numeric index (default "YES").
+        side: "BUY" or "SELL" for limit orders.
+        Other args: see action-specific descriptions above.
+    """
     try:
         sign_callback, sender = await get_wallet_signing_callback(wallet_label or "")
     except ValueError as e:

--- a/wayfinder_paths/mcp/tools/quotes.py
+++ b/wayfinder_paths/mcp/tools/quotes.py
@@ -69,6 +69,27 @@ async def onchain_quote_swap(
     recipient: str | None = None,
     include_calldata: bool = False,
 ) -> dict[str, Any]:
+    """Quote a BRAP cross-chain/cross-DEX swap without broadcasting.
+
+    Mandatory before `core_execute(kind="swap", ...)`: verifies the resolved token symbols,
+    addresses, and chains match intent, surfaces the best route, output, and fees, and returns
+    a ready-to-use `suggested_execute_request` payload.
+
+    Args:
+        wallet_label: Sender wallet (config.json label).
+        from_token / to_token: Token id (`<coingecko_id>-<chain_code>`), address id
+            (`<chain_code>_<address>`), or symbol query.
+        amount: Wei string of the input amount (use `to_erc20_raw(human, decimals)` to convert).
+            Note: NOT human units — this is the raw on-chain amount.
+        slippage_bps: Slippage cap in basis points (50 = 0.50%).
+        recipient: Destination address (defaults to sender).
+        include_calldata: Include the raw tx calldata in the response (off by default to keep
+            payload small; only the `len` is reported when false).
+
+    Returns:
+        `{preview, quote: {best_quote, quote_count, providers}, suggested_execute_request, ...}`.
+        `preview` flags `⚠ RECIPIENT DIFFERS FROM SENDER` when applicable.
+    """
     w = await find_wallet_by_label(wallet_label)
     if not w:
         return err("not_found", f"Unknown wallet_label: {wallet_label}")

--- a/wayfinder_paths/mcp/tools/run_script.py
+++ b/wayfinder_paths/mcp/tools/run_script.py
@@ -142,6 +142,24 @@ async def core_run_script(
     env: dict[str, str] | None = None,
     wallet_label: str | None = None,
 ) -> dict[str, Any]:
+    """Run a Python script from `.wayfinder_runs/` and return its stdout/stderr/exit code.
+
+    The script must already exist on disk inside the runs directory (write the file first).
+    For recurring jobs, use `runner(action="add_job", type="script", ...)` instead so the runner
+    daemon owns scheduling, retries, and timeouts.
+
+    Args:
+        script_path: Path to a `.py` file inside `.wayfinder_runs/` (absolute or repo-relative).
+        args: Argv list passed after the script path.
+        timeout_s: Kill the process if it runs longer than this (default 600s).
+        env: Extra environment variables merged on top of the inherited environment.
+        wallet_label: Optional — annotates the wallet profile when the script name implies a
+            known protocol (moonwell, hyperliquid, hyperlend, pendle, boros, brap, swap).
+
+    Returns:
+        `{status: "completed"|"failed"|"timeout", exit_code, duration_s, stdout, stderr, ...}`.
+        stdout/stderr are truncated to 20k chars each.
+    """
     ok_path, resolved_or_error = _resolve_script_path(script_path)
     if not ok_path:
         payload = resolved_or_error if isinstance(resolved_or_error, dict) else {}

--- a/wayfinder_paths/mcp/tools/runner.py
+++ b/wayfinder_paths/mcp/tools/runner.py
@@ -77,11 +77,36 @@ async def core_runner(
     env: dict[str, str] | None = None,
     debug: bool = False,
 ) -> dict[str, Any]:
-    """Control the local runner daemon via its Unix socket.
+    """Control the local runner daemon — the only sanctioned scheduler for recurring jobs.
 
-    Notes:
-      - Use `daemon_status`/`ensure_started`/`daemon_start`/`daemon_stop` to manage the daemon lifecycle.
-      - `add_job` creates a new job; `run_once` triggers an immediate execution.
+    All scheduled/recurring tasks MUST go through this tool. Don't use cron, systemd timers,
+    or background loops. The daemon owns persistence, failure tracking, timeouts, and (on
+    Wayfinder Shells) backend job/run sync.
+
+    Lifecycle actions:
+      - `daemon_status`: lightweight probe — has the socket, is anyone listening.
+      - `ensure_started`: idempotent start. Safe to call before adding a job.
+      - `daemon_start` / `daemon_stop`: explicit lifecycle. `daemon_start` accepts
+        `tick_seconds`, `max_workers`, `max_failures`, `default_timeout_seconds`, `log_level`.
+
+    Job actions:
+      - `add_job`: schedule a recurring `name` at `interval_seconds`. Two `type`s:
+          * `strategy` — pass `strategy`, `strategy_action`, optional `config`, `wallet_label`,
+            `timeout_seconds`. See `research_run_strategy` for action semantics.
+          * `script` — pass `script_path` (inside `.wayfinder_runs/`), optional `args`, `env`,
+            `timeout_seconds`.
+      - `update_job`: mutate an existing job's payload / interval.
+      - `pause_job` / `resume_job` / `delete_job`: by `name`.
+      - `run_once`: trigger an immediate run of `name` (off the schedule).
+
+    Inspection actions:
+      - `status`: daemon state + all jobs.
+      - `job_runs`: recent runs for a job (`name`, optional `limit`).
+      - `run_report`: detailed log for a single run (`run_id`, optional `tail_bytes`).
+
+    Args:
+        sock_path: Override the daemon socket (default: standard runner location).
+        debug: Verbose response payload for troubleshooting.
     """
 
     client = _client(sock_path)

--- a/wayfinder_paths/mcp/tools/strategies.py
+++ b/wayfinder_paths/mcp/tools/strategies.py
@@ -59,6 +59,33 @@ async def research_run_strategy(
     gas_token_amount: float = 0.0,
     amount: float | None = None,
 ) -> dict[str, Any]:
+    """Run a lifecycle action against an installed strategy.
+
+    Strategies are discovered via `wayfinder://strategies`. Each one implements the same surface;
+    not every action is supported by every strategy (returns `not_supported` if missing).
+
+    Read-only actions:
+      - `status`: current positions, balances, internal state
+      - `analyze`: simulate behavior at a hypothetical `amount_usdc` deposit
+      - `snapshot`: build batch snapshot for scoring (uses `amount_usdc`)
+      - `policy`: declared permission policy (no instance needed)
+      - `quote`: point-in-time expected APY for `amount_usdc`
+
+    Fund-moving actions (trigger safety review):
+      - `deposit`: requires `main_token_amount`; optional `gas_token_amount` (recommend `0.001`
+        on first deposit). `amount` is accepted as a back-compat alias for `main_token_amount`.
+      - `update`: rebalance / execute the strategy's recurring logic
+      - `withdraw`: liquidate all positions to stablecoins (funds stay in strategy wallet);
+        partial withdraw is unsupported — leave `amount` unset.
+      - `exit`: transfer remaining funds from strategy wallet → main wallet. Run after `withdraw`.
+
+    Args:
+        strategy: Strategy name (folder under `wayfinder_paths/strategies/`).
+        action: Lifecycle action above.
+        amount_usdc: Used by `analyze` / `snapshot` / `quote` (default 1000).
+        main_token_amount / gas_token_amount: Deposit sizing.
+        amount: Back-compat alias for `main_token_amount` on deposit.
+    """
     if not strategy.strip():
         return err("invalid_request", "strategy is required")
 

--- a/wayfinder_paths/mcp/tools/wallets.py
+++ b/wayfinder_paths/mcp/tools/wallets.py
@@ -177,6 +177,36 @@ async def core_wallets(
     policies: list[dict] = [],  # noqa: B006
     wallet_type: str | None = None,
 ) -> dict[str, Any]:
+    """Create wallets, annotate wallet profiles, and discover cross-protocol portfolios.
+
+    Read wallets via `wayfinder://wallets` resources — don't grep `config.json`. On Wayfinder
+    Shells instances all wallets must be remote (`remote=True`); local wallets are rejected.
+
+    Actions:
+      - `create`: provision a new wallet under `label`. On Shells set `remote=True` and pick
+        `wallet_type` ("session" 1h-TTL recommended, or "strategy" 7d-TTL for unattended jobs).
+        Optional `policies` list shapes the remote signing policy. Off Shells, omits `remote`
+        for a local mnemonic-derived wallet written to `config.json`.
+      - `annotate`: attach a `protocol` + `annotate_action` + `tool` + `status` record to the
+        wallet profile so future `discover_portfolio` calls know where to look.
+      - `discover_portfolio`: query each protocol the wallet has touched (or filter via
+        `protocols=[...]`) and aggregate positions. Set `parallel=True` for concurrent fan-out;
+        ≥3 protocols requires `parallel=True` or returns `requires_confirmation`.
+
+    Args:
+        label / wallet_label / wallet_address: Identify the target wallet.
+        protocol: Protocol slug for `annotate` (e.g. "hyperliquid", "moonwell").
+        annotate_action / tool / status / chain_id / details: Profile annotation fields.
+        protocols: Filter list for `discover_portfolio` (defaults to all profile-tracked protocols).
+        parallel: Fan out adapter calls concurrently in `discover_portfolio`.
+        include_zero_positions: Include dust / closed positions in adapter responses.
+        remote: True → remote (managed) wallet on `create`. Required on Shells.
+        policies: Remote-wallet signing policies (passed through to the wallet service).
+        wallet_type: "session" or "strategy" — required when `remote=True`.
+
+    Supported protocols for `discover_portfolio`: hyperliquid, hyperlend, moonwell, morpho,
+    boros, pendle, polymarket, aave.
+    """
     config_path = resolve_config_path()
     store = WalletProfileStore.default()
 


### PR DESCRIPTION
### Summary
Most MCP tool entrypoints had no docstring; the agent had to infer behavior from the signature. Filled in concise descriptions covering action enums, parameter expectations, and cross-tool references for: `hyperliquid_wait`, `hyperliquid_execute`, `core_run_script`, `research_run_strategy`, `core_wallets`, `polymarket_read`, `polymarket_execute`, `core_execute`, `onchain_quote_swap`, plus an expanded `core_runner` docstring. AGENTS.md gains an MCP-vs-scripting guidance block (MCP for one-shots, scripts for complex/repetitive work).