### PR TITLE
Fix Hyperliquid unified balance interpretation

### DIFF
--- a/.claude/skills/developing-wayfinder-strategies/rules/reference-strategies.md
+++ b/.claude/skills/developing-wayfinder-strategies/rules/reference-strategies.md
@@ -146,10 +146,13 @@ Don't deviate on:
     set to wallet-appropriate values. Verify it loads:
     poetry run python -c "from wayfinder_paths.core.strategies.risk_limits import RiskLimits; print(RiskLimits.load_optional('wayfinder_paths/strategies/<name>'))"
 
-[ ] Wallet exists with label == strategy.name and has USDC in HL PERP
-    (not just spot). Use core_get_wallets(label="<name>") to verify both;
-    if spot-only, run hyperliquid_execute(action="spot_to_perp_transfer", ...)
-    before the first update.
+[ ] Wallet exists with label == strategy.name and has Hyperliquid USDC usable
+    for perp orders. Use hyperliquid_get_state(label="<name>") and read
+    account.mode plus perp_collateral. In unifiedAccount / portfolioMargin,
+    spot USDC is also perp collateral; do not transfer just because the perp
+    clearinghouse summary is zero. In non-unified modes, if the account is
+    spot-only, run hyperliquid_execute(action="spot_to_perp_transfer", ...)
+    only after explicit user confirmation.
 
 [ ] CLI status returns clean StatusDict (no risk_warning):
     poetry run python -m wayfinder_paths.run_strategy <name> --action status \

--- a/.claude/skills/using-hyperliquid-adapter/rules/gotchas.md
+++ b/.claude/skills/using-hyperliquid-adapter/rules/gotchas.md
@@ -22,6 +22,16 @@ Trading on HIP-3 dexes (xyz, flx, vntl, hyna, km, etc.) requires **UnifiedAccoun
 - HIP-3 asset IDs use offsets: first builder dex starts at 110000, then 120000, 130000, etc.
 - HIP-3 coin names are prefixed: `xyz:NVDA`, `vntl:SPACEX`, `hyna:BTC`, etc.
 
+### Unified account balance interpretation
+
+Before telling a user they need to fund perps, call `hyperliquid_get_state(label)` and read:
+
+- `account.mode`
+- `perp_collateral.spot_usdc_usable_for_perp_orders`
+- `perp_collateral.estimated_usdc_available_for_perp_orders`
+
+In `unifiedAccount` / `portfolioMargin`, Hyperliquid exposes balances and holds through `spotClearinghouseState`; the USDC spot balance is also the cross-margin source for USDC perps and HIP-3 USDC-quoted perps. A zero or low `perp.state.crossMarginSummary.totalRawUsd`, `accountValue`, or `withdrawable` can simply mean there is no open perp leg yet. Do **not** describe the USDC as spot-only, and do **not** recommend a `spot_to_perp_transfer` just because the perp clearinghouse summary is zero.
+
 ## Asset ID conventions
 
 - Perp assets: `asset_id < 10000`
@@ -51,7 +61,7 @@ Spot "index" is usually: `spot_index = spot_asset_id - 10000`.
 - `usd_amount` is always treated as notional (no `usd_amount_kind` required)
 - `leverage` and `reduce_only` are ignored for spot
 
-**Spot balance location:** Spot tokens live in your spot wallet, separate from perp margin. Use `spot_to_perp_transfer` / `perp_to_spot_transfer` to move USDC between them.
+**Spot balance location:** Spot balances are separate from perp margin only in non-unified account modes. In `unifiedAccount` / `portfolioMargin`, USDC spot balance is also usable as perp collateral. Use `spot_to_perp_transfer` / `perp_to_spot_transfer` only after checking `account.mode` and confirming the user really needs a transfer.
 
 ## Spot L2 naming quirks
 

--- a/.claude/skills/using-hyperliquid-adapter/rules/high-value-reads.md
+++ b/.claude/skills/using-hyperliquid-adapter/rules/high-value-reads.md
@@ -52,8 +52,10 @@ Use one of:
 
 ### Account state
 
-`mcp__wayfinder__hyperliquid_get_state(label)` returns all three asset surfaces in one shot:
+`mcp__wayfinder__hyperliquid_get_state(label)` returns account mode, a derived perp-collateral interpretation, and all three asset surfaces in one shot:
 
+- `account.mode` — Hyperliquid account abstraction mode, such as `unifiedAccount`.
+- `perp_collateral` — normalized guidance for perp order planning. In `unifiedAccount` / `portfolioMargin`, `spot_usdc_usable_for_perp_orders=true` and `estimated_usdc_available_for_perp_orders` comes from `spotClearinghouseState.balances[USDC]` (`total - hold`). Do **not** treat zero/low `perp.state.crossMarginSummary.totalRawUsd` or `accountValue` alone as proof that the account lacks perp collateral.
 - `perp.state` — perp clearinghouse (margin summary, asset positions, withdrawable).
 - `spot.state.balances` — pure spot balances (USDC / HYPE / USDH / …). `+N` HIP-4 outcome entries are filtered out into the `outcomes` bucket.
 - `outcomes.positions` — outcome positions only (`+N` entries with non-zero total), parsed `outcome_id` / `side`. See `rules/outcomes.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,13 @@ Hyperliquid minimums:
 
 Hyperliquid surfaces in the adapter/MCP: perp, spot, HIP-3 builder-deployed perp dexes (`xyz`/`flx`/`vntl`/`hyna`/`km`...), and HIP-4 outcome markets (binary/multi-outcome prediction contracts). Outcomes use a separate asset-id space (`100_000_000 + 10*outcome_id + side`) and integer contract sizes; **settle in USDH** (token 360), not USDC; settle daily at 06:00 UTC; written via `hyperliquid_execute(action="place_outcome_order", ...)`. See `/using-hyperliquid-adapter` rules for details.
 
-Hyperliquid spot_to_perp_transfer and perp_to_spot_transfer only work with USDC spot to/from USDC perps. Other USD stables will need to be converted first.
+Hyperliquid spot_to_perp_transfer and perp_to_spot_transfer only work with USDC
+spot to/from USDC perps. Other USD stables will need to be converted first.
+Before recommending a transfer, check `hyperliquid_get_state(label)` and read
+`account.mode` plus `perp_collateral`: in `unifiedAccount` / `portfolioMargin`,
+USDC spot balance is already usable as perp collateral, so zero
+`perp.state.crossMarginSummary.totalRawUsd` alone does not mean the perp account
+is unfunded.
 
 **Outcome / prediction markets — search both venues, let the user pick.** When a user mentions "outcome market" or "prediction market" without naming the platform, **search both venues in parallel** and present candidates side-by-side so the user can choose. Two venues:
 

--- a/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
+++ b/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
@@ -479,6 +479,20 @@ class HyperliquidAdapter(BaseAdapter):
             self.logger.error(f"Failed to fetch spot_user_state for {address}: {exc}")
             return False, str(exc)
 
+    async def get_user_abstraction_state(
+        self, address: str
+    ) -> tuple[Literal[True], str] | tuple[Literal[False], str]:
+        try:
+            data = await asyncio.to_thread(
+                get_info().query_user_abstraction_state, address
+            )
+            return True, str(data)
+        except Exception as exc:
+            self.logger.error(
+                f"Failed to fetch user_abstraction_state for {address}: {exc}"
+            )
+            return False, str(exc)
+
     async def get_full_user_state(
         self,
         *,
@@ -1377,8 +1391,11 @@ class HyperliquidAdapter(BaseAdapter):
         return success, result
 
     async def ensure_unified_account(self, address: str) -> tuple[bool, str]:
-        if get_info().query_user_abstraction_state(address) == "unifiedAccount":
-            return True, "Unified account already enabled"
+        ok, state = await self.get_user_abstraction_state(address)
+        if ok and state in {"unifiedAccount", "portfolioMargin"}:
+            return True, f"{state} already enabled"
+        if not ok:
+            return False, f"Failed to query account abstraction mode: {state}"
 
         ok, result = await self.set_account_abstraction(address, "unifiedAccount")
         if ok:

--- a/wayfinder_paths/adapters/hyperliquid_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/hyperliquid_adapter/test_adapter.py
@@ -110,6 +110,32 @@ class TestHyperliquidAdapter:
             assert success
             assert "assetPositions" in data
 
+    @pytest.mark.asyncio
+    async def test_get_user_abstraction_state(self, adapter, mock_info, _patch_adapter):
+        mock_info.query_user_abstraction_state.return_value = "unifiedAccount"
+
+        p1, p2 = _patch_adapter()
+        with p1, p2:
+            success, state = await adapter.get_user_abstraction_state("0x1234")
+
+        assert success
+        assert state == "unifiedAccount"
+
+    @pytest.mark.asyncio
+    async def test_ensure_unified_account_accepts_portfolio_margin(
+        self, adapter, mock_info, _patch_adapter
+    ):
+        mock_info.query_user_abstraction_state.return_value = "portfolioMargin"
+        adapter.set_account_abstraction = AsyncMock()
+
+        p1, p2 = _patch_adapter()
+        with p1, p2:
+            success, message = await adapter.ensure_unified_account("0x1234")
+
+        assert success
+        assert message == "portfolioMargin already enabled"
+        adapter.set_account_abstraction.assert_not_awaited()
+
     def test_get_sz_decimals(self, adapter, mock_info, _patch_adapter):
         p1, p2 = _patch_adapter()
         with p1, p2:

--- a/wayfinder_paths/mcp/tools/hyperliquid.py
+++ b/wayfinder_paths/mcp/tools/hyperliquid.py
@@ -55,6 +55,96 @@ def _annotate_hl_profile(
     )
 
 
+_UNIFIED_BALANCE_ACCOUNT_MODES = {"unifiedAccount", "portfolioMargin"}
+
+
+def _float_or_none(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _spot_balance_amounts(
+    spot: dict[str, Any] | str,
+    coin: str,
+) -> dict[str, float | None]:
+    if not isinstance(spot, dict):
+        return {"total": None, "hold": None, "available": None}
+
+    for bal in spot.get("balances") or []:
+        if not isinstance(bal, dict) or bal.get("coin") != coin:
+            continue
+        total = _float_or_none(bal.get("total"))
+        hold = _float_or_none(bal.get("hold"))
+        available = None
+        if total is not None:
+            available = total - (hold or 0.0)
+            if available < 0:
+                available = 0.0
+        return {"total": total, "hold": hold, "available": available}
+
+    return {"total": None, "hold": None, "available": None}
+
+
+def _perp_margin_amounts(perp: dict[str, Any] | str) -> dict[str, float | None]:
+    if not isinstance(perp, dict):
+        return {"account_value": None, "withdrawable": None}
+
+    summary = perp.get("crossMarginSummary") or perp.get("marginSummary") or {}
+    if not isinstance(summary, dict):
+        summary = {}
+    return {
+        "account_value": _float_or_none(summary.get("accountValue")),
+        "withdrawable": _float_or_none(perp.get("withdrawable")),
+    }
+
+
+def _build_perp_collateral_summary(
+    *,
+    account_mode: str | None,
+    mode_success: bool,
+    perp: dict[str, Any] | str,
+    spot: dict[str, Any] | str,
+) -> dict[str, Any]:
+    spot_usdc = _spot_balance_amounts(spot, "USDC")
+    perp_margin = _perp_margin_amounts(perp)
+    unified = account_mode in _UNIFIED_BALANCE_ACCOUNT_MODES
+
+    if unified:
+        balance_source = "spotClearinghouseState.balances[USDC]"
+        estimated_available = spot_usdc["available"]
+        guidance = (
+            "This account mode unifies spot USDC with cross-margin perp collateral. "
+            "Do not treat a zero perp totalRawUsd/accountValue alone as an unfunded perp account."
+        )
+    else:
+        balance_source = "clearinghouseState"
+        estimated_available = (
+            perp_margin["withdrawable"]
+            if perp_margin["withdrawable"] is not None
+            else perp_margin["account_value"]
+        )
+        guidance = (
+            "Spot balances are separate from perp margin unless the account mode is unified. "
+            "Only suggest transfers/deposits after checking account mode and getting explicit user approval."
+        )
+
+    return {
+        "account_mode_success": mode_success,
+        "account_mode": account_mode,
+        "spot_usdc_usable_for_perp_orders": unified,
+        "perp_balance_source": balance_source,
+        "spot_usdc_total": spot_usdc["total"],
+        "spot_usdc_hold": spot_usdc["hold"],
+        "spot_usdc_available": spot_usdc["available"],
+        "perp_account_value": perp_margin["account_value"],
+        "perp_withdrawable": perp_margin["withdrawable"],
+        "estimated_usdc_available_for_perp_orders": estimated_available,
+        "guidance": guidance,
+    }
+
+
 async def _ensure_builder_fee_approval(
     adapter: HyperliquidAdapter,
     *,
@@ -857,8 +947,11 @@ async def hyperliquid_get_state(label: str) -> dict[str, Any]:
         return err("not_found", f"Wallet not found: {label}")
 
     adapter = HyperliquidAdapter()
-    perp_ok, perp = await adapter.get_user_state(addr)
-    spot_ok, spot = await adapter.get_spot_user_state(addr)
+    (mode_ok, account_mode), (perp_ok, perp), (spot_ok, spot) = await asyncio.gather(
+        adapter.get_user_abstraction_state(addr),
+        adapter.get_user_state(addr),
+        adapter.get_spot_user_state(addr),
+    )
 
     spot_balances: list[dict[str, Any]] = []
     outcome_positions: list[dict[str, Any]] = []
@@ -887,6 +980,17 @@ async def hyperliquid_get_state(label: str) -> dict[str, Any]:
         {
             "label": label,
             "address": addr,
+            "account": {
+                "success": mode_ok,
+                "mode": account_mode if mode_ok else None,
+                "error": None if mode_ok else account_mode,
+            },
+            "perp_collateral": _build_perp_collateral_summary(
+                account_mode=account_mode if mode_ok else None,
+                mode_success=mode_ok,
+                perp=perp,
+                spot=spot,
+            ),
             "perp": {"success": perp_ok, "state": perp},
             "spot": {"success": spot_ok, "state": spot},
             "outcomes": {"success": spot_ok, "positions": outcome_positions},

--- a/wayfinder_paths/tests/test_mcp_hyperliquid_execute.py
+++ b/wayfinder_paths/tests/test_mcp_hyperliquid_execute.py
@@ -6,7 +6,10 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from wayfinder_paths.adapters.hyperliquid_adapter import HyperliquidAdapter
-from wayfinder_paths.mcp.tools.hyperliquid import hyperliquid_execute
+from wayfinder_paths.mcp.tools.hyperliquid import (
+    hyperliquid_execute,
+    hyperliquid_get_state,
+)
 
 
 class _StubAdapter(HyperliquidAdapter):
@@ -101,3 +104,113 @@ async def test_hyperliquid_execute_withdraw(tmp_path: Path, monkeypatch):
             "withdraw", wallet_label="main", amount_usdc=10
         )
         assert out1["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_hyperliquid_get_state_marks_unified_spot_usdc_as_perp_collateral():
+    address = "0x000000000000000000000000000000000000dEaD"
+    perp_state = {
+        "assetPositions": [],
+        "crossMarginSummary": {
+            "accountValue": "0.0",
+            "totalRawUsd": "0.0",
+            "totalMarginUsed": "0.0",
+        },
+        "withdrawable": "0.0",
+    }
+    spot_state = {
+        "balances": [
+            {"coin": "USDC", "total": "11.07", "hold": "1.00"},
+            {"coin": "+41", "total": "3", "hold": "0", "entryNtl": "1.5"},
+        ]
+    }
+
+    with (
+        patch(
+            "wayfinder_paths.mcp.tools.hyperliquid.resolve_wallet_address",
+            new=AsyncMock(return_value=(address, {})),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.hyperliquid.HyperliquidAdapter.get_user_abstraction_state",
+            new=AsyncMock(return_value=(True, "unifiedAccount")),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.hyperliquid.HyperliquidAdapter.get_user_state",
+            new=AsyncMock(return_value=(True, perp_state)),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.hyperliquid.HyperliquidAdapter.get_spot_user_state",
+            new=AsyncMock(return_value=(True, spot_state)),
+        ),
+    ):
+        out = await hyperliquid_get_state("main")
+
+    assert out["ok"] is True
+    result = out["result"]
+    assert result["account"]["mode"] == "unifiedAccount"
+    assert result["perp_collateral"] == {
+        "account_mode_success": True,
+        "account_mode": "unifiedAccount",
+        "spot_usdc_usable_for_perp_orders": True,
+        "perp_balance_source": "spotClearinghouseState.balances[USDC]",
+        "spot_usdc_total": 11.07,
+        "spot_usdc_hold": 1.0,
+        "spot_usdc_available": pytest.approx(10.07),
+        "perp_account_value": 0.0,
+        "perp_withdrawable": 0.0,
+        "estimated_usdc_available_for_perp_orders": pytest.approx(10.07),
+        "guidance": result["perp_collateral"]["guidance"],
+    }
+    assert "Do not treat" in result["perp_collateral"]["guidance"]
+    assert result["spot"]["state"]["balances"] == [
+        {"coin": "USDC", "total": "11.07", "hold": "1.00"}
+    ]
+    assert result["outcomes"]["positions"] == [
+        {
+            "coin": "+41",
+            "outcome_id": 4,
+            "side": 1,
+            "total": "3",
+            "hold": "0",
+            "entryNtl": "1.5",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_hyperliquid_get_state_keeps_standard_spot_usdc_separate_from_perps():
+    address = "0x000000000000000000000000000000000000dEaD"
+    perp_state = {
+        "assetPositions": [],
+        "crossMarginSummary": {"accountValue": "6.0", "totalRawUsd": "6.0"},
+        "withdrawable": "5.5",
+    }
+    spot_state = {"balances": [{"coin": "USDC", "total": "11.07", "hold": "0"}]}
+
+    with (
+        patch(
+            "wayfinder_paths.mcp.tools.hyperliquid.resolve_wallet_address",
+            new=AsyncMock(return_value=(address, {})),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.hyperliquid.HyperliquidAdapter.get_user_abstraction_state",
+            new=AsyncMock(return_value=(True, "standard")),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.hyperliquid.HyperliquidAdapter.get_user_state",
+            new=AsyncMock(return_value=(True, perp_state)),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.hyperliquid.HyperliquidAdapter.get_spot_user_state",
+            new=AsyncMock(return_value=(True, spot_state)),
+        ),
+    ):
+        out = await hyperliquid_get_state("main")
+
+    assert out["ok"] is True
+    collateral = out["result"]["perp_collateral"]
+    assert collateral["account_mode"] == "standard"
+    assert collateral["spot_usdc_usable_for_perp_orders"] is False
+    assert collateral["perp_balance_source"] == "clearinghouseState"
+    assert collateral["estimated_usdc_available_for_perp_orders"] == 5.5
+    assert "explicit user approval" in collateral["guidance"]


### PR DESCRIPTION
## Summary
- add Hyperliquid account mode and derived perp collateral fields to `hyperliquid_get_state`
- treat unified/portfolio account spot USDC as usable perp collateral in agent-facing state output
- update Hyperliquid and strategy guidance so agents do not recommend unnecessary spot-to-perp transfers
- add focused tests for unified vs standard account balance interpretation

## Validation
- `POETRY_VIRTUALENVS_IN_PROJECT=true POETRY_CACHE_DIR=/private/tmp/wayst-238-poetry-cache poetry run pytest wayfinder_paths/tests/test_mcp_hyperliquid_execute.py wayfinder_paths/adapters/hyperliquid_adapter/test_adapter.py -q`
- `POETRY_VIRTUALENVS_IN_PROJECT=true POETRY_CACHE_DIR=/private/tmp/wayst-238-poetry-cache poetry run ruff check wayfinder_paths/mcp/tools/hyperliquid.py wayfinder_paths/adapters/hyperliquid_adapter/adapter.py wayfinder_paths/adapters/hyperliquid_adapter/test_adapter.py wayfinder_paths/tests/test_mcp_hyperliquid_execute.py`
- `POETRY_VIRTUALENVS_IN_PROJECT=true POETRY_CACHE_DIR=/private/tmp/wayst-238-poetry-cache poetry run ruff format --check wayfinder_paths/mcp/tools/hyperliquid.py wayfinder_paths/adapters/hyperliquid_adapter/adapter.py wayfinder_paths/adapters/hyperliquid_adapter/test_adapter.py wayfinder_paths/tests/test_mcp_hyperliquid_execute.py`
- `git diff --check`

Linear: WAYST-238
