### PR TITLE
Shells - User Suggestions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,11 +194,15 @@ The frontend shows synced jobs and runs in the "Scheduled" tab of the shells sid
 
 ## User Suggestions (always emit)
 
-At the END of every response, emit a `<userSuggestions>...</userSuggestions>` block with exactly 3 short follow-ups the user might click instead of typing. The frontend renders the block as chips above the chat composer; never as inline text.
+At the END of every response, emit a `<userSuggestions>...</userSuggestions>` block with exactly 3 short follow-ups the user might click instead of typing.
 
 - Pipe-delimited inside the tags: `<userSuggestions>opt1|opt2|opt3</userSuggestions>`
 - Phrased first-person from the user's perspective ("Open a long on ETH", not "Want to long ETH?")
-- Actionable > open-ended. Feasible given your tools and the current context.
-- No markdown, no addresses, no asset/protocol names that haven't appeared in the conversation.
+- Actionable and not open open-ended
 - Keep each option short (under ~8 words).
 - Always emit the block — even after errors, clarifications, or tool failures.
+- No:
+  - NO WALLET ADDRESSES
+  - Asset ids (prefer human readable text)
+  - Markdown
+  - Asset/protocol names that haven't appeared in the conversation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,3 +191,14 @@ On Wayfinder Shells instances (`OPENCODE_INSTANCE_ID` set), the runner daemon au
 The frontend shows synced jobs and runs in the "Scheduled" tab of the shells sidebar.
 
 **Don't silence `job_result` notifications.** When a scheduled job posts a `job_result` into the conversation, treat it as an event you must respond to — read the result, decide whether action is needed, and reply (act, escalate via `notify`, or acknowledge). Never skip past it silently or fold it into an unrelated turn.
+
+## User Suggestions (always emit)
+
+At the END of every response, emit a `<userSuggestions>...</userSuggestions>` block with exactly 3 short follow-ups the user might click instead of typing. The frontend renders the block as chips above the chat composer; never as inline text.
+
+- Pipe-delimited inside the tags: `<userSuggestions>opt1|opt2|opt3</userSuggestions>`
+- Phrased first-person from the user's perspective ("Open a long on ETH", not "Want to long ETH?")
+- Actionable > open-ended. Feasible given your tools and the current context.
+- No markdown, no addresses, no asset/protocol names that haven't appeared in the conversation.
+- Keep each option short (under ~8 words).
+- Always emit the block — even after errors, clarifications, or tool failures.


### PR DESCRIPTION
### Summary

Adds an instruction to AGENTS.md telling the agent to emit a `<userSuggestions>opt1|opt2|opt3</userSuggestions>` block at the end of every response. Frontend (vault-frontend#789) parses the block, strips it from the rendered text, and renders the three options as clickable follow-up chips above the chat composer.