### PR TITLE
MCP - Squash discovery and HL state tools

### DIFF
--- a/wayfinder_paths/mcp/resources/discovery.py
+++ b/wayfinder_paths/mcp/resources/discovery.py
@@ -1,105 +1,64 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 from wayfinder_paths.mcp.utils import read_text_excerpt, read_yaml, repo_root
 
 
-async def core_list_adapters() -> str:
-    root = repo_root()
-    base = root / "wayfinder_paths" / "adapters"
-    if not base.exists():
-        return json.dumps({"error": f"Directory not found: {base}"})
+def _describe_dir(base: Path, name: str) -> dict[str, Any] | None:
+    target = base / name
+    manifest_path = target / "manifest.yaml"
+    if not manifest_path.exists():
+        return None
+    out: dict[str, Any] = {"name": name, "manifest": read_yaml(manifest_path)}
+    readme = read_text_excerpt(target / "README.md")
+    if readme:
+        out["readme_excerpt"] = readme
+    return out
 
+
+def _describe_all(base: Path) -> list[dict[str, Any]]:
+    if not base.exists():
+        return []
     items: list[dict[str, Any]] = []
     for child in sorted(base.iterdir()):
         if not child.is_dir():
             continue
-        manifest_path = child / "manifest.yaml"
-        if not manifest_path.exists():
-            continue
-        manifest = read_yaml(manifest_path)
-        items.append(
+        described = _describe_dir(base, child.name)
+        if described:
+            items.append(described)
+    return items
+
+
+async def get_adapters_and_strategies(name: str | None = None) -> str:
+    """List adapters and strategies with their manifests and README excerpts.
+
+    No args → full catalog of every adapter and strategy with manifest + readme excerpt.
+    Pass `name` to filter to a single adapter or strategy (matches across both directories).
+    """
+    root = repo_root()
+    adapters_base = root / "wayfinder_paths" / "adapters"
+    strategies_base = root / "wayfinder_paths" / "strategies"
+
+    if name:
+        adapter = _describe_dir(adapters_base, name)
+        strategy = _describe_dir(strategies_base, name)
+        if not adapter and not strategy:
+            return json.dumps({"error": f"Unknown adapter or strategy: {name}"})
+        return json.dumps(
             {
-                "name": child.name,
-                "entrypoint": manifest.get("entrypoint"),
-                "capabilities": manifest.get("capabilities", []),
-                "dependencies": manifest.get("dependencies", []),
-            }
+                "adapters": [adapter] if adapter else [],
+                "strategies": [strategy] if strategy else [],
+            },
+            indent=2,
         )
 
-    return json.dumps({"adapters": items}, indent=2)
-
-
-async def core_list_strategies() -> str:
-    root = repo_root()
-    base = root / "wayfinder_paths" / "strategies"
-    if not base.exists():
-        return json.dumps({"error": f"Directory not found: {base}"})
-
-    items: list[dict[str, Any]] = []
-    for child in sorted(base.iterdir()):
-        if not child.is_dir():
-            continue
-        manifest_path = child / "manifest.yaml"
-        if not manifest_path.exists():
-            continue
-        manifest = read_yaml(manifest_path)
-        adapters = manifest.get("adapters", [])
-        items.append(
-            {
-                "name": child.name,
-                "status": manifest.get("status", "stable"),
-                "entrypoint": manifest.get("entrypoint"),
-                "adapters": adapters if isinstance(adapters, list) else [],
-                "permissions_policy_present": bool(
-                    isinstance(manifest.get("permissions"), dict)
-                    and (manifest.get("permissions") or {}).get("policy")
-                ),
-            }
-        )
-
-    return json.dumps({"strategies": items}, indent=2)
-
-
-async def core_describe_adapter(name: str) -> str:
-    root = repo_root()
-    target = root / "wayfinder_paths" / "adapters" / name
-    if not target.exists():
-        return json.dumps({"error": f"Unknown adapter: {name}"})
-
-    manifest_path = target / "manifest.yaml"
-    if not manifest_path.exists():
-        return json.dumps({"error": f"Missing manifest.yaml for adapter: {name}"})
-
-    out: dict[str, Any] = {
-        "name": name,
-        "manifest": read_yaml(manifest_path),
-    }
-    readme = read_text_excerpt(target / "README.md")
-    if readme:
-        out["readme_excerpt"] = readme
-
-    return json.dumps(out, indent=2)
-
-
-async def core_describe_strategy(name: str) -> str:
-    root = repo_root()
-    target = root / "wayfinder_paths" / "strategies" / name
-    if not target.exists():
-        return json.dumps({"error": f"Unknown strategy: {name}"})
-
-    manifest_path = target / "manifest.yaml"
-    if not manifest_path.exists():
-        return json.dumps({"error": f"Missing manifest.yaml for strategy: {name}"})
-
-    out: dict[str, Any] = {
-        "name": name,
-        "manifest": read_yaml(manifest_path),
-    }
-    readme = read_text_excerpt(target / "README.md")
-    if readme:
-        out["readme_excerpt"] = readme
-
-    return json.dumps(out, indent=2)
+    return json.dumps(
+        {
+            "adapters": _describe_all(adapters_base),
+            "strategies": _describe_all(strategies_base),
+        },
+        indent=2,
+    )

--- a/wayfinder_paths/mcp/resources/hyperliquid.py
+++ b/wayfinder_paths/mcp/resources/hyperliquid.py
@@ -10,33 +10,48 @@ from wayfinder_paths.mcp.utils import resolve_wallet_address
 _PERP_SUFFIX_RE = re.compile(r"[-_ ]?perp$", re.IGNORECASE)
 
 
-async def hyperliquid_get_user_state(label: str) -> str:
+async def hyperliquid_get_state(label: str) -> str:
+    """Return perp + spot + outcome state for a Hyperliquid wallet in one shot."""
     addr, _ = await resolve_wallet_address(wallet_label=label)
     if not addr:
         return json.dumps({"error": f"Wallet not found: {label}"})
 
     adapter = HyperliquidAdapter()
-    success, data = await adapter.get_user_state(addr)
+    perp_ok, perp = await adapter.get_user_state(addr)
+    spot_ok, spot = await adapter.get_spot_user_state(addr)
+
+    spot_balances: list[dict[str, Any]] = []
+    outcome_positions: list[dict[str, Any]] = []
+    if spot_ok and isinstance(spot, dict):
+        for bal in spot.get("balances", []):
+            coin = str(bal.get("coin") or "")
+            if coin.startswith("+"):
+                if float(bal.get("total") or 0) == 0:
+                    continue
+                encoding = int(coin[1:])
+                outcome_positions.append(
+                    {
+                        "coin": coin,
+                        "outcome_id": encoding // 10,
+                        "side": encoding % 10,
+                        "total": bal.get("total"),
+                        "hold": bal.get("hold"),
+                        "entryNtl": bal.get("entryNtl"),
+                    }
+                )
+            else:
+                spot_balances.append(bal)
+        spot["balances"] = spot_balances
+
     return json.dumps(
-        {"label": label, "address": addr, "success": success, "state": data}, indent=2
-    )
-
-
-async def hyperliquid_get_spot_user_state(label: str) -> str:
-    addr, _ = await resolve_wallet_address(wallet_label=label)
-    if not addr:
-        return json.dumps({"error": f"Wallet not found: {label}"})
-
-    adapter = HyperliquidAdapter()
-    success, data = await adapter.get_spot_user_state(addr)
-    if success and isinstance(data, dict):
-        data["balances"] = [
-            b
-            for b in data.get("balances", [])
-            if not str(b.get("coin") or "").startswith("+")
-        ]
-    return json.dumps(
-        {"label": label, "address": addr, "success": success, "spot": data}, indent=2
+        {
+            "label": label,
+            "address": addr,
+            "perp": {"success": perp_ok, "state": perp},
+            "spot": {"success": spot_ok, "state": spot},
+            "outcomes": {"success": spot_ok, "positions": outcome_positions},
+        },
+        indent=2,
     )
 
 
@@ -93,35 +108,3 @@ async def hyperliquid_get_outcomes() -> str:
     adapter = HyperliquidAdapter()
     success, data = await adapter.get_outcome_markets()
     return json.dumps({"success": success, "outcomes": data}, indent=2)
-
-
-async def hyperliquid_get_outcome_user_state(label: str) -> str:
-    addr, _ = await resolve_wallet_address(wallet_label=label)
-    if not addr:
-        return json.dumps({"error": f"Wallet not found: {label}"})
-
-    adapter = HyperliquidAdapter()
-    success, data = await adapter.get_spot_user_state(addr)
-    positions: list[dict[str, Any]] = []
-    if success and isinstance(data, dict):
-        for bal in data.get("balances", []):
-            coin = str(bal.get("coin") or "")
-            if not coin.startswith("+"):
-                continue
-            if float(bal.get("total") or 0) == 0:
-                continue
-            encoding = int(coin[1:])
-            positions.append(
-                {
-                    "coin": coin,
-                    "outcome_id": encoding // 10,
-                    "side": encoding % 10,
-                    "total": bal.get("total"),
-                    "hold": bal.get("hold"),
-                    "entryNtl": bal.get("entryNtl"),
-                }
-            )
-    return json.dumps(
-        {"label": label, "address": addr, "success": success, "positions": positions},
-        indent=2,
-    )

--- a/wayfinder_paths/mcp/server.py
+++ b/wayfinder_paths/mcp/server.py
@@ -46,22 +46,15 @@ from wayfinder_paths.mcp.resources.delta_lab import (
     research_screen_price,
     research_search_delta_lab_assets,
 )
-from wayfinder_paths.mcp.resources.discovery import (
-    core_describe_adapter,
-    core_describe_strategy,
-    core_list_adapters,
-    core_list_strategies,
-)
+from wayfinder_paths.mcp.resources.discovery import get_adapters_and_strategies
 from wayfinder_paths.mcp.resources.hyperliquid import (
     hyperliquid_get_markets,
     hyperliquid_get_mid_price,
     hyperliquid_get_mid_prices,
     hyperliquid_get_orderbook,
-    hyperliquid_get_outcome_user_state,
     hyperliquid_get_outcomes,
     hyperliquid_get_spot_assets,
-    hyperliquid_get_spot_user_state,
-    hyperliquid_get_user_state,
+    hyperliquid_get_state,
 )
 from wayfinder_paths.mcp.resources.tokens import (
     onchain_fuzzy_search_tokens,
@@ -127,9 +120,7 @@ mcp.tool()(research_run_strategy)
 # Coin naming reference: /using-hyperliquid-adapter/rules/coin-naming.md.
 mcp.tool()(hyperliquid_wait)
 mcp.tool()(hyperliquid_execute)
-mcp.tool()(hyperliquid_get_user_state)
-mcp.tool()(hyperliquid_get_spot_user_state)
-mcp.tool()(hyperliquid_get_outcome_user_state)
+mcp.tool()(hyperliquid_get_state)
 mcp.tool()(hyperliquid_get_mid_prices)
 mcp.tool()(hyperliquid_get_mid_price)
 mcp.tool()(hyperliquid_get_markets)
@@ -159,10 +150,7 @@ mcp.tool()(contracts_call)
 mcp.tool()(contracts_execute)
 
 # ─── core_* (cross-persona — every subagent should allowlist these) ───
-mcp.tool()(core_list_adapters)
-mcp.tool()(core_list_strategies)
-mcp.tool()(core_describe_adapter)
-mcp.tool()(core_describe_strategy)
+mcp.tool()(get_adapters_and_strategies)
 mcp.tool()(core_get_wallet)
 mcp.tool()(core_get_wallet_balances)
 mcp.tool()(core_wallets)

--- a/wayfinder_paths/tests/test_mcp_discovery.py
+++ b/wayfinder_paths/tests/test_mcp_discovery.py
@@ -4,59 +4,45 @@ import json
 
 import pytest
 
-from wayfinder_paths.mcp.resources.discovery import (
-    core_describe_adapter,
-    core_describe_strategy,
-    core_list_adapters,
-    core_list_strategies,
-)
+from wayfinder_paths.mcp.resources.discovery import get_adapters_and_strategies
 
 
 @pytest.mark.asyncio
-async def test_list_adapters_includes_hyperliquid():
-    out = await core_list_adapters()
+async def test_full_catalog_includes_known_entries():
+    out = await get_adapters_and_strategies()
     result = json.loads(out)
-    names = {i["name"] for i in result["adapters"]}
-    assert "hyperliquid_adapter" in names
+    adapter_names = {i["name"] for i in result["adapters"]}
+    strategy_names = {i["name"] for i in result["strategies"]}
+    assert "hyperliquid_adapter" in adapter_names
+    assert "boros_hype_strategy" in strategy_names
+    assert "basis_trading_strategy" in strategy_names
 
 
 @pytest.mark.asyncio
-async def test_list_strategies_includes_basis_and_boros():
-    out = await core_list_strategies()
+async def test_entries_carry_manifest():
+    out = await get_adapters_and_strategies()
     result = json.loads(out)
-    names = {i["name"] for i in result["strategies"]}
-    assert "boros_hype_strategy" in names
-    assert "basis_trading_strategy" in names
+    for entry in result["adapters"] + result["strategies"]:
+        assert isinstance(entry["manifest"], dict)
 
 
 @pytest.mark.asyncio
-async def test_describe_strategy_returns_manifest_and_readme_excerpt():
-    out = await core_describe_strategy("boros_hype_strategy")
+async def test_filter_by_name_returns_single_entry():
+    out = await get_adapters_and_strategies(name="boros_hype_strategy")
     result = json.loads(out)
-    assert result["name"] == "boros_hype_strategy"
-    assert isinstance(result.get("manifest"), dict)
+    assert result["adapters"] == []
+    assert len(result["strategies"]) == 1
+    assert result["strategies"][0]["name"] == "boros_hype_strategy"
+
+    out = await get_adapters_and_strategies(name="hyperliquid_adapter")
+    result = json.loads(out)
+    assert len(result["adapters"]) == 1
+    assert result["adapters"][0]["name"] == "hyperliquid_adapter"
+    assert result["strategies"] == []
 
 
 @pytest.mark.asyncio
-async def test_describe_adapter_returns_manifest():
-    out = await core_describe_adapter("hyperliquid_adapter")
+async def test_unknown_name_returns_error():
+    out = await get_adapters_and_strategies(name="does_not_exist")
     result = json.loads(out)
-    assert result["name"] == "hyperliquid_adapter"
-    assert isinstance(result.get("manifest"), dict)
-
-
-@pytest.mark.asyncio
-async def test_list_strategies_includes_status_field():
-    out = await core_list_strategies()
-    result = json.loads(out)
-    strategies = result["strategies"]
-    # All strategies should have a status field
-    for s in strategies:
-        assert "status" in s, f"Strategy {s['name']} missing status field"
-        assert s["status"] in ("stable", "wip", "deprecated")
-    # stablecoin_yield_strategy should be marked as wip
-    stablecoin = next(
-        (s for s in strategies if s["name"] == "stablecoin_yield_strategy"), None
-    )
-    assert stablecoin is not None, "stablecoin_yield_strategy not found"
-    assert stablecoin["status"] == "wip"
+    assert "error" in result


### PR DESCRIPTION
### Summary
Collapse `core_list_adapters` / `core_list_strategies` / `core_describe_adapter` / `core_describe_strategy` into a single `get_adapters_and_strategies(name?)` that returns the full catalog (manifests + readme excerpts), or filters to one name. Collapse `hyperliquid_get_user_state` / `hyperliquid_get_spot_user_state` / `hyperliquid_get_outcome_user_state` into one `hyperliquid_get_state(label)` that returns perp + spot + outcome positions in a single payload (the spot pass already produces both balance lists, so this also drops a redundant network call).