### PR TITLE
Speed up Hyperliquid MCP market orders

### DIFF
--- a/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
+++ b/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
@@ -705,19 +705,30 @@ class HyperliquidAdapter(BaseAdapter):
         reduce_only: bool = False,
         cloid: str | None = None,
         builder: dict[str, Any] | None = None,
+        builder_fee_preapproved: bool = False,
+        mid_price: float | None = None,
     ) -> tuple[bool, dict[str, Any]]:
         builder_fee = self._mandatory_builder_fee(builder)
         await self.ensure_unified_account(address)
-        await self.ensure_builder_fee_approved(address, builder_fee)
+        if not builder_fee_preapproved:
+            await self.ensure_builder_fee_approved(address, builder_fee)
 
-        asset_name = get_info().asset_to_coin[asset_id]
-        ok, mids = await self.get_all_mid_prices()
-        if not ok or asset_name not in mids:
-            return False, {
-                "status": "err",
-                "error": f"Could not fetch mid price for {asset_name}",
-            }
-        midprice = mids[asset_name]
+        if mid_price is None:
+            asset_name = get_info().asset_to_coin[asset_id]
+            ok, mids = await self.get_all_mid_prices()
+            if not ok or asset_name not in mids:
+                return False, {
+                    "status": "err",
+                    "error": f"Could not fetch mid price for {asset_name}",
+                }
+            midprice = mids[asset_name]
+        else:
+            midprice = float(mid_price)
+            if midprice <= 0:
+                return False, {
+                    "status": "err",
+                    "error": f"mid_price must be positive, got {mid_price}",
+                }
 
         if slippage >= 1 or slippage < 0:
             return False, {
@@ -834,6 +845,8 @@ class HyperliquidAdapter(BaseAdapter):
         reduce_only: bool = False,
         cloid: str | None = None,
         builder: dict[str, Any] | None = None,
+        builder_fee_preapproved: bool = False,
+        mid_price: float | None = None,
     ) -> tuple[bool, dict[str, Any]]:
         """Place an outcome order. Reuses the existing wire/sign/broadcast path.
 
@@ -861,19 +874,29 @@ class HyperliquidAdapter(BaseAdapter):
             }
         builder_fee = self._mandatory_builder_fee(builder)
         await self.ensure_unified_account(address)
-        await self.ensure_builder_fee_approved(address, builder_fee)
+        if not builder_fee_preapproved:
+            await self.ensure_builder_fee_approved(address, builder_fee)
 
         asset_id = outcome_asset_id(outcome_id, side)
         book_coin = outcome_book_coin(outcome_id, side)
 
         if price is None:
-            ok, mids = await self.get_all_mid_prices()
-            if not ok or book_coin not in mids:
-                return False, {
-                    "status": "err",
-                    "error": f"Could not fetch mid price for {book_coin}",
-                }
-            price = mids[book_coin] * ((1 + slippage) if is_buy else (1 - slippage))
+            if mid_price is None:
+                ok, mids = await self.get_all_mid_prices()
+                if not ok or book_coin not in mids:
+                    return False, {
+                        "status": "err",
+                        "error": f"Could not fetch mid price for {book_coin}",
+                    }
+                mid = mids[book_coin]
+            else:
+                mid = float(mid_price)
+                if mid <= 0:
+                    return False, {
+                        "status": "err",
+                        "error": f"mid_price must be positive, got {mid_price}",
+                    }
+            price = mid * ((1 + slippage) if is_buy else (1 - slippage))
 
         # Clamp inside (0, 1); HL rejects 0/1.
         price = max(0.0001, min(0.9999, float(price)))
@@ -1168,10 +1191,12 @@ class HyperliquidAdapter(BaseAdapter):
         is_market: bool = True,
         limit_price: float | None = None,
         builder: dict[str, Any] | None = None,
+        builder_fee_preapproved: bool = False,
     ) -> tuple[bool, dict[str, Any]]:
         builder_fee = self._mandatory_builder_fee(builder)
         await self.ensure_unified_account(address)
-        await self.ensure_builder_fee_approved(address, builder_fee)
+        if not builder_fee_preapproved:
+            await self.ensure_builder_fee_approved(address, builder_fee)
         builder_info = BuilderInfo(b=builder_fee.get("b"), f=builder_fee.get("f"))
 
         order_type: OrderType = {
@@ -1431,10 +1456,12 @@ class HyperliquidAdapter(BaseAdapter):
         reduce_only: bool = False,
         builder: dict[str, Any] | None = None,
         cloid: str | None = None,
+        builder_fee_preapproved: bool = False,
     ) -> tuple[bool, dict[str, Any]]:
         builder_fee = self._mandatory_builder_fee(builder)
         await self.ensure_unified_account(address)
-        await self.ensure_builder_fee_approved(address, builder_fee)
+        if not builder_fee_preapproved:
+            await self.ensure_builder_fee_approved(address, builder_fee)
         order_actions = self._create_hypecore_order_actions(
             asset_id,
             is_buy,

--- a/wayfinder_paths/adapters/hyperliquid_adapter/test_exchange_mid_prices.py
+++ b/wayfinder_paths/adapters/hyperliquid_adapter/test_exchange_mid_prices.py
@@ -7,12 +7,17 @@ from wayfinder_paths.adapters.hyperliquid_adapter.adapter import HyperliquidAdap
 
 
 class _InfoStub(SimpleNamespace):
+    def __init__(self):
+        super().__init__()
+        self.post_payload_types = []
+
     def all_mids(self):
         return {"HYPE": "1.0"}
 
     def post(self, url_path, payload=None):
         if isinstance(payload, dict):
             req_type = payload.get("type", "")
+            self.post_payload_types.append(req_type)
             if req_type == "allMids":
                 return {"HYPE": "1.0"}
             if req_type == "maxBuilderFee":
@@ -68,3 +73,42 @@ class TestAdapterMidPriceFetch:
             assert action["orders"][0]["a"] == 7
             assert action["orders"][0]["b"] is True
             assert action["orders"][0]["p"] == "1.01"
+
+    @pytest.mark.asyncio
+    async def test_place_market_order_reuses_prevalidated_context(self):
+        info_stub = _InfoStub()
+        with (
+            patch(
+                "wayfinder_paths.adapters.hyperliquid_adapter.adapter.get_info",
+                return_value=info_stub,
+            ),
+            patch(
+                "wayfinder_paths.adapters.hyperliquid_adapter.adapter.get_perp_dexes",
+                return_value=[""],
+            ),
+        ):
+            adapter = HyperliquidAdapter(
+                config={},
+                sign_typed_data_callback=AsyncMock(return_value="0x" + "00" * 65),
+            )
+
+            async def _no_broadcast(action, address):
+                return {"status": "ok", "action": action}
+
+            adapter._sign_and_broadcast_hypecore = _no_broadcast
+
+            success, result = await adapter.place_market_order(
+                asset_id=7,
+                is_buy=False,
+                slippage=0.01,
+                size=1.0,
+                address="0xabc",
+                builder_fee_preapproved=True,
+                mid_price=1.0,
+            )
+
+            action = result["action"]
+            assert success is True
+            assert action["orders"][0]["p"] == "0.99"
+            assert "allMids" not in info_stub.post_payload_types
+            assert "maxBuilderFee" not in info_stub.post_payload_types

--- a/wayfinder_paths/mcp/tools/hyperliquid.py
+++ b/wayfinder_paths/mcp/tools/hyperliquid.py
@@ -97,6 +97,26 @@ async def _ensure_builder_fee_approval(
         raise ValueError(f"Failed to approve Wayfinder builder fee: {appr}")
 
 
+def _mid_price_from_snapshot(
+    adapter: HyperliquidAdapter,
+    *,
+    asset_name: str,
+    asset_id: int,
+    mids: dict[str, Any],
+) -> float | None:
+    for key in adapter.get_mid_price_key(asset_name, asset_id):
+        v = mids.get(key)
+        if v is None:
+            continue
+        try:
+            mid = float(v)
+        except (TypeError, ValueError):
+            continue
+        if mid > 0:
+            return mid
+    return None
+
+
 @catch_errors
 async def hyperliquid_execute(
     action: Literal[
@@ -327,7 +347,19 @@ async def hyperliquid_execute(
         )
     market_type = adapter.get_market_type(asset_name)
 
-    await _ensure_builder_fee_approval(adapter, sender=sender, effects=effects)
+    prefetch_mids_task: asyncio.Task[tuple[bool, Any]] | None = None
+    if action == "place_order" and order_type == "market":
+        needs_mid_price = market_type != "hip4" or price is None or size is None
+        if needs_mid_price:
+            prefetch_mids_task = asyncio.create_task(adapter.get_all_mid_prices())
+
+    try:
+        await _ensure_builder_fee_approval(adapter, sender=sender, effects=effects)
+    except Exception:
+        if prefetch_mids_task is not None:
+            prefetch_mids_task.cancel()
+            await asyncio.gather(prefetch_mids_task, return_exceptions=True)
+        raise
 
     match action:
         case "update_leverage":
@@ -470,6 +502,7 @@ async def hyperliquid_execute(
                 is_market=bool(is_market_trigger),
                 limit_price=limit_px,
                 builder=DEFAULT_HYPERLIQUID_BUILDER_FEE,
+                builder_fee_preapproved=True,
             )
             effects.append(
                 {
@@ -520,6 +553,10 @@ async def hyperliquid_execute(
             return response
 
         case "place_order":
+            prefetched_mids: tuple[bool, Any] | None = None
+            if prefetch_mids_task is not None:
+                prefetched_mids = await prefetch_mids_task
+
             match market_type:
                 case "hip4":
                     outcome_id_v, side_v = decode_outcome_encoding(int(asset_name[1:]))
@@ -530,6 +567,7 @@ async def hyperliquid_execute(
                     # Outcomes are integer contracts (szDecimals=0) with no $10 floor;
                     # accept either explicit `size` or `usd_amount` for market orders.
                     size_i: int | None = None if size is None else int(size)
+                    outcome_mid_price: float | None = None
                     if size_i is None:
                         throw_if_none(
                             "size or usd_amount is required for outcome orders",
@@ -539,7 +577,13 @@ async def hyperliquid_execute(
                             raise ValueError(
                                 "usd_amount sizing is only supported for market outcome orders"
                             )
-                        ok_mids, mids = await adapter.get_all_mid_prices()
+
+                    if order_type == "market" and (size_i is None or price is None):
+                        ok_mids, mids = (
+                            prefetched_mids
+                            if prefetched_mids is not None
+                            else await adapter.get_all_mid_prices()
+                        )
                         if not ok_mids or not isinstance(mids, dict):
                             return err("price_error", "Failed to fetch mid prices")
                         mid = mids.get(asset_name)
@@ -548,7 +592,10 @@ async def hyperliquid_execute(
                                 "price_error",
                                 f"Could not resolve mid price for {asset_name}",
                             )
-                        size_i = max(1, round(float(usd_amount) / float(mid)))
+                        outcome_mid_price = float(mid)
+
+                    if size_i is None:
+                        size_i = max(1, round(float(usd_amount) / outcome_mid_price))
 
                     ok_order, res = await adapter.place_outcome_order(
                         outcome_id=outcome_id_v,
@@ -561,6 +608,9 @@ async def hyperliquid_execute(
                         reduce_only=bool(reduce_only),
                         cloid=cloid,
                         address=sender,
+                        builder=DEFAULT_HYPERLIQUID_BUILDER_FEE,
+                        builder_fee_preapproved=True,
+                        mid_price=outcome_mid_price,
                     )
                     effects.append(
                         {
@@ -635,6 +685,27 @@ async def hyperliquid_execute(
                             raise ValueError("slippage > 0.25 is too risky")
                         px_for_sizing = None
 
+                    market_mid_price: float | None = None
+                    if order_type == "market":
+                        ok_mids, mids = (
+                            prefetched_mids
+                            if prefetched_mids is not None
+                            else await adapter.get_all_mid_prices()
+                        )
+                        if not ok_mids or not isinstance(mids, dict):
+                            return err("price_error", "Failed to fetch mid prices")
+                        market_mid_price = _mid_price_from_snapshot(
+                            adapter,
+                            asset_name=asset_name,
+                            asset_id=resolved_asset_id,
+                            mids=mids,
+                        )
+                        if market_mid_price is None:
+                            return err(
+                                "price_error",
+                                f"Could not resolve mid price for {asset_name}",
+                            )
+
                     sizing: dict[str, Any] = {"source": "size"}
                     if size is not None:
                         sz = throw_if_not_number("size must be a number", size)
@@ -681,31 +752,7 @@ async def hyperliquid_execute(
                                     margin_usd = None
 
                         if px_for_sizing is None:
-                            ok_mids, mids = await adapter.get_all_mid_prices()
-                            if not ok_mids or not isinstance(mids, dict):
-                                response = err(
-                                    "price_error", "Failed to fetch mid prices"
-                                )
-                                return response
-                            mid = None
-                            for key in adapter.get_mid_price_key(
-                                asset_name, resolved_asset_id
-                            ):
-                                v = mids.get(key)
-                                if v is None:
-                                    continue
-                                try:
-                                    mid = float(v)
-                                    break
-                                except (TypeError, ValueError):
-                                    continue
-                            if mid is None or mid <= 0:
-                                response = err(
-                                    "price_error",
-                                    f"Could not resolve mid price for {asset_name}",
-                                )
-                                return response
-                            px_for_sizing = mid
+                            px_for_sizing = market_mid_price
 
                         sz = notional_usd / float(px_for_sizing)
                         sizing = {
@@ -773,6 +820,7 @@ async def hyperliquid_execute(
                             sender,
                             reduce_only=bool(reduce_only),
                             builder=DEFAULT_HYPERLIQUID_BUILDER_FEE,
+                            builder_fee_preapproved=True,
                         )
                         effects.append(
                             {
@@ -792,6 +840,8 @@ async def hyperliquid_execute(
                             reduce_only=bool(reduce_only),
                             cloid=cloid,
                             builder=DEFAULT_HYPERLIQUID_BUILDER_FEE,
+                            builder_fee_preapproved=True,
+                            mid_price=market_mid_price,
                         )
                         effects.append(
                             {

--- a/wayfinder_paths/tests/test_mcp_hyperliquid_execute.py
+++ b/wayfinder_paths/tests/test_mcp_hyperliquid_execute.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -24,6 +25,41 @@ class _StubAdapter(HyperliquidAdapter):
 
     async def get_spot_assets(self):
         return True, self._spot_assets
+
+
+class _FastOrderAdapter:
+    def __init__(self):
+        self.wallet_address = "0x000000000000000000000000000000000000bEEF"
+        self.get_all_mid_prices_calls = 0
+        self.get_max_builder_fee_calls = 0
+        self.place_market_order_call: dict[str, Any] | None = None
+
+    async def get_asset_id(self, asset_name: str):
+        return 0 if asset_name == "BTC-USDC" else None
+
+    def get_market_type(self, asset_name: str):
+        return HyperliquidAdapter.get_market_type(asset_name)
+
+    def get_mid_price_key(self, asset_name: str, asset_id: int):
+        return HyperliquidAdapter.get_mid_price_key(asset_name, asset_id)
+
+    async def get_all_mid_prices(self):
+        self.get_all_mid_prices_calls += 1
+        return True, {"BTC": 50000.0}
+
+    async def get_max_builder_fee(self, user: str, builder: str):
+        self.get_max_builder_fee_calls += 1
+        return True, 30
+
+    async def approve_builder_fee(self, builder: str, max_fee_rate: str, address: str):
+        raise AssertionError("builder fee should already be approved")
+
+    def get_valid_order_size(self, asset_id: int, size: float):
+        return size
+
+    async def place_market_order(self, *args: Any, **kwargs: Any):
+        self.place_market_order_call = {"args": args, "kwargs": kwargs}
+        return True, {"status": "ok"}
 
 
 @pytest.mark.asyncio
@@ -101,3 +137,48 @@ async def test_hyperliquid_execute_withdraw(tmp_path: Path, monkeypatch):
             "withdraw", wallet_label="main", amount_usdc=10
         )
         assert out1["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_hyperliquid_execute_reuses_mid_price_and_builder_check(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.setenv("WAYFINDER_MCP_STATE_PATH", str(tmp_path / "mcp.sqlite3"))
+    monkeypatch.setenv("WAYFINDER_RUNS_DIR", str(tmp_path / "runs"))
+
+    adapter = _FastOrderAdapter()
+    with (
+        patch("wayfinder_paths.mcp.tools.hyperliquid.CONFIG", {}),
+        patch(
+            "wayfinder_paths.mcp.tools.hyperliquid.get_adapter",
+            new=AsyncMock(return_value=adapter),
+        ),
+    ):
+        out = await hyperliquid_execute(
+            "place_order",
+            wallet_label="main",
+            asset_name="BTC-USDC",
+            order_type="market",
+            is_buy=False,
+            usd_amount=100,
+            usd_amount_kind="notional",
+            slippage=0.01,
+        )
+
+    assert out["ok"] is True
+    result = out["result"]
+    assert adapter.get_all_mid_prices_calls == 1
+    assert adapter.get_max_builder_fee_calls == 1
+    assert adapter.place_market_order_call is not None
+    assert adapter.place_market_order_call["args"][:5] == (
+        0,
+        False,
+        0.01,
+        pytest.approx(0.002),
+        adapter.wallet_address,
+    )
+    assert adapter.place_market_order_call["kwargs"]["mid_price"] == 50000.0
+    assert adapter.place_market_order_call["kwargs"]["builder_fee_preapproved"] is True
+    assert result["order"]["sizing"]["price_used"] == 50000.0
+    assert result["effects"][0]["label"] == "get_max_builder_fee"
+    assert result["effects"][1]["label"] == "place_market_order"


### PR DESCRIPTION
## Summary
- Prefetch and reuse a single Hyperliquid `allMids` snapshot for MCP market-order sizing and IOC pricing.
- Avoid duplicate adapter builder-fee checks after `hyperliquid_execute` has already completed its builder-fee approval helper.
- Keep adapter defaults checked for non-MCP callers and add focused coverage for the fast path.

## Validation
- `POETRY_CACHE_DIR=/private/tmp/wayfinder-poetry-cache POETRY_VIRTUALENVS_PATH=/private/tmp/wayfinder-poetry-venvs poetry run pytest wayfinder_paths/tests/test_mcp_hyperliquid_execute.py wayfinder_paths/adapters/hyperliquid_adapter/test_exchange_mid_prices.py -q`
- `POETRY_CACHE_DIR=/private/tmp/wayfinder-poetry-cache POETRY_VIRTUALENVS_PATH=/private/tmp/wayfinder-poetry-venvs poetry run ruff check wayfinder_paths/mcp/tools/hyperliquid.py wayfinder_paths/adapters/hyperliquid_adapter/adapter.py wayfinder_paths/tests/test_mcp_hyperliquid_execute.py wayfinder_paths/adapters/hyperliquid_adapter/test_exchange_mid_prices.py`
- `POETRY_CACHE_DIR=/private/tmp/wayfinder-poetry-cache POETRY_VIRTUALENVS_PATH=/private/tmp/wayfinder-poetry-venvs poetry run ruff format --check wayfinder_paths/mcp/tools/hyperliquid.py wayfinder_paths/adapters/hyperliquid_adapter/adapter.py wayfinder_paths/tests/test_mcp_hyperliquid_execute.py wayfinder_paths/adapters/hyperliquid_adapter/test_exchange_mid_prices.py`

Linear: WAYST-228