### PR TITLE
MCP - hyperliquid_search_mid_prices (rename + asset_names filter)

### DIFF
--- a/wayfinder_paths/mcp/server.py
+++ b/wayfinder_paths/mcp/server.py
@@ -59,9 +59,9 @@ from wayfinder_paths.mcp.tools.evm_contract import (
 from wayfinder_paths.mcp.tools.execute import core_execute
 from wayfinder_paths.mcp.tools.hyperliquid import (
     hyperliquid_execute,
-    hyperliquid_get_mid_prices,
     hyperliquid_get_state,
     hyperliquid_search_market,
+    hyperliquid_search_mid_prices,
 )
 from wayfinder_paths.mcp.tools.instance_state import (
     shells_add_chart_projection,
@@ -118,8 +118,8 @@ mcp.tool()(research_search_borrow_routes)
 # Coin naming reference: /using-hyperliquid-adapter/rules/coin-naming.md.
 mcp.tool()(hyperliquid_execute)
 mcp.tool()(hyperliquid_get_state)
-mcp.tool()(hyperliquid_get_mid_prices)
 mcp.tool()(hyperliquid_search_market)
+mcp.tool()(hyperliquid_search_mid_prices)
 
 # ─── onchain_* ─────────────────────────────────────────────────────────
 mcp.tool()(onchain_resolve_token)

--- a/wayfinder_paths/mcp/tools/hyperliquid.py
+++ b/wayfinder_paths/mcp/tools/hyperliquid.py
@@ -1053,8 +1053,8 @@ async def hyperliquid_search_mid_prices(
     """
     Search Hyperliquid perpetual, spot, hip3 perpetual and hip4 outcome markets for current mid prices.
 
-    asset_names: Canonical market paths to filter for (e.g. "BTC-USDC", "xyz:NVDA",
-        "KNTQ/USDH", "#40"). If omitted, returns every market's mid price.
+    asset_names: Canonical market paths to filter mid prices (e.g. "BTC-USDC", "xyz:NVDA",
+        "KNTQ/USDH", "#40"), get these from hyperliquid_search_market(). If omitted, returns every market's mid price. Prefer non empty asset_names for efficiency.
     """
     adapter = HyperliquidAdapter()
     success, prices = await adapter.get_all_mid_prices()
@@ -1062,19 +1062,15 @@ async def hyperliquid_search_mid_prices(
         return ok({"success": success, "prices": prices})
 
     filtered: dict[str, str] = {}
-    unresolved: list[str] = []
     for name in asset_names:
         asset_id = await adapter.get_asset_id(name)
         if asset_id is None:
-            unresolved.append(name)
             continue
         for key in adapter.get_mid_price_key(name, asset_id):
             if (mid := prices.get(key)) is not None:
                 filtered[name] = mid
                 break
-        else:
-            unresolved.append(name)
-    return ok({"success": success, "prices": filtered, "unresolved": unresolved})
+    return ok({"prices": filtered})
 
 
 async def hyperliquid_search_market(query: str, limit: int = 10) -> dict[str, Any]:
@@ -1082,7 +1078,7 @@ async def hyperliquid_search_market(query: str, limit: int = 10) -> dict[str, An
     Search Hyperliquid perpetual, spot, hip3 perpetual and hip4 outcome markets by a simple query string. An empty
     query returns the first `limit` items from each bucket unfiltered.
 
-    query: A simple string containing asset names, for example: btc, eth, oil
+    query: A simple string containing asset names, for example: btc, eth, oil. Prefer non empty queries for efficiency.
     limit: Max number of results to return per category
 
     Returns a list of asset names to be used when executing Hyperliquid orders.

--- a/wayfinder_paths/mcp/tools/hyperliquid.py
+++ b/wayfinder_paths/mcp/tools/hyperliquid.py
@@ -1047,10 +1047,34 @@ async def hyperliquid_get_state(label: str) -> dict[str, Any]:
     )
 
 
-async def hyperliquid_get_mid_prices() -> dict[str, Any]:
+async def hyperliquid_search_mid_prices(
+    asset_names: list[str] | None = None,
+) -> dict[str, Any]:
+    """
+    Search Hyperliquid perpetual, spot, hip3 perpetual and hip4 outcome markets for current mid prices.
+
+    asset_names: Canonical market paths to filter for (e.g. "BTC-USDC", "xyz:NVDA",
+        "KNTQ/USDH", "#40"). If omitted, returns every market's mid price.
+    """
     adapter = HyperliquidAdapter()
-    success, data = await adapter.get_all_mid_prices()
-    return ok({"success": success, "prices": data})
+    success, prices = await adapter.get_all_mid_prices()
+    if not asset_names:
+        return ok({"success": success, "prices": prices})
+
+    filtered: dict[str, str] = {}
+    unresolved: list[str] = []
+    for name in asset_names:
+        asset_id = await adapter.get_asset_id(name)
+        if asset_id is None:
+            unresolved.append(name)
+            continue
+        for key in adapter.get_mid_price_key(name, asset_id):
+            if (mid := prices.get(key)) is not None:
+                filtered[name] = mid
+                break
+        else:
+            unresolved.append(name)
+    return ok({"success": success, "prices": filtered, "unresolved": unresolved})
 
 
 async def hyperliquid_search_market(query: str, limit: int = 10) -> dict[str, Any]:

--- a/wayfinder_paths/tests/test_mcp_hyperliquid_mid_prices.py
+++ b/wayfinder_paths/tests/test_mcp_hyperliquid_mid_prices.py
@@ -69,7 +69,6 @@ async def test_search_mid_prices_unfiltered():
     res = await hyperliquid_search_mid_prices()
     assert res["ok"] and res["result"]["success"]
     assert len(res["result"]["prices"]) > 100
-    assert "unresolved" not in res["result"]
 
 
 @pytest.mark.asyncio
@@ -83,8 +82,7 @@ async def test_search_mid_prices_filter_mixed_markets():
     res = await hyperliquid_search_mid_prices(
         ["BTC-USDC", "xyz:NVDA", "KNTQ/USDH", hip4, "BOGUS"],
     )
-    assert res["ok"] and res["result"]["success"]
+    assert res["ok"]
     prices = res["result"]["prices"]
-    assert {"BTC-USDC", "xyz:NVDA", "KNTQ/USDH", hip4} <= prices.keys()
+    assert {"BTC-USDC", "xyz:NVDA", "KNTQ/USDH", hip4} == prices.keys()
     assert all(float(prices[k]) > 0 for k in prices)
-    assert res["result"]["unresolved"] == ["BOGUS"]

--- a/wayfinder_paths/tests/test_mcp_hyperliquid_mid_prices.py
+++ b/wayfinder_paths/tests/test_mcp_hyperliquid_mid_prices.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import pytest
 
 from wayfinder_paths.adapters.hyperliquid_adapter import HyperliquidAdapter
+from wayfinder_paths.mcp.tools.hyperliquid import hyperliquid_search_mid_prices
 
 
 async def _resolved_mid(asset_name: str) -> float | None:
@@ -61,3 +62,29 @@ async def test_mid_price_hip4_outcome():
 
     mid = await _resolved_mid(book_coin)
     assert mid is not None and mid > 0
+
+
+@pytest.mark.asyncio
+async def test_search_mid_prices_unfiltered():
+    res = await hyperliquid_search_mid_prices()
+    assert res["ok"] and res["result"]["success"]
+    assert len(res["result"]["prices"]) > 100
+    assert "unresolved" not in res["result"]
+
+
+@pytest.mark.asyncio
+async def test_search_mid_prices_filter_mixed_markets():
+    # Pick a HIP-4 outcome that's currently on book.
+    adapter = HyperliquidAdapter()
+    ok_outs, outcomes = await adapter.get_outcome_markets()
+    assert ok_outs and outcomes
+    hip4 = outcomes[0]["sides"][0]["book_coin"]
+
+    res = await hyperliquid_search_mid_prices(
+        ["BTC-USDC", "xyz:NVDA", "KNTQ/USDH", hip4, "BOGUS"],
+    )
+    assert res["ok"] and res["result"]["success"]
+    prices = res["result"]["prices"]
+    assert {"BTC-USDC", "xyz:NVDA", "KNTQ/USDH", hip4} <= prices.keys()
+    assert all(float(prices[k]) > 0 for k in prices)
+    assert res["result"]["unresolved"] == ["BOGUS"]


### PR DESCRIPTION
## Summary

- Renames `hyperliquid_get_mid_prices` → `hyperliquid_search_mid_prices` to match sibling `hyperliquid_search_market`.
- Adds optional `asset_names: list[str]` filter so callers can fetch mids for specific canonical paths instead of the full ~700-key feed.
- Resolution reuses `HyperliquidAdapter.get_asset_id` + `get_mid_price_key`, so perp / hip3 / spot / hip4 all work without per-type branching.
- Misses come back in an `unresolved` list rather than failing the call.

## Test plan

- [x] `poetry run pytest wayfinder_paths/tests/test_mcp_hyperliquid_mid_prices.py` (7 passing, live)
  - existing per-market-type adapter coverage (perp / hip3 / spot KNTQ / spot PURR-grandfathered / hip4)
  - new `test_search_mid_prices_unfiltered` — no-arg returns full feed
  - new `test_search_mid_prices_filter_mixed_markets` — perp + hip3 + spot + live hip4 + unresolved
- [x] `poetry run ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)