### PR TITLE
MCP - Docstring for onchain_get_wallet_activity

### DIFF
--- a/wayfinder_paths/mcp/tools/wallets.py
+++ b/wayfinder_paths/mcp/tools/wallets.py
@@ -496,6 +496,11 @@ async def core_get_wallets(label: str | None = None) -> dict[str, Any]:
 
 @catch_errors
 async def onchain_get_wallet_activity(label: str) -> dict[str, Any]:
+    """Return the last 20 on-chain transactions for a wallet across supported chains.
+
+    Args:
+        label: Wallet label as configured in config.json, e.g. main.
+    """
     w = await find_wallet_by_label(label)
     if not w:
         return err("not_found", f"Wallet not found: {label}")


### PR DESCRIPTION
## Summary
- `onchain_get_wallet_activity` was the last registered MCP tool without a docstring.
- Adds a one-sentence summary + `Args:` block, matching the style used in `tokens.py` and elsewhere.

## Test plan
- [x] Audit script (AST scan over registered tools in `server.py`) confirms 0 missing docstrings after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)