### PR TITLE
HL - Note USDC-only on spot↔perp transfer actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,8 @@ Hyperliquid minimums:
 
 Hyperliquid surfaces in the adapter/MCP: perp, spot, HIP-3 builder-deployed perp dexes (`xyz`/`flx`/`vntl`/`hyna`/`km`...), and HIP-4 outcome markets (binary/multi-outcome prediction contracts). Outcomes use a separate asset-id space (`100_000_000 + 10*outcome_id + side`) and integer contract sizes; **settle in USDH** (token 360), not USDC; settle daily at 06:00 UTC; written via `hyperliquid_execute(action="place_outcome_order", ...)`. See `/using-hyperliquid-adapter` rules for details.
 
+Hyperliquid spot_to_perp_transfer and perp_to_spot_transfer only work with USDC spot to/from USDC perps. Other USD stables will need to be converted first.
+
 **Outcome / prediction markets — search both venues, let the user pick.** When a user mentions "outcome market" or "prediction market" without naming the platform, **search both venues in parallel** and present candidates side-by-side so the user can choose. Two venues:
 
 - **Hyperliquid HIP-4** — daily binary price contracts settled in USDH on the HL L1; rotating daily lineup. Search via `mcp__wayfinder__hyperliquid_search_market(query=...)` (read the `outcomes` bucket).

--- a/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
+++ b/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
@@ -1054,7 +1054,6 @@ class HyperliquidAdapter(BaseAdapter):
         amount: float,
         address: str,
     ) -> tuple[bool, dict[str, Any]]:
-        """USDC only — no other spot tokens (HYPE, USDH, etc.) move via this action."""
         return await self._usd_class_transfer(
             amount=amount, address=address, to_perp=True
         )
@@ -1064,7 +1063,6 @@ class HyperliquidAdapter(BaseAdapter):
         amount: float,
         address: str,
     ) -> tuple[bool, dict[str, Any]]:
-        """USDC only — no other spot tokens (HYPE, USDH, etc.) move via this action."""
         return await self._usd_class_transfer(
             amount=amount, address=address, to_perp=False
         )

--- a/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
+++ b/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
@@ -1054,6 +1054,7 @@ class HyperliquidAdapter(BaseAdapter):
         amount: float,
         address: str,
     ) -> tuple[bool, dict[str, Any]]:
+        """USDC only — no other spot tokens (HYPE, USDH, etc.) move via this action."""
         return await self._usd_class_transfer(
             amount=amount, address=address, to_perp=True
         )
@@ -1063,6 +1064,7 @@ class HyperliquidAdapter(BaseAdapter):
         amount: float,
         address: str,
     ) -> tuple[bool, dict[str, Any]]:
+        """USDC only — no other spot tokens (HYPE, USDH, etc.) move via this action."""
         return await self._usd_class_transfer(
             amount=amount, address=address, to_perp=False
         )

--- a/wayfinder_paths/mcp/tools/hyperliquid.py
+++ b/wayfinder_paths/mcp/tools/hyperliquid.py
@@ -146,6 +146,7 @@ async def hyperliquid_execute(
         (≥ 5 USDC; below is lost). Auto-waits for the perp clearinghouse credit before returning.
       - `withdraw`: bridge `amount_usdc` from perp account back to Arbitrum.
       - `spot_to_perp_transfer` / `perp_to_spot_transfer`: shift `usd_amount` between sub-accounts.
+        USDC only — no other spot tokens (HYPE, USDH, etc.) move via this action.
     """
     wallet_label = throw_if_empty_str("wallet_label is required", wallet_label)
 

--- a/wayfinder_paths/mcp/tools/hyperliquid.py
+++ b/wayfinder_paths/mcp/tools/hyperliquid.py
@@ -146,7 +146,7 @@ async def hyperliquid_execute(
         (≥ 5 USDC; below is lost). Auto-waits for the perp clearinghouse credit before returning.
       - `withdraw`: bridge `amount_usdc` from perp account back to Arbitrum.
       - `spot_to_perp_transfer` / `perp_to_spot_transfer`: shift `usd_amount` between sub-accounts.
-        USDC only — no other spot tokens (HYPE, USDH, etc.) move via this action.
+        Only works with USDC spot to/from USDC perps. Other USD stables (USDH, etc.) must be converted first.
     """
     wallet_label = throw_if_empty_str("wallet_label is required", wallet_label)
 


### PR DESCRIPTION
## Summary
- `spot_to_perp_transfer` / `perp_to_spot_transfer` only move USDC between sub-accounts. Spot-only assets like HYPE or USDH cannot be transferred this way.
- Adds a one-line note to both the MCP `hyperliquid_execute` action docs and the underlying `HyperliquidAdapter.transfer_spot_to_perp` / `transfer_perp_to_spot` methods.

## Test plan
- [x] Docstring-only change, no behavior diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)