### PR TITLE
HL - Migrate from dexAbstraction to UnifiedAccount mode

### DIFF
--- a/.claude/skills/using-hyperliquid-adapter/rules/gotchas.md
+++ b/.claude/skills/using-hyperliquid-adapter/rules/gotchas.md
@@ -13,11 +13,11 @@ Constants available in `wayfinder_paths.core.constants.hyperliquid`:
 - `MIN_DEPOSIT_USD = 5.0`
 - `MIN_ORDER_USD_NOTIONAL = 10.0`
 
-## HIP-3 dex abstraction
+## HIP-3 collateral via UnifiedAccount
 
-Trading on HIP-3 dexes (xyz, flx, vntl, hyna, km, etc.) requires **dex abstraction** enabled on the account. Without it, orders on non-default dexes fail with "Insufficient margin" or similar errors.
+Trading on HIP-3 dexes (xyz, flx, vntl, hyna, km, etc.) requires **UnifiedAccount mode** enabled on the account. Without it, orders on non-default dexes fail with "Insufficient margin" or similar errors.
 
-- The adapter auto-enables this before `place_market_order`, `place_limit_order`, and `place_trigger_order` via `ensure_dex_abstraction(address)`.
+- The adapter auto-enables this before `place_market_order`, `place_limit_order`, `place_tp_sl_order`, and `place_outcome_order` via `ensure_unified_account(address)`.
 - One-time on-chain action per account — once enabled, it stays enabled.
 - HIP-3 asset IDs use offsets: first builder dex starts at 110000, then 120000, 130000, etc.
 - HIP-3 coin names are prefixed: `xyz:NVDA`, `vntl:SPACEX`, `hyna:BTC`, etc.

--- a/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
+++ b/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
@@ -1292,19 +1292,8 @@ class HyperliquidAdapter(BaseAdapter):
         return success, result
 
     async def ensure_unified_account(self, address: str) -> tuple[bool, str]:
-        # /info userAbstraction returns the current mode string. Anything other
-        # than "unifiedAccount" (including legacy dex-abstraction wallets that
-        # still report "disabled") triggers a one-time userSetAbstraction sign.
-        try:
-            state = get_info().query_user_abstraction_state(address)
-            if isinstance(state, dict):
-                state = state.get("abstraction") or state.get("mode")
-            if state == "unifiedAccount":
-                return True, "Unified account already enabled"
-        except Exception as exc:
-            logger.warning(
-                f"Failed to query account abstraction state: {exc}, proceeding with set"
-            )
+        if get_info().query_user_abstraction_state(address) == "unifiedAccount":
+            return True, "Unified account already enabled"
 
         ok, result = await self.set_account_abstraction(address, "unifiedAccount")
         if ok:

--- a/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
+++ b/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
@@ -24,7 +24,7 @@ from hyperliquid.utils.signing import (
     order_wires_to_order_action,
     user_signed_payload,
 )
-from hyperliquid.utils.types import OUTCOME_ASSET_OFFSET, BuilderInfo
+from hyperliquid.utils.types import OUTCOME_ASSET_OFFSET, Abstraction, BuilderInfo
 from loguru import logger
 
 from wayfinder_paths.adapters.hyperliquid_adapter.info import get_info, get_perp_dexes
@@ -1268,7 +1268,7 @@ class HyperliquidAdapter(BaseAdapter):
     async def set_account_abstraction(
         self,
         address: str,
-        mode: Literal["unifiedAccount", "portfolioMargin", "disabled"],
+        mode: Abstraction,
     ) -> tuple[bool, dict[str, Any]]:
         nonce = get_timestamp_ms()
         action = {

--- a/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
+++ b/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
@@ -13,7 +13,7 @@ from hyperliquid.utils.signing import (
     BUILDER_FEE_SIGN_TYPES,
     SPOT_TRANSFER_SIGN_TYPES,
     USD_CLASS_TRANSFER_SIGN_TYPES,
-    USER_DEX_ABSTRACTION_SIGN_TYPES,
+    USER_SET_ABSTRACTION_SIGN_TYPES,
     WITHDRAW_SIGN_TYPES,
     OrderType,
     OrderWire,
@@ -165,7 +165,10 @@ class HyperliquidAdapter(BaseAdapter):
 
     def _get_price_decimals(self, asset_id: int) -> int:
         is_spot = asset_id >= 10_000
-        return (6 if not is_spot else 8) - self.get_sz_decimals(asset_id)
+        max_decimals = 6 if not is_spot else 8
+        if asset_id >= OUTCOME_ASSET_OFFSET:
+            max_decimals = 8
+        return max_decimals - self.get_sz_decimals(asset_id)
 
     def _sig_hex_to_hl_signature(self, sig_hex: str) -> dict[str, Any]:
         """Convert a 65-byte hex signature into Hyperliquid {r,s,v}."""
@@ -580,6 +583,8 @@ class HyperliquidAdapter(BaseAdapter):
                 return [asset_name]
 
     def get_sz_decimals(self, asset_id: int) -> int:
+        if asset_id >= OUTCOME_ASSET_OFFSET:
+            return 0
         try:
             return self.asset_to_sz_decimals[asset_id]
         except KeyError:
@@ -661,7 +666,7 @@ class HyperliquidAdapter(BaseAdapter):
         builder: dict[str, Any] | None = None,
     ) -> tuple[bool, dict[str, Any]]:
         builder_fee = self._mandatory_builder_fee(builder)
-        await self.ensure_dex_abstraction(address)
+        await self.ensure_unified_account(address)
         await self.ensure_builder_fee_approved(address, builder_fee)
 
         asset_name = get_info().asset_to_coin[asset_id]
@@ -771,7 +776,7 @@ class HyperliquidAdapter(BaseAdapter):
                 "status": "err",
                 "error": f"size must be a positive integer number of contracts, got {size}",
             }
-        await self.ensure_dex_abstraction(address)
+        await self.ensure_unified_account(address)
 
         asset_id = outcome_asset_id(outcome_id, side)
         book_coin = outcome_book_coin(outcome_id, side)
@@ -1080,7 +1085,7 @@ class HyperliquidAdapter(BaseAdapter):
         builder: dict[str, Any] | None = None,
     ) -> tuple[bool, dict[str, Any]]:
         builder_fee = self._mandatory_builder_fee(builder)
-        await self.ensure_dex_abstraction(address)
+        await self.ensure_unified_account(address)
         await self.ensure_builder_fee_approved(address, builder_fee)
         builder_info = BuilderInfo(b=builder_fee.get("b"), f=builder_fee.get("f"))
 
@@ -1260,21 +1265,23 @@ class HyperliquidAdapter(BaseAdapter):
         success = result.get("status") == "ok"
         return success, result
 
-    async def set_dex_abstraction(
-        self, address: str, enabled: bool
+    async def set_account_abstraction(
+        self,
+        address: str,
+        mode: Literal["unifiedAccount", "portfolioMargin", "disabled"],
     ) -> tuple[bool, dict[str, Any]]:
         nonce = get_timestamp_ms()
         action = {
             "hyperliquidChain": MAINNET,
             "signatureChainId": ARBITRUM_CHAIN_ID,
             "user": address.lower(),
-            "enabled": enabled,
+            "abstraction": mode,
             "nonce": nonce,
-            "type": "userDexAbstraction",
+            "type": "userSetAbstraction",
         }
         payload = user_signed_payload(
-            "HyperliquidTransaction:UserDexAbstraction",
-            USER_DEX_ABSTRACTION_SIGN_TYPES,
+            "HyperliquidTransaction:UserSetAbstraction",
+            USER_SET_ABSTRACTION_SIGN_TYPES,
             action,
         )
         if not (sig := await self._sign(payload, action, address)):
@@ -1284,20 +1291,25 @@ class HyperliquidAdapter(BaseAdapter):
         success = result.get("status") == "ok"
         return success, result
 
-    async def ensure_dex_abstraction(self, address: str) -> tuple[bool, str]:
+    async def ensure_unified_account(self, address: str) -> tuple[bool, str]:
+        # /info userAbstraction returns the current mode string. Anything other
+        # than "unifiedAccount" (including legacy dex-abstraction wallets that
+        # still report "disabled") triggers a one-time userSetAbstraction sign.
         try:
-            state = get_info().query_user_dex_abstraction_state(address)
-            if state:
-                return True, "Dex abstraction already enabled"
+            state = get_info().query_user_abstraction_state(address)
+            if isinstance(state, dict):
+                state = state.get("abstraction") or state.get("mode")
+            if state == "unifiedAccount":
+                return True, "Unified account already enabled"
         except Exception as exc:
             logger.warning(
-                f"Failed to query dex abstraction state: {exc}, proceeding with enable"
+                f"Failed to query account abstraction state: {exc}, proceeding with set"
             )
 
-        ok, result = await self.set_dex_abstraction(address, enabled=True)
+        ok, result = await self.set_account_abstraction(address, "unifiedAccount")
         if ok:
-            return True, "Dex abstraction enabled"
-        return False, f"Failed to enable dex abstraction: {result}"
+            return True, "Unified account enabled"
+        return False, f"Failed to enable unified account: {result}"
 
     async def ensure_builder_fee_approved(
         self,
@@ -1347,7 +1359,7 @@ class HyperliquidAdapter(BaseAdapter):
         cloid: str | None = None,
     ) -> tuple[bool, dict[str, Any]]:
         builder_fee = self._mandatory_builder_fee(builder)
-        await self.ensure_dex_abstraction(address)
+        await self.ensure_unified_account(address)
         await self.ensure_builder_fee_approved(address, builder_fee)
         order_actions = self._create_hypecore_order_actions(
             asset_id,

--- a/wayfinder_paths/adapters/hyperliquid_adapter/test_exchange_mid_prices.py
+++ b/wayfinder_paths/adapters/hyperliquid_adapter/test_exchange_mid_prices.py
@@ -19,8 +19,8 @@ class _InfoStub(SimpleNamespace):
                 return 0
         return {"status": "ok"}
 
-    def query_user_dex_abstraction_state(self, user):
-        return True
+    def query_user_abstraction_state(self, user):
+        return "unifiedAccount"
 
     @property
     def asset_to_sz_decimals(self):


### PR DESCRIPTION
## Summary
- Replace `userDexAbstraction` (bool) with `userSetAbstraction` (mode literal: `unifiedAccount` | `portfolioMargin` | `disabled`); rename `set_dex_abstraction` → `set_account_abstraction`, `ensure_dex_abstraction` → `ensure_unified_account`. Order entrypoints (`place_market_order`, `place_outcome_order`, `place_tp_sl_order`, `place_limit_order`) now call `ensure_unified_account`, auto-migrating legacy wallets on their next order via the new `/info userAbstraction` query.
- Outcome-asset decimals: pin `sz_decimals=0` and `price max_decimals=8` for `asset_id >= OUTCOME_ASSET_OFFSET` so HIP-4 books quote correctly.

## Why UnifiedAccount

Per [HL docs](https://hyperliquid.gitbook.io/hyperliquid-docs/trading/account-abstraction-modes), dex abstraction is being deprecated. UnifiedAccount unifies spot + cross-margin per asset:
- USDC unifies validator perps + xyz perps + USDC spot
- USDH unifies KM/FLX/VNTL perps + USDH spot + HIP-4 outcome shares
- USDe spot becomes collateral for USDe-quoted markets
- HIP-3 perp dexes draw collateral from whichever spot token they're denominated in

## Builder fees stay wired

Per HL docs (verbatim): *"Builder code addresses must be in Standard mode to accrue builder fees."* The restriction is on the **recipient** wallet (`HYPE_FEE_WALLET`), not the trader. Traders in UnifiedAccount can still pay builder fees on orders, so `_mandatory_builder_fee` + `ensure_builder_fee_approved` are unchanged. Operational note: keep the builder recipient in Standard.

## Empirical sample (current `main` wallet, dexAbstraction mode)

Captured to inform the read-path scope decision:
- `/info userAbstraction` → `"dexAbstraction"` (legacy bool still returns `True`)
- Per-dex `clearinghouseState` returns the standard schema across `[validator, xyz, flx, vntl, hyna, km, abcd, cash, para]` — currently zero positions everywhere; schema intact regardless of mode
- `spotClearinghouseState.balances` already carries spot tokens (USDC/USDE/USDH/KNTQ/HYPE), perp-dex tokens, and outcome shares (e.g. `+120: 15.0`)
- `portfolio` is non-dict

## Read paths NOT touched in this PR (follow-up)

`get_user_state` aggregates `clearinghouseState` across all perp dexes via `_post_across_dexes`. Per HL: *"For API users, unified account and portfolio margin shows all balances and holds in the spot clearinghouse state. Individual perp dex user states are not meaningful."* The per-dex schema still parses in unified mode — `marginSummary`/`withdrawable` just reflect a per-dex local view rather than the unified collateral pool. Strategies that aggregate-and-`min()` across dexes (boros_hype_strategy) remain correctness-safe (conservative under-estimate). To rewrite reads against the empirical unified-mode shape, sample a flipped wallet first. Affected sites:
- `wayfinder_paths/adapters/hyperliquid_adapter/adapter.py:1391, 1417, 1450, 1739, 1750`
- `wayfinder_paths/adapters/hyperliquid_adapter/paired_filler.py:217`
- `wayfinder_paths/strategies/boros_hype_strategy/hyperliquid_ops_mixin.py:339, 444, 510, 850`
- `wayfinder_paths/strategies/boros_hype_strategy/withdraw_mixin.py:596, 731, 796, 1036`
- `wayfinder_paths/strategies/boros_hype_strategy/snapshot_mixin.py:101`

## Other considerations

- UnifiedAccount has a 50,000 actions/day soft cap (vs. unlimited in Standard). Fine for current strategies; relevant only to HFT.
- HIP-4 outcomes (USDH-collateralized) work natively because UnifiedAccount unifies USDH spot with the HL L1 holding.
- Migration is one-time per wallet (one `userSetAbstraction` signature on the next order). Idempotent on repeat calls.

## Test plan
- [x] Existing `test_exchange_mid_prices.py` updated and passing (info-stub method renamed to `query_user_abstraction_state`).
- [ ] Manually flip one wallet to `unifiedAccount` on next order placement; verify the signature flow lands and orders fill.
- [ ] Sample `clearinghouseState` (per-dex) and `spotClearinghouseState` post-flip to confirm read-path assumptions; track follow-up PR if shapes warrant a refactor.
- [ ] Confirm `HYPE_FEE_WALLET` is in Standard mode so builder fees keep accruing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)