### PR TITLE
WAYST-196: Add path invocation guidance

### DIFF
--- a/wayfinder_paths/paths/cli.py
+++ b/wayfinder_paths/paths/cli.py
@@ -23,6 +23,7 @@ from wayfinder_paths.paths.doctor import PathDoctorError, PathDoctorReport, run_
 from wayfinder_paths.paths.evaluator import PathEvalError, run_path_eval
 from wayfinder_paths.paths.formatter import PathFormatError, format_path
 from wayfinder_paths.paths.hooks import PathHooksError, install_path_hooks
+from wayfinder_paths.paths.invocation import build_path_invocation_guidance
 from wayfinder_paths.paths.manifest import (
     PathManifest,
     PathManifestError,
@@ -552,6 +553,18 @@ def _read_export_manifest(source_dir: Path) -> dict[str, Any]:
     except Exception:
         return {}
     return payload if isinstance(payload, dict) else {}
+
+
+def _export_invocation_guidance(
+    export_manifest: dict[str, Any],
+) -> dict[str, Any] | None:
+    invocation = export_manifest.get("invocation")
+    if isinstance(invocation, dict):
+        return invocation
+    install = export_manifest.get("install")
+    if isinstance(install, dict) and isinstance(install.get("invocation"), dict):
+        return install["invocation"]
+    return None
 
 
 def _deep_merge(base: dict[str, Any], patch: dict[str, Any]) -> dict[str, Any]:
@@ -1099,6 +1112,12 @@ def _activate_export(
 
     export_manifest = _read_export_manifest(source_dir)
     install_targets = export_manifest.get("install_targets") or []
+    invocation = _export_invocation_guidance(export_manifest)
+    if invocation is None and path_dir is not None:
+        invocation = build_path_invocation_guidance(
+            _load_path_manifest(path_dir),
+            host=normalized_host,
+        )
     if install_targets:
         destination_root_path = destination_root or _activate_install_root(
             normalized_host, normalized_scope, cwd=Path.cwd()
@@ -1115,7 +1134,7 @@ def _activate_export(
         applied = [str(dest)]
         mode = "copy"
     root = _activation_root_from_result(mode=mode, dest=dest)
-    return {
+    result = {
         "host": normalized_host,
         "scope": normalized_scope,
         "source": str(source_dir),
@@ -1124,6 +1143,9 @@ def _activate_export(
         "mode": mode,
         "applied": applied,
     }
+    if invocation:
+        result["invocation"] = invocation
+    return result
 
 
 @click.group(name="path", help="Build, publish, and emit signals for Paths.")
@@ -2196,6 +2218,12 @@ def _install_path_with_options(
 
     dependency_results: list[dict[str, Any]] = []
     normalized_host = str(host or "").strip().lower() or None
+    installed_manifest = _load_path_manifest(installed_path)
+    invocation = build_path_invocation_guidance(
+        installed_manifest,
+        host=normalized_host,
+    )
+    response["invocation"] = invocation
     normalized_scope = (
         _normalize_host_scope(normalized_host, scope)
         if normalized_host and scope
@@ -2277,9 +2305,9 @@ def _install_path_with_options(
         response["next_steps"] = (
             [
                 "Restart OpenCode if it was already running so new plugins are loaded.",
-                f"Run /{_load_path_manifest(installed_path).pipeline.entry_command if _load_path_manifest(installed_path).pipeline and _load_path_manifest(installed_path).pipeline.entry_command else _load_path_manifest(installed_path).skill.name}.",
+                f"Run {invocation['slash_command']}.",
             ]
-            if normalized_host == "opencode"
+            if normalized_host == "opencode" and invocation.get("slash_command")
             else []
         )
     return response

--- a/wayfinder_paths/paths/invocation.py
+++ b/wayfinder_paths/paths/invocation.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Any
+
+from wayfinder_paths.paths.manifest import PathManifest
+
+
+def _skill_name(manifest: PathManifest) -> str:
+    if manifest.skill and manifest.skill.name:
+        return manifest.skill.name
+    return manifest.slug
+
+
+def _command_name(manifest: PathManifest, *, skill_name: str) -> str:
+    if manifest.pipeline and manifest.pipeline.entry_command:
+        return manifest.pipeline.entry_command
+    return skill_name
+
+
+def build_path_invocation_guidance(
+    manifest: PathManifest,
+    *,
+    host: str | None = None,
+) -> dict[str, Any]:
+    """Return deterministic user-facing guidance for running an installed Path."""
+
+    normalized_host = str(host or "").strip().lower() or None
+    skill_name = _skill_name(manifest)
+    command_name = _command_name(manifest, skill_name=skill_name)
+    display_name = manifest.name.strip() or manifest.slug
+    example_prompt = f"Run the {display_name} Path."
+    example_prompts = [example_prompt]
+    if manifest.summary.strip():
+        example_prompts.append(f"Use {skill_name} for: {manifest.summary.strip()}")
+    else:
+        example_prompts.append(f"Use {skill_name} to complete this workflow.")
+
+    slash_command = f"/{command_name}" if normalized_host == "opencode" else None
+    instructions = (
+        [
+            f"In OpenCode, type `{slash_command}` followed by your task or context.",
+            f'You can also ask your agent: "{example_prompt}"',
+        ]
+        if slash_command
+        else [f'Ask your agent: "{example_prompt}"']
+    )
+
+    return {
+        "title": "How to invoke this Path",
+        "host": normalized_host,
+        "skill_name": skill_name,
+        "command_name": command_name,
+        "slash_command": slash_command,
+        "example_prompt": example_prompt,
+        "example_prompts": example_prompts,
+        "instructions": instructions,
+    }

--- a/wayfinder_paths/paths/renderer.py
+++ b/wayfinder_paths/paths/renderer.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from wayfinder_paths.paths.invocation import build_path_invocation_guidance
 from wayfinder_paths.paths.manifest import (
     PathAgentConfig,
     PathManifest,
@@ -1239,6 +1240,7 @@ def _export_manifest(
     opencode_model_override: str | None = None,
 ) -> dict[str, Any]:
     mode = str(runtime_manifest.get("mode") or "thin")
+    invocation = build_path_invocation_guidance(manifest, host=host)
     payload = {
         "host": host,
         "slug": manifest.slug,
@@ -1246,6 +1248,7 @@ def _export_manifest(
         "skill_name": skill.name,
         "mode": mode,
         "filename": f"skill-{host}-{mode}.zip",
+        "invocation": invocation,
     }
     dependencies = [
         {
@@ -1281,6 +1284,7 @@ def _export_manifest(
             ],
             "restart_required": True,
             "scopes": ["project", "user"],
+            "invocation": invocation,
         }
         if explicit_model:
             payload["install"]["model"] = explicit_model

--- a/wayfinder_paths/tests/test_opencode_export.py
+++ b/wayfinder_paths/tests/test_opencode_export.py
@@ -127,6 +127,10 @@ def test_opencode_export_is_model_neutral_and_callable_by_default(tmp_path: Path
     assert export_manifest["install"]["preferred_sdk_command"].startswith(
         "wayfinder path install --slug multi-asset-hedge-finder --version 0.1.0 --host opencode --scope project"
     )
+    assert export_manifest["install"]["invocation"]["slash_command"] == "/hedge-finder"
+    assert export_manifest["invocation"]["example_prompt"] == (
+        "Run the Multi Asset Hedge Finder Path."
+    )
     assert export_manifest["requires"]["skills"][0]["path_slug"] == "using-delta-lab"
     assert export_manifest["requires"]["skills"][0]["skill_name"] == "using-delta-lab"
 

--- a/wayfinder_paths/tests/test_paths_publish_install.py
+++ b/wayfinder_paths/tests/test_paths_publish_install.py
@@ -480,6 +480,11 @@ def test_path_install_requests_intent_and_submits_receipt(tmp_path: Path, monkey
     assert output["result"]["heartbeat_enabled"] is True
     assert output["result"]["verified_install"] is True
     assert output["result"]["warnings"] == []
+    assert output["result"]["invocation"]["title"] == "How to invoke this Path"
+    assert output["result"]["invocation"]["example_prompt"] == (
+        "Run the Install Demo Path."
+    )
+    assert output["result"]["invocation"]["slash_command"] is None
 
     receipt = FakeInstallClient.receipt_calls[0]
     assert receipt["runtime"] == "sdk-cli"
@@ -1203,6 +1208,11 @@ def test_path_install_opencode_activates_and_installs_required_dependencies(
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)
     assert payload["result"]["activated"] is True
+    assert payload["result"]["invocation"]["slash_command"] == "/install-opencode-demo"
+    assert payload["result"]["next_steps"] == [
+        "Restart OpenCode if it was already running so new plugins are loaded.",
+        "Run /install-opencode-demo.",
+    ]
     assert payload["result"]["dependencies"][0]["slug"] == "custom-market-data-pack"
     assert len(activation_calls) == 2
     assert {Path(call["path_dir"]).parent.name for call in activation_calls} == {


### PR DESCRIPTION
## Summary
- add canonical SDK invocation guidance from Path manifests
- include guidance in host export metadata and install/activate JSON responses
- update path install/export tests for example prompts and OpenCode slash commands

## Validation
- PYTHONPATH=. ../vault-backend/.venv/bin/python -m pytest -o addopts='' wayfinder_paths/tests/test_paths_publish_install.py::test_path_install_requests_intent_and_submits_receipt wayfinder_paths/tests/test_paths_publish_install.py::test_path_install_opencode_activates_and_installs_required_dependencies wayfinder_paths/tests/test_opencode_export.py::test_opencode_export_is_model_neutral_and_callable_by_default
- ../vault-backend/.venv/bin/python -m ruff check wayfinder_paths/paths/invocation.py wayfinder_paths/paths/cli.py wayfinder_paths/paths/renderer.py wayfinder_paths/tests/test_paths_publish_install.py wayfinder_paths/tests/test_opencode_export.py
- ../vault-backend/.venv/bin/python -m ruff format --check wayfinder_paths/paths/invocation.py wayfinder_paths/paths/cli.py wayfinder_paths/paths/renderer.py wayfinder_paths/tests/test_paths_publish_install.py wayfinder_paths/tests/test_opencode_export.py
- git diff --check

Note: poetry install was attempted but PyPI connectivity failed, so validation used the populated backend venv with the SDK on PYTHONPATH.

Linear: WAYST-196