### PR TITLE
[WAYST-175] Add SMS option to Shells notify client

### DIFF
--- a/wayfinder_paths/core/clients/NotifyClient.py
+++ b/wayfinder_paths/core/clients/NotifyClient.py
@@ -6,12 +6,29 @@ from wayfinder_paths.core.clients.WayfinderClient import WayfinderClient
 from wayfinder_paths.core.config import get_api_base_url
 
 
+def normalize_notify_delivery(delivery: str | None) -> str:
+    value = str(delivery or "email").strip().lower()
+    if value == "text":
+        value = "sms"
+    if value not in {"email", "sms"}:
+        raise ValueError("delivery must be one of: email, sms, text")
+    return value
+
+
 class NotifyClient(WayfinderClient):
-    async def notify(self, title: str, message: str) -> dict[str, Any]:
+    async def notify(
+        self,
+        title: str,
+        message: str,
+        *,
+        delivery: str = "email",
+    ) -> dict[str, Any]:
         url = f"{get_api_base_url()}/opencode/notify/"
-        response = await self._authed_request(
-            "POST", url, json={"title": title, "message": message}
-        )
+        delivery_normalized = normalize_notify_delivery(delivery)
+        payload = {"title": title, "message": message}
+        if delivery_normalized != "email":
+            payload["delivery"] = delivery_normalized
+        response = await self._authed_request("POST", url, json=payload)
         return response.json()
 
 

--- a/wayfinder_paths/mcp/tools/notify.py
+++ b/wayfinder_paths/mcp/tools/notify.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import httpx
 
-from wayfinder_paths.core.clients.NotifyClient import NOTIFY_CLIENT
+from wayfinder_paths.core.clients.NotifyClient import (
+    NOTIFY_CLIENT,
+    normalize_notify_delivery,
+)
 from wayfinder_paths.mcp.utils import catch_errors, err, ok, throw_if_empty_str
 
 TITLE_MAX = 200
@@ -10,15 +13,16 @@ MESSAGE_MAX = 20_000
 
 
 @catch_errors
-async def shells_notify(title: str, message: str) -> dict:
-    """Email the OpenCode instance owner (verified email only).
+async def shells_notify(title: str, message: str, delivery: str = "email") -> dict:
+    """Notify the OpenCode instance owner by email or SMS.
 
-    The message is rendered from Markdown into a themed HTML email on
-    vault-backend. Use headings, lists, code blocks, links, etc.
+    Email requires a verified email address and renders Markdown into a themed
+    HTML email. SMS requires a verified phone number and sends plain text.
 
     Args:
         title: Short subject line (<= 200 chars).
         message: Markdown body (<= 20 000 chars).
+        delivery: "email" (default), "sms", or "text".
     """
     title_s = throw_if_empty_str("title is required", title)
     if len(title_s) > TITLE_MAX:
@@ -26,9 +30,17 @@ async def shells_notify(title: str, message: str) -> dict:
     throw_if_empty_str("message is required", message)
     if len(message) > MESSAGE_MAX:
         raise ValueError(f"message exceeds {MESSAGE_MAX} chars")
+    try:
+        delivery_s = normalize_notify_delivery(delivery)
+    except ValueError as exc:
+        return err("invalid_request", str(exc))
 
     try:
-        data = await NOTIFY_CLIENT.notify(title=title_s, message=message)
+        data = await NOTIFY_CLIENT.notify(
+            title=title_s,
+            message=message,
+            delivery=delivery_s,
+        )
     except httpx.HTTPStatusError as exc:
         try:
             body = exc.response.json()

--- a/wayfinder_paths/tests/test_notify_client.py
+++ b/wayfinder_paths/tests/test_notify_client.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import importlib
+from unittest.mock import AsyncMock
+
+import pytest
+
+from wayfinder_paths.core.clients.NotifyClient import (
+    NotifyClient,
+    normalize_notify_delivery,
+)
+
+
+class _Response:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+notify_client_module = importlib.import_module(
+    "wayfinder_paths.core.clients.NotifyClient"
+)
+notify_tool_module = importlib.import_module("wayfinder_paths.mcp.tools.notify")
+
+
+@pytest.mark.asyncio
+async def test_notify_client_default_email_payload_omits_delivery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        notify_client_module,
+        "get_api_base_url",
+        lambda: "https://example.com/api/v1",
+    )
+    client = NotifyClient()
+    client._authed_request = AsyncMock(return_value=_Response({"sent": True}))  # type: ignore[method-assign]
+
+    out = await client.notify(title="Alert", message="Body")
+
+    assert out == {"sent": True}
+    client._authed_request.assert_awaited_once()
+    args, kwargs = client._authed_request.await_args
+    assert args == ("POST", "https://example.com/api/v1/opencode/notify/")
+    assert kwargs["json"] == {"title": "Alert", "message": "Body"}
+
+
+@pytest.mark.asyncio
+async def test_notify_client_text_alias_requests_sms(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        notify_client_module,
+        "get_api_base_url",
+        lambda: "https://example.com/api/v1",
+    )
+    client = NotifyClient()
+    client._authed_request = AsyncMock(return_value=_Response({"sent": True}))  # type: ignore[method-assign]
+
+    await client.notify(title="Alert", message="Body", delivery="text")
+
+    assert client._authed_request.await_args.kwargs["json"] == {
+        "title": "Alert",
+        "message": "Body",
+        "delivery": "sms",
+    }
+
+
+def test_normalize_notify_delivery_rejects_unknown_delivery() -> None:
+    with pytest.raises(ValueError):
+        normalize_notify_delivery("fax")
+
+
+@pytest.mark.asyncio
+async def test_shells_notify_passes_sms_delivery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_client = AsyncMock()
+    fake_client.notify.return_value = {"sent": True, "delivery": "sms"}
+    monkeypatch.setattr(notify_tool_module, "NOTIFY_CLIENT", fake_client)
+
+    out = await notify_tool_module.shells_notify("Alert", "Body", delivery="text")
+
+    assert out == {"ok": True, "result": {"sent": True, "delivery": "sms"}}
+    fake_client.notify.assert_awaited_once_with(
+        title="Alert",
+        message="Body",
+        delivery="sms",
+    )
+
+
+@pytest.mark.asyncio
+async def test_shells_notify_rejects_invalid_delivery() -> None:
+    out = await notify_tool_module.shells_notify("Alert", "Body", delivery="fax")
+
+    assert out["ok"] is False
+    assert out["error"]["code"] == "invalid_request"


### PR DESCRIPTION
## Summary
- add optional `delivery` support to `NotifyClient.notify`, defaulting to the existing email payload
- normalize `text` to `sms` for the backend notify endpoint
- expose the same option through the `shells_notify` MCP tool
- add focused client/tool tests for the new delivery passthrough

## Dependency
- Pairs with the WAYST-175 backend PR for `/api/v1/opencode/notify/` SMS delivery. Default email behavior remains compatible with the current backend.

## Validation
- `POETRY_VIRTUALENVS_IN_PROJECT=true POETRY_CACHE_DIR=/private/tmp/poetry-cache poetry install`
- `POETRY_VIRTUALENVS_IN_PROJECT=true POETRY_CACHE_DIR=/private/tmp/poetry-cache poetry run pytest wayfinder_paths/tests/test_notify_client.py` -> 5 passed, 238 warnings
- `POETRY_VIRTUALENVS_IN_PROJECT=true POETRY_CACHE_DIR=/private/tmp/poetry-cache poetry run ruff check wayfinder_paths/core/clients/NotifyClient.py wayfinder_paths/mcp/tools/notify.py wayfinder_paths/tests/test_notify_client.py`
- `POETRY_VIRTUALENVS_IN_PROJECT=true POETRY_CACHE_DIR=/private/tmp/poetry-cache poetry run ruff format --check wayfinder_paths/core/clients/NotifyClient.py wayfinder_paths/mcp/tools/notify.py wayfinder_paths/tests/test_notify_client.py`
- `git diff --check`