### PR TITLE
Reconcile hedge applet display snapshot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,8 @@ When creating or updating a Wayfinder pack with a browser applet:
   - prefer `wf:state.apiBase`
   - otherwise use the `wf:hello` origin when embedded by the Strategies host
   - do not probe both dev and prod from the same applet build
+- if the applet renders an execution result, render the run snapshot artifact instead of re-fetching browser data; if it intentionally shows live browser data, label it as `Applet: live as of HH:MM`
+- post `wf:state` with `state._meta.dataUpdatedAt` (ms epoch) whenever displayed applet data changes so hosts can show freshness next to CLI/run output
 - treat non-200 responses, especially `404`, as expected unavailability:
   - show a clear "data unavailable" or "waiting for host API" state
   - do not crash the applet on missing data

--- a/README.md
+++ b/README.md
@@ -331,6 +331,8 @@ For applet authors and agents:
 - do not probe both dev and prod from the same applet build
 - do not call `/api/v1/delta-lab/symbols/`; that route does not exist
 - use the public `.../public/assets/<symbol>/timeseries/` route for presentation data, and reserve authenticated Delta Lab routes for SDK/server-side use
+- if the applet renders an execution result, render the run snapshot artifact rather than re-fetching browser data; if it intentionally shows live browser data, label it as `Applet: live as of HH:MM`
+- post `wf:state` with `state._meta.dataUpdatedAt` (ms epoch) whenever displayed applet data changes so hosts can show freshness next to CLI/run output
 - treat non-200 responses, especially `404`, as expected unavailability and show a clear fallback UI instead of crashing the applet
 - make sure every referenced static asset exists under `applet/dist/`
 - include explicit `icon`, `shortcut icon`, and `apple-touch-icon` tags in the applet HTML to avoid implicit browser favicon 404s

--- a/wayfinder_paths/paths/pipeline.py
+++ b/wayfinder_paths/paths/pipeline.py
@@ -229,6 +229,7 @@ _ARCHETYPES: dict[str, PipelineArchetype] = {
             "skeptic",
             "risk_gate",
             "compile_job",
+            "display_compose",
             "finalize",
         ),
         default_edges=(
@@ -239,12 +240,13 @@ _ARCHETYPES: dict[str, PipelineArchetype] = {
             ("optimizer", "skeptic"),
             ("skeptic", "risk_gate"),
             ("risk_gate", "compile_job"),
-            ("compile_job", "finalize"),
+            ("compile_job", "display_compose"),
+            ("display_compose", "finalize"),
         ),
         default_failure_edges=(
             ("hedge_search", "retryable_error", "hedge_search", 1),
             ("optimizer", "failed", "skeptic", 0),
-            ("risk_gate", "failed", "finalize", 0),
+            ("risk_gate", "failed", "display_compose", 0),
         ),
         input_slots=(
             ArchetypeInputSlot(
@@ -304,6 +306,16 @@ _ARCHETYPES: dict[str, PipelineArchetype] = {
                 description="Compile the selected hedge into a draft or armed rebalance job.",
                 tools=("read", "glob", "grep", "bash"),
                 output_name="job.json",
+            ),
+            ArchetypeAgent(
+                agent_id="display-composer",
+                phase="display_compose",
+                description=(
+                    "Transform the selected hedge run artifacts into a "
+                    "display-ready snapshot for applets and console output."
+                ),
+                tools=("read", "glob", "grep", "bash"),
+                output_name="display.json",
             ),
         ),
     ),

--- a/wayfinder_paths/paths/scaffold.py
+++ b/wayfinder_paths/paths/scaffold.py
@@ -845,6 +845,44 @@ def _pipeline_instructions(slug: str, archetype: str) -> str:
             "   - `job`\n"
             "   - `next_invalidation`\n"
         )
+    if archetype == "hedge-finder":
+        return (
+            f"# {humanize_slug(slug)}\n\n"
+            "Use this skill when the user wants to hedge a multi-asset portfolio with "
+            "perpetuals or other available SDK surfaces while preserving one run "
+            "snapshot for console and applet output.\n\n"
+            "Read `references/pipeline.md`, `references/signals.md`, and "
+            "`references/risk.md` before starting.\n\n"
+            "Execution order:\n"
+            "1. Load `inputs/assets.yaml`, `inputs/constraints.yaml`, and "
+            "`policy/default.yaml`.\n"
+            "2. Run `exposure-reader`, `beta-modeler`, and `hedge-searcher`, "
+            "complete the optimizer phase from their artifacts, then run "
+            "`skeptic` -> `risk-verifier` -> `job-compiler` -> "
+            "`display-composer`.\n"
+            "3. Treat `.wf-artifacts/$RUN_ID/display.json` as the display "
+            "snapshot for both console summaries and applet dashboards.\n"
+            "4. Surface the same funding rates, notionals, leverage, and "
+            "market-quality values from `display.json`; do not recompute or "
+            "browser-refetch those values in the final answer.\n\n"
+            "Rules:\n"
+            "1. You are the only orchestrator.\n"
+            "2. Workers are leaf agents and must not spawn more agents.\n"
+            "3. Every worker writes exactly one artifact under `.wf-artifacts/$RUN_ID/`.\n"
+            "4. Never skip the null state, even when a hedge looks strong.\n"
+            "5. If market quality is weak or risk validation fails, degrade to "
+            "`draft` or `null`.\n"
+            "6. The final output must contain:\n"
+            "   - `signal_snapshot`\n"
+            "   - `selected_playbook`\n"
+            "   - `candidate_expressions`\n"
+            "   - `null_state`\n"
+            "   - `risk_checks`\n"
+            "   - `job`\n"
+            "   - `next_invalidation`\n"
+            "   - `display` — path to `.wf-artifacts/$RUN_ID/display.json`, "
+            "the authoritative rendered snapshot for this run\n"
+        )
     if archetype == "narrative-radar":
         return (
             f"# {humanize_slug(slug)}\n\n"
@@ -920,6 +958,31 @@ def _pipeline_reference_pipeline(archetype: str) -> str:
             "Artifact rule:\n"
             "- every worker owns exactly one JSON artifact under `.wf-artifacts/$RUN_ID/`\n"
             "- the orchestrator reads artifacts and owns final synthesis\n"
+        )
+    if archetype == "hedge-finder":
+        return (
+            "# Pipeline\n\n"
+            "This path finds hedge candidates for a multi-asset portfolio and "
+            "publishes one run snapshot for both console and applet views.\n\n"
+            "Ordered phases:\n"
+            "1. `intake` — load assets, constraints, and policy\n"
+            "2. `exposure_reader` — resolve symbols and build the portfolio series\n"
+            "3. `beta_modeler` — estimate factor betas and residual exposures\n"
+            "4. `hedge_search` — collect candidates with funding, spread, and liquidity context\n"
+            "5. `optimizer` — select hedge weights against residual beta and net cost\n"
+            "6. `skeptic` — compare selected hedges against the null state\n"
+            "7. `risk_gate` — apply notional, leverage, and execution protections\n"
+            "8. `compile_job` — compile a draft or armed rebalance job\n"
+            "9. `display_compose` — write `display.json`, the display snapshot "
+            "used by applets and console output\n"
+            "10. `finalize` — emit the standard response envelope including a "
+            "`display` pointer\n\n"
+            "Artifact rule:\n"
+            "- every worker owns exactly one JSON artifact under `.wf-artifacts/$RUN_ID/`\n"
+            "- `display.json` is the authoritative rendered snapshot for user-facing "
+            "funding rates, notionals, leverage, and hedge metrics\n"
+            "- if an applet intentionally performs a browser-side live refresh, it "
+            "must label the live timestamp separately from the run snapshot\n"
         )
     if archetype == "narrative-radar":
         return (
@@ -1113,6 +1176,157 @@ def _pipeline_agent_body(agent: ArchetypeAgent, *, archetype: str) -> str:
                 [
                     "Do not arm the job if the risk gate returned `draft` or `null`.",
                     "Write the final artifact only after validation passes.",
+                ],
+            ),
+        }
+        read_items, write_items, rules = instructions.get(
+            agent.agent_id,
+            ([], [], ["Stay inside your assigned phase."]),
+        )
+        lines = [f"# {agent.agent_id}", "", agent.description, "", "Read:"]
+        lines.extend(
+            [f"- {item}" for item in read_items]
+            or ["- only the inputs required for your phase"]
+        )
+        lines.extend(
+            [
+                "",
+                "Write:",
+                f"- exactly one JSON object to `{DEFAULT_ARTIFACTS_DIR}/$RUN_ID/{agent.output_name}`",
+            ]
+        )
+        lines.extend([f"- include {item}" for item in write_items])
+        lines.extend(
+            [
+                "",
+                "Rules:",
+                "- Do not spawn other agents.",
+                "- Do not compile the final answer.",
+            ]
+        )
+        lines.extend([f"- {item}" for item in rules])
+        return "\n".join(lines) + "\n"
+    if archetype == "hedge-finder":
+        instructions: dict[str, tuple[list[str], list[str], list[str]]] = {
+            "exposure-reader": (
+                [
+                    "`inputs/assets.yaml` — portfolio symbols and weights",
+                    "`policy/default.yaml` — portfolio series signal config",
+                ],
+                [
+                    "resolved asset symbols and weights",
+                    "the portfolio time series used for all later calculations",
+                    "data freshness timestamps for every fetched source",
+                ],
+                [
+                    "Do not estimate hedges or rank candidates.",
+                    "Record source timestamps so display output can cite the run snapshot.",
+                ],
+            ),
+            "beta-modeler": (
+                [
+                    "the exposure-reader artifact",
+                    "`inputs/constraints.yaml` — factor universe and residual beta target",
+                    "`policy/default.yaml` — lookback and decision settings",
+                ],
+                [
+                    "portfolio factor betas and residual exposures",
+                    "stability diagnostics for the lookback window",
+                    "factor series timestamps reused from upstream artifacts",
+                ],
+                [
+                    "Do not fetch fresh browser/public data.",
+                    "Use the upstream run artifact as the only portfolio snapshot.",
+                ],
+            ),
+            "hedge-searcher": (
+                [
+                    "the beta-modeler artifact",
+                    "`inputs/constraints.yaml` — hedge limits",
+                    "`policy/default.yaml` — hedge universe and market-quality rules",
+                ],
+                [
+                    "candidate hedges with funding rates, spreads, liquidity, and timestamps",
+                    "annualized funding values derived from the captured run data",
+                    "rejection reasons for candidates that fail market-quality checks",
+                ],
+                [
+                    "Do not mix live browser-fetched values into the run artifact.",
+                    "For each funding rate, include the raw period rate, annualized rate, "
+                    "and provider timestamp used in this run.",
+                ],
+            ),
+            "skeptic": (
+                [
+                    "the hedge-searcher artifact",
+                    "the optimizer phase result if present",
+                    "`policy/default.yaml` — null-state rules",
+                ],
+                [
+                    "selected hedge versus null-state comparison",
+                    "materiality checks and veto reasons",
+                    "the exact candidate metrics accepted for risk verification",
+                ],
+                [
+                    "Never force a hedge if the improvement is not material.",
+                    "Carry forward the exact funding, notional, and leverage inputs "
+                    "from upstream artifacts.",
+                ],
+            ),
+            "risk-verifier": (
+                [
+                    "the skeptic artifact",
+                    "`inputs/constraints.yaml`",
+                    "`policy/default.yaml` — risk limits",
+                ],
+                [
+                    "notional, leverage, margin, spread, and liquidity checks",
+                    "the final execution mode: `armed`, `draft`, or `null`",
+                    "downgrade or rejection reasons when limits are exceeded",
+                ],
+                [
+                    "Do not increase leverage or notional to force an armed result.",
+                    "Use the same candidate metrics that will be shown in display output.",
+                ],
+            ),
+            "job-compiler": (
+                [
+                    "the risk-verifier artifact",
+                    "`policy/default.yaml` — scheduler and execution settings",
+                ],
+                [
+                    "a runner-compatible draft or armed rebalance job",
+                    "poll interval, cooldown, and invalidation logic",
+                    "the exact mode approved by the risk gate",
+                ],
+                [
+                    "Do not arm the job if the risk gate returned `draft` or `null`.",
+                    "Write the job artifact before display composition.",
+                ],
+            ),
+            "display-composer": (
+                [
+                    "all run artifacts written under `.wf-artifacts/$RUN_ID/`",
+                    "especially `exposure_reader.json`, `beta_modeler.json`, "
+                    "`hedge_search.json`, `risk_gate.json`, and `job.json`",
+                ],
+                [
+                    "a `run_meta` object with `run_id`, `generated_at`, and "
+                    "`source: \"run_snapshot\"`",
+                    "a `data_freshness` object with the source/provider timestamps "
+                    "used by the run",
+                    "display-ready hedge rows with funding rates, notionals, leverage, "
+                    "residual beta, spread, liquidity, and risk status",
+                    "a `cli_summary` object using the same values the applet will render",
+                ],
+                [
+                    "This is a presentation transform only; do not fetch or recompute "
+                    "market data.",
+                    "Every displayed funding rate, notional, and leverage value must "
+                    "come from the existing run artifacts.",
+                    "If an applet intentionally live-refetches later, label it separately "
+                    "as live data and include its timestamp; do not overwrite this "
+                    "run snapshot.",
                 ],
             ),
         }

--- a/wayfinder_paths/paths/templates/README.md.tmpl
+++ b/wayfinder_paths/paths/templates/README.md.tmpl
@@ -45,6 +45,9 @@ If this path includes a presentation applet:
 - prefer the host-provided base URL from the bridge (`wf:state.apiBase`, then `wf:hello` origin) instead of hardcoding or probing multiple environments
 - do not probe both dev and prod from the same applet build
 - do not call `/api/v1/delta-lab/symbols/`; it does not exist
+- if the applet renders an execution result, render the run snapshot artifact instead of re-fetching browser data
+- if the applet intentionally shows live browser data, label it as `Applet: live as of HH:MM`
+- post `wf:state` with `state._meta.dataUpdatedAt` (ms epoch) whenever displayed data changes
 - treat non-200 responses, especially `404`, as expected unavailability and show a data-unavailable state instead of crashing
 - ensure every referenced file exists under `applet/dist/`
 - include explicit `icon`, `shortcut icon`, and `apple-touch-icon` tags in the applet HTML to avoid implicit browser favicon 404s

--- a/wayfinder_paths/paths/templates/applet/dist/assets/app.js.tmpl
+++ b/wayfinder_paths/paths/templates/applet/dist/assets/app.js.tmpl
@@ -1,5 +1,28 @@
 (function () {
-  let state = { counter: 0, updatedAt: new Date().toISOString() };
+  function metaFor(existing, ts) {
+    const dataUpdatedAt = ts
+      || (typeof existing.dataUpdatedAt === "number" ? existing.dataUpdatedAt : Date.now());
+    return {
+      source: "live_applet",
+      label: "Applet: live as of",
+      ...existing,
+      dataUpdatedAt,
+    };
+  }
+
+  function withFreshness(next, ts) {
+    const existing = next && typeof next._meta === "object" && !Array.isArray(next._meta)
+      ? next._meta
+      : {};
+    return {
+      ...next,
+      _meta: {
+        ...metaFor(existing, ts),
+      },
+    };
+  }
+
+  let state = withFreshness({ counter: 0, updatedAt: new Date().toISOString() });
 
   function post(message) {
     try {
@@ -12,6 +35,19 @@
   function render() {
     const el = document.querySelector("[data-path-state]");
     if (el) el.textContent = JSON.stringify(state, null, 2);
+    const freshness = document.querySelector("[data-path-freshness]");
+    const ts = state._meta && typeof state._meta.dataUpdatedAt === "number"
+      ? state._meta.dataUpdatedAt
+      : null;
+    if (freshness && ts) {
+      const label = typeof state._meta.label === "string"
+        ? state._meta.label
+        : "Applet: live as of";
+      freshness.textContent = label + " " + new Date(ts).toLocaleTimeString([], {
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+    }
   }
 
   window.addEventListener("message", (event) => {
@@ -25,7 +61,7 @@
     }
 
     if (msg.type === "wf:apply_state" && msg.state && typeof msg.state === "object") {
-      state = { ...(msg.state || {}) };
+      state = withFreshness({ ...(msg.state || {}) });
       render();
       post({ type: "wf:state", state });
       return;
@@ -39,8 +75,13 @@
     if (!action) return;
 
     if (action === "bump") {
-      state = { ...state, counter: (Number(state.counter) || 0) + 1, updatedAt: new Date().toISOString() };
+      state = withFreshness({
+        ...state,
+        counter: (Number(state.counter) || 0) + 1,
+        updatedAt: new Date().toISOString(),
+      });
       render();
+      post({ type: "wf:state", state });
     }
 
     if (action === "emit") {
@@ -50,4 +91,3 @@
 
   render();
 })();
-

--- a/wayfinder_paths/paths/templates/applet/dist/index.html.tmpl
+++ b/wayfinder_paths/paths/templates/applet/dist/index.html.tmpl
@@ -48,6 +48,9 @@
       <div style="font-size: 14px; opacity: 0.8">Applet</div>
       <div style="font-size: 20px; margin-top: 6px">{{name}}</div>
       <div style="opacity: 0.75; margin-top: 10px">{{summary}}</div>
+      <div style="font-size: 13px; opacity: 0.7; margin-top: 10px" data-path-freshness>
+        Applet: live as of --
+      </div>
 
       <div style="margin-top: 14px; display: flex; gap: 10px; flex-wrap: wrap">
         <button type="button" data-action="bump">Bump state</button>

--- a/wayfinder_paths/paths/templates/skill/instructions.md.tmpl
+++ b/wayfinder_paths/paths/templates/skill/instructions.md.tmpl
@@ -30,5 +30,8 @@ Use this skill when you need to inspect, install, or operate the `{{slug}}` path
 - If the applet is embedded by the Strategies path page, same-origin `/api/v1/delta-lab/public/assets/<symbol>/timeseries/` is fine.
 - Prefer the host bridge base URL (`wf:state.apiBase`, then `wf:hello` origin) instead of hardcoding or probing environments.
 - Do not probe multiple environments from one applet build, and do not call `/api/v1/delta-lab/symbols/`.
+- If the applet renders an execution result, render the run snapshot artifact instead of re-fetching browser data.
+- If the applet intentionally shows live browser data, label it as `Applet: live as of HH:MM`.
+- Post `wf:state` with `state._meta.dataUpdatedAt` (ms epoch) whenever displayed data changes.
 - Treat non-200 responses, especially `404`, as data unavailability and render a safe fallback UI.
 - Ensure every referenced file exists in `applet/dist/`, and include explicit `icon`, `shortcut icon`, and `apple-touch-icon` tags in the applet HTML to avoid implicit browser favicon 404s.

--- a/wayfinder_paths/tests/test_opencode_export.py
+++ b/wayfinder_paths/tests/test_opencode_export.py
@@ -62,6 +62,13 @@ def test_opencode_export_is_model_neutral_and_callable_by_default(tmp_path: Path
         / "agents"
         / "multi-asset-hedge-finder-exposure-reader.md"
     )
+    display_worker = (
+        export_dir
+        / "install"
+        / ".opencode"
+        / "agents"
+        / "multi-asset-hedge-finder-display-composer.md"
+    )
     artifact_gate = (
         export_dir / "install" / ".opencode" / "tools" / "wayfinder_artifact_gate.ts"
     )
@@ -101,8 +108,10 @@ def test_opencode_export_is_model_neutral_and_callable_by_default(tmp_path: Path
     validate_order_text = _read_text(validate_order)
     command_text = _read_text(command)
     orchestrator_text = _read_text(orchestrator)
+    display_worker_text = _read_text(display_worker)
     assert "required_files: tool.schema.array" not in artifact_gate_text
     assert 'const REQUIRED_FILES = ["exposure_reader.json"' in artifact_gate_text
+    assert '"display.json"' in artifact_gate_text
     assert (
         "context?.worktree ?? context?.directory ?? process.cwd()" in artifact_gate_text
     )
@@ -115,6 +124,10 @@ def test_opencode_export_is_model_neutral_and_callable_by_default(tmp_path: Path
     assert "return { ok:" not in validate_order_text
     assert "scripts/wf_run.py" in command_text
     assert "scripts/wf_run.py" in orchestrator_text
+    assert "display-composer" in orchestrator_text
+    assert "display.json" in display_worker_text
+    assert "source: \"run_snapshot\"" in display_worker_text
+    assert "do not fetch or recompute market data" in display_worker_text
     assert "not direct files under `path/`" in command_text
     assert "Do not run files under `path/` directly" in orchestrator_text
     assert "AGENTS.md" in opencode_config_payload["instructions"]

--- a/wayfinder_paths/tests/test_paths_scaffold.py
+++ b/wayfinder_paths/tests/test_paths_scaffold.py
@@ -40,6 +40,15 @@ def test_path_init_creates_expected_files(tmp_path: Path):
     assert (path_dir / "applet" / "dist" / "index.html").exists()
     assert (path_dir / "applet" / "dist" / "assets" / "app.js").exists()
     assert (path_dir / ".wayfinder" / "template.json").exists()
+    applet_html = (path_dir / "applet" / "dist" / "index.html").read_text(
+        encoding="utf-8"
+    )
+    applet_js = (path_dir / "applet" / "dist" / "assets" / "app.js").read_text(
+        encoding="utf-8"
+    )
+    assert "Applet: live as of" in applet_html
+    assert "dataUpdatedAt" in applet_js
+    assert 'source: "live_applet"' in applet_js
 
     manifest = PathManifest.load(result.manifest_path)
     assert manifest.slug == "basis-board"


### PR DESCRIPTION
## Summary
- add a hedge-finder display_compose phase and display-composer worker that produces `.wf-artifacts/$RUN_ID/display.json` as the shared run snapshot
- update generated hedge-finder instructions so console/app output uses the same funding, notional, leverage, and freshness values from run artifacts
- add applet freshness metadata and docs for `Applet: live as of HH:MM` when browser-side live data is shown

## Validation
- `POETRY_VIRTUALENVS_IN_PROJECT=true POETRY_CACHE_DIR=/private/tmp/wayst-194-poetry poetry run pytest wayfinder_paths/tests/test_opencode_export.py wayfinder_paths/tests/test_paths_scaffold.py`
- `POETRY_VIRTUALENVS_IN_PROJECT=true POETRY_CACHE_DIR=/private/tmp/wayst-194-poetry poetry run ruff check wayfinder_paths/paths/pipeline.py wayfinder_paths/paths/scaffold.py wayfinder_paths/tests/test_opencode_export.py wayfinder_paths/tests/test_paths_scaffold.py`
- `git diff --check`

Linear: WAYST-194