### PR TITLE
MCP - Add opencode wallet-context plugin

### DIFF
--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "wayfinder-opencode-plugins",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0"
+  }
+}

--- a/.opencode/plugins/wallet-context.ts
+++ b/.opencode/plugins/wallet-context.ts
@@ -1,0 +1,43 @@
+import type { Plugin } from "@opencode-ai/plugin"
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
+
+let clientPromise: Promise<Client> | null = null
+function getClient(): Promise<Client> {
+  if (!clientPromise) {
+    clientPromise = (async () => {
+      const transport = new StreamableHTTPClientTransport(
+        new URL("http://127.0.0.1:8000/mcp"),
+      )
+      const c = new Client({ name: "wayfinder-wallet-context", version: "0.1.0" })
+      await c.connect(transport)
+      return c
+    })()
+  }
+  return clientPromise
+}
+
+async function fetchWallets(): Promise<string> {
+  try {
+    const client = await getClient()
+    const res = await client.callTool({ name: "wayfinder_core_get_wallets", arguments: {} })
+    return JSON.stringify(res.content, null, 2)
+  } catch (err) {
+    return JSON.stringify({ error: err instanceof Error ? err.message : String(err) })
+  }
+}
+
+export const WalletContext: Plugin = async () => ({
+  "experimental.chat.system.transform": async (_input, output) => {
+    const wallets = await fetchWallets()
+    output.system.push(
+      [
+        "<wallet-state>",
+        "Live result of wayfinder_core_get_wallets — refreshed on every LLM call.",
+        "Verify against user intent before any execute tool call (correct label, sufficient balance on the right chain).",
+        wallets,
+        "</wallet-state>",
+      ].join("\n"),
+    )
+  },
+})


### PR DESCRIPTION
### Summary
`.opencode/plugins/wallet-context.ts` hooks `experimental.chat.system.transform` and pushes the result of `wayfinder_core_get_wallets` into the system-prompt block list on every LLM invocation. This is the right hook for "before LLM processes a response" — fires per model call, not just once per user turn, so multi-step agentic loops see fresh wallet state on every step. Single MCP `Client` opened lazily over Streamable HTTP to the local FastMCP server on `127.0.0.1:8000`.

cloud-harness Dockerfile follow-up: `npm install` in `/opt/wayfinder-paths-sdk/.opencode/` so Bun resolves `@modelcontextprotocol/sdk` at plugin load time.