### PR TITLE
ABIs - In constants files and nowhere else

### DIFF
--- a/wayfinder_paths/adapters/multicall_adapter/adapter.py
+++ b/wayfinder_paths/adapters/multicall_adapter/adapter.py
@@ -9,38 +9,7 @@ from hexbytes import HexBytes
 from wayfinder_paths.core.adapters.BaseAdapter import BaseAdapter
 from wayfinder_paths.core.constants.contracts import MULTICALL3_ADDRESS
 from wayfinder_paths.core.constants.erc20_abi import ERC20_ABI
-
-MULTICALL3_ABI = [
-    {
-        "inputs": [
-            {
-                "components": [
-                    {"internalType": "address", "name": "target", "type": "address"},
-                    {"internalType": "bytes", "name": "callData", "type": "bytes"},
-                ],
-                "internalType": "struct Multicall3.Call[]",
-                "name": "calls",
-                "type": "tuple[]",
-            }
-        ],
-        "name": "aggregate",
-        "outputs": [
-            {"internalType": "uint256", "name": "blockNumber", "type": "uint256"},
-            {"internalType": "bytes[]", "name": "returnData", "type": "bytes[]"},
-        ],
-        "stateMutability": "payable",
-        "type": "function",
-    },
-    {
-        "inputs": [{"internalType": "address", "name": "addr", "type": "address"}],
-        "name": "getEthBalance",
-        "outputs": [
-            {"internalType": "uint256", "name": "balance", "type": "uint256"},
-        ],
-        "stateMutability": "view",
-        "type": "function",
-    },
-]
+from wayfinder_paths.core.constants.multicall3_abi import MULTICALL3_ABI
 
 
 @dataclass(frozen=True)

--- a/wayfinder_paths/adapters/pendle_adapter/adapter.py
+++ b/wayfinder_paths/adapters/pendle_adapter/adapter.py
@@ -11,6 +11,7 @@ from eth_utils import to_checksum_address
 from wayfinder_paths.adapters.multicall_adapter.adapter import MulticallAdapter
 from wayfinder_paths.core.adapters.BaseAdapter import BaseAdapter
 from wayfinder_paths.core.constants.erc20_abi import ERC20_ABI
+from wayfinder_paths.core.constants.pendle_abi import PENDLE_ROUTER_STATIC_ABI
 from wayfinder_paths.core.utils.tokens import (
     ensure_allowance,
     get_token_balance,
@@ -63,37 +64,6 @@ PENDLE_CHAIN_IDS: dict[str, int] = {
 }
 
 PENDLE_DEFAULT_DEPLOYMENTS_BASE_URL = "https://raw.githubusercontent.com/pendle-finance/pendle-core-v2-public/main/deployments"
-
-PENDLE_ROUTER_STATIC_ABI: list[dict[str, Any]] = [
-    {
-        "inputs": [{"internalType": "address", "name": "market", "type": "address"}],
-        "name": "getLpToSyRate",
-        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
-        "stateMutability": "view",
-        "type": "function",
-    },
-    {
-        "inputs": [{"internalType": "address", "name": "market", "type": "address"}],
-        "name": "getPtToSyRate",
-        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
-        "stateMutability": "view",
-        "type": "function",
-    },
-    {
-        "inputs": [{"internalType": "address", "name": "market", "type": "address"}],
-        "name": "getLpToAssetRate",
-        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
-        "stateMutability": "view",
-        "type": "function",
-    },
-    {
-        "inputs": [{"internalType": "address", "name": "market", "type": "address"}],
-        "name": "getPtToAssetRate",
-        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
-        "stateMutability": "view",
-        "type": "function",
-    },
-]
 
 ChainLike = int | str
 

--- a/wayfinder_paths/core/constants/eip897_abi.py
+++ b/wayfinder_paths/core/constants/eip897_abi.py
@@ -1,0 +1,24 @@
+"""EIP-897 (DelegateProxy) ABI used to introspect upgradeable proxy contracts."""
+
+from typing import Any
+
+EIP897_ABI: list[dict[str, Any]] = [
+    {
+        "constant": True,
+        "inputs": [],
+        "name": "proxyType",
+        "outputs": [{"name": "proxyTypeId", "type": "uint256"}],
+        "payable": False,
+        "stateMutability": "pure",
+        "type": "function",
+    },
+    {
+        "constant": True,
+        "inputs": [],
+        "name": "implementation",
+        "outputs": [{"name": "codeAddr", "type": "address"}],
+        "payable": False,
+        "stateMutability": "view",
+        "type": "function",
+    },
+]

--- a/wayfinder_paths/core/constants/erc20_abi.py
+++ b/wayfinder_paths/core/constants/erc20_abi.py
@@ -99,3 +99,25 @@ ERC20_APPROVAL_ABI = [
         "type": "function",
     },
 ]
+
+# Fallback ABIs for non-standard ERC20s that return bytes32 instead of string
+# for name()/symbol() (e.g. MakerDAO's original MKR token).
+ERC20_NAME_BYTES32_ABI = [
+    {
+        "constant": True,
+        "inputs": [],
+        "name": "name",
+        "outputs": [{"name": "", "type": "bytes32"}],
+        "type": "function",
+    }
+]
+
+ERC20_SYMBOL_BYTES32_ABI = [
+    {
+        "constant": True,
+        "inputs": [],
+        "name": "symbol",
+        "outputs": [{"name": "", "type": "bytes32"}],
+        "type": "function",
+    }
+]

--- a/wayfinder_paths/core/constants/hype_abi.py
+++ b/wayfinder_paths/core/constants/hype_abi.py
@@ -1,0 +1,44 @@
+"""ABIs for the HYPE token ecosystem on HyperEVM:
+- WHYPE (wrapped HYPE, WETH-like interface)
+- kHYPE staking accountant (exchange rate oracle)
+- lHYPE looping accountant (exchange rate oracle)
+"""
+
+WHYPE_ABI = [
+    {
+        "name": "withdraw",
+        "type": "function",
+        "stateMutability": "nonpayable",
+        "inputs": [{"name": "wad", "type": "uint256"}],
+        "outputs": [],
+    },
+    {
+        "name": "balanceOf",
+        "type": "function",
+        "stateMutability": "view",
+        "inputs": [{"name": "owner", "type": "address"}],
+        "outputs": [{"type": "uint256"}],
+    },
+]
+
+KHYPE_STAKING_ACCOUNTANT_ABI = [
+    {
+        "inputs": [
+            {"internalType": "uint256", "name": "kHYPEAmount", "type": "uint256"}
+        ],
+        "name": "kHYPEToHYPE",
+        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    }
+]
+
+LHYPE_ACCOUNTANT_ABI = [
+    {
+        "inputs": [{"internalType": "address", "name": "quote", "type": "address"}],
+        "name": "getRateInQuote",
+        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    }
+]

--- a/wayfinder_paths/core/constants/multicall3_abi.py
+++ b/wayfinder_paths/core/constants/multicall3_abi.py
@@ -1,0 +1,33 @@
+"""Multicall3 ABI subset used by the multicall adapter."""
+
+MULTICALL3_ABI = [
+    {
+        "inputs": [
+            {
+                "components": [
+                    {"internalType": "address", "name": "target", "type": "address"},
+                    {"internalType": "bytes", "name": "callData", "type": "bytes"},
+                ],
+                "internalType": "struct Multicall3.Call[]",
+                "name": "calls",
+                "type": "tuple[]",
+            }
+        ],
+        "name": "aggregate",
+        "outputs": [
+            {"internalType": "uint256", "name": "blockNumber", "type": "uint256"},
+            {"internalType": "bytes[]", "name": "returnData", "type": "bytes[]"},
+        ],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [{"internalType": "address", "name": "addr", "type": "address"}],
+        "name": "getEthBalance",
+        "outputs": [
+            {"internalType": "uint256", "name": "balance", "type": "uint256"},
+        ],
+        "stateMutability": "view",
+        "type": "function",
+    },
+]

--- a/wayfinder_paths/core/constants/pendle_abi.py
+++ b/wayfinder_paths/core/constants/pendle_abi.py
@@ -1,0 +1,34 @@
+"""Pendle ABI subsets used by the pendle adapter."""
+
+from typing import Any
+
+PENDLE_ROUTER_STATIC_ABI: list[dict[str, Any]] = [
+    {
+        "inputs": [{"internalType": "address", "name": "market", "type": "address"}],
+        "name": "getLpToSyRate",
+        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [{"internalType": "address", "name": "market", "type": "address"}],
+        "name": "getPtToSyRate",
+        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [{"internalType": "address", "name": "market", "type": "address"}],
+        "name": "getLpToAssetRate",
+        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [{"internalType": "address", "name": "market", "type": "address"}],
+        "name": "getPtToAssetRate",
+        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+]

--- a/wayfinder_paths/core/utils/proxy.py
+++ b/wayfinder_paths/core/utils/proxy.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from typing import Any
-
 from web3 import AsyncWeb3
 
+from wayfinder_paths.core.constants.eip897_abi import EIP897_ABI
 from wayfinder_paths.core.utils import web3 as web3_utils
 
 EIP1967_IMPLEMENTATION_SLOT = (
@@ -12,27 +11,6 @@ EIP1967_IMPLEMENTATION_SLOT = (
 ZEPPELINOS_IMPLEMENTATION_SLOT = (
     "0x7050c9e0f4ca769c69bd3a8ef740bc37934f8e2c036e5a723fd8ee048ed3f8c3"
 )
-
-EIP897_ABI: list[dict[str, Any]] = [
-    {
-        "constant": True,
-        "inputs": [],
-        "name": "proxyType",
-        "outputs": [{"name": "proxyTypeId", "type": "uint256"}],
-        "payable": False,
-        "stateMutability": "pure",
-        "type": "function",
-    },
-    {
-        "constant": True,
-        "inputs": [],
-        "name": "implementation",
-        "outputs": [{"name": "codeAddr", "type": "address"}],
-        "payable": False,
-        "stateMutability": "view",
-        "type": "function",
-    },
-]
 
 
 async def _impl_from_storage_slot(

--- a/wayfinder_paths/core/utils/tokens.py
+++ b/wayfinder_paths/core/utils/tokens.py
@@ -7,7 +7,11 @@ from web3 import AsyncWeb3
 from web3.exceptions import BadFunctionCallOutput
 
 from wayfinder_paths.core.constants.contracts import TOKENS_REQUIRING_APPROVAL_RESET
-from wayfinder_paths.core.constants.erc20_abi import ERC20_ABI
+from wayfinder_paths.core.constants.erc20_abi import (
+    ERC20_ABI,
+    ERC20_NAME_BYTES32_ABI,
+    ERC20_SYMBOL_BYTES32_ABI,
+)
 from wayfinder_paths.core.constants.erc1155_abi import ERC1155_APPROVAL_ABI
 from wayfinder_paths.core.utils.transaction import encode_call, send_transaction
 from wayfinder_paths.core.utils.web3 import web3_from_chain_id
@@ -53,16 +57,10 @@ async def _erc20_string(
         return _coerce_bytes32_str(value)
     except (BadFunctionCallOutput, ValueError):
         # Some ERC20s use bytes32 for name/symbol (non-standard).
-        bytes32_abi = [
-            {
-                "constant": True,
-                "inputs": [],
-                "name": field,
-                "outputs": [{"name": "", "type": "bytes32"}],
-                "type": "function",
-            }
-        ]
-        contract32 = web3.eth.contract(address=checksum_token, abi=bytes32_abi)
+        fallback_abi = (
+            ERC20_NAME_BYTES32_ABI if field == "name" else ERC20_SYMBOL_BYTES32_ABI
+        )
+        contract32 = web3.eth.contract(address=checksum_token, abi=fallback_abi)
         fn32 = getattr(contract32.functions, field)
         value = await fn32().call(block_identifier=block_identifier)
         return _coerce_bytes32_str(value)

--- a/wayfinder_paths/strategies/boros_hype_strategy/constants.py
+++ b/wayfinder_paths/strategies/boros_hype_strategy/constants.py
@@ -8,15 +8,23 @@ from wayfinder_paths.core.constants.contracts import (
 from wayfinder_paths.core.constants.contracts import (
     HYPEREVM_WHYPE as WHYPE_ADDRESS,
 )
+from wayfinder_paths.core.constants.hype_abi import (
+    KHYPE_STAKING_ACCOUNTANT_ABI,
+    LHYPE_ACCOUNTANT_ABI,
+    WHYPE_ABI,
+)
 
-# Re-export addresses for use by strategy modules
+# Re-export addresses and ABIs for use by strategy modules
 __all__ = [
     "HYPE_OFT_ADDRESS",
-    "WHYPE_ADDRESS",
     "KHYPE_ADDRESS",
     "KHYPE_STAKING_ACCOUNTANT",
+    "KHYPE_STAKING_ACCOUNTANT_ABI",
     "LHYPE_ACCOUNTANT",
+    "LHYPE_ACCOUNTANT_ABI",
     "LOOPED_HYPE_ADDRESS",
+    "WHYPE_ABI",
+    "WHYPE_ADDRESS",
 ]
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -39,47 +47,8 @@ USDC_HYPE = "usd-coin-hyperevm"
 HYPEREVM_CHAIN_ID = 999
 ARBITRUM_CHAIN_ID = 42161
 
-# ABIs for exchange rate reads
-KHYPE_STAKING_ACCOUNTANT_ABI = [
-    {
-        "inputs": [
-            {"internalType": "uint256", "name": "kHYPEAmount", "type": "uint256"}
-        ],
-        "name": "kHYPEToHYPE",
-        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
-        "stateMutability": "view",
-        "type": "function",
-    }
-]
-
-LHYPE_ACCOUNTANT_ABI = [
-    {
-        "inputs": [{"internalType": "address", "name": "quote", "type": "address"}],
-        "name": "getRateInQuote",
-        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
-        "stateMutability": "view",
-        "type": "function",
-    }
-]
-
-# WHYPE contract ABI for unwrapping (standard WETH-like interface)
-WHYPE_ABI = [
-    {
-        "name": "withdraw",
-        "type": "function",
-        "stateMutability": "nonpayable",
-        "inputs": [{"name": "wad", "type": "uint256"}],
-        "outputs": [],
-    },
-    {
-        "name": "balanceOf",
-        "type": "function",
-        "stateMutability": "view",
-        "inputs": [{"name": "owner", "type": "address"}],
-        "outputs": [{"type": "uint256"}],
-    },
-]
-
+# ABIs (KHYPE_STAKING_ACCOUNTANT_ABI, LHYPE_ACCOUNTANT_ABI, WHYPE_ABI) live
+# in `wayfinder_paths/core/constants/hype_abi.py` and are re-exported above.
 
 # ─────────────────────────────────────────────────────────────────────────────
 # STRATEGY THRESHOLDS

--- a/wayfinder_paths/tests/test_abi_location.py
+++ b/wayfinder_paths/tests/test_abi_location.py
@@ -1,0 +1,114 @@
+"""Enforce that every ABI literal lives in `wayfinder_paths/core/constants/`.
+
+An ABI literal is a list whose first element is a dict containing the
+`"type"` key set to one of `function | event | constructor | error |
+fallback | receive`. Adapters, strategies, mcp tools, and core utils
+should import from `core/constants/*_abi.py` rather than redefining the
+shape inline.
+
+Test fixtures are exempt — purpose-built minimal ABIs in `test_*.py`
+exercise overload / proxy / fallback edge cases and shouldn't be coupled
+to production constants.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+import wayfinder_paths
+
+SDK_ROOT = Path(wayfinder_paths.__path__[0])
+CONSTANTS_DIR = SDK_ROOT / "core" / "constants"
+ABI_FRAGMENT_TYPES = {
+    "function",
+    "event",
+    "constructor",
+    "error",
+    "fallback",
+    "receive",
+}
+
+
+def _is_abi_fragment(node: ast.AST) -> bool:
+    if not isinstance(node, ast.Dict):
+        return False
+    for key, value in zip(node.keys, node.values, strict=True):
+        if (
+            isinstance(key, ast.Constant)
+            and key.value == "type"
+            and isinstance(value, ast.Constant)
+            and value.value in ABI_FRAGMENT_TYPES
+        ):
+            return True
+    return False
+
+
+def _is_abi_list(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.List)
+        and len(node.elts) > 0
+        and _is_abi_fragment(node.elts[0])
+    )
+
+
+def _find_inline_abis(path: Path) -> list[int]:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    return [node.lineno for node in ast.walk(tree) if _is_abi_list(node)]
+
+
+def _python_files_outside_constants_and_tests() -> list[Path]:
+    files: list[Path] = []
+    for path in SDK_ROOT.rglob("*.py"):
+        if CONSTANTS_DIR in path.parents:
+            continue
+        if path.name.startswith("test_"):
+            continue
+        files.append(path)
+    return files
+
+
+def test_no_inline_abis_in_production_code() -> None:
+    offenders: list[str] = []
+    for path in _python_files_outside_constants_and_tests():
+        for lineno in _find_inline_abis(path):
+            offenders.append(f"{path.relative_to(SDK_ROOT)}:{lineno}")
+    assert not offenders, (
+        "Inline ABI literals found outside `core/constants/` — move each "
+        "to a `_abi.py` file and import from there:\n  " + "\n  ".join(offenders)
+    )
+
+
+def _exports_abi(value: object) -> bool:
+    """A constants module export counts as an ABI if it's a list of ABI
+    fragments OR a single ABI fragment (some files export a single event
+    descriptor as a dict)."""
+    if isinstance(value, dict) and value.get("type") in ABI_FRAGMENT_TYPES:
+        return True
+    if (
+        isinstance(value, list)
+        and value
+        and isinstance(value[0], dict)
+        and value[0].get("type") in ABI_FRAGMENT_TYPES
+    ):
+        return True
+    return False
+
+
+@pytest.mark.parametrize(
+    "abi_module",
+    [p.stem for p in sorted(CONSTANTS_DIR.glob("*_abi.py"))],
+)
+def test_abi_module_is_importable(abi_module: str) -> None:
+    import importlib
+
+    module = importlib.import_module(f"wayfinder_paths.core.constants.{abi_module}")
+    abi_exports = [
+        name
+        for name, value in vars(module).items()
+        if not name.startswith("_") and _exports_abi(value)
+    ]
+    assert abi_exports, (
+        f"{abi_module}.py exports no ABI lists — either drop the file or "
+        "add a NAME_ABI constant."
+    )


### PR DESCRIPTION
### Summary

Moves every production-code ABI literal into `core/constants/*_abi.py` and adds a CI guard that fails on any new inline ABI outside that directory.

**ABIs relocated:**
- `multicall3_abi.py` ← `MULTICALL3_ABI` (was in `multicall_adapter/adapter.py`)
- `pendle_abi.py` ← `PENDLE_ROUTER_STATIC_ABI` (was in `pendle_adapter/adapter.py`)
- `eip897_abi.py` ← `EIP897_ABI` (was in `core/utils/proxy.py`)
- `hype_abi.py` ← `WHYPE_ABI`, `KHYPE_STAKING_ACCOUNTANT_ABI`, `LHYPE_ACCOUNTANT_ABI` (were in `boros_hype_strategy/constants.py`, which now re-exports them so consumers stay unchanged)
- `erc20_abi.py` gains `ERC20_NAME_BYTES32_ABI` / `ERC20_SYMBOL_BYTES32_ABI`; `core/utils/tokens.py` no longer constructs the fallback ABI on the fly.

**Enforcement (`tests/test_abi_location.py`):**
- `test_no_inline_abis_in_production_code` walks every `.py` file outside `core/constants/` and `test_*.py`, AST-detects any list whose first element is an ABI fragment (`{"type": "function" | "event" | "constructor" | "error" | "fallback" | "receive", ...}`), and fails CI if any are found.
- `test_abi_module_is_importable` parametrizes over every `*_abi.py` and asserts each exports at least one ABI list or single-fragment dict (`erc721_abi.py` uses the single-dict shape).

**Out of scope** (intentionally exempt):
- `tests/test_mcp_evm_contract.py` and friends define minimal/overloaded/proxy-variant ABIs as purpose-built fixtures — coupling those to production constants would obscure what each test is exercising.
- `etherfi_adapter` and `eigencloud_adapter` derive single-event ABIs at module-load time from the full constants-resident ABI (no new ABI shape is being defined inline).

Net: +295 / −140 across 11 files (4 new constants files + 1 new test file + 6 production files).