### PR TITLE
CI - Mock wait_for_withdrawal in hyperliquid withdraw test (~62 min/run savings)

### DIFF
--- a/wayfinder_paths/tests/test_mcp_hyperliquid_execute.py
+++ b/wayfinder_paths/tests/test_mcp_hyperliquid_execute.py
@@ -55,6 +55,10 @@ async def test_hyperliquid_execute_withdraw(tmp_path: Path, monkeypatch):
             "wayfinder_paths.mcp.tools.hyperliquid.HyperliquidAdapter.withdraw",
             new=AsyncMock(return_value=(True, {"status": "ok"})),
         ),
+        patch(
+            "wayfinder_paths.mcp.tools.hyperliquid.HyperliquidAdapter.wait_for_withdrawal",
+            new=AsyncMock(return_value=(True, {"status": "ok"})),
+        ),
     ):
         out1 = await hyperliquid_execute(
             "withdraw", wallet_label="main", amount_usdc=10


### PR DESCRIPTION
## Summary

- `test_hyperliquid_execute_withdraw` mocks `HyperliquidAdapter.withdraw` but not `wait_for_withdrawal`, which the MCP withdraw action invokes since `08d4c8f` (#257).
- The unmocked wait polls live Hyperliquid for an unrelated address and times out at the hardcoded 30-min cap (`adapter.py:1445`), eating **~31 min per job**.
- The test runs in **both** `Test Coverage Validation` and `MCP Tests` jobs, which are serialized via `needs:`. Together that's the entire ~65-min wall-clock for every `Test Pipeline` run.

## Impact

| | Before | After |
|---|---|---|
| `test_hyperliquid_execute_withdraw` | 1861s (31 min) | 0.11s |
| `Test Coverage Validation` job | 32.6 min | ~30s |
| `MCP Tests` job | 32.4 min | ~30s |
| Total `Test Pipeline` wall-clock | **~65 min** | **~3 min** |

p50 across the last 18 successful runs was 65.9 min — every run, on every branch, paying this tax.

## Test plan

- [x] `pytest wayfinder_paths/tests/test_mcp_hyperliquid_execute.py -v --no-cov` — 4 passed in 0.11s
- [ ] Confirm `Test Pipeline` on this PR drops to ~3 min wall-clock
- [ ] Spot-check `MCP Tests` job for any other regressions

## Follow-ups (not in this PR)

Found during the audit; worth filing separately:
- Add `concurrency: cancel-in-progress: true` to `test-pipeline.yml` (every PR push currently queues another full run).
- Drop the `Test Coverage Validation` gate (it duplicates the per-folder jobs) or unblock the children from `needs:`.
- Move `--cov` out of `pyproject.toml` `addopts` (no consumer in CI; 15-30% overhead on every test job).
- Enable `pytest-xdist -n auto` (already a dev dep, unused).
- Add `pytest-timeout` to fail-fast on future runaways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)