### PR TITLE
WAYST-204: Expose Shells path inventory tool

### DIFF
--- a/wayfinder_paths/core/clients/InstanceStateClient.py
+++ b/wayfinder_paths/core/clients/InstanceStateClient.py
@@ -14,8 +14,15 @@ class InstanceStateClient(WayfinderClient):
     def _opencode_base_url(self) -> str:
         return f"{get_api_base_url()}/opencode"
 
+    def _paths_base_url(self) -> str:
+        return f"{get_api_base_url()}/opencode/instances/{get_opencode_instance_id()}/paths"
+
     async def get_state(self) -> dict[str, Any]:
         resp = await self._authed_request("GET", f"{self._base_url()}/")
+        return resp.json()
+
+    async def list_paths(self) -> dict[str, Any]:
+        resp = await self._authed_request("GET", f"{self._paths_base_url()}/")
         return resp.json()
 
     async def search_chart_series(

--- a/wayfinder_paths/mcp/server.py
+++ b/wayfinder_paths/mcp/server.py
@@ -70,6 +70,7 @@ from wayfinder_paths.mcp.tools.instance_state import (
     shells_clear_chart_workspace,
     shells_create_chart,
     shells_get_frontend_context,
+    shells_list_paths,
     shells_search_chart_series,
     shells_set_active_chart,
     shells_set_active_market,
@@ -101,6 +102,7 @@ mcp = FastMCP("wayfinder")
 # ─── shells_* ──────────────────────────────────────────────────────────
 if is_opencode_instance():
     mcp.tool()(shells_get_frontend_context)
+    mcp.tool()(shells_list_paths)
     mcp.tool()(shells_search_chart_series)
     mcp.tool()(shells_set_active_market)
     mcp.tool()(shells_create_chart)

--- a/wayfinder_paths/mcp/tools/instance_state.py
+++ b/wayfinder_paths/mcp/tools/instance_state.py
@@ -43,6 +43,24 @@ async def shells_get_frontend_context() -> dict[str, Any]:
         return err("state_http_error", f"HTTP {exc.response.status_code}")
 
 
+@catch_errors
+async def shells_list_paths() -> dict[str, Any]:
+    """List Paths available to this Shell.
+
+    Use this when the user asks which Paths are available or installable in
+    Shells. The response comes from the backend Shells inventory endpoint, so
+    it matches the Paths tab filtering and includes compatibility counts such
+    as bonded paths that are not yet available for Shells.
+    """
+    if not is_opencode_instance():
+        return err(*_NOT_OPENCODE_ERR)
+    try:
+        return ok(await INSTANCE_STATE_CLIENT.list_paths())
+    except httpx.HTTPStatusError as exc:
+        message, details = _http_error_message(exc)
+        return err("shell_paths_http_error", message, details)
+
+
 async def shells_search_chart_series(
     query: str,
     kind: str | None = None,

--- a/wayfinder_paths/tests/test_shell_paths_inventory.py
+++ b/wayfinder_paths/tests/test_shell_paths_inventory.py
@@ -1,0 +1,88 @@
+from typing import Any
+
+import pytest
+
+import wayfinder_paths.core.clients.InstanceStateClient as instance_state_module
+from wayfinder_paths.core.clients.InstanceStateClient import InstanceStateClient
+from wayfinder_paths.mcp.tools import instance_state
+
+
+class FakeResponse:
+    def __init__(self, payload: dict[str, Any]):
+        self.payload = payload
+
+    def json(self) -> dict[str, Any]:
+        return self.payload
+
+
+@pytest.mark.asyncio
+async def test_instance_state_client_lists_shell_paths(monkeypatch):
+    calls: list[tuple[str, str]] = []
+
+    async def fake_request(self, method: str, url: str, **kwargs):
+        calls.append((method, url))
+        return FakeResponse(
+            {
+                "paths": [{"slug": "shell-ready"}],
+                "compatibility": {
+                    "compatible_count": 1,
+                    "total_bonded_count": 2,
+                    "incompatible_bonded_count": 1,
+                },
+            }
+        )
+
+    monkeypatch.setattr(instance_state_module, "get_api_base_url", lambda: "https://api.test")
+    monkeypatch.setattr(
+        instance_state_module,
+        "get_opencode_instance_id",
+        lambda: "shell-app",
+    )
+    monkeypatch.setattr(InstanceStateClient, "_authed_request", fake_request)
+
+    payload = await InstanceStateClient().list_paths()
+
+    assert calls == [("GET", "https://api.test/opencode/instances/shell-app/paths/")]
+    assert payload["paths"] == [{"slug": "shell-ready"}]
+    assert payload["compatibility"]["incompatible_bonded_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_shells_list_paths_tool_requires_opencode(monkeypatch):
+    monkeypatch.delenv("OPENCODE_INSTANCE_ID", raising=False)
+
+    payload = await instance_state.shells_list_paths()
+
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "not_opencode_instance"
+
+
+@pytest.mark.asyncio
+async def test_shells_list_paths_tool_returns_backend_inventory(monkeypatch):
+    class FakeClient:
+        async def list_paths(self):
+            return {
+                "paths": [{"slug": "shell-ready"}],
+                "compatibility": {
+                    "compatible_count": 1,
+                    "total_bonded_count": 2,
+                    "incompatible_bonded_count": 1,
+                },
+            }
+
+    monkeypatch.setenv("OPENCODE_INSTANCE_ID", "shell-app")
+    monkeypatch.setattr(instance_state, "INSTANCE_STATE_CLIENT", FakeClient())
+
+    payload = await instance_state.shells_list_paths()
+
+    assert payload == {
+        "ok": True,
+        "result": {
+            "paths": [{"slug": "shell-ready"}],
+            "compatibility": {
+                "compatible_count": 1,
+                "total_bonded_count": 2,
+                "incompatible_bonded_count": 1,
+            },
+        },
+    }


### PR DESCRIPTION
## Summary
- adds InstanceStateClient.list_paths for the backend Shells inventory endpoint
- registers a read-only shells_list_paths MCP tool in OpenCode instances
- adds focused SDK tests for URL construction, tool pass-through, and non-OpenCode guard behavior

## Validation
- POETRY_VIRTUALENVS_IN_PROJECT=true POETRY_CACHE_DIR=.poetry-cache poetry install
- POETRY_VIRTUALENVS_IN_PROJECT=true POETRY_CACHE_DIR=.poetry-cache poetry run pytest wayfinder_paths/tests/test_shell_paths_inventory.py wayfinder_paths/tests/test_paths_publish_install.py -q
- POETRY_VIRTUALENVS_IN_PROJECT=true POETRY_CACHE_DIR=.poetry-cache poetry run pytest wayfinder_paths/tests/test_shell_paths_inventory.py -q
- POETRY_VIRTUALENVS_IN_PROJECT=true POETRY_CACHE_DIR=.poetry-cache poetry run ruff check wayfinder_paths/core/clients/InstanceStateClient.py wayfinder_paths/mcp/tools/instance_state.py wayfinder_paths/mcp/server.py wayfinder_paths/tests/test_shell_paths_inventory.py
- git diff --check