### PR TITLE
HL - Attach builder code to outcome orders

### DIFF
--- a/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
+++ b/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
@@ -833,12 +833,19 @@ class HyperliquidAdapter(BaseAdapter):
         tif: Literal["Ioc", "Gtc"] = "Ioc",
         reduce_only: bool = False,
         cloid: str | None = None,
+        builder: dict[str, Any] | None = None,
     ) -> tuple[bool, dict[str, Any]]:
         """Place an outcome order. Reuses the existing wire/sign/broadcast path.
 
-        HIP-4 ships zero-fee — no builder is sent. Sizes are integer contracts
-        (szDecimals=0). When `price` is omitted, anchor on the live mid via
-        `allMids()` and apply slippage.
+        Sizes are integer contracts (szDecimals=0; size=1 is the floor).
+        When `price` is omitted, anchor on the live mid via `allMids()` and
+        apply slippage.
+
+        HIP-4 protocol fees are zero during initial testing, but per the
+        HIP-4 spec "builder codes do work the same as normal spot trading,
+        where builders earn builder fees on sell orders that specify their
+        builder code." We attach the standard Wayfinder builder code on
+        every outcome order; HL accrues the fee on the sell side.
         """
         if side not in (0, 1):
             return False, {"status": "err", "error": f"side must be 0 or 1, got {side}"}
@@ -852,7 +859,9 @@ class HyperliquidAdapter(BaseAdapter):
                 "status": "err",
                 "error": f"size must be a positive integer number of contracts, got {size}",
             }
+        builder_fee = self._mandatory_builder_fee(builder)
         await self.ensure_unified_account(address)
+        await self.ensure_builder_fee_approved(address, builder_fee)
 
         asset_id = outcome_asset_id(outcome_id, side)
         book_coin = outcome_book_coin(outcome_id, side)
@@ -877,7 +886,7 @@ class HyperliquidAdapter(BaseAdapter):
             int(size),
             reduce_only,
             {"limit": {"tif": tif}},
-            None,  # HIP-4 zero-fee; no builder
+            BuilderInfo(b=builder_fee.get("b"), f=builder_fee.get("f")),
             cloid,
         )
         result = await self._sign_and_broadcast_hypecore(order_actions, address)


### PR DESCRIPTION
## Summary
Per HIP-4: *"Fees are currently zero for outcome markets for initial testing. However, builder codes do work the same as normal spot trading, where builders earn builder fees on sell orders that specify their builder code."*

We were leaving builder-fee revenue on the table — `place_outcome_order` was passing `None` for the builder with a comment claiming HIP-4 is "zero-fee". Protocol fees are zero, but builder codes still accrue. This PR threads the standard Wayfinder builder code through outcome orders the same way we do for perps/spot.

## Change
- `place_outcome_order` gains a `builder: dict[str, Any] | None = None` arg (matching `place_market_order` / `place_limit_order` / `place_tp_sl_order`).
- Runs `_mandatory_builder_fee(builder)` and `ensure_builder_fee_approved(...)` before placing.
- `_create_hypecore_order_actions` now receives `BuilderInfo(b=..., f=...)` instead of `None`.
- Docstring updated to capture the HIP-4 quote and the sell-side accrual rule.

## Sizing note
`size=1` remains the floor for outcome orders (szDecimals=0 → integer contracts only). Adapter-level validation already accepts `size > 0`, and the MCP layer at `tools/hyperliquid.py:551` does `max(1, round(usd_amount / mid))` when sizing from a USD amount, so the floor is preserved.

## Operational note
HL accrues the fee specifically on **sell orders** that include the builder code. We attach uniformly on both sides — buy-side codes are accepted by HL but don't accrue (per spec). Recipient wallet `HYPE_FEE_WALLET` must remain in Standard account-abstraction mode (already required for perps).

## Test plan
- [x] Existing adapter + MCP search + mid-price tests pass (13 tests).
- [ ] Place a real outcome order (size=1) on mainnet with the builder code attached; confirm acceptance and that no extra cost shows up to the trader (zero protocol fee + builder fee already approved).
- [ ] After a sell-side outcome trade, verify the builder fee accrues to `HYPE_FEE_WALLET`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)