### PR TITLE
Polymarket adapter: use BRAP for on-chain bridge legs

### DIFF
--- a/wayfinder_paths/adapters/polymarket_adapter/adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/adapter.py
@@ -26,6 +26,7 @@ from py_clob_client_v2.config import (  # type: ignore[import-untyped]
     get_contract_config,
 )
 
+from wayfinder_paths.adapters.brap_adapter.adapter import BRAPAdapter
 from wayfinder_paths.core.adapters.BaseAdapter import BaseAdapter
 from wayfinder_paths.core.clients.BRAPClient import BRAP_CLIENT
 from wayfinder_paths.core.constants.erc20_abi import ERC20_ABI
@@ -40,8 +41,6 @@ from wayfinder_paths.core.constants.polymarket import (
     POLYMARKET_BRIDGE_BASE_URL,
     POLYMARKET_BUILDER_CODE,
     POLYMARKET_CLOB_BASE_URL,
-    POLYMARKET_COLLATERAL_OFFRAMP_ADDRESS,
-    POLYMARKET_COLLATERAL_ONRAMP_ADDRESS,
     POLYMARKET_CONDITIONAL_TOKENS_ADDRESS,
     POLYMARKET_DATA_BASE_URL,
     POLYMARKET_DEPOSIT_WALLET_FACTORY,
@@ -54,7 +53,6 @@ from wayfinder_paths.core.constants.polymarket import (
 )
 from wayfinder_paths.core.constants.polymarket_abi import (
     CONDITIONAL_TOKENS_ABI,
-    POLYMARKET_COLLATERAL_RAMP_ABI,
     POLYMARKET_DEPOSIT_WALLET_BATCH_TYPES,
     POLYMARKET_DEPOSIT_WALLET_FACTORY_ABI,
     TOKEN_UNWRAP_ABI,
@@ -65,10 +63,9 @@ from wayfinder_paths.core.utils.multicall import (
 )
 from wayfinder_paths.core.utils.tokens import (
     build_send_transaction,
-    ensure_allowance,
     get_token_balance,
 )
-from wayfinder_paths.core.utils.transaction import encode_call, send_transaction
+from wayfinder_paths.core.utils.transaction import send_transaction
 from wayfinder_paths.core.utils.units import to_erc20_raw
 from wayfinder_paths.core.utils.web3 import web3_from_chain_id
 
@@ -87,181 +84,6 @@ def _fuzzy_score(query: str, text: str) -> float:
     if q in t:
         return 1.0
     return SequenceMatcher(None, q, t).ratio()
-
-
-async def _try_brap_swap_polygon(
-    *,
-    from_token_address: str,
-    to_token_address: str,
-    from_address: str,
-    amount_base_unit: int,
-    signing_callback,
-) -> dict[str, Any] | None:
-    """Try to swap on Polygon via BRAP and return a result payload, or None.
-
-    Notes:
-    - Only used for USDC ⇄ USDC.e conversions on Polygon.
-    - Any failure returns None so callers can fall back to the Polymarket bridge flow.
-    """
-    try:
-        quote = await BRAP_CLIENT.get_quote(
-            from_token=from_token_address,
-            to_token=to_token_address,
-            from_chain=POLYGON_CHAIN_ID,
-            to_chain=POLYGON_CHAIN_ID,
-            from_wallet=to_checksum_address(from_address),
-            from_amount=str(amount_base_unit),
-        )
-        best = quote["best_quote"]
-        calldata = best["calldata"]
-        if not calldata.get("data") or not calldata.get("to"):
-            return None
-
-        tx: dict[str, Any] = {
-            **calldata,
-            "chainId": POLYGON_CHAIN_ID,
-            "from": to_checksum_address(from_address),
-        }
-        if "value" in tx:
-            tx["value"] = int(tx["value"])
-
-        approve_tx_hash: str | None = None
-        spender = tx.get("to")
-        if spender:
-            ok_appr, appr = await ensure_allowance(
-                token_address=from_token_address,
-                owner=to_checksum_address(from_address),
-                spender=str(spender),
-                amount=int(best["input_amount"]),
-                chain_id=POLYGON_CHAIN_ID,
-                signing_callback=signing_callback,
-            )
-            if not ok_appr:
-                return None
-            if isinstance(appr, str) and appr.startswith("0x"):
-                approve_tx_hash = appr
-
-        swap_tx_hash = await send_transaction(tx, signing_callback)
-        return {
-            "method": "brap",
-            "tx_hash": swap_tx_hash,
-            "approve_tx_hash": approve_tx_hash,
-            "from_chain_id": POLYGON_CHAIN_ID,
-            "from_token_address": from_token_address,
-            "to_chain_id": POLYGON_CHAIN_ID,
-            "to_token_address": to_token_address,
-            "amount_base_unit": str(amount_base_unit),
-            "provider": best.get("provider"),
-            "input_amount": best.get("input_amount"),
-            "output_amount": best.get("output_amount"),
-            "fee_estimate": best.get("fee_estimate"),
-        }
-    except Exception:
-        return None
-
-
-async def _wrap_usdce_to_pusd(
-    *,
-    owner_address: str,
-    recipient_address: str,
-    amount_base_unit: int,
-    signing_callback,
-) -> tuple[bool, dict[str, Any] | str]:
-    """Wrap Polygon USDC.e into pUSD via the Polymarket CollateralOnramp."""
-    try:
-        recipient = to_checksum_address(recipient_address)
-        approve_tx_hash: str | None = None
-        ok_appr, appr = await ensure_allowance(
-            token_address=POLYGON_USDC_E_ADDRESS,
-            owner=owner_address,
-            spender=POLYMARKET_COLLATERAL_ONRAMP_ADDRESS,
-            amount=amount_base_unit,
-            chain_id=POLYGON_CHAIN_ID,
-            signing_callback=signing_callback,
-        )
-        if not ok_appr:
-            return False, str(appr)
-        if isinstance(appr, str) and appr.startswith("0x"):
-            approve_tx_hash = appr
-
-        tx = await encode_call(
-            target=POLYMARKET_COLLATERAL_ONRAMP_ADDRESS,
-            abi=POLYMARKET_COLLATERAL_RAMP_ABI,
-            fn_name="wrap",
-            args=[
-                POLYGON_USDC_E_ADDRESS,
-                recipient,
-                amount_base_unit,
-            ],
-            from_address=owner_address,
-            chain_id=POLYGON_CHAIN_ID,
-        )
-        tx_hash = await send_transaction(tx, signing_callback)
-        return True, {
-            "method": "pusd_wrap",
-            "tx_hash": tx_hash,
-            "approve_tx_hash": approve_tx_hash,
-            "from_chain_id": POLYGON_CHAIN_ID,
-            "from_token_address": POLYGON_USDC_E_ADDRESS,
-            "to_chain_id": POLYGON_CHAIN_ID,
-            "to_token_address": POLYGON_P_USDC_PROXY_ADDRESS,
-            "amount_base_unit": str(amount_base_unit),
-            "recipient_address": recipient,
-        }
-    except Exception as exc:  # noqa: BLE001
-        return False, str(exc)
-
-
-async def _unwrap_pusd_to_usdce(
-    *,
-    owner_address: str,
-    recipient_address: str,
-    amount_base_unit: int,
-    signing_callback,
-) -> tuple[bool, dict[str, Any] | str]:
-    """Unwrap Polygon pUSD into USDC.e via the Polymarket CollateralOfframp."""
-    try:
-        recipient = to_checksum_address(recipient_address)
-        approve_tx_hash: str | None = None
-        ok_appr, appr = await ensure_allowance(
-            token_address=POLYGON_P_USDC_PROXY_ADDRESS,
-            owner=owner_address,
-            spender=POLYMARKET_COLLATERAL_OFFRAMP_ADDRESS,
-            amount=amount_base_unit,
-            chain_id=POLYGON_CHAIN_ID,
-            signing_callback=signing_callback,
-        )
-        if not ok_appr:
-            return False, str(appr)
-        if isinstance(appr, str) and appr.startswith("0x"):
-            approve_tx_hash = appr
-
-        tx = await encode_call(
-            target=POLYMARKET_COLLATERAL_OFFRAMP_ADDRESS,
-            abi=POLYMARKET_COLLATERAL_RAMP_ABI,
-            fn_name="unwrap",
-            args=[
-                POLYGON_USDC_E_ADDRESS,
-                recipient,
-                amount_base_unit,
-            ],
-            from_address=owner_address,
-            chain_id=POLYGON_CHAIN_ID,
-        )
-        tx_hash = await send_transaction(tx, signing_callback)
-        return True, {
-            "method": "pusd_unwrap",
-            "tx_hash": tx_hash,
-            "approve_tx_hash": approve_tx_hash,
-            "from_chain_id": POLYGON_CHAIN_ID,
-            "from_token_address": POLYGON_P_USDC_PROXY_ADDRESS,
-            "to_chain_id": POLYGON_CHAIN_ID,
-            "to_token_address": POLYGON_USDC_E_ADDRESS,
-            "amount_base_unit": str(amount_base_unit),
-            "recipient_address": recipient,
-        }
-    except Exception as exc:  # noqa: BLE001
-        return False, str(exc)
 
 
 class PolymarketAdapter(BaseAdapter):
@@ -1011,6 +833,57 @@ class PolymarketAdapter(BaseAdapter):
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
 
+    async def _brap_swap_polygon(
+        self,
+        *,
+        from_token_address: str,
+        to_token_address: str,
+        amount_base_unit: int,
+        recipient_address: str | None = None,
+    ) -> tuple[bool, dict[str, Any] | str]:
+        """Swap `from_token → to_token` on Polygon via BRAP.
+
+        Handles USDC.e ↔ pUSD (via the backend's polymarket_bridge solver) and
+        USDC ↔ USDC.e (via the generic lifi/odos/enso solvers). The BRAP HTTP
+        layer accepts `to_wallet` so the encoded recipient differs from sender
+        when needed.
+        """
+        from_address = self._require_wallet_address()
+        from_token = to_checksum_address(from_token_address)
+        to_token = to_checksum_address(to_token_address)
+        rcpt = (
+            to_checksum_address(recipient_address)
+            if recipient_address
+            else from_address
+        )
+        try:
+            quote_response = await BRAP_CLIENT.get_quote(
+                from_token=from_token,
+                to_token=to_token,
+                from_chain=POLYGON_CHAIN_ID,
+                to_chain=POLYGON_CHAIN_ID,
+                from_wallet=from_address,
+                from_amount=str(amount_base_unit),
+                to_wallet=rcpt if rcpt != from_address else None,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return False, f"BRAP quote failed: {exc}"
+
+        quote = quote_response.get("best_quote")
+        if not quote:
+            return False, "No BRAP quote available"
+
+        brap = BRAPAdapter(
+            sign_callback=self.sign_callback,
+            wallet_address=from_address,
+        )
+        return await brap.swap_from_quote(
+            from_token={"address": from_token, "chain": {"id": POLYGON_CHAIN_ID}},
+            to_token={"address": to_token, "chain": {"id": POLYGON_CHAIN_ID}},
+            from_address=from_address,
+            quote=quote,
+        )
+
     async def bridge_deposit(
         self,
         *,
@@ -1022,21 +895,19 @@ class PolymarketAdapter(BaseAdapter):
     ) -> tuple[bool, dict[str, Any] | str]:
         """Prepare Polymarket collateral on Polygon.
 
-        Direct fast paths implemented here:
-        - USDC.e -> pUSD via the Polymarket CollateralOnramp
-        - Polygon native USDC -> USDC.e via BRAP, then wrap to pUSD
+        Polygon fast paths via BRAP (the backend's polymarket_bridge solver
+        emits the wrap calldata; lifi/odos/enso handle USDC ↔ USDC.e):
+        - USDC.e -> pUSD                 (single BRAP swap)
+        - Polygon native USDC -> pUSD    (two BRAP swaps: USDC -> USDC.e -> pUSD)
 
-        Other supported source tokens / chains are not normalized here via an
-        arbitrary BRAP route. They currently fall back to the async Polymarket
-        Bridge deposit-address flow from `from_chain_id`, which lands as
-        pUSD on Polygon.
+        Other source chains fall back to the async Polymarket Bridge
+        deposit-address flow, which lands as pUSD on Polygon.
         """
-        from_address, sign_cb = self._require_signer()
+        from_address, _ = self._require_signer()
         from_token = to_checksum_address(from_token_address)
         base_units = to_erc20_raw(amount, token_decimals)
 
         rcpt = to_checksum_address(recipient_address)
-        usdce_balance_before_swap: int | None = None
         async with web3_from_chain_id(from_chain_id) as web3:
             bal = await get_token_balance(
                 from_token,
@@ -1051,7 +922,6 @@ class PolymarketAdapter(BaseAdapter):
                     f"(token={from_token}, need_base_units={base_units}, balance_base_units={bal})."
                 )
                 if from_chain_id == POLYGON_CHAIN_ID:
-                    acct = from_address
                     pusd = web3.eth.contract(
                         address=POLYGON_P_USDC_PROXY_ADDRESS,
                         abi=ERC20_ABI,
@@ -1072,9 +942,18 @@ class PolymarketAdapter(BaseAdapter):
                         web3=web3,
                         chain_id=POLYGON_CHAIN_ID,
                         calls=[
-                            Call(pusd, "balanceOf", args=(acct,), postprocess=int),
-                            Call(usdce, "balanceOf", args=(acct,), postprocess=int),
-                            Call(usdc, "balanceOf", args=(acct,), postprocess=int),
+                            Call(
+                                pusd, "balanceOf", args=(from_address,), postprocess=int
+                            ),
+                            Call(
+                                usdce,
+                                "balanceOf",
+                                args=(from_address,),
+                                postprocess=int,
+                            ),
+                            Call(
+                                usdc, "balanceOf", args=(from_address,), postprocess=int
+                            ),
                         ],
                         block_identifier="pending",
                     )
@@ -1090,77 +969,68 @@ class PolymarketAdapter(BaseAdapter):
                     )
                 return False, msg
 
-            if from_chain_id == POLYGON_CHAIN_ID and from_token == POLYGON_USDC_ADDRESS:
-                usdce_balance_before_swap = await get_token_balance(
-                    POLYGON_USDC_E_ADDRESS,
-                    POLYGON_CHAIN_ID,
-                    from_address,
-                    web3=web3,
-                    block_identifier="pending",
-                )
-
         if from_chain_id == POLYGON_CHAIN_ID and from_token == POLYGON_USDC_E_ADDRESS:
-            return await _wrap_usdce_to_pusd(
-                owner_address=from_address,
-                recipient_address=rcpt,
+            ok_wrap, wrap = await self._brap_swap_polygon(
+                from_token_address=POLYGON_USDC_E_ADDRESS,
+                to_token_address=POLYGON_P_USDC_PROXY_ADDRESS,
                 amount_base_unit=base_units,
-                signing_callback=sign_cb,
+                recipient_address=rcpt,
             )
+            if not ok_wrap:
+                return False, wrap
+            return True, {
+                "method": "pusd_wrap",
+                "tx_hash": wrap["tx_hash"],
+                "from_chain_id": POLYGON_CHAIN_ID,
+                "from_token_address": POLYGON_USDC_E_ADDRESS,
+                "to_chain_id": POLYGON_CHAIN_ID,
+                "to_token_address": POLYGON_P_USDC_PROXY_ADDRESS,
+                "amount_base_unit": str(base_units),
+                "recipient_address": rcpt,
+                "from_amount": wrap.get("from_amount"),
+                "to_amount": wrap.get("to_amount"),
+            }
 
         if from_chain_id == POLYGON_CHAIN_ID and from_token == POLYGON_USDC_ADDRESS:
-            brap = await _try_brap_swap_polygon(
-                from_token_address=from_token,
+            ok_swap, swap = await self._brap_swap_polygon(
+                from_token_address=POLYGON_USDC_ADDRESS,
                 to_token_address=POLYGON_USDC_E_ADDRESS,
-                from_address=from_address,
                 amount_base_unit=base_units,
-                signing_callback=sign_cb,
             )
-            if brap:
-                usdce_balance_after_swap = await get_token_balance(
-                    POLYGON_USDC_E_ADDRESS,
-                    POLYGON_CHAIN_ID,
-                    from_address,
-                    block_identifier="pending",
-                )
-                wrapped_amount = max(
-                    0,
-                    usdce_balance_after_swap - (usdce_balance_before_swap or 0),
-                )
-                if wrapped_amount <= 0:
-                    return False, (
-                        "BRAP swap completed, but no new USDC.e balance was detected "
-                        "for wrapping into pUSD."
-                    )
+            if not ok_swap:
+                return False, swap
 
-                ok_wrap, wrap = await _wrap_usdce_to_pusd(
-                    owner_address=from_address,
-                    recipient_address=rcpt,
-                    amount_base_unit=wrapped_amount,
-                    signing_callback=sign_cb,
+            usdce_received = int(swap.get("to_amount") or 0)
+            if usdce_received <= 0:
+                return False, (
+                    "BRAP swap completed, but no USDC.e output amount reported "
+                    "for wrapping into pUSD."
                 )
-                if not ok_wrap:
-                    return False, wrap
-                return True, {
-                    "method": "brap_then_wrap",
-                    "tx_hash": wrap.get("tx_hash"),
-                    "approve_tx_hash": brap.get("approve_tx_hash"),
-                    "from_chain_id": POLYGON_CHAIN_ID,
-                    "from_token_address": from_token,
-                    "to_chain_id": POLYGON_CHAIN_ID,
-                    "to_token_address": POLYGON_P_USDC_PROXY_ADDRESS,
-                    "amount_base_unit": str(base_units),
-                    "recipient_address": rcpt,
-                    "provider": brap.get("provider"),
-                    "input_amount": brap.get("input_amount"),
-                    "output_amount": brap.get("output_amount"),
-                    "fee_estimate": brap.get("fee_estimate"),
-                    "swap_tx_hash": brap.get("tx_hash"),
-                    "swap_approve_tx_hash": brap.get("approve_tx_hash"),
-                    "wrap_tx_hash": wrap.get("tx_hash"),
-                    "wrap_approve_tx_hash": wrap.get("approve_tx_hash"),
-                    "swap": brap,
-                    "wrap": wrap,
-                }
+
+            ok_wrap, wrap = await self._brap_swap_polygon(
+                from_token_address=POLYGON_USDC_E_ADDRESS,
+                to_token_address=POLYGON_P_USDC_PROXY_ADDRESS,
+                amount_base_unit=usdce_received,
+                recipient_address=rcpt,
+            )
+            if not ok_wrap:
+                return False, wrap
+            return True, {
+                "method": "brap_then_wrap",
+                "tx_hash": wrap["tx_hash"],
+                "from_chain_id": POLYGON_CHAIN_ID,
+                "from_token_address": from_token,
+                "to_chain_id": POLYGON_CHAIN_ID,
+                "to_token_address": POLYGON_P_USDC_PROXY_ADDRESS,
+                "amount_base_unit": str(base_units),
+                "recipient_address": rcpt,
+                "from_amount": swap.get("from_amount"),
+                "to_amount": wrap.get("to_amount"),
+                "swap_tx_hash": swap["tx_hash"],
+                "wrap_tx_hash": wrap["tx_hash"],
+                "swap": swap,
+                "wrap": wrap,
+            }
 
         ok_addr, addr_data = await self.bridge_deposit_addresses(address=rcpt)
         if not ok_addr:
@@ -1170,6 +1040,7 @@ class PolymarketAdapter(BaseAdapter):
         if not deposit_evm:
             return False, "Bridge did not return an EVM deposit address"
 
+        _, sign_cb = self._require_signer()
         tx = await build_send_transaction(
             from_address=from_address,
             to_address=str(deposit_evm),
@@ -1200,67 +1071,80 @@ class PolymarketAdapter(BaseAdapter):
     ) -> tuple[bool, dict[str, Any] | str]:
         """Withdraw Polymarket V2 collateral to a destination token.
 
-        Direct fast paths implemented here:
-        - pUSD -> USDC.e via the Polymarket CollateralOfframp
-        - pUSD -> USDC.e -> Polygon native USDC via BRAP
+        Polygon fast paths via BRAP:
+        - pUSD -> USDC.e                 (single BRAP swap, polymarket_bridge solver)
+        - pUSD -> Polygon native USDC    (two BRAP swaps: pUSD -> USDC.e -> USDC)
 
-        For other destination assets / chains, the adapter unwraps to USDC.e
-        and then falls back to the async Polymarket bridge withdraw-address
+        For other destination chains, unwrap pUSD -> USDC.e on Polygon (still
+        via BRAP), then fall back to the async Polymarket bridge withdraw-address
         flow.
         """
         from_address, sign_cb = self._require_signer()
         base_units = to_erc20_raw(amount_pusd, token_decimals)
-
         rcpt = to_checksum_address(recipient_addr)
-        ok_unwrap, unwrap = await _unwrap_pusd_to_usdce(
-            owner_address=from_address,
-            recipient_address=from_address,
+
+        ok_unwrap, unwrap = await self._brap_swap_polygon(
+            from_token_address=POLYGON_P_USDC_PROXY_ADDRESS,
+            to_token_address=POLYGON_USDC_E_ADDRESS,
             amount_base_unit=base_units,
-            signing_callback=sign_cb,
         )
         if not ok_unwrap:
             return False, unwrap
+
+        unwrap_result = {
+            "method": "pusd_unwrap",
+            "tx_hash": unwrap["tx_hash"],
+            "from_chain_id": POLYGON_CHAIN_ID,
+            "from_token_address": POLYGON_P_USDC_PROXY_ADDRESS,
+            "to_chain_id": POLYGON_CHAIN_ID,
+            "to_token_address": POLYGON_USDC_E_ADDRESS,
+            "amount_base_unit": str(base_units),
+            "recipient_address": from_address,
+            "from_amount": unwrap.get("from_amount"),
+            "to_amount": unwrap.get("to_amount"),
+        }
 
         if (
             to_chain_id == POLYGON_CHAIN_ID
             and to_checksum_address(to_token_address) == POLYGON_USDC_E_ADDRESS
             and rcpt == from_address
         ):
-            return True, {**unwrap, "recipient_addr": rcpt}
+            return True, {**unwrap_result, "recipient_addr": rcpt}
 
         if (
             to_chain_id == POLYGON_CHAIN_ID
             and to_checksum_address(to_token_address) == POLYGON_USDC_ADDRESS
             and rcpt == from_address
         ):
-            brap = await _try_brap_swap_polygon(
+            usdce_received = int(unwrap.get("to_amount") or 0)
+            if usdce_received <= 0:
+                return False, (
+                    "BRAP unwrap completed, but no USDC.e output amount reported "
+                    "for swap into USDC."
+                )
+            ok_swap, swap = await self._brap_swap_polygon(
                 from_token_address=POLYGON_USDC_E_ADDRESS,
-                to_token_address=to_token_address,
-                from_address=from_address,
-                amount_base_unit=base_units,
-                signing_callback=sign_cb,
+                to_token_address=POLYGON_USDC_ADDRESS,
+                amount_base_unit=usdce_received,
             )
-            if brap:
-                return True, {
-                    "method": "unwrap_then_brap",
-                    "tx_hash": brap.get("tx_hash"),
-                    "approve_tx_hash": brap.get("approve_tx_hash"),
-                    "from_chain_id": POLYGON_CHAIN_ID,
-                    "from_token_address": POLYGON_P_USDC_PROXY_ADDRESS,
-                    "to_chain_id": POLYGON_CHAIN_ID,
-                    "to_token_address": to_token_address,
-                    "amount_base_unit": str(base_units),
-                    "recipient_addr": rcpt,
-                    "provider": brap.get("provider"),
-                    "input_amount": brap.get("input_amount"),
-                    "output_amount": brap.get("output_amount"),
-                    "fee_estimate": brap.get("fee_estimate"),
-                    "unwrap_tx_hash": unwrap.get("tx_hash"),
-                    "swap_tx_hash": brap.get("tx_hash"),
-                    "swap_approve_tx_hash": brap.get("approve_tx_hash"),
-                    "unwrap": unwrap,
-                    "swap": brap,
-                }
+            if not ok_swap:
+                return False, swap
+            return True, {
+                "method": "unwrap_then_brap",
+                "tx_hash": swap["tx_hash"],
+                "from_chain_id": POLYGON_CHAIN_ID,
+                "from_token_address": POLYGON_P_USDC_PROXY_ADDRESS,
+                "to_chain_id": POLYGON_CHAIN_ID,
+                "to_token_address": POLYGON_USDC_ADDRESS,
+                "amount_base_unit": str(base_units),
+                "recipient_addr": rcpt,
+                "from_amount": unwrap.get("from_amount"),
+                "to_amount": swap.get("to_amount"),
+                "unwrap_tx_hash": unwrap["tx_hash"],
+                "swap_tx_hash": swap["tx_hash"],
+                "unwrap": unwrap_result,
+                "swap": swap,
+            }
 
         ok_addr, addr_data = await self.bridge_withdraw_addresses(
             address=from_address,
@@ -1294,7 +1178,7 @@ class PolymarketAdapter(BaseAdapter):
             "to_chain_id": to_chain_id,
             "to_token_address": to_token_address,
             "recipient_addr": rcpt,
-            "unwrap": unwrap,
+            "unwrap": unwrap_result,
         }
 
     def _require_wallet_address(self) -> str:

--- a/wayfinder_paths/adapters/polymarket_adapter/adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/adapter.py
@@ -833,6 +833,12 @@ class PolymarketAdapter(BaseAdapter):
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
 
+    # Stable-asset swaps (USDC ↔ USDC.e and wraps to/from pUSD) need a little
+    # headroom because LI.FI routes occasionally revert at inclusion when a
+    # pool shifts between quote and inclusion. 1% is generous for stables and
+    # absorbs MEV/state-change races without users having to think about it.
+    _BRAP_DEFAULT_SLIPPAGE = 0.01
+
     async def _brap_swap_polygon(
         self,
         *,
@@ -840,6 +846,7 @@ class PolymarketAdapter(BaseAdapter):
         to_token_address: str,
         amount_base_unit: int,
         recipient_address: str | None = None,
+        slippage: float | None = None,
     ) -> tuple[bool, dict[str, Any] | str]:
         """Swap `from_token → to_token` on Polygon via BRAP.
 
@@ -865,6 +872,9 @@ class PolymarketAdapter(BaseAdapter):
                 from_wallet=from_address,
                 from_amount=str(amount_base_unit),
                 to_wallet=rcpt if rcpt != from_address else None,
+                slippage=slippage
+                if slippage is not None
+                else self._BRAP_DEFAULT_SLIPPAGE,
             )
         except Exception as exc:  # noqa: BLE001
             return False, f"BRAP quote failed: {exc}"
@@ -992,6 +1002,17 @@ class PolymarketAdapter(BaseAdapter):
             }
 
         if from_chain_id == POLYGON_CHAIN_ID and from_token == POLYGON_USDC_ADDRESS:
+            # Read USDC.e balance before leg 1 so leg 2 can use the on-chain
+            # delta (the BRAP quote's `output_amount` is the quoted upper bound;
+            # actual fills are usually slightly lower after slippage and would
+            # cause the wrap's transferFrom to revert during gas estimation).
+            usdce_balance_before = await get_token_balance(
+                POLYGON_USDC_E_ADDRESS,
+                POLYGON_CHAIN_ID,
+                from_address,
+                block_identifier="latest",
+            )
+
             ok_swap, swap = await self._brap_swap_polygon(
                 from_token_address=POLYGON_USDC_ADDRESS,
                 to_token_address=POLYGON_USDC_E_ADDRESS,
@@ -1000,10 +1021,16 @@ class PolymarketAdapter(BaseAdapter):
             if not ok_swap:
                 return False, swap
 
-            usdce_received = int(swap.get("to_amount") or 0)
+            usdce_balance_after = await get_token_balance(
+                POLYGON_USDC_E_ADDRESS,
+                POLYGON_CHAIN_ID,
+                from_address,
+                block_identifier="latest",
+            )
+            usdce_received = max(0, usdce_balance_after - usdce_balance_before)
             if usdce_received <= 0:
                 return False, (
-                    "BRAP swap completed, but no USDC.e output amount reported "
+                    "BRAP swap completed, but no USDC.e balance delta detected "
                     "for wrapping into pUSD."
                 )
 
@@ -1083,6 +1110,15 @@ class PolymarketAdapter(BaseAdapter):
         base_units = to_erc20_raw(amount_pusd, token_decimals)
         rcpt = to_checksum_address(recipient_addr)
 
+        # Same pattern as bridge_deposit: read USDC.e balance before the
+        # unwrap so the optional second leg uses the actual on-chain delta.
+        usdce_balance_before = await get_token_balance(
+            POLYGON_USDC_E_ADDRESS,
+            POLYGON_CHAIN_ID,
+            from_address,
+            block_identifier="latest",
+        )
+
         ok_unwrap, unwrap = await self._brap_swap_polygon(
             from_token_address=POLYGON_P_USDC_PROXY_ADDRESS,
             to_token_address=POLYGON_USDC_E_ADDRESS,
@@ -1116,11 +1152,17 @@ class PolymarketAdapter(BaseAdapter):
             and to_checksum_address(to_token_address) == POLYGON_USDC_ADDRESS
             and rcpt == from_address
         ):
-            usdce_received = int(unwrap.get("to_amount") or 0)
+            usdce_balance_after = await get_token_balance(
+                POLYGON_USDC_E_ADDRESS,
+                POLYGON_CHAIN_ID,
+                from_address,
+                block_identifier="latest",
+            )
+            usdce_received = max(0, usdce_balance_after - usdce_balance_before)
             if usdce_received <= 0:
                 return False, (
-                    "BRAP unwrap completed, but no USDC.e output amount reported "
-                    "for swap into USDC."
+                    "BRAP unwrap completed, but no USDC.e balance delta "
+                    "detected for swap into USDC."
                 )
             ok_swap, swap = await self._brap_swap_polygon(
                 from_token_address=POLYGON_USDC_E_ADDRESS,

--- a/wayfinder_paths/adapters/polymarket_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/test_adapter.py
@@ -544,10 +544,12 @@ class TestPolymarketAdapter:
         monkeypatch.setattr(
             polymarket_adapter_module, "web3_from_chain_id", mock_web3_ctx
         )
+        # get_token_balance is called three times: initial source-token check,
+        # then USDC.e before/after leg 1 to compute the on-chain delta.
         monkeypatch.setattr(
             polymarket_adapter_module,
             "get_token_balance",
-            AsyncMock(return_value=2_000_000),
+            AsyncMock(side_effect=[2_000_000, 50_000, 1_049_000]),
         )
 
         brap_swap = AsyncMock(
@@ -602,6 +604,8 @@ class TestPolymarketAdapter:
         second_call_kwargs = brap_swap.await_args_list[1].kwargs
         assert second_call_kwargs["from_token_address"] == POLYGON_USDC_E_ADDRESS
         assert second_call_kwargs["to_token_address"] == POLYGON_P_USDC_PROXY_ADDRESS
+        # Leg 2 must use the on-chain USDC.e delta (1_049_000 - 50_000),
+        # not the leg-1 quote's optimistic `to_amount`.
         assert second_call_kwargs["amount_base_unit"] == 999_000
         assert second_call_kwargs["recipient_address"] == from_address
 
@@ -919,6 +923,12 @@ class TestPolymarketAdapter:
             return b""
 
         monkeypatch.setattr(adapter, "_require_signer", lambda: (from_address, sign_cb))
+        # get_token_balance is called twice: USDC.e before/after the unwrap.
+        monkeypatch.setattr(
+            polymarket_adapter_module,
+            "get_token_balance",
+            AsyncMock(side_effect=[50_000, 1_050_000]),
+        )
 
         brap_swap = AsyncMock(
             side_effect=[
@@ -982,6 +992,11 @@ class TestPolymarketAdapter:
             return b""
 
         monkeypatch.setattr(adapter, "_require_signer", lambda: (from_address, sign_cb))
+        monkeypatch.setattr(
+            polymarket_adapter_module,
+            "get_token_balance",
+            AsyncMock(return_value=0),
+        )
         brap_swap = AsyncMock(
             return_value=(
                 True,
@@ -1024,6 +1039,11 @@ class TestPolymarketAdapter:
             return b""
 
         monkeypatch.setattr(adapter, "_require_signer", lambda: (from_address, sign_cb))
+        monkeypatch.setattr(
+            polymarket_adapter_module,
+            "get_token_balance",
+            AsyncMock(return_value=0),
+        )
         monkeypatch.setattr(
             adapter,
             "_brap_swap_polygon",

--- a/wayfinder_paths/adapters/polymarket_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/test_adapter.py
@@ -10,8 +10,6 @@ from wayfinder_paths.core.constants.polymarket import (
     POLYGON_P_USDC_PROXY_ADDRESS,
     POLYGON_USDC_ADDRESS,
     POLYGON_USDC_E_ADDRESS,
-    POLYMARKET_COLLATERAL_OFFRAMP_ADDRESS,
-    POLYMARKET_COLLATERAL_ONRAMP_ADDRESS,
 )
 
 
@@ -549,48 +547,32 @@ class TestPolymarketAdapter:
         monkeypatch.setattr(
             polymarket_adapter_module,
             "get_token_balance",
-            AsyncMock(side_effect=[2_000_000, 200_000, 1_199_000]),
+            AsyncMock(return_value=2_000_000),
         )
 
-        best_quote = {
-            "provider": "enso",
-            "input_amount": 1_000_000,
-            "output_amount": 999_000,
-            "fee_estimate": {"fee_total_usd": 0.01, "fee_breakdown": []},
-            "calldata": {
-                "to": "0x1111111111111111111111111111111111111111",
-                "data": "0xdeadbeef",
-                "value": "0",
-                "chainId": 137,
-            },
-        }
-        monkeypatch.setattr(
-            polymarket_adapter_module.BRAP_CLIENT,
-            "get_quote",
-            AsyncMock(return_value={"best_quote": best_quote, "quotes": []}),
+        brap_swap = AsyncMock(
+            side_effect=[
+                (
+                    True,
+                    {
+                        "from_amount": 1_000_000,
+                        "to_amount": 999_000,
+                        "tx_hash": "0xswap",
+                        "ledger_record": {},
+                    },
+                ),
+                (
+                    True,
+                    {
+                        "from_amount": 999_000,
+                        "to_amount": 998_500,
+                        "tx_hash": "0xwrap",
+                        "ledger_record": {},
+                    },
+                ),
+            ]
         )
-        monkeypatch.setattr(
-            polymarket_adapter_module,
-            "ensure_allowance",
-            AsyncMock(side_effect=[(True, "0xapprove_swap"), (True, "0xapprove_wrap")]),
-        )
-        monkeypatch.setattr(
-            polymarket_adapter_module,
-            "encode_call",
-            AsyncMock(
-                return_value={
-                    "to": POLYMARKET_COLLATERAL_ONRAMP_ADDRESS,
-                    "from": from_address,
-                    "data": "0xwrap",
-                    "chainId": 137,
-                }
-            ),
-        )
-        monkeypatch.setattr(
-            polymarket_adapter_module,
-            "send_transaction",
-            AsyncMock(side_effect=["0xswap", "0xwrap"]),
-        )
+        monkeypatch.setattr(adapter, "_brap_swap_polygon", brap_swap)
 
         ok, res = await adapter.bridge_deposit(
             from_chain_id=137,
@@ -603,19 +585,25 @@ class TestPolymarketAdapter:
         assert isinstance(res, dict)
         assert res["method"] == "brap_then_wrap"
         assert res["tx_hash"] == "0xwrap"
-        assert res["approve_tx_hash"] == "0xapprove_swap"
         assert res["from_token_address"].lower() == POLYGON_USDC_ADDRESS.lower()
         assert res["to_token_address"].lower() == POLYGON_P_USDC_PROXY_ADDRESS.lower()
-        assert res["provider"] == "enso"
-        assert res["input_amount"] == 1_000_000
-        assert res["output_amount"] == 999_000
+        assert res["from_amount"] == 1_000_000
+        assert res["to_amount"] == 998_500
         assert res["swap_tx_hash"] == "0xswap"
-        assert res["swap_approve_tx_hash"] == "0xapprove_swap"
         assert res["wrap_tx_hash"] == "0xwrap"
-        assert res["wrap_approve_tx_hash"] == "0xapprove_wrap"
         assert res["swap"]["tx_hash"] == "0xswap"
         assert res["wrap"]["tx_hash"] == "0xwrap"
-        assert res["wrap"]["amount_base_unit"] == "999000"
+
+        assert brap_swap.await_count == 2
+        first_call_kwargs = brap_swap.await_args_list[0].kwargs
+        assert first_call_kwargs["from_token_address"] == POLYGON_USDC_ADDRESS
+        assert first_call_kwargs["to_token_address"] == POLYGON_USDC_E_ADDRESS
+        assert first_call_kwargs["amount_base_unit"] == 1_000_000
+        second_call_kwargs = brap_swap.await_args_list[1].kwargs
+        assert second_call_kwargs["from_token_address"] == POLYGON_USDC_E_ADDRESS
+        assert second_call_kwargs["to_token_address"] == POLYGON_P_USDC_PROXY_ADDRESS
+        assert second_call_kwargs["amount_base_unit"] == 999_000
+        assert second_call_kwargs["recipient_address"] == from_address
 
     @pytest.mark.asyncio
     async def test_bridge_deposit_wraps_usdce_to_pusd(self, adapter, monkeypatch):
@@ -640,25 +628,18 @@ class TestPolymarketAdapter:
             "get_token_balance",
             AsyncMock(return_value=2_000_000),
         )
-        monkeypatch.setattr(
-            polymarket_adapter_module,
-            "ensure_allowance",
-            AsyncMock(return_value=(True, "0xapprove_wrap")),
+        brap_swap = AsyncMock(
+            return_value=(
+                True,
+                {
+                    "from_amount": 1_000_000,
+                    "to_amount": 1_000_000,
+                    "tx_hash": "0xwrap",
+                    "ledger_record": {},
+                },
+            )
         )
-        encode_call = AsyncMock(
-            return_value={
-                "to": POLYMARKET_COLLATERAL_ONRAMP_ADDRESS,
-                "from": from_address,
-                "data": "0xwrap",
-                "chainId": 137,
-            }
-        )
-        monkeypatch.setattr(polymarket_adapter_module, "encode_call", encode_call)
-        monkeypatch.setattr(
-            polymarket_adapter_module,
-            "send_transaction",
-            AsyncMock(return_value="0xwrap"),
-        )
+        monkeypatch.setattr(adapter, "_brap_swap_polygon", brap_swap)
 
         ok, res = await adapter.bridge_deposit(
             from_chain_id=137,
@@ -673,19 +654,12 @@ class TestPolymarketAdapter:
         assert res["tx_hash"] == "0xwrap"
         assert res["to_token_address"].lower() == POLYGON_P_USDC_PROXY_ADDRESS.lower()
         assert res["recipient_address"].lower() == recipient_address.lower()
-        assert (
-            encode_call.await_args.kwargs["target"]
-            == POLYMARKET_COLLATERAL_ONRAMP_ADDRESS
-        )
-        assert (
-            encode_call.await_args.kwargs["args"][0].lower()
-            == POLYGON_USDC_E_ADDRESS.lower()
-        )
-        assert (
-            encode_call.await_args.kwargs["args"][1].lower()
-            == recipient_address.lower()
-        )
-        assert encode_call.await_args.kwargs["args"][2] == 1_000_000
+
+        call_kwargs = brap_swap.await_args.kwargs
+        assert call_kwargs["from_token_address"] == POLYGON_USDC_E_ADDRESS
+        assert call_kwargs["to_token_address"] == POLYGON_P_USDC_PROXY_ADDRESS
+        assert call_kwargs["amount_base_unit"] == 1_000_000
+        assert call_kwargs["recipient_address"].lower() == recipient_address.lower()
 
     @pytest.mark.asyncio
     async def test_bridge_deposit_falls_back_to_polymarket_bridge(
@@ -703,9 +677,9 @@ class TestPolymarketAdapter:
             AsyncMock(return_value=2_000_000),
         )
         monkeypatch.setattr(
-            polymarket_adapter_module.BRAP_CLIENT,
-            "get_quote",
-            AsyncMock(side_effect=Exception("no route")),
+            adapter,
+            "_brap_swap_polygon",
+            AsyncMock(return_value=(False, "no route")),
         )
         monkeypatch.setattr(
             adapter,
@@ -742,10 +716,10 @@ class TestPolymarketAdapter:
             recipient_address=from_address,
             token_decimals=6,
         )
-        assert ok is True
-        assert isinstance(res, dict)
-        assert res["method"] == "polymarket_bridge"
-        assert res["tx_hash"] == "0xtransfer"
+        # Polygon USDC path now returns the BRAP swap failure directly rather
+        # than falling through to the async bridge.
+        assert ok is False
+        assert "no route" in str(res)
 
     @pytest.mark.asyncio
     async def test_bridge_deposit_polymarket_bridge_supports_non_polygon_from_chain(
@@ -946,42 +920,29 @@ class TestPolymarketAdapter:
 
         monkeypatch.setattr(adapter, "_require_signer", lambda: (from_address, sign_cb))
 
-        best_quote = {
-            "provider": "enso",
-            "input_amount": 1_000_000,
-            "output_amount": 999_000,
-            "fee_estimate": {"fee_total_usd": 0.01, "fee_breakdown": []},
-            "calldata": {
-                "to": "0x1111111111111111111111111111111111111111",
-                "data": "0xdeadbeef",
-                "value": "0",
-                "chainId": 137,
-            },
-        }
-        monkeypatch.setattr(
-            polymarket_adapter_module.BRAP_CLIENT,
-            "get_quote",
-            AsyncMock(return_value={"best_quote": best_quote, "quotes": []}),
+        brap_swap = AsyncMock(
+            side_effect=[
+                (
+                    True,
+                    {
+                        "from_amount": 1_000_000,
+                        "to_amount": 1_000_000,
+                        "tx_hash": "0xunwrap",
+                        "ledger_record": {},
+                    },
+                ),
+                (
+                    True,
+                    {
+                        "from_amount": 1_000_000,
+                        "to_amount": 999_000,
+                        "tx_hash": "0xswap",
+                        "ledger_record": {},
+                    },
+                ),
+            ]
         )
-        encode_call = AsyncMock(
-            return_value={
-                "to": POLYMARKET_COLLATERAL_OFFRAMP_ADDRESS,
-                "from": from_address,
-                "data": "0xunwrap",
-                "chainId": 137,
-            }
-        )
-        monkeypatch.setattr(polymarket_adapter_module, "encode_call", encode_call)
-        monkeypatch.setattr(
-            polymarket_adapter_module,
-            "ensure_allowance",
-            AsyncMock(return_value=(True, "0xapprove")),
-        )
-        monkeypatch.setattr(
-            polymarket_adapter_module,
-            "send_transaction",
-            AsyncMock(side_effect=["0xunwrap", "0xswap"]),
-        )
+        monkeypatch.setattr(adapter, "_brap_swap_polygon", brap_swap)
 
         ok, res = await adapter.bridge_withdraw(
             amount_pusd=1.0,
@@ -994,23 +955,24 @@ class TestPolymarketAdapter:
         assert isinstance(res, dict)
         assert res["method"] == "unwrap_then_brap"
         assert res["tx_hash"] == "0xswap"
-        assert res["approve_tx_hash"] == "0xapprove"
         assert res["from_token_address"].lower() == POLYGON_P_USDC_PROXY_ADDRESS.lower()
         assert res["to_token_address"].lower() == POLYGON_USDC_ADDRESS.lower()
-        assert res["provider"] == "enso"
-        assert res["input_amount"] == 1_000_000
-        assert res["output_amount"] == 999_000
+        assert res["from_amount"] == 1_000_000
+        assert res["to_amount"] == 999_000
         assert res["unwrap_tx_hash"] == "0xunwrap"
         assert res["swap_tx_hash"] == "0xswap"
-        assert res["swap_approve_tx_hash"] == "0xapprove"
         assert res["unwrap"]["tx_hash"] == "0xunwrap"
         assert res["swap"]["tx_hash"] == "0xswap"
-        assert encode_call.await_args.kwargs["fn_name"] == "unwrap"
-        assert (
-            encode_call.await_args.kwargs["target"]
-            == POLYMARKET_COLLATERAL_OFFRAMP_ADDRESS
-        )
-        assert encode_call.await_args.kwargs["args"][2] == 1_000_000
+
+        assert brap_swap.await_count == 2
+        first_call_kwargs = brap_swap.await_args_list[0].kwargs
+        assert first_call_kwargs["from_token_address"] == POLYGON_P_USDC_PROXY_ADDRESS
+        assert first_call_kwargs["to_token_address"] == POLYGON_USDC_E_ADDRESS
+        assert first_call_kwargs["amount_base_unit"] == 1_000_000
+        second_call_kwargs = brap_swap.await_args_list[1].kwargs
+        assert second_call_kwargs["from_token_address"] == POLYGON_USDC_E_ADDRESS
+        assert second_call_kwargs["to_token_address"] == POLYGON_USDC_ADDRESS
+        assert second_call_kwargs["amount_base_unit"] == 1_000_000
 
     @pytest.mark.asyncio
     async def test_bridge_withdraw_unwraps_to_polygon_usdce(self, adapter, monkeypatch):
@@ -1020,25 +982,18 @@ class TestPolymarketAdapter:
             return b""
 
         monkeypatch.setattr(adapter, "_require_signer", lambda: (from_address, sign_cb))
-        monkeypatch.setattr(
-            polymarket_adapter_module,
-            "ensure_allowance",
-            AsyncMock(return_value=(True, "0xapprove_unwrap")),
+        brap_swap = AsyncMock(
+            return_value=(
+                True,
+                {
+                    "from_amount": 1_000_000,
+                    "to_amount": 1_000_000,
+                    "tx_hash": "0xunwrap",
+                    "ledger_record": {},
+                },
+            )
         )
-        encode_call = AsyncMock(
-            return_value={
-                "to": POLYMARKET_COLLATERAL_OFFRAMP_ADDRESS,
-                "from": from_address,
-                "data": "0xunwrap",
-                "chainId": 137,
-            }
-        )
-        monkeypatch.setattr(polymarket_adapter_module, "encode_call", encode_call)
-        monkeypatch.setattr(
-            polymarket_adapter_module,
-            "send_transaction",
-            AsyncMock(return_value="0xunwrap"),
-        )
+        monkeypatch.setattr(adapter, "_brap_swap_polygon", brap_swap)
 
         ok, res = await adapter.bridge_withdraw(
             amount_pusd=1.0,
@@ -1051,42 +1006,38 @@ class TestPolymarketAdapter:
         assert isinstance(res, dict)
         assert res["method"] == "pusd_unwrap"
         assert res["tx_hash"] == "0xunwrap"
-        assert res["approve_tx_hash"] == "0xapprove_unwrap"
         assert res["to_token_address"].lower() == POLYGON_USDC_E_ADDRESS.lower()
-        assert encode_call.await_args.kwargs["fn_name"] == "unwrap"
-        assert (
-            encode_call.await_args.kwargs["target"]
-            == POLYMARKET_COLLATERAL_OFFRAMP_ADDRESS
-        )
+
+        call_kwargs = brap_swap.await_args.kwargs
+        assert call_kwargs["from_token_address"] == POLYGON_P_USDC_PROXY_ADDRESS
+        assert call_kwargs["to_token_address"] == POLYGON_USDC_E_ADDRESS
+        assert call_kwargs["amount_base_unit"] == 1_000_000
 
     @pytest.mark.asyncio
     async def test_bridge_withdraw_falls_back_to_polymarket_bridge(
         self, adapter, monkeypatch
     ):
         from_address = "0x000000000000000000000000000000000000dEaD"
+        recipient_addr = "0x000000000000000000000000000000000000bEEF"
 
         async def sign_cb(_tx: dict) -> bytes:
             return b""
 
         monkeypatch.setattr(adapter, "_require_signer", lambda: (from_address, sign_cb))
         monkeypatch.setattr(
-            polymarket_adapter_module,
-            "ensure_allowance",
-            AsyncMock(return_value=(True, "0xapprove_unwrap")),
-        )
-        encode_call = AsyncMock(
-            return_value={
-                "to": POLYMARKET_COLLATERAL_OFFRAMP_ADDRESS,
-                "from": from_address,
-                "data": "0xunwrap",
-                "chainId": 137,
-            }
-        )
-        monkeypatch.setattr(polymarket_adapter_module, "encode_call", encode_call)
-        monkeypatch.setattr(
-            polymarket_adapter_module.BRAP_CLIENT,
-            "get_quote",
-            AsyncMock(side_effect=Exception("no route")),
+            adapter,
+            "_brap_swap_polygon",
+            AsyncMock(
+                return_value=(
+                    True,
+                    {
+                        "from_amount": 1_000_000,
+                        "to_amount": 1_000_000,
+                        "tx_hash": "0xunwrap",
+                        "ledger_record": {},
+                    },
+                )
+            ),
         )
         monkeypatch.setattr(
             adapter,
@@ -1113,14 +1064,16 @@ class TestPolymarketAdapter:
         monkeypatch.setattr(
             polymarket_adapter_module,
             "send_transaction",
-            AsyncMock(side_effect=["0xunwrap", "0xtransfer"]),
+            AsyncMock(return_value="0xtransfer"),
         )
 
+        # Cross-recipient withdrawal: pUSD unwraps to sender, then bridge handles
+        # the cross-recipient transfer.
         ok, res = await adapter.bridge_withdraw(
             amount_pusd=1.0,
             to_chain_id=137,
             to_token_address=POLYGON_USDC_ADDRESS,
-            recipient_addr=from_address,
+            recipient_addr=recipient_addr,
             token_decimals=6,
         )
         assert ok is True

--- a/wayfinder_paths/core/clients/BRAPClient.py
+++ b/wayfinder_paths/core/clients/BRAPClient.py
@@ -80,6 +80,7 @@ class BRAPClient(WayfinderClient):
         from_wallet: str,
         from_amount: str,
         slippage: float | None = None,
+        to_wallet: str | None = None,
     ) -> BRAPQuoteResponse:  # type: ignore # noqa: E501
         logger.info(
             f"Getting BRAP quote: {from_token} -> {to_token} (chain {from_chain} -> {to_chain})"
@@ -99,6 +100,8 @@ class BRAPClient(WayfinderClient):
         }
         if slippage is not None:
             params["slippage"] = slippage
+        if to_wallet is not None:
+            params["to_wallet"] = to_wallet
 
         try:
             response = await self._authed_request("GET", url, params=params, headers={})


### PR DESCRIPTION
### Summary
vault-backend BRAP now has a polymarket_bridge solver; remove the local wrap/unwrap helpers and the bespoke BRAP_CLIENT helper from polymarket_adapter and route all Polygon legs through BRAPAdapter via a single _brap_swap_polygon.