### PR TITLE
MCP - Collapse response= assign-then-return pattern

### DIFF
--- a/wayfinder_paths/mcp/tools/execute.py
+++ b/wayfinder_paths/mcp/tools/execute.py
@@ -300,22 +300,20 @@ async def core_execute(
             from_meta = await TokenResolver.resolve_token_meta(str(req.from_token))
             to_meta = await TokenResolver.resolve_token_meta(str(req.to_token))
         except Exception as exc:  # noqa: BLE001
-            response = err("token_error", str(exc))
-            return response
+            return err("token_error", str(exc))
 
         from_chain_id = from_meta.get("chain_id")
         to_chain_id = to_meta.get("chain_id")
         from_token_addr = str(from_meta.get("address") or "").strip() or None
         to_token_addr = str(to_meta.get("address") or "").strip() or None
         if from_chain_id is None or to_chain_id is None:
-            response = err(
+            return err(
                 "invalid_token",
                 "Could not resolve chain_id for one or more tokens",
                 {"from_chain_id": from_chain_id, "to_chain_id": to_chain_id},
             )
-            return response
         if not from_token_addr or not to_token_addr:
-            response = err(
+            return err(
                 "invalid_token",
                 "Could not resolve token address for one or more tokens",
                 {
@@ -323,14 +321,12 @@ async def core_execute(
                     "to_token_address": to_token_addr,
                 },
             )
-            return response
 
         decimals = int(from_meta.get("decimals") or 18)
         try:
             amount_raw = parse_amount_to_raw(req.amount, decimals)
         except ValueError as exc:
-            response = err("invalid_amount", str(exc))
-            return response
+            return err("invalid_amount", str(exc))
 
         slippage = max(0.0, float(int(req.slippage_bps)) / 10_000.0)
         try:
@@ -344,8 +340,7 @@ async def core_execute(
                 slippage=slippage,
             )
         except Exception as exc:  # noqa: BLE001
-            response = err("quote_error", str(exc))
-            return response
+            return err("quote_error", str(exc))
 
         # BRAP quote responses have historically appeared in two shapes:
         # 1) {"quotes": [...], "best_quote": {...}}
@@ -362,17 +357,13 @@ async def core_execute(
                     best_quote = quotes_block.get("best_quote")
 
         if not isinstance(best_quote, dict):
-            response = err(
-                "quote_error", "No best_quote returned", {"quote": quote_data}
-            )
-            return response
+            return err("quote_error", "No best_quote returned", {"quote": quote_data})
 
         calldata = best_quote.get("calldata") or {}
         if not isinstance(calldata, dict) or not calldata:
-            response = err(
+            return err(
                 "quote_error", "best_quote missing calldata", {"best_quote": best_quote}
             )
-            return response
 
         swap_tx = dict(calldata)
         swap_tx["chainId"] = int(from_chain_id)
@@ -459,26 +450,23 @@ async def core_execute(
                 token_q, chain_id=req.chain_id
             )
         except Exception as exc:  # noqa: BLE001
-            response = err("token_error", str(exc))
-            return response
+            return err("token_error", str(exc))
 
         token_address = str(token_meta.get("address") or "").strip()
         chain_id = token_meta.get("chain_id")
         if not token_address or chain_id is None:
-            response = err(
+            return err(
                 "invalid_token",
                 "Token missing address/chain_id",
                 {"token": token_meta},
             )
-            return response
         decimals = int(token_meta.get("decimals") or 18)
         is_native = token_address.lower() == ZERO_ADDRESS.lower()
 
         try:
             amount_raw = parse_amount_to_raw(req.amount, decimals)
         except ValueError as exc:
-            response = err("invalid_amount", str(exc))
-            return response
+            return err("invalid_amount", str(exc))
 
         transaction = await build_send_transaction(
             from_address=sender,

--- a/wayfinder_paths/mcp/tools/hyperliquid.py
+++ b/wayfinder_paths/mcp/tools/hyperliquid.py
@@ -324,7 +324,14 @@ async def hyperliquid_execute(
             )
 
         status = "confirmed" if all(e["ok"] for e in effects) else "failed"
-        response = ok(
+        _annotate_hl_profile(
+            address=deposit_sender,
+            label=want,
+            action="deposit",
+            status=status,
+            details={"amount_usdc": amt, "chain_id": chain_id},
+        )
+        return ok(
             {
                 "status": status,
                 "action": action,
@@ -335,27 +342,16 @@ async def hyperliquid_execute(
                 "effects": effects,
             }
         )
-        _annotate_hl_profile(
-            address=deposit_sender,
-            label=want,
-            action="deposit",
-            status=status,
-            details={"amount_usdc": amt, "chain_id": chain_id},
-        )
-        return response
 
     if action == "withdraw":
         if amount_usdc is None:
-            response = err("invalid_request", "amount_usdc is required for withdraw")
-            return response
+            return err("invalid_request", "amount_usdc is required for withdraw")
         try:
             amt = float(amount_usdc)
         except (TypeError, ValueError):
-            response = err("invalid_request", "amount_usdc must be a number")
-            return response
+            return err("invalid_request", "amount_usdc must be a number")
         if amt <= 0:
-            response = err("invalid_request", "amount_usdc must be positive")
-            return response
+            return err("invalid_request", "amount_usdc must be positive")
 
         ok_wd, res = await adapter.withdraw(amount=amt, address=sender)
         effects.append({"type": "hl", "label": "withdraw", "ok": ok_wd, "result": res})
@@ -372,7 +368,14 @@ async def hyperliquid_execute(
             )
 
         status = "confirmed" if all(e["ok"] for e in effects) else "failed"
-        response = ok(
+        _annotate_hl_profile(
+            address=sender,
+            label=want,
+            action="withdraw",
+            status=status,
+            details={"amount_usdc": amt},
+        )
+        return ok(
             {
                 "status": status,
                 "action": action,
@@ -383,15 +386,6 @@ async def hyperliquid_execute(
                 "effects": effects,
             }
         )
-        _annotate_hl_profile(
-            address=sender,
-            label=want,
-            action="withdraw",
-            status=status,
-            details={"amount_usdc": amt},
-        )
-
-        return response
 
     if action in ("spot_to_perp_transfer", "perp_to_spot_transfer"):
         if usd_amount is None:
@@ -416,7 +410,14 @@ async def hyperliquid_execute(
             {"type": "hl", "label": action, "ok": ok_transfer, "result": res}
         )
         status = "confirmed" if ok_transfer else "failed"
-        response = ok(
+        _annotate_hl_profile(
+            address=sender,
+            label=want,
+            action=action,
+            status=status,
+            details={"usd_amount": amt, "to_perp": to_perp},
+        )
+        return ok(
             {
                 "status": status,
                 "action": action,
@@ -428,15 +429,6 @@ async def hyperliquid_execute(
                 "effects": effects,
             }
         )
-        _annotate_hl_profile(
-            address=sender,
-            label=want,
-            action=action,
-            status=status,
-            details={"usd_amount": amt, "to_perp": to_perp},
-        )
-
-        return response
 
     def _coin_from_asset_id(aid: int) -> str | None:
         for k, v in (adapter.coin_to_asset or {}).items():
@@ -519,28 +511,22 @@ async def hyperliquid_execute(
         )
     if not ok_aid:
         payload = aid_or_err if isinstance(aid_or_err, dict) else {}
-        response = err(
+        return err(
             payload.get("code") or "invalid_request",
             payload.get("message") or "Invalid asset",
             payload.get("details"),
         )
-        return response
     resolved_asset_id = int(aid_or_err)
 
     if action == "update_leverage":
         if leverage is None:
-            response = err(
-                "invalid_request", "leverage is required for update_leverage"
-            )
-            return response
+            return err("invalid_request", "leverage is required for update_leverage")
         try:
             lev = int(leverage)
         except (TypeError, ValueError):
-            response = err("invalid_request", "leverage must be an int")
-            return response
+            return err("invalid_request", "leverage must be an int")
         if lev <= 0:
-            response = err("invalid_request", "leverage must be positive")
-            return response
+            return err("invalid_request", "leverage must be positive")
 
         ok_lev, res = await adapter.update_leverage(
             resolved_asset_id, lev, bool(is_cross), sender
@@ -549,7 +535,14 @@ async def hyperliquid_execute(
             {"type": "hl", "label": "update_leverage", "ok": ok_lev, "result": res}
         )
         status = "confirmed" if ok_lev else "failed"
-        response = ok(
+        _annotate_hl_profile(
+            address=sender,
+            label=want,
+            action="update_leverage",
+            status=status,
+            details={"asset_id": resolved_asset_id, "coin": coin, "leverage": lev},
+        )
+        return ok(
             {
                 "status": status,
                 "action": action,
@@ -561,15 +554,6 @@ async def hyperliquid_execute(
                 "effects": effects,
             }
         )
-        _annotate_hl_profile(
-            address=sender,
-            label=want,
-            action="update_leverage",
-            status=status,
-            details={"asset_id": resolved_asset_id, "coin": coin, "leverage": lev},
-        )
-
-        return response
 
     if action == "cancel_order":
         if cancel_cloid:
@@ -586,11 +570,10 @@ async def hyperliquid_execute(
             )
         else:
             if order_id is None:
-                response = err(
+                return err(
                     "invalid_request",
                     "order_id or cancel_cloid is required for cancel_order",
                 )
-                return response
             ok_cancel, res = await adapter.cancel_order(
                 resolved_asset_id, int(order_id), sender
             )
@@ -600,18 +583,6 @@ async def hyperliquid_execute(
 
         ok_all = all(bool(e.get("ok")) for e in effects) if effects else False
         status = "confirmed" if ok_all else "failed"
-        response = ok(
-            {
-                "status": status,
-                "action": action,
-                "wallet_label": want,
-                "address": sender,
-                "asset_id": resolved_asset_id,
-                "coin": coin,
-                "preview": preview_text,
-                "effects": effects,
-            }
-        )
         _annotate_hl_profile(
             address=sender,
             label=want,
@@ -624,8 +595,18 @@ async def hyperliquid_execute(
                 "cancel_cloid": cancel_cloid,
             },
         )
-
-        return response
+        return ok(
+            {
+                "status": status,
+                "action": action,
+                "wallet_label": want,
+                "address": sender,
+                "asset_id": resolved_asset_id,
+                "coin": coin,
+                "preview": preview_text,
+                "effects": effects,
+            }
+        )
 
     if action == "place_trigger_order":
         if tpsl not in ("tp", "sl"):
@@ -707,7 +688,21 @@ async def hyperliquid_execute(
 
         ok_all = all(bool(e.get("ok")) for e in effects) if effects else False
         status = "confirmed" if ok_all else "failed"
-        response = ok(
+        _annotate_hl_profile(
+            address=sender,
+            label=want,
+            action="place_trigger_order",
+            status=status,
+            details={
+                "asset_id": resolved_asset_id,
+                "coin": coin,
+                "tpsl": tpsl,
+                "is_buy": bool(is_buy),
+                "trigger_price": tpx,
+                "size": float(sz_valid),
+            },
+        )
+        return ok(
             {
                 "status": status,
                 "action": action,
@@ -729,21 +724,6 @@ async def hyperliquid_execute(
                 "effects": effects,
             }
         )
-        _annotate_hl_profile(
-            address=sender,
-            label=want,
-            action="place_trigger_order",
-            status=status,
-            details={
-                "asset_id": resolved_asset_id,
-                "coin": coin,
-                "tpsl": tpsl,
-                "is_buy": bool(is_buy),
-                "trigger_price": tpx,
-                "size": float(sz_valid),
-            },
-        )
-        return response
 
     # spot/perp orders require explicit is_spot
     if is_spot is None:
@@ -753,46 +733,37 @@ async def hyperliquid_execute(
         )
 
     if size is not None and usd_amount is not None:
-        response = err(
+        return err(
             "invalid_request",
             "Provide either size (coin units) or usd_amount (USD notional/margin), not both",
         )
-        return response
     if usd_amount_kind is not None and usd_amount is None:
-        response = err(
+        return err(
             "invalid_request",
             "usd_amount_kind is only valid when usd_amount is provided",
         )
-        return response
 
     if is_buy is None:
-        response = err("invalid_request", "is_buy is required for place_order")
-        return response
+        return err("invalid_request", "is_buy is required for place_order")
 
     if order_type == "limit":
         if price is None:
-            response = err("invalid_request", "price is required for limit orders")
-            return response
+            return err("invalid_request", "price is required for limit orders")
         try:
             px_for_sizing = float(price)
         except (TypeError, ValueError):
-            response = err("invalid_request", "price must be a number")
-            return response
+            return err("invalid_request", "price must be a number")
         if px_for_sizing <= 0:
-            response = err("invalid_request", "price must be positive")
-            return response
+            return err("invalid_request", "price must be positive")
     else:
         try:
             slip = float(slippage)
         except (TypeError, ValueError):
-            response = err("invalid_request", "slippage must be a number")
-            return response
+            return err("invalid_request", "slippage must be a number")
         if slip < 0:
-            response = err("invalid_request", "slippage must be >= 0")
-            return response
+            return err("invalid_request", "slippage must be >= 0")
         if slip > 0.25:
-            response = err("invalid_request", "slippage > 0.25 is too risky")
-            return response
+            return err("invalid_request", "slippage > 0.25 is too risky")
         px_for_sizing = None
 
     sizing: dict[str, Any] = {"source": "size"}
@@ -800,52 +771,43 @@ async def hyperliquid_execute(
         try:
             sz = float(size)
         except (TypeError, ValueError):
-            response = err("invalid_request", "size must be a number")
-            return response
+            return err("invalid_request", "size must be a number")
         if sz <= 0:
-            response = err("invalid_request", "size must be positive")
-            return response
+            return err("invalid_request", "size must be positive")
     else:
         if usd_amount is None:
-            response = err(
+            return err(
                 "invalid_request",
                 "Provide either size (coin units) or usd_amount for place_order",
             )
-            return response
         try:
             usd_amt = float(usd_amount)
         except (TypeError, ValueError):
-            response = err("invalid_request", "usd_amount must be a number")
-            return response
+            return err("invalid_request", "usd_amount must be a number")
         if usd_amt <= 0:
-            response = err("invalid_request", "usd_amount must be positive")
-            return response
+            return err("invalid_request", "usd_amount must be positive")
 
         # Spot: usd_amount is always notional (no leverage)
         if is_spot:
             notional_usd = usd_amt
             margin_usd = None
         elif usd_amount_kind is None:
-            response = err(
+            return err(
                 "invalid_request",
                 "usd_amount_kind is required for perp: 'notional' or 'margin'",
             )
-            return response
         elif usd_amount_kind == "margin":
             if leverage is None:
-                response = err(
+                return err(
                     "invalid_request",
                     "leverage is required when usd_amount_kind='margin'",
                 )
-                return response
             try:
                 lev = int(leverage)
             except (TypeError, ValueError):
-                response = err("invalid_request", "leverage must be an int")
-                return response
+                return err("invalid_request", "leverage must be an int")
             if lev <= 0:
-                response = err("invalid_request", "leverage must be positive")
-                return response
+                return err("invalid_request", "leverage must be positive")
             notional_usd = usd_amt * float(lev)
             margin_usd = usd_amt
         else:
@@ -864,15 +826,13 @@ async def hyperliquid_execute(
             if not coin_name:
                 coin_name = _coin_from_asset_id(resolved_asset_id) or ""
             if not coin_name:
-                response = err(
+                return err(
                     "invalid_request",
                     "coin is required when computing size from usd_amount for market orders",
                 )
-                return response
             ok_mids, mids = await adapter.get_all_mid_prices()
             if not ok_mids or not isinstance(mids, dict):
-                response = err("price_error", "Failed to fetch mid prices")
-                return response
+                return err("price_error", "Failed to fetch mid prices")
             mid = None
             for k, v in mids.items():
                 if str(k).lower() == coin_name.lower():
@@ -882,11 +842,10 @@ async def hyperliquid_execute(
                         mid = None
                     break
             if mid is None or mid <= 0:
-                response = err(
+                return err(
                     "price_error",
                     f"Could not resolve mid price for {coin_name}",
                 )
-                return response
             px_for_sizing = mid
 
         sz = notional_usd / float(px_for_sizing)
@@ -903,8 +862,7 @@ async def hyperliquid_execute(
 
     sz_valid = adapter.get_valid_order_size(resolved_asset_id, sz)
     if sz_valid <= 0:
-        response = err("invalid_request", "size is too small after lot-size rounding")
-        return response
+        return err("invalid_request", "size is too small after lot-size rounding")
 
     try:
         builder = _resolve_builder_fee(
@@ -912,18 +870,15 @@ async def hyperliquid_execute(
             builder_fee_tenths_bp=builder_fee_tenths_bp,
         )
     except ValueError as exc:
-        response = err("invalid_request", str(exc))
-        return response
+        return err("invalid_request", str(exc))
 
     if leverage is not None:
         try:
             lev = int(leverage)
         except (TypeError, ValueError):
-            response = err("invalid_request", "leverage must be an int")
-            return response
+            return err("invalid_request", "leverage must be an int")
         if lev <= 0:
-            response = err("invalid_request", "leverage must be positive")
-            return response
+            return err("invalid_request", "leverage must be positive")
         ok_lev, res = await adapter.update_leverage(
             resolved_asset_id, lev, bool(is_cross), sender
         )
@@ -931,7 +886,7 @@ async def hyperliquid_execute(
             {"type": "hl", "label": "update_leverage", "ok": ok_lev, "result": res}
         )
         if not ok_lev:
-            response = ok(
+            return ok(
                 {
                     "status": "failed",
                     "action": action,
@@ -943,7 +898,6 @@ async def hyperliquid_execute(
                     "effects": effects,
                 }
             )
-            return response
 
     # Builder attribution is mandatory; ensure approval before placing orders.
     desired = int(builder.get("f") or 0)
@@ -975,7 +929,7 @@ async def hyperliquid_execute(
             }
         )
         if not ok_appr:
-            response = ok(
+            return ok(
                 {
                     "status": "failed",
                     "action": action,
@@ -987,7 +941,6 @@ async def hyperliquid_execute(
                     "effects": effects,
                 }
             )
-            return response
 
     if order_type == "limit":
         ok_order, res = await adapter.place_limit_order(
@@ -1019,7 +972,20 @@ async def hyperliquid_execute(
 
     ok_all = all(bool(e.get("ok")) for e in effects) if effects else False
     status = "confirmed" if ok_all else "failed"
-    response = ok(
+    _annotate_hl_profile(
+        address=sender,
+        label=want,
+        action="place_order",
+        status=status,
+        details={
+            "asset_id": resolved_asset_id,
+            "coin": coin,
+            "order_type": order_type,
+            "is_buy": bool(is_buy),
+            "size": float(sz_valid),
+        },
+    )
+    return ok(
         {
             "status": status,
             "action": action,
@@ -1043,21 +1009,6 @@ async def hyperliquid_execute(
             "effects": effects,
         }
     )
-    _annotate_hl_profile(
-        address=sender,
-        label=want,
-        action="place_order",
-        status=status,
-        details={
-            "asset_id": resolved_asset_id,
-            "coin": coin,
-            "order_type": order_type,
-            "is_buy": bool(is_buy),
-            "size": float(sz_valid),
-        },
-    )
-
-    return response
 
 
 async def hyperliquid_get_state(label: str) -> str:

--- a/wayfinder_paths/mcp/tools/run_script.py
+++ b/wayfinder_paths/mcp/tools/run_script.py
@@ -235,7 +235,16 @@ async def core_run_script(
     exit_code = int(proc.returncode or 0)
     status = "timeout" if timed_out else ("completed" if exit_code == 0 else "failed")
 
-    response = ok(
+    inferred_protocol = _infer_protocol_from_script(script)
+    if inferred_protocol and wallet_label:
+        await _annotate_script_run(
+            script_path=display_path,
+            status=status,
+            wallet_label=wallet_label,
+            protocol=inferred_protocol,
+        )
+
+    return ok(
         {
             "status": status,
             "script_path": display_path,
@@ -249,14 +258,3 @@ async def core_run_script(
             "preview": preview_text,
         }
     )
-
-    inferred_protocol = _infer_protocol_from_script(script)
-    if inferred_protocol and wallet_label:
-        await _annotate_script_run(
-            script_path=display_path,
-            status=status,
-            wallet_label=wallet_label,
-            protocol=inferred_protocol,
-        )
-
-    return response


### PR DESCRIPTION
### Summary

Replace `response = ok/err(...); return response` with `return ok/err(...)` across `hyperliquid_execute`, `core_execute`, and `core_run_script`. Where an intervening `_annotate_*` call separates the assignment from the return, the annotate is reordered to run before the return so the dict literal moves directly into the return statement (logical no-op since profile annotation has no side effects on the returned data).

Re-opens #264 against a clean branch (the previous one had picked up commits from a closed stack).