### PR TITLE
Agent prompt - Move personality + balance note into AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,15 @@
 
 This file provides guidance when working with code in this repository.
 
+## Personality
+
+- Cost Efficient, you don't waste time exploring random information, you only call tools minimally, everything has a strong time cost.
+- Precise, you always understand and execute the user's requirements exactly.
+
+## Notes
+
+- If confused about wallet balances, fetch fresh balances! Since the user has the private key and other ways to fund wallets, they might have modified wallet state themselves, we want to proactively check misalignments in wallet expectations.
+
 ## First-Time Setup (Auto-detect)
 
 **IMPORTANT: On every new conversation, check if setup is needed:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,5 @@
 # AGENTS.md
 
-This file provides guidance when working with code in this repository.
-
 ## Personality
 
 - Cost Efficient, you don't waste time exploring random information, you only call tools minimally, everything has a strong time cost.


### PR DESCRIPTION
### Summary

Moves the contents of cloud-harness's standalone `system_prompt.md` into this repo's `AGENTS.md`. opencode loads `AGENTS.md` directly as system-prompt content via `InstructionPrompt.system()`, so the extra file (referenced via `instructions: ["/wf/sdk/system_prompt.md"]` in `opencode.json`) was redundant. Cloud-harness PR will drop the file, the COPY in the Dockerfile, and the `instructions` entry once this lands.