### PR TITLE
MCP - Add generic preflight opencode plugin (FastMCP client)

### DIFF
--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "wayfinder-opencode-plugins",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0"
+  }
+}

--- a/.opencode/plugins/preflight.ts
+++ b/.opencode/plugins/preflight.ts
@@ -1,0 +1,83 @@
+import type { Plugin } from "@opencode-ai/plugin"
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
+
+type Args = Record<string, unknown>
+type Call = {
+  name: string
+  args?: Args
+  key?: string
+}
+
+const AGENT_PREFLIGHT: Record<string, Call[]> = {
+  hyperliquid: [
+    { key: "wallets", name: "wayfinder_onchain_list_wallets" },
+    { key: "perp_markets", name: "wayfinder_hyperliquid_get_markets" },
+    { key: "spot_assets", name: "wayfinder_hyperliquid_get_spot_assets" },
+    { key: "outcomes", name: "wayfinder_hyperliquid_get_outcomes" },
+  ],
+  polymarket: [{ key: "wallets", name: "wayfinder_onchain_list_wallets" }],
+  onchain: [{ key: "wallets", name: "wayfinder_onchain_list_wallets" }],
+}
+
+let clientPromise: Promise<Client> | null = null
+function getClient(): Promise<Client> {
+  if (!clientPromise) {
+    clientPromise = (async () => {
+      const transport = new StreamableHTTPClientTransport(
+        new URL("http://127.0.0.1:8000/mcp"),
+      )
+      const c = new Client({ name: "wayfinder-preflight", version: "0.1.0" })
+      await c.connect(transport)
+      return c
+    })()
+  }
+  return clientPromise
+}
+
+async function runCalls(
+  client: Client,
+  calls: Call[],
+): Promise<Record<string, unknown>> {
+  const results = await Promise.all(
+    calls.map(async (c) => {
+      try {
+        const res = await client.callTool({
+          name: c.name,
+          arguments: c.args ?? {},
+        })
+        return [c.key ?? c.name, res.content] as const
+      } catch (err) {
+        return [
+          c.key ?? c.name,
+          { error: err instanceof Error ? err.message : String(err) },
+        ] as const
+      }
+    }),
+  )
+  return Object.fromEntries(results)
+}
+
+export const Preflight: Plugin = async () => ({
+  "chat.message": async (input, output) => {
+    const calls = input.agent ? AGENT_PREFLIGHT[input.agent] : undefined
+    if (!calls) return
+
+    const client = await getClient()
+    const bundle = await runCalls(client, calls)
+
+    output.parts.push({
+      id: `prt_preflight_${Date.now()}`,
+      sessionID: input.sessionID,
+      messageID: input.messageID ?? "",
+      type: "text",
+      synthetic: true,
+      text: [
+        "<system-reminder>",
+        `Current state for the ${input.agent} surface — verify against user intent before any execute call:`,
+        JSON.stringify(bundle, null, 2),
+        "</system-reminder>",
+      ].join("\n"),
+    })
+  },
+})


### PR DESCRIPTION
### Summary

Adds `.opencode/plugins/preflight.ts` — a generic preflight pattern that gates configured MCP write tools behind a context-bundle read.

**How it works:**
- On `tool.execute.before`, plugin checks if the tool is in the `GUARDS` table.
- If yes, opens an MCP client to the local FastMCP server (\`http://127.0.0.1:8000/mcp\` via \`StreamableHTTPClientTransport\` from \`@modelcontextprotocol/sdk\`).
- Calls every configured context tool in parallel via \`client.callTool\`.
- Throws the bundle as a tool error so the agent sees it as the tool's result.
- Agent re-calls the tool with \`confirmed: true\` to bypass on retry; plugin strips that flag before the underlying tool sees args.

**Currently guarded:**
- \`wayfinder_hyperliquid_execute\` → perp / spot / outcome user state
- \`wayfinder_polymarket_execute\` → positions + open orders

Add more entries to the \`GUARDS\` table as new write surfaces land. Each entry is just \`{ tool, argsFrom? }\` — no Python sidecar route needed; we reuse the existing MCP tool surface.

**Why MCP client instead of a REST sidecar:**
- No drift between plugin and Python helper code — the plugin reads exactly what the agent reads.
- New context bundles are config-only changes (no Python registration).
- One MCP client opens lazily and is cached for the session.

**Cloud-harness follow-up needed:** Dockerfile must run \`npm install\` inside \`/opt/wayfinder-paths-sdk/.opencode/\` so the plugin's \`@modelcontextprotocol/sdk\` dep is available at runtime. I'll prep that PR after this lands.