### PR TITLE
Docs - Move shells notify + projections into skills, trim CLAUDE/AGENTS

### DIFF
--- a/.claude/skills/using-shells-notify/SKILL.md
+++ b/.claude/skills/using-shells-notify/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: using-shells-notify
+description: How to email the Wayfinder Shells instance owner from agents/scripts via the notify MCP tool or NotifyClient (Markdown body rendered to themed HTML, throttled).
+metadata:
+  tags: wayfinder, shells, notify, email, opencode
+---
+
+## TL;DR
+
+Email the user who owns this Wayfinder Shells instance. Markdown in, themed HTML email out.
+
+**MCP tool (preferred from agents):**
+
+```
+shells_notify(
+  title="Rebalance complete",
+  message="Moved **50 USDC** from Aave → Morpho.\n\n- tx: 0x…\n- new APY: 7.4%",
+)
+```
+
+**Python client (from scripts):**
+
+```python
+from wayfinder_paths.core.clients.NotifyClient import NOTIFY_CLIENT
+
+await NOTIFY_CLIENT.notify(
+    title="Rebalance complete",
+    message="Moved **50 USDC** from Aave → Morpho.\n\n- tx: 0x…\n- new APY: 7.4%",
+)
+```
+
+Both POST to `{api_base}/opencode/notify/` with the configured `WAYFINDER_API_KEY`.
+
+## Limits & gotchas
+
+- **Title:** ≤ 200 chars (required, non-empty after strip).
+- **Message:** ≤ 20 000 chars (required). Rendered as Markdown — headings, lists, tables, fenced code, links all work.
+- **Delivery gate:** Only sent if the owner has `email_verified: true` on vault-backend. No verified email = silently dropped.
+- **Throttle:** Backend caps at **4 emails / user / day**. Budget your sends; don't spam progress updates.
+- **Shells-only:** No-op (or HTTP error) outside a Wayfinder Shells instance. The MCP tool gates on `is_opencode_instance()` indirectly via the API; the client just hits the URL. Detection: `OPENCODE_INSTANCE_ID` env var is set, or the health probe at `http://localhost:4096/global/health` returns `healthy: true`.
+- Client returns the parsed JSON dict directly (no `(ok, data)` tuple — it's a `WayfinderClient`, not an adapter).
+
+## When to use
+
+- Report completed fund-moving work to the owner ("rebalance done", "withdraw confirmed").
+- Surface decisions that need them ("APY dropped below threshold — pause strategy?").
+- Flag failures you can't auto-resolve.
+- Escalate `job_result` events from scheduled jobs that need owner attention.
+
+Don't use for chatty progress updates — the daily quota is small.
+
+## Markdown formatting tips
+
+- Use `**bold**` for amounts and statuses.
+- Code-fence tx hashes / addresses so they don't wrap mid-string.
+- Tables work for multi-step rebalance summaries.
+- Links: `[Block explorer](https://...)` → clickable in the rendered email.
+
+## Error shape
+
+MCP tool returns `{"ok": false, "error": {"code": ..., "message": ...}}` for:
+- `invalid_request` — title/message empty or exceeds limit.
+- `notify_http_error` — backend rejected (check `details` for body).
+- `notify_error` — transport failure.

--- a/.claude/skills/using-shells-projections/SKILL.md
+++ b/.claude/skills/using-shells-projections/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: using-shells-projections
+description: How to read the Wayfinder Shells frontend UI state (active chart) and draw projections (overlays like price lines, markers, ranges, trends) onto the user's chart in real-time.
+metadata:
+  tags: wayfinder, shells, opencode, frontend, projections, charts, overlays
+---
+
+## TL;DR
+
+Read what the user is viewing in Wayfinder Shells, then draw on top of their chart.
+
+**Typical flow (MCP):**
+
+```
+1. shells_get_frontend_context()
+   → {"ok": true, "data": {"frontend_context": {"chart": {"id": "hl-perp-BTC", "market_id": "BTC", "market_type": "hl-perp", "interval": "1m"}}, "sdk_projection": {...}}}
+2. chart_id = data["frontend_context"]["chart"]["id"]   # "hl-perp-BTC"
+3. shells_add_chart_projection(chart_id="hl-perp-BTC", type="horizontal_line", config={"price": 73500, "color": "#ef4444", "label": "Support"})
+4. Line appears on the user's chart (within ~5s, faster on SSE).
+```
+
+**Python (from scripts):**
+
+```python
+from wayfinder_paths.core.clients.InstanceStateClient import INSTANCE_STATE_CLIENT
+
+state = await INSTANCE_STATE_CLIENT.get_state()
+chart_id = state["frontend_context"]["chart"]["id"]
+
+await INSTANCE_STATE_CLIENT.add_projection(chart_id, {
+    "type": "horizontal_line",
+    "config": {"price": 73500, "color": "#ef4444", "label": "Support"},
+})
+```
+
+## MCP tools
+
+| Tool | Args | Use |
+|------|------|-----|
+| `shells_get_frontend_context` | (none) | Read current chart context + all projections |
+| `shells_add_chart_projection` | `chart_id`, `type`, `config` | Add one overlay |
+| `shells_clear_chart_projections` | `chart_id` | Wipe all overlays on a chart |
+
+All gate on `is_opencode_instance()` and return `{"ok": false, "error": {"code": "not_opencode_instance"}}` when run outside Shells.
+
+## Projection types
+
+The backend is type-agnostic — these are the renderers the frontend currently maps to TradingView shapes.
+
+| `type` | `config` |
+|--------|----------|
+| `horizontal_line` | `price`, `color?`, `label?` |
+| `vertical_line` | `time` (unix sec), `color?`, `label?` |
+| `marker` | `time`, `price?`, `shape?` (`arrow_up` / `arrow_down` / `flag` / `icon` / `emoji`), `color?` |
+| `range` | `from_time?`, `to_time?`, `from_price`, `to_price`, `color?` |
+| `text_label` | `time`, `price`, `text`, `color?` |
+| `trend` | `from: {time, price}`, `to: {time, price}`, `color?`, `label?` |
+
+## Gotchas
+
+- **`marker` does not accept `label`** — TradingView's marker shapes auto-generate text. Use `text_label` for an annotated point.
+- **All `time` values are unix seconds** (not ms).
+- **Per-chart scope:** Projections are stored per `chart_id`; switching markets shows only that chart's overlays.
+- **Latency:** Adding a projection emits a state-changed notification; FE renders within one poll cycle (~5s) or sooner on SSE.
+- **Client returns data directly** — `INSTANCE_STATE_CLIENT` is a `WayfinderClient`, not an adapter, so no `(ok, data)` tuple.
+- **Shells-only:** Detection via `OPENCODE_INSTANCE_ID` env var or `http://localhost:4096/global/health`.
+
+## Use the helpers
+
+`InstanceStateClient` exposes shortcuts so scripts don't have to walk the state dict:
+
+```python
+chart_id = await INSTANCE_STATE_CLIENT.get_chart_id()              # "hl-perp-BTC"
+fc = await INSTANCE_STATE_CLIENT.get_frontend_context()             # just the frontend_context subtree
+await INSTANCE_STATE_CLIENT.clear_projections(chart_id)             # wipe all
+await INSTANCE_STATE_CLIENT.patch_projection(chart_id, [...])       # replace full list
+```
+
+## When to use
+
+- "Highlight the liquidation price on my chart"
+- "Mark where my entry / exit was"
+- "Draw a target range I'm laddering into"
+- "Show the funding flip points I'm watching"
+
+Don't use for unrelated reporting — that's `shells_notify` (see `/using-shells-notify`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,75 +41,21 @@ Config priority: `Constructor parameter > config.json > WAYFINDER_API_KEY env va
 
 ## Messaging the user (Shells instances only)
 
-If you detected a Wayfinder Shells instance in "First-Time Setup" (health probe at `http://localhost:4096/global/health` returned `healthy: true`), you may email the owner to report completed work, surface decisions that need them, or flag anything you can't resolve. The backend only delivers when `email_verified` is true on the user, and throttles to **4 emails / user / day** — budget your sends accordingly. The `message` field is rendered as Markdown (headings, lists, code blocks, tables, links) into a themed HTML email, so format it nicely.
+If you detected a Wayfinder Shells instance in "First-Time Setup", you may email the owner to report completed work, surface decisions that need them, or flag anything you can't resolve. Backend only delivers when `email_verified` is true on the user, and throttles to **4 emails / user / day** — budget your sends accordingly.
 
-**MCP tool:**
-```
-notify(
-  title="Rebalance complete",
-  message="Moved **50 USDC** from Aave → Morpho.\n\n- tx: 0x…\n- new APY: 7.4%",
-)
-```
+See `/using-shells-notify` for the MCP tool, Python client, limits, and Markdown formatting tips.
 
-**Python client:**
-```python
-from wayfinder_paths.core.clients.NotifyClient import NOTIFY_CLIENT
+## Frontend Context (Shells instances only)
 
-await NOTIFY_CLIENT.notify(
-    title="Rebalance complete",
-    message="Moved **50 USDC** from Aave → Morpho.\n\n- tx: 0x…\n- new APY: 7.4%",
-)
-```
+If you detected a Wayfinder Shells instance, you can read what the user is currently viewing (active chart) and project overlays (price lines, markers, ranges, trends) onto their chart in real-time.
 
-Both POST to `/api/v1/opencode/notify/` on vault-backend with your `WAYFINDER_API_KEY`. Limits: title ≤ 200 chars, message ≤ 20 000 chars.
-
-## Frontend Context (reading UI state + drawing on charts)
-
-If you detected a Wayfinder Shells instance, you can read what the user is viewing and project overlays (price lines, markers, series) onto their chart in real-time.
-
-**MCP tools:**
-
-| Tool | Args | Description |
-|------|------|-------------|
-| `get_frontend_context` | (none) | Read current chart context + all projections |
-| `add_chart_projection` | `chart_id`, `type`, `config` | Add overlay to a chart |
-| `remove_chart_projection` | `chart_id`, `projection_id` | Remove a specific overlay |
-| `clear_chart_projections` | `chart_id` | Remove all overlays from a chart |
-
-**Typical flow:**
-1. Call `get_frontend_context` → returns `{frontend_context: {chart: {id: "hl-perp-BTC", market_id: "BTC", market_type: "hl-perp", interval: "1m"}}, sdk_projection: {...}}`
-2. Read `chart_id` from `frontend_context.chart.id` → `"hl-perp-BTC"`
-3. Call `add_chart_projection` with `chart_id="hl-perp-BTC"`, `type="horizontal_line"`, `config={"price": 73500, "color": "#ef4444", "label": "Support"}`
-4. Line appears on the user's chart in real-time
-
-**Projection types:**
-
-| type | config |
-|------|--------|
-| `horizontal_line` | `price`, `color?`, `label?` |
-| `marker` | `time` (unix sec), `position` (aboveBar/belowBar), `shape` (circle/arrowUp/arrowDown), `color?`, `label?` |
-| `line_series` | `data: [{time, value}]`, `color?`, `label?`, `line_width?` |
-
-**Python client:**
-```python
-from wayfinder_paths.core.clients.InstanceStateClient import INSTANCE_STATE_CLIENT
-
-state = await INSTANCE_STATE_CLIENT.get_state()
-chart_id = state["frontend_context"]["chart"]["id"]
-
-await INSTANCE_STATE_CLIENT.add_projection(chart_id, {
-    "type": "horizontal_line",
-    "config": {"price": 73500, "color": "#ef4444", "label": "Support"},
-})
-```
-
-Projections are scoped per chart — switching markets shows only that chart's projections. The backend is type-agnostic; new projection types only need a frontend renderer.
+See `/using-shells-projections` for the MCP tools, Python client, projection types, and gotchas.
 
 ## Memories
 
 Eagerly use the memory tools. Persist user preferences, recurring strategies, wallet labels, project context, and anything else the user is likely to reference again — read on session start, write whenever you learn something durable. Don't ration them: a memory the user has to repeat is a memory you should have written.
 
-## Scheduled Jobs (backend sync)
+## Scheduled Jobs (Shells instances only)
 
 On Wayfinder Shells instances (`OPENCODE_INSTANCE_ID` set), the runner daemon automatically syncs job and run state to vault-backend. This happens transparently — no agent action needed.
 
@@ -427,51 +373,6 @@ runner(action="daemon_stop")                          # shut down daemon
 
 See `RUNNER_ARCHITECTURE.md`.
 
-## Common Commands
-
-```bash
-# Install dependencies
-poetry install
-
-# Generate test wallets (required before running tests/strategies)
-just create-wallets
-
-# Run all smoke tests
-just test-smoke
-
-# Test specific strategy or adapter
-just test-strategy stablecoin_yield_strategy
-just test-adapter pool_adapter
-
-# Run all tests with coverage
-just test-cov
-
-# Lint and format
-just lint
-just format
-
-# Validate all manifests
-just validate-manifests
-
-# Create new strategy with dedicated wallet
-just create-strategy "My Strategy Name"
-
-# Create new adapter
-just create-adapter "my_protocol"
-
-# Update one installed path to the live bonded version
-poetry run wayfinder path update my-path
-
-# Override the target version for one installed path
-poetry run wayfinder path update my-path --version 1.2.3
-
-# Run a strategy via MCP
-# run_strategy(strategy="stablecoin_yield_strategy", action="status")
-
-# Publish to PyPI (main branch only)
-just publish
-```
-
 ## Path updates
 
 - `poetry run wayfinder path update <slug>` is the single-path update command for installed paths.
@@ -555,12 +456,6 @@ Strategies extend `wayfinder_paths.core.strategies.Strategy` and must implement:
 - **Required**: Basic functionality tests with mocked dependencies
 - **Optional**: `examples.json` file
 
-### Test Markers
-
-- `@pytest.mark.smoke` - Basic functionality validation
-- `@pytest.mark.requires_wallets` - Tests needing local wallets configured
-- `@pytest.mark.requires_config` - Tests needing config.json
-
 ## Wallets
 
 **On Wayfinder Shells Instances, ALL wallets MUST be remote. No local wallets — ever.** Remote wallets are managed for you and provide analytics, activity tracking, and session-aware policies. Local wallets are invisible to the rest of the platform and break those guarantees. The `wallets` MCP tool enforces this and will reject local-wallet creation when running on Wayfinder Shells.
@@ -601,16 +496,6 @@ Copy `config.example.json` to `config.json` (or run `python3 scripts/setup.py`) 
 
 On a Wayfinder Shells Instance, the API key comes from the `WAYFINDER_API_KEY` env var and `OPENCODE_INSTANCE_ID` identifies the runtime — see [Wayfinder Shells environment variables](#wayfinder-shells-instance-environment-variables).
 
-## CI/CD Pipeline
-
-PRs are tested with:
-
-1. Lint & format checks (Ruff)
-2. Smoke tests
-3. Adapter tests (mocked dependencies)
-4. Integration tests (PRs only)
-5. Security scans (Bandit, Safety)
-
 ## Key Patterns
 
 - Adapters compose one or more clients and raise `NotImplementedError` for unsupported ops
@@ -618,12 +503,3 @@ PRs are tested with:
 - Return types are `StatusTuple` (success bool, message str) or `StatusDict` (portfolio data)
 - Wallet generation updates `config.json` in repo root
 - Per-strategy wallets are created automatically via `just create-strategy`
-
-## Publishing
-
-Publishing to PyPI is restricted to `main` branch. Order of operations:
-
-1. Merge changes to main
-2. Bump version in `pyproject.toml`
-3. Run `just publish`
-4. Then dependent apps can update their dependencies

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -522,51 +522,6 @@ Token identifiers (important for quoting/execution/lookups):
 
 - Use **token IDs** (`<coingecko_id>-<chain_code>`) or **address IDs** (`<chain_code>_<address>`). Full details: `.claude/skills/using-pool-token-balance-data/rules/tokens.md`.
 
-## Common Commands
-
-```bash
-# Install dependencies
-poetry install
-
-# Generate test wallets (required before running tests/strategies)
-just create-wallets                    # or: poetry run python scripts/make_wallets.py -n 1
-
-# Run all smoke tests
-just test-smoke                        # or: poetry run pytest -k smoke -v
-
-# Test specific strategy or adapter
-just test-strategy stablecoin_yield_strategy
-just test-adapter pool_adapter
-
-# Run all tests with coverage
-just test-cov                          # or: poetry run pytest --cov=wayfinder-paths --cov-report=html -v
-
-# Lint and format
-just lint                              # or: poetry run ruff check --fix
-just format                            # or: poetry run ruff format
-
-# Validate all manifests
-just validate-manifests
-
-# Create new strategy with dedicated wallet
-just create-strategy "My Strategy Name"
-
-# Create new adapter
-just create-adapter "my_protocol"
-
-# Update one installed path to the live bonded version
-poetry run wayfinder path update my-path
-
-# Override the target version for one installed path
-poetry run wayfinder path update my-path --version 1.2.3
-
-# Run a strategy locally
-poetry run python -m wayfinder_paths.run_strategy stablecoin_yield_strategy --action status --config config.json
-
-# Publish to PyPI (main branch only)
-just publish
-```
-
 ### Path updates
 
 - `poetry run wayfinder path update <slug>` compares the locally installed version in `.wayfinder/paths.lock.json` to the API's `active_bonded_version`.
@@ -651,27 +606,11 @@ Strategies extend `wayfinder_paths.core.strategies.Strategy` and must implement:
 - **Required**: Basic functionality tests with mocked dependencies
 - **Optional**: `examples.json` file
 
-### Test Markers
-
-- `@pytest.mark.smoke` - Basic functionality validation
-- `@pytest.mark.requires_wallets` - Tests needing local wallets configured
-- `@pytest.mark.requires_config` - Tests needing config.json
-
 ## Configuration
 
 Config priority: Constructor parameter > config.json > Environment variable (`WAYFINDER_API_KEY`)
 
 Copy `config.example.json` to `config.json` (or run `python3 scripts/setup.py`) for local development.
-
-## CI/CD Pipeline
-
-PRs are tested with:
-
-1. Lint & format checks (Ruff)
-2. Smoke tests
-3. Adapter tests (mocked dependencies)
-4. Integration tests (PRs only)
-5. Security scans (Bandit, Safety)
 
 ## Key Patterns
 
@@ -680,15 +619,6 @@ PRs are tested with:
 - Return types are `StatusTuple` (success bool, message str) or `StatusDict` (portfolio data)
 - Wallet generation updates `config.json` in repo root
 - Per-strategy wallets are created automatically via `just create-strategy`
-
-## Publishing
-
-Publishing to PyPI is restricted to `main` branch. Order of operations:
-
-1. Merge changes to main
-2. Bump version in `pyproject.toml`
-3. Run `just publish`
-4. Then dependent apps can update their dependencies
 
 ## Wallet management and portfolio discovery
 


### PR DESCRIPTION
## Summary

Two new skills + context cleanup. CLAUDE.md and AGENTS.md were duplicating syntax that's better off as on-demand skill content.

**New skills:**
- `/using-shells-notify` — `shells_notify` MCP tool + `NOTIFY_CLIENT.notify(...)`. Title/message limits, 4/day throttle, Markdown rendering, error shapes.
- `/using-shells-projections` — `shells_get_frontend_context` / `shells_add_chart_projection` / `shells_clear_chart_projections` + `INSTANCE_STATE_CLIENT`. Full canonical projection-type list pulled from `instance_state.py` (was stale in AGENTS.md — `remove_chart_projection` doesn't exist; `range`/`text_label`/`trend` weren't documented).

**AGENTS.md / CLAUDE.md trims:**
- Replaced the "Messaging the user" syntax block with a one-line skill pointer (header still flagged "Shells instances only").
- Replaced the "Frontend Context" syntax block + table with a one-line skill pointer; added the "(Shells instances only)" qualifier to the heading.
- Added "(Shells instances only)" to the "Scheduled Jobs" heading for consistency.
- Nuked sections derivable from code or stale: `## CI/CD Pipeline`, `## Publishing`, `### Test Markers`, `## Common Commands`.

## Net diff
- 4 files changed, +156 / -200 (-44 net).
- New skill files: +150
- AGENTS.md: -130
- CLAUDE.md: -70

## Test plan
- [x] Both skills load via `/using-shells-notify` and `/using-shells-projections` (frontmatter + tags valid).
- [ ] Spot-check that any other docs referencing the old `notify` / `get_frontend_context` examples still make sense (none found in this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)