### PR TITLE
MCP - Split polymarket_get_state out of polymarket_read

### DIFF
--- a/wayfinder_paths/mcp/server.py
+++ b/wayfinder_paths/mcp/server.py
@@ -69,7 +69,11 @@ from wayfinder_paths.mcp.tools.instance_state import (
     shells_get_frontend_context,
 )
 from wayfinder_paths.mcp.tools.notify import shells_notify
-from wayfinder_paths.mcp.tools.polymarket import polymarket_execute, polymarket_read
+from wayfinder_paths.mcp.tools.polymarket import (
+    polymarket_execute,
+    polymarket_get_state,
+    polymarket_read,
+)
 from wayfinder_paths.mcp.tools.quotes import onchain_quote_swap
 from wayfinder_paths.mcp.tools.run_script import core_run_script
 from wayfinder_paths.mcp.tools.runner import core_runner
@@ -126,6 +130,7 @@ mcp.tool()(onchain_quote_swap)
 
 # ─── polymarket_* ──────────────────────────────────────────────────────
 mcp.tool()(polymarket_read)
+mcp.tool()(polymarket_get_state)
 mcp.tool()(polymarket_execute)
 
 # ─── contracts_* ───────────────────────────────────────────────────────

--- a/wayfinder_paths/mcp/tools/polymarket.py
+++ b/wayfinder_paths/mcp/tools/polymarket.py
@@ -124,9 +124,87 @@ def _annotate(
     )
 
 
+async def polymarket_get_state(
+    *,
+    wallet_label: str | None = None,
+    wallet_address: str | None = None,
+    account: str | None = None,
+    include_orders: bool = True,
+    include_activity: bool = False,
+    activity_limit: int = 50,
+    include_trades: bool = False,
+    trades_limit: int = 50,
+    positions_limit: int = 500,
+    max_positions_pages: int = 10,
+) -> dict[str, Any]:
+    """Full Polymarket account state — positions, optional orders / activity / trades.
+
+    Account precedence: `account` > `wallet_address` > `wallet_label`-resolved address.
+    `include_orders` defaults to true; `include_activity` / `include_trades` default false
+    to keep payloads tight. Each `*_limit` caps its respective list.
+    """
+    waddr, want = await resolve_wallet_address(wallet_label=wallet_label)
+    acct = normalize_address(account) or normalize_address(wallet_address) or waddr
+
+    if want and not waddr:
+        return err("not_found", f"Unknown wallet_label: {want}")
+    if not acct:
+        return err(
+            "invalid_request",
+            "account (or wallet_label/wallet_address) is required",
+            {
+                "wallet_label": wallet_label,
+                "wallet_address": wallet_address,
+                "account": account,
+            },
+        )
+
+    sign_cb = None
+    sign_hash_cb = None
+    config: dict[str, Any] | None = None
+    if want and waddr:
+        try:
+            sign_cb, _ = await get_wallet_signing_callback(want)
+        except ValueError:
+            pass
+        try:
+            sign_hash_cb, _ = await get_wallet_sign_hash_callback(want)
+        except ValueError:
+            pass
+        config = dict(CONFIG)
+        config["strategy_wallet"] = {"address": waddr}
+
+    adapter = PolymarketAdapter(
+        config=config,
+        sign_callback=sign_cb,
+        sign_hash_callback=sign_hash_cb,
+        wallet_address=waddr,
+    )
+    try:
+        ok_state, state = await adapter.get_full_user_state(
+            account=str(acct),
+            include_orders=bool(include_orders),
+            include_activity=bool(include_activity),
+            activity_limit=int(activity_limit),
+            include_trades=bool(include_trades),
+            trades_limit=int(trades_limit),
+            positions_limit=int(positions_limit),
+            max_positions_pages=int(max_positions_pages),
+        )
+        return ok(
+            {
+                "wallet_label": want,
+                "account": acct,
+                "ok": bool(ok_state),
+                "state": state,
+            }
+        )
+    finally:
+        await adapter.close()
+
+
 async def polymarket_read(
     action: Literal[
-        "status",
         "search",
         "trending",
         "get_market",
@@ -142,13 +220,6 @@ async def polymarket_read(
     wallet_label: str | None = None,
     wallet_address: str | None = None,
     account: str | None = None,
-    include_orders: bool = True,
-    include_activity: bool = False,
-    activity_limit: int = 50,
-    include_trades: bool = False,
-    trades_limit: int = 50,
-    positions_limit: int = 500,
-    max_positions_pages: int = 10,
     # search/trending
     query: str | None = None,
     limit: int = 10,
@@ -172,11 +243,11 @@ async def polymarket_read(
     end_ts: int | None = None,
     fidelity: int | None = None,
 ) -> dict[str, Any]:
-    """Read-only Polymarket queries: account state, market discovery, prices, books, history.
+    """Read-only Polymarket queries: market discovery, prices, books, history.
+
+    For account state (positions / orders / activity / trades) call `polymarket_get_state`.
 
     Actions:
-      - `status`: full user state — positions, optional `include_orders` / `include_activity`
-        / `include_trades` with their respective `*_limit`s. Requires a wallet/account.
       - `search`: fuzzy market search by `query`. `events_status` filters active/closed/archived;
         `end_date_min` (YYYY-MM-DD) filters out resolved markets; `rerank` re-scores results.
       - `trending`: list markets sorted by 24h volume (`limit`, `offset`).
@@ -204,7 +275,7 @@ async def polymarket_read(
     if want and not waddr:
         return err("not_found", f"Unknown wallet_label: {want}")
 
-    if action in {"status", "bridge_status"} and not acct:
+    if action == "bridge_status" and not acct:
         return err(
             "invalid_request",
             "account (or wallet_label/wallet_address) is required",
@@ -240,27 +311,6 @@ async def polymarket_read(
         wallet_address=waddr,
     )
     try:
-        if action == "status":
-            ok_state, state = await adapter.get_full_user_state(
-                account=str(acct),
-                include_orders=bool(include_orders),
-                include_activity=bool(include_activity),
-                activity_limit=int(activity_limit),
-                include_trades=bool(include_trades),
-                trades_limit=int(trades_limit),
-                positions_limit=int(positions_limit),
-                max_positions_pages=int(max_positions_pages),
-            )
-            return ok(
-                {
-                    "action": action,
-                    "wallet_label": want,
-                    "account": acct,
-                    "ok": bool(ok_state),
-                    "state": state,
-                }
-            )
-
         if action == "search":
             q = str(query or "").strip()
             if not q:

--- a/wayfinder_paths/tests/test_mcp_polymarket_tool.py
+++ b/wayfinder_paths/tests/test_mcp_polymarket_tool.py
@@ -5,7 +5,11 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from wayfinder_paths.mcp.tools.polymarket import polymarket_execute, polymarket_read
+from wayfinder_paths.mcp.tools.polymarket import (
+    polymarket_execute,
+    polymarket_get_state,
+    polymarket_read,
+)
 
 _FIND_WALLET = "wayfinder_paths.mcp.utils.find_wallet_by_label"
 _GET_SIGN_CB = "wayfinder_paths.mcp.tools.polymarket.get_wallet_signing_callback"
@@ -18,7 +22,7 @@ _HASH_CB = AsyncMock(return_value="0x" + "00" * 65)
 
 
 @pytest.mark.asyncio
-async def test_polymarket_status_uses_adapter_full_state():
+async def test_polymarket_get_state_uses_adapter_full_state():
     with (
         patch(_FIND_WALLET, AsyncMock(return_value=_WALLET)),
         patch(_GET_SIGN_CB, AsyncMock(return_value=(_SIGN_CB, _ADDR))),
@@ -29,9 +33,8 @@ async def test_polymarket_status_uses_adapter_full_state():
             new=AsyncMock(return_value=(True, {"protocol": "polymarket_read"})),
         ),
     ):
-        out = await polymarket_read("status", wallet_label="main")
+        out = await polymarket_get_state(wallet_label="main")
         assert out["ok"] is True
-        assert out["result"]["action"] == "status"
         assert out["result"]["ok"] is True
         assert out["result"]["state"]["protocol"] == "polymarket_read"
 


### PR DESCRIPTION
### Summary
Stacked on #257. Extract the `status` action of `polymarket_read` into its own `polymarket_get_state` tool — same shape as `hyperliquid_get_state`, no action enum, kwargs-only. `polymarket_read` keeps the market-discovery / quote / book / history surface.