### PR TITLE
Hyperliquid - Drop spot↔perp USD class transfers

### DIFF
--- a/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
+++ b/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
@@ -12,7 +12,6 @@ from hyperliquid.exchange import get_timestamp_ms
 from hyperliquid.utils.signing import (
     BUILDER_FEE_SIGN_TYPES,
     SPOT_TRANSFER_SIGN_TYPES,
-    USD_CLASS_TRANSFER_SIGN_TYPES,
     USER_SET_ABSTRACTION_SIGN_TYPES,
     WITHDRAW_SIGN_TYPES,
     OrderType,
@@ -1114,48 +1113,6 @@ class HyperliquidAdapter(BaseAdapter):
 
         success = result.get("status") == "ok"
         return success, result
-
-    async def _usd_class_transfer(
-        self, amount: float, address: str, to_perp: bool
-    ) -> tuple[bool, dict[str, Any]]:
-        nonce = get_timestamp_ms()
-        action = {
-            "hyperliquidChain": MAINNET,
-            "signatureChainId": ARBITRUM_CHAIN_ID,
-            "amount": str(amount),
-            "toPerp": to_perp,
-            "nonce": nonce,
-            "type": "usdClassTransfer",
-        }
-        payload = user_signed_payload(
-            "HyperliquidTransaction:UsdClassTransfer",
-            USD_CLASS_TRANSFER_SIGN_TYPES,
-            action,
-        )
-        if not (sig := await self._sign(payload, action, address)):
-            return False, USER_DECLINED_ERROR
-        result = self._broadcast_hypecore(action, nonce, sig)
-
-        success = result.get("status") == "ok"
-        return success, result
-
-    async def transfer_spot_to_perp(
-        self,
-        amount: float,
-        address: str,
-    ) -> tuple[bool, dict[str, Any]]:
-        return await self._usd_class_transfer(
-            amount=amount, address=address, to_perp=True
-        )
-
-    async def transfer_perp_to_spot(
-        self,
-        amount: float,
-        address: str,
-    ) -> tuple[bool, dict[str, Any]]:
-        return await self._usd_class_transfer(
-            amount=amount, address=address, to_perp=False
-        )
 
     async def place_trigger_order(
         self,

--- a/wayfinder_paths/core/clients/protocols.py
+++ b/wayfinder_paths/core/clients/protocols.py
@@ -186,20 +186,6 @@ class HyperliquidExecutorProtocol(Protocol):
         address: str,
     ) -> dict[str, Any]: ...
 
-    async def transfer_spot_to_perp(
-        self,
-        *,
-        amount: float,
-        address: str,
-    ) -> dict[str, Any]: ...
-
-    async def transfer_perp_to_spot(
-        self,
-        *,
-        amount: float,
-        address: str,
-    ) -> dict[str, Any]: ...
-
     async def place_stop_loss(
         self,
         *,

--- a/wayfinder_paths/mcp/preview.py
+++ b/wayfinder_paths/mcp/preview.py
@@ -183,14 +183,6 @@ async def build_hyperliquid_execute_preview(
         details = f"\n\nWITHDRAW\namount_usdc: {req.get('amount_usdc')}"
         return {"summary": header + base + details}
 
-    if action == "spot_to_perp_transfer":
-        details = f"\n\nTRANSFER SPOT → PERP\nusd_amount: {req.get('usd_amount')}"
-        return {"summary": header + base + details}
-
-    if action == "perp_to_spot_transfer":
-        details = f"\n\nTRANSFER PERP → SPOT\nusd_amount: {req.get('usd_amount')}"
-        return {"summary": header + base + details}
-
     return {"summary": header + base}
 
 

--- a/wayfinder_paths/mcp/tools/hyperliquid.py
+++ b/wayfinder_paths/mcp/tools/hyperliquid.py
@@ -106,8 +106,6 @@ async def hyperliquid_execute(
         "update_leverage",
         "deposit",
         "withdraw",
-        "spot_to_perp_transfer",
-        "perp_to_spot_transfer",
     ],
     *,
     wallet_label: str,
@@ -145,8 +143,6 @@ async def hyperliquid_execute(
       - `deposit`: bridge `amount_usdc` from Arbitrum USDC into the HL perp account
         (≥ 5 USDC; below is lost). Auto-waits for the perp clearinghouse credit before returning.
       - `withdraw`: bridge `amount_usdc` from perp account back to Arbitrum.
-      - `spot_to_perp_transfer` / `perp_to_spot_transfer`: shift `usd_amount` between sub-accounts.
-        Only works with USDC spot to/from USDC perps. Other USD stables (USDH, etc.) must be converted first.
     """
     wallet_label = throw_if_empty_str("wallet_label is required", wallet_label)
 
@@ -272,46 +268,6 @@ async def hyperliquid_execute(
                 action="withdraw",
                 status=status,
                 details={"amount_usdc": amt},
-            )
-
-            return response
-
-        case "spot_to_perp_transfer" | "perp_to_spot_transfer":
-            throw_if_none(f"usd_amount is required for {action}", usd_amount)
-            amt = throw_if_not_number("usd_amount must be a number", usd_amount)
-            if amt <= 0:
-                raise ValueError("usd_amount must be positive")
-
-            to_perp = action == "spot_to_perp_transfer"
-            if to_perp:
-                ok_transfer, res = await adapter.transfer_spot_to_perp(
-                    amount=amt, address=sender
-                )
-            else:
-                ok_transfer, res = await adapter.transfer_perp_to_spot(
-                    amount=amt, address=sender
-                )
-            effects.append(
-                {"type": "hl", "label": action, "ok": ok_transfer, "result": res}
-            )
-            status = "confirmed" if ok_transfer else "failed"
-            response = ok(
-                {
-                    "status": status,
-                    "action": action,
-                    "wallet_label": wallet_label,
-                    "address": sender,
-                    "usd_amount": amt,
-                    "to_perp": to_perp,
-                    "effects": effects,
-                }
-            )
-            _annotate_hl_profile(
-                address=sender,
-                label=wallet_label,
-                action=action,
-                status=status,
-                details={"usd_amount": amt, "to_perp": to_perp},
             )
 
             return response

--- a/wayfinder_paths/strategies/basis_trading_strategy/strategy.py
+++ b/wayfinder_paths/strategies/basis_trading_strategy/strategy.py
@@ -7,7 +7,7 @@ import time
 import traceback
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
-from decimal import ROUND_DOWN, ROUND_UP, Decimal, getcontext
+from decimal import ROUND_UP, Decimal, getcontext
 from pathlib import Path
 from statistics import fmean
 from typing import Any
@@ -829,53 +829,8 @@ class BasisTradingStrategy(BasisSnapshotMixin, Strategy):
             if not close_success:
                 return (False, f"Failed to close position: {close_msg}")
 
-        # Wait for spot sale to settle before checking balance
+        # Wait for spot sale to settle before checking the unified balance.
         await asyncio.sleep(5)
-
-        for _transfer_attempt in range(3):
-            spot_state_result = await self.hyperliquid_adapter.get_spot_user_state(
-                address
-            )
-            if not spot_state_result[0]:
-                continue
-
-            spot_balances = spot_state_result[1].get("balances", [])
-            for bal in spot_balances:
-                if bal.get("coin") == "USDC":
-                    # Use available balance (total - hold), not total
-                    total = float(bal.get("total", 0))
-                    hold = float(bal.get("hold", 0))
-                    available = total - hold
-
-                    # Floor to 2 decimal places to avoid precision issues
-                    spot_usdc = math.floor(available * 100) / 100
-
-                    if spot_usdc > 1.0:
-                        self.logger.info(
-                            f"Transferring ${spot_usdc:.2f} from spot to perp "
-                            f"(available={available:.8f}, floored={spot_usdc:.2f})"
-                        )
-                        (
-                            transfer_ok,
-                            transfer_result,
-                        ) = await self.hyperliquid_adapter.transfer_spot_to_perp(
-                            amount=spot_usdc,
-                            address=address,
-                        )
-                        if transfer_ok:
-                            self.logger.info("Spot to perp transfer successful")
-                        else:
-                            self.logger.warning(
-                                f"Spot to perp transfer failed: {transfer_result}. "
-                                f"Retrying after delay..."
-                            )
-                            await asyncio.sleep(5)
-                            continue
-                    break
-            break
-
-        # Wait a moment for transfers to settle
-        await asyncio.sleep(2)
 
         withdrawable = 0.0
         for attempt in range(3):
@@ -1241,14 +1196,6 @@ class BasisTradingStrategy(BasisSnapshotMixin, Strategy):
                 self.logger.warning(f"Failed to set leverage: {lev_result}")
                 # Continue anyway - leverage might already be set
 
-            # Target: spot has order_usd for the spot buy, perp holds the remainder as margin.
-            split_ok, split_msg = await self._rebalance_usdc_between_perp_and_spot(
-                target_spot_usdc=order_usd,
-                address=address,
-            )
-            if not split_ok:
-                self.logger.warning(f"USDC rebalance failed: {split_msg}")
-
             filler = PairedFiller(
                 adapter=self.hyperliquid_adapter,
                 address=address,
@@ -1492,69 +1439,6 @@ class BasisTradingStrategy(BasisSnapshotMixin, Strategy):
 
         return withdrawable, spot_usdc
 
-    async def _rebalance_usdc_between_perp_and_spot(
-        self,
-        *,
-        target_spot_usdc: float,
-        address: str,
-    ) -> tuple[bool, str]:
-        if target_spot_usdc <= 0:
-            return False, "Target spot USDC must be positive"
-
-        perp_margin, spot_usdc = await self._get_undeployed_capital()
-        total_usdc = perp_margin + spot_usdc
-        if total_usdc <= 0:
-            return False, "No deployable USDC on Hyperliquid"
-
-        # Operate at cent precision to avoid dust churn.
-        eps = 0.01
-        target = float(
-            Decimal(str(target_spot_usdc)).quantize(Decimal("0.01"), rounding=ROUND_UP)
-        )
-
-        if target > total_usdc + eps:
-            return (
-                False,
-                f"Target spot ${target:.2f} exceeds total deployable ${total_usdc:.2f}",
-            )
-
-        delta = target - spot_usdc
-        if abs(delta) < eps:
-            return True, "Spot/perp USDC already balanced"
-
-        if delta > 0:
-            # Need more spot USDC: move from perp to spot.
-            amount = float(
-                Decimal(str(min(delta, perp_margin))).quantize(
-                    Decimal("0.01"), rounding=ROUND_UP
-                )
-            )
-            if amount < eps:
-                return True, "No meaningful perp->spot transfer needed"
-            success, result = await self.hyperliquid_adapter.transfer_perp_to_spot(
-                amount=amount,
-                address=address,
-            )
-            if not success:
-                return False, f"Perp->spot transfer failed: {result}"
-            return True, f"Transferred ${amount:.2f} perp->spot"
-
-        # Need more perp USDC: move from spot to perp.
-        amount = float(
-            Decimal(str(min(-delta, spot_usdc))).quantize(
-                Decimal("0.01"), rounding=ROUND_DOWN
-            )
-        )
-        if amount < eps:
-            return True, "No meaningful spot->perp transfer needed"
-        success, result = await self.hyperliquid_adapter.transfer_spot_to_perp(
-            amount=amount,
-            address=address,
-        )
-        if not success:
-            return False, f"Spot->perp transfer failed: {result}"
-        return True, f"Transferred ${amount:.2f} spot->perp"
-
     async def _scale_up_position(self, additional_capital: float) -> StatusTuple:
         if self.current_position is None:
             return False, "No position to scale up"
@@ -1603,14 +1487,6 @@ class BasisTradingStrategy(BasisSnapshotMixin, Strategy):
             f"Scaling up {pos.coin} position: adding {units_to_add:.4f} units "
             f"(${order_usd:.2f}) at {leverage}x leverage"
         )
-
-        # Target: spot has order_usd for the spot buy, perp holds the remainder as margin.
-        split_ok, split_msg = await self._rebalance_usdc_between_perp_and_spot(
-            target_spot_usdc=order_usd,
-            address=address,
-        )
-        if not split_ok:
-            self.logger.warning(f"USDC rebalance failed: {split_msg}")
 
         filler = PairedFiller(
             adapter=self.hyperliquid_adapter,

--- a/wayfinder_paths/strategies/basis_trading_strategy/test_strategy.py
+++ b/wayfinder_paths/strategies/basis_trading_strategy/test_strategy.py
@@ -109,8 +109,6 @@ class TestBasisTradingStrategy:
             return_value=(True, "Builder fee approved: 0.030%")
         )
         mock.update_leverage = AsyncMock(return_value=(True, {"status": "ok"}))
-        mock.transfer_perp_to_spot = AsyncMock(return_value=(True, {"status": "ok"}))
-        mock.transfer_spot_to_perp = AsyncMock(return_value=(True, {"status": "ok"}))
         mock.place_market_order = AsyncMock(return_value=(True, {"status": "ok"}))
         mock.place_limit_order = AsyncMock(return_value=(True, {"status": "ok"}))
         mock.place_stop_loss = AsyncMock(return_value=(True, {"status": "ok"}))
@@ -538,9 +536,6 @@ class TestBasisTradingStrategy:
         mock_hyperliquid_adapter.get_valid_order_size = MagicMock(
             side_effect=lambda _aid, sz: sz
         )
-        mock_hyperliquid_adapter.transfer_perp_to_spot = AsyncMock(
-            return_value=(True, "ok")
-        )
         mock_hyperliquid_adapter.get_frontend_open_orders = AsyncMock(
             return_value=(
                 True,
@@ -614,9 +609,6 @@ class TestBasisTradingStrategy:
         )
         mock_hyperliquid_adapter.get_spot_user_state = AsyncMock(
             return_value=(True, {"balances": [{"coin": "ETH", "total": "1.08"}]})
-        )
-        strategy._rebalance_usdc_between_perp_and_spot = AsyncMock(
-            return_value=(True, "ok")
         )
 
         with patch(
@@ -1236,74 +1228,6 @@ class TestBasisTradingStrategy:
 
         # deposit_amount should now be set from detected balance
         assert strategy.deposit_amount == 50.0
-
-    @pytest.mark.asyncio
-    async def test_update_spot_usdc_only_rebalances_before_open(
-        self, strategy, mock_hyperliquid_adapter
-    ):
-        strategy.deposit_amount = 0.0
-        strategy.current_position = None
-
-        # Perp account has $0 withdrawable, spot has $100 USDC
-        mock_hyperliquid_adapter.get_user_state = AsyncMock(
-            return_value=(
-                True,
-                {
-                    "marginSummary": {"accountValue": "0"},
-                    "withdrawable": "0",
-                    "assetPositions": [],
-                },
-            )
-        )
-        mock_hyperliquid_adapter.get_spot_user_state = AsyncMock(
-            return_value=(
-                True,
-                {"balances": [{"coin": "USDC", "total": "100"}]},
-            )
-        )
-
-        # Avoid running the full solver; return a deterministic best trade.
-        strategy.find_best_trade_with_backtest = AsyncMock(
-            return_value={
-                "coin": "ETH",
-                "spot_asset_id": 10000,
-                "perp_asset_id": 1,
-                "net_apy": 0.1,
-                "best_L": 2,
-                "safe": {
-                    "7": {
-                        "safe_leverage": 2,
-                        "spot_usdc": 66.67,
-                        "spot_amount": 0.033335,
-                        "perp_amount": 0.033335,
-                    }
-                },
-            }
-        )
-
-        # Mock the paired filler to avoid actual execution
-        with patch(
-            "wayfinder_paths.strategies.basis_trading_strategy.strategy.PairedFiller"
-        ) as mock_filler_class:
-            mock_filler = MagicMock()
-            mock_filler.fill_pair_units = AsyncMock(
-                return_value=(0.5, 0.5, 1000.0, 1000.0, [], [])
-            )
-            mock_filler_class.return_value = mock_filler
-
-            success, _ = assert_status_tuple(await strategy.update())
-            assert success
-
-        # Target spot was $66.67, so we should transfer $33.33 spot->perp.
-        mock_hyperliquid_adapter.transfer_spot_to_perp.assert_called_once()
-        _, kwargs = mock_hyperliquid_adapter.transfer_spot_to_perp.call_args
-        assert kwargs["address"] == "0x5678"
-        assert abs(kwargs["amount"] - 33.33) < 1e-6
-
-        # Should not attempt perp->spot when spot already has sufficient USDC.
-        mock_hyperliquid_adapter.transfer_perp_to_spot.assert_not_called()
-
-        assert strategy.deposit_amount == 100.0
 
     @pytest.mark.asyncio
     async def test_update_near_liquidation_closes_and_redeploys(

--- a/wayfinder_paths/strategies/boros_hype_strategy/hyperliquid_ops_mixin.py
+++ b/wayfinder_paths/strategies/boros_hype_strategy/hyperliquid_ops_mixin.py
@@ -6,7 +6,6 @@ Kept as a mixin so the main strategy file stays readable without changing behavi
 
 from __future__ import annotations
 
-from decimal import ROUND_DOWN, Decimal
 from typing import Any
 
 from loguru import logger
@@ -249,68 +248,6 @@ class BorosHypeHyperliquidOpsMixin:
         if canceled:
             logger.info(f"Canceled {canceled} Hyperliquid HYPE order(s)")
 
-    async def _sweep_hl_spot_usdc_to_perp(
-        self,
-        *,
-        address: str,
-        min_usdc: float = 0.5,
-    ) -> tuple[bool, str]:
-        """Best-effort: keep HL USDC on perp margin (not spot) when possible."""
-        if not self.hyperliquid_adapter:
-            return False, "Hyperliquid adapter not configured"
-
-        try:
-            # HL spot USDC amounts can have >6dp; usdClassTransfer may effectively round
-            # to USDC decimals. Round down and retry with a small epsilon if needed.
-            quant = Decimal("0.000001")  # USDC precision (6dp)
-            min_usdc_dec = Decimal(str(min_usdc))
-            last_res: object | None = None
-
-            for attempt in range(3):
-                (
-                    success,
-                    spot_state,
-                ) = await self.hyperliquid_adapter.get_spot_user_state(address)
-                if not success or not isinstance(spot_state, dict):
-                    return False, "Failed to read HL spot balances"
-
-                balances = spot_state.get("balances", [])
-                total_dec = Decimal("0")
-                hold_dec = Decimal("0")
-                for bal in balances:
-                    token = bal.get("coin") or bal.get("token")
-                    if token != "USDC":
-                        continue
-                    hold_dec = Decimal(str(bal.get("hold", 0)))
-                    total_dec = Decimal(str(bal.get("total", 0)))
-                    break
-
-                available_dec = max(Decimal("0"), total_dec - hold_dec)
-                amount_dec = available_dec.quantize(quant, rounding=ROUND_DOWN)
-                if attempt:
-                    amount_dec = max(
-                        Decimal("0"), amount_dec - (quant * Decimal(attempt))
-                    )
-
-                if amount_dec <= min_usdc_dec:
-                    return True, "No meaningful HL spot USDC to sweep"
-
-                ok, res = await self.hyperliquid_adapter.transfer_spot_to_perp(
-                    amount=float(amount_dec),
-                    address=address,
-                )
-                if ok:
-                    return True, f"Swept ${float(amount_dec):.2f} HL spot USDC → perp"
-
-                last_res = res
-                err_str = str(res.get("response") if isinstance(res, dict) else res)
-                if "insufficient balance" not in err_str.lower():
-                    break
-
-            return False, f"HL spot→perp transfer failed: {last_res}"
-        except Exception as exc:  # noqa: BLE001
-            return False, f"Failed to sweep HL spot USDC → perp: {exc}"
-
     async def _deploy_excess_hl_margin(
         self, params: dict[str, Any], inventory: Inventory
     ) -> tuple[bool, str]:
@@ -365,17 +302,6 @@ class BorosHypeHyperliquidOpsMixin:
                 "Skipping excess margin deployment: insufficient HL withdrawable after buffer "
                 f"(withdrawable=${withdrawable_now:.2f}, buffer=${buffer_usd:.2f})"
             )
-
-        success, result = await self.hyperliquid_adapter.transfer_perp_to_spot(
-            amount=float(deploy_usd),
-            address=address,
-        )
-
-        if not success:
-            error_msg = result if isinstance(result, str) else str(result)
-            return False, f"Perp to spot transfer failed: {error_msg}"
-
-        logger.info(f"Transferred ${deploy_usd:.2f} from perp margin to spot")
 
         if deploy_usd < MIN_NOTIONAL_USD:
             return True, f"Excess margin ${deploy_usd:.2f} too small for paired fill"
@@ -470,14 +396,6 @@ class BorosHypeHyperliquidOpsMixin:
                 address=address,
             )
             if ok:
-                try:
-                    ok_sweep, sweep_msg = await self._sweep_hl_spot_usdc_to_perp(
-                        address=address
-                    )
-                    if not ok_sweep:
-                        logger.warning(sweep_msg)
-                except Exception as exc:  # noqa: BLE001
-                    logger.warning(f"HL spot USDC sweep failed: {exc}")
                 return (
                     True,
                     f"Deployed ${deploy_usd:.2f} excess margin → {amount_to_bridge:.4f} HYPE to HyperEVM",
@@ -740,11 +658,10 @@ class BorosHypeHyperliquidOpsMixin:
         if hype_price <= 0:
             return False, "Could not determine HYPE price"
 
-        # Transfer from perp→spot, but never below the reserved perp margin.
-        spot_usdc_before = float(inventory.hl_spot_usdc or 0.0)
-        perp_margin = float(inventory.hl_perp_margin or 0.0)
+        # Unified-account pool funds both legs of the paired fill (spot buy +
+        # short margin). Total consumption is deployable * (1 + 1/leverage);
+        # cap so we keep the reserved short margin + buffer untouched.
         withdrawable = float(inventory.hl_withdrawable_usd or 0.0)
-
         leverage = float(MAX_HL_LEVERAGE or 2.0)
         if leverage <= 0:
             leverage = 2.0
@@ -752,40 +669,16 @@ class BorosHypeHyperliquidOpsMixin:
             getattr(self._planner_config, "hl_withdrawable_buffer_usd", 5.0) or 0.0
         )
         denom = 1.0 + (1.0 / leverage)
-        max_xfer_by_margin = max(
-            0.0,
-            (withdrawable - buffer_usd - (spot_usdc_before / leverage)) / denom,
+        max_deployable = max(
+            0.0, (withdrawable - buffer_usd - reserve_hl_margin_usd) / denom
         )
-        transferable_from_perp = max(
-            0.0,
-            min(
-                max_xfer_by_margin,
-                perp_margin - reserve_hl_margin_usd,
-            ),
-        )
-
-        need_from_perp = max(0.0, desired_usd - spot_usdc_before)
-        xfer_usd = min(need_from_perp, transferable_from_perp)
-
-        if xfer_usd >= self._planner_config.min_usdc_action:
-            xfer_ok, xfer_res = await self.hyperliquid_adapter.transfer_perp_to_spot(
-                amount=float(xfer_usd),
-                address=address,
-            )
-            if not xfer_ok:
-                return False, f"Perp→spot transfer failed: {xfer_res}"
-            logger.info(
-                f"Transferred ${xfer_usd:.2f} from HL perp→spot "
-                f"(reserve_perp=${reserve_hl_margin_usd:.2f})"
-            )
-
-        deployable_usd = min(desired_usd, spot_usdc_before + xfer_usd)
+        deployable_usd = min(desired_usd, max_deployable)
         if deployable_usd < MIN_NOTIONAL_USD:
             return False, (
-                "Insufficient deployable HL spot USDC after reserving perp margin "
+                "Insufficient deployable HL USDC after reserving perp margin "
                 f"(${deployable_usd:.2f} < ${MIN_NOTIONAL_USD:.2f}; "
-                f"reserve=${reserve_hl_margin_usd:.2f}, perp=${perp_margin:.2f}, "
-                f"withdrawable=${withdrawable:.2f}, spot=${spot_usdc_before:.2f})"
+                f"reserve=${reserve_hl_margin_usd:.2f}, "
+                f"withdrawable=${withdrawable:.2f})"
             )
 
         # Atomic Paired Fill: buy spot HYPE, short perp HYPE
@@ -873,14 +766,6 @@ class BorosHypeHyperliquidOpsMixin:
             address=address,
         )
         if ok:
-            try:
-                ok_sweep, sweep_msg = await self._sweep_hl_spot_usdc_to_perp(
-                    address=address
-                )
-                if not ok_sweep:
-                    logger.warning(sweep_msg)
-            except Exception as exc:  # noqa: BLE001
-                logger.warning(f"HL spot USDC sweep failed: {exc}")
             return True, f"Bridged {amount_to_bridge:.4f} HYPE to HyperEVM"
 
         err = res if isinstance(res, str) else str(res)

--- a/wayfinder_paths/strategies/boros_hype_strategy/risk_ops_mixin.py
+++ b/wayfinder_paths/strategies/boros_hype_strategy/risk_ops_mixin.py
@@ -203,56 +203,6 @@ class BorosHypeRiskOpsMixin:
         except Exception as exc:  # noqa: BLE001
             logger.warning(f"Failed to sell spot HYPE: {exc}")
 
-        try:
-            usdc_sz_decimals = 8
-
-            ok_spot, spot_state = await self.hyperliquid_adapter.get_spot_user_state(
-                address
-            )
-            spot_usdc = 0.0
-            spot_total_s = "0"
-            spot_hold_s = "0"
-            if ok_spot and isinstance(spot_state, dict):
-                for bal in spot_state.get("balances", []):
-                    token = bal.get("coin") or bal.get("token")
-                    if token != "USDC":
-                        continue
-                    spot_total_s = str(bal.get("total", "0") or "0")
-                    spot_hold_s = str(bal.get("hold", "0") or "0")
-                    hold = float(spot_hold_s)
-                    total = float(spot_total_s)
-                    spot_usdc = max(0.0, total - hold)
-                    break
-            if spot_usdc > 1.0:
-                amount = self.hyperliquid_adapter.max_transferable_amount(
-                    spot_total_s,
-                    spot_hold_s,
-                    sz_decimals=int(usdc_sz_decimals),
-                    leave_one_tick=True,
-                )
-                (
-                    ok_xfer,
-                    res_xfer,
-                ) = await self.hyperliquid_adapter.transfer_spot_to_perp(
-                    amount=float(amount),
-                    address=address,
-                )
-                if (not ok_xfer) and int(usdc_sz_decimals) != 2:
-                    if "insufficient balance" in str(res_xfer).lower():
-                        fallback_2dp = self.hyperliquid_adapter.max_transferable_amount(
-                            spot_total_s,
-                            spot_hold_s,
-                            sz_decimals=2,
-                            leave_one_tick=True,
-                        )
-                        if fallback_2dp > 1.0:
-                            await self.hyperliquid_adapter.transfer_spot_to_perp(
-                                amount=float(fallback_2dp),
-                                address=address,
-                            )
-        except Exception as exc:  # noqa: BLE001
-            logger.warning(f"Failed to move spot USDC to perp: {exc}")
-
         hl_perp_balance = 0.0
         try:
             ok_state, user_state = await self.hyperliquid_adapter.get_user_state(
@@ -281,12 +231,6 @@ class BorosHypeRiskOpsMixin:
 
         if spot_target > self._planner_config.min_usdc_action:
             try:
-                await self.hyperliquid_adapter.transfer_perp_to_spot(
-                    amount=float(spot_target),
-                    address=address,
-                )
-                await asyncio.sleep(2)
-
                 success, mids = await self.hyperliquid_adapter.get_all_mid_prices()
                 hype_price = (
                     float(mids.get("HYPE", 0.0))
@@ -874,57 +818,6 @@ class BorosHypeRiskOpsMixin:
                     )
         except Exception as exc:  # noqa: BLE001
             logger.warning(f"Failed to sell spot HYPE: {exc}")
-
-        try:
-            usdc_sz_decimals = 8
-
-            ok_spot, spot_state = await self.hyperliquid_adapter.get_spot_user_state(
-                address
-            )
-            spot_usdc = 0.0
-            spot_total_s = "0"
-            spot_hold_s = "0"
-            if ok_spot and isinstance(spot_state, dict):
-                for bal in spot_state.get("balances", []):
-                    token = bal.get("coin") or bal.get("token")
-                    if token != "USDC":
-                        continue
-                    spot_total_s = str(bal.get("total", "0") or "0")
-                    spot_hold_s = str(bal.get("hold", "0") or "0")
-                    hold = float(spot_hold_s)
-                    total = float(spot_total_s)
-                    spot_usdc = max(0.0, total - hold)
-                    break
-
-            if spot_usdc > 1.0:
-                amount = self.hyperliquid_adapter.max_transferable_amount(
-                    spot_total_s,
-                    spot_hold_s,
-                    sz_decimals=int(usdc_sz_decimals),
-                    leave_one_tick=True,
-                )
-                (
-                    ok_xfer,
-                    res_xfer,
-                ) = await self.hyperliquid_adapter.transfer_spot_to_perp(
-                    amount=float(amount),
-                    address=address,
-                )
-                if (not ok_xfer) and int(usdc_sz_decimals) != 2:
-                    if "insufficient balance" in str(res_xfer).lower():
-                        fallback_2dp = self.hyperliquid_adapter.max_transferable_amount(
-                            spot_total_s,
-                            spot_hold_s,
-                            sz_decimals=2,
-                            leave_one_tick=True,
-                        )
-                        if fallback_2dp > 1.0:
-                            await self.hyperliquid_adapter.transfer_spot_to_perp(
-                                amount=float(fallback_2dp),
-                                address=address,
-                            )
-        except Exception as exc:  # noqa: BLE001
-            logger.warning(f"Failed to move USDC spot→perp: {exc}")
 
         inv_after = await self.observe()
         ok_short, msg_short = await self._ensure_hl_short(

--- a/wayfinder_paths/strategies/boros_hype_strategy/withdraw_mixin.py
+++ b/wayfinder_paths/strategies/boros_hype_strategy/withdraw_mixin.py
@@ -699,8 +699,6 @@ class BorosHypeWithdrawMixin:
         # ─────────────────────────────────────────────────────────────────
         # STEP 5: Unwind HYPE exposure on Hyperliquid (paired when possible)
         # ─────────────────────────────────────────────────────────────────
-        sold_hl_spot_hype = False
-
         try:
             await self._cancel_hl_open_orders_for_hype(address)
         except Exception as exc:  # noqa: BLE001
@@ -764,7 +762,6 @@ class BorosHypeWithdrawMixin:
                         direction="short_spot_long_perp",
                         builder_fee=self.builder_fee,
                     )
-                    sold_hl_spot_hype = filled_spot > 0.0
                     logger.info(
                         f"Paired unwind complete: sold_spot={filled_spot:.4f} (${spot_notional:.2f}), "
                         f"closed_perp={filled_perp:.4f} (${perp_notional:.2f})"
@@ -825,7 +822,6 @@ class BorosHypeWithdrawMixin:
                     if not ok_sell:
                         return False, f"Failed to sell HL spot HYPE: {res_sell}"
                     logger.info(f"Sold {rounded_size:.4f} HYPE to USDC on HL spot")
-                    sold_hl_spot_hype = True
                     # HL spot trades need time to clear hold
                     await asyncio.sleep(10)
 
@@ -879,154 +875,7 @@ class BorosHypeWithdrawMixin:
             return False, f"Failed to unwind HYPE on Hyperliquid: {exc}"
 
         # ─────────────────────────────────────────────────────────────────
-        # STEP 7: Move all USDC from spot to perp margin (poll until cleared)
-        # ─────────────────────────────────────────────────────────────────
-        usdc_sz_decimals = 8
-
-        spot_transfer_succeeded = False
-        did_transfer_spot_usdc_to_perp = False
-        observed_spot_usdc_after_sell = not sold_hl_spot_hype
-        spot_total = 0.0
-        spot_hold = 0.0
-        spot_usdc = 0.0
-        attempt = 0
-        while True:
-            attempt += 1
-            try:
-                spot_total = 0.0
-                spot_hold = 0.0
-                spot_usdc = 0.0
-                spot_total_s = "0"
-                spot_hold_s = "0"
-
-                (
-                    ok_spot,
-                    spot_state,
-                ) = await self.hyperliquid_adapter.get_spot_user_state(address)
-                if ok_spot and isinstance(spot_state, dict):
-                    for bal in spot_state.get("balances", []):
-                        token = bal.get("coin") or bal.get("token")
-                        if token == "USDC":
-                            spot_total_s = str(bal.get("total", "0") or "0")
-                            spot_hold_s = str(bal.get("hold", "0") or "0")
-                            spot_hold = float(spot_hold_s)
-                            spot_total = float(spot_total_s)
-                            spot_usdc = spot_total - spot_hold
-                            break
-
-                logger.info(
-                    f"Spot USDC balance (attempt {attempt}): "
-                    f"total={spot_total:.2f}, hold={spot_hold:.2f}, available={spot_usdc:.2f}"
-                )
-
-                if not observed_spot_usdc_after_sell:
-                    if spot_total > 1.0 or spot_hold > 0.5 or spot_usdc > 1.0:
-                        observed_spot_usdc_after_sell = True
-                    else:
-                        if time.time() >= deadline_ts:
-                            break
-                        logger.info(
-                            "Waiting for HL spot USDC to settle after HYPE sale..."
-                        )
-                        await asyncio.sleep(poll_interval_s)
-                        continue
-
-                if spot_total <= 1.0:
-                    # No significant USDC remaining on spot (including hold), nothing to transfer.
-                    spot_transfer_succeeded = True
-                    break
-
-                if spot_usdc > 1.0:
-                    # Compute a safe amount using Decimal math and szDecimals, leaving 1 tick.
-                    spot_usdc_to_xfer = (
-                        self.hyperliquid_adapter.max_transferable_amount(
-                            spot_total_s,
-                            spot_hold_s,
-                            sz_decimals=int(usdc_sz_decimals),
-                            leave_one_tick=True,
-                        )
-                    )
-                    # Fallback: some Hyperliquid client versions effectively round to 2dp
-                    # internally for usdClassTransfer. If we get an "insufficient balance"
-                    # error, retry with 2dp floor.
-                    fallback_2dp = (
-                        self.hyperliquid_adapter.max_transferable_amount(
-                            spot_total_s,
-                            spot_hold_s,
-                            sz_decimals=2,
-                            leave_one_tick=True,
-                        )
-                        if int(usdc_sz_decimals) != 2
-                        else 0.0
-                    )
-
-                    if spot_usdc_to_xfer <= 1.0:
-                        if time.time() >= deadline_ts:
-                            break
-                        await asyncio.sleep(poll_interval_s)
-                        continue
-
-                    # Transfer the full available amount (fresh balance query each attempt)
-                    (
-                        ok_xfer,
-                        res_xfer,
-                    ) = await self.hyperliquid_adapter.transfer_spot_to_perp(
-                        amount=float(spot_usdc_to_xfer),
-                        address=address,
-                    )
-                    if ok_xfer:
-                        logger.info(
-                            f"Transferred ${spot_usdc_to_xfer:.2f} USDC from spot to perp"
-                        )
-                        did_transfer_spot_usdc_to_perp = True
-                        await asyncio.sleep(3)
-                    else:
-                        res_s = str(res_xfer)
-                        if fallback_2dp > 1.0 and (
-                            "insufficient balance" in res_s.lower()
-                        ):
-                            (
-                                ok_xfer2,
-                                res_xfer2,
-                            ) = await self.hyperliquid_adapter.transfer_spot_to_perp(
-                                amount=float(fallback_2dp),
-                                address=address,
-                            )
-                            if ok_xfer2:
-                                logger.info(
-                                    f"Transferred ${fallback_2dp:.2f} USDC from spot to perp (2dp fallback)"
-                                )
-                                did_transfer_spot_usdc_to_perp = True
-                                await asyncio.sleep(3)
-                                continue
-                            res_xfer = res_xfer2
-
-                        logger.warning(
-                            f"Failed to move USDC spot→perp (attempt {attempt}): {res_xfer}"
-                        )
-                else:
-                    # USDC exists but is still held (trade settlement). Wait and retry.
-                    if time.time() >= deadline_ts:
-                        break
-                    await asyncio.sleep(poll_interval_s)
-            except Exception as exc:  # noqa: BLE001
-                logger.warning(
-                    f"Failed to move USDC spot→perp (attempt {attempt}): {exc}"
-                )
-                if time.time() >= deadline_ts:
-                    break
-                await asyncio.sleep(poll_interval_s)
-
-        remaining_spot_usdc = 0.0
-        if not spot_transfer_succeeded:
-            remaining_spot_usdc = spot_total
-            logger.error(
-                f"Failed to transfer spot USDC to perp before timeout. "
-                f"Spot USDC may still be on Hyperliquid spot account (total=${spot_total:.2f}, hold=${spot_hold:.2f})."
-            )
-
-        # ─────────────────────────────────────────────────────────────────
-        # STEP 8: Withdraw all from Hyperliquid to Arbitrum
+        # STEP 7: Withdraw all from Hyperliquid to Arbitrum
         # ─────────────────────────────────────────────────────────────────
         hl_wait_min_usdc_raw: int | None = None
         try:
@@ -1117,15 +966,7 @@ class BorosHypeWithdrawMixin:
                     await asyncio.sleep(poll_interval_s)
                     continue
 
-                # No perp balance yet. If we just moved spot→perp, wait for it to reflect.
-                if not did_transfer_spot_usdc_to_perp:
-                    break
-                if time.time() >= deadline_ts:
-                    break
-                logger.info(
-                    f"Waiting for spot→perp transfer to reflect in HL margin (attempt {attempt})..."
-                )
-                await asyncio.sleep(poll_interval_s)
+                break
         except Exception as exc:  # noqa: BLE001
             logger.warning(f"Failed Hyperliquid withdrawal: {exc}")
 
@@ -1349,12 +1190,6 @@ class BorosHypeWithdrawMixin:
                 )
         except Exception as exc:  # noqa: BLE001
             logger.debug(f"Final withdrawal inventory check failed: {exc}")
-
-        if remaining_spot_usdc > 1.0:
-            return False, (
-                f"Withdrawal incomplete: ${remaining_spot_usdc:.2f} USDC still on Hyperliquid spot. "
-                "Run withdraw again (or increase max_wait_s) to retry the spot→perp transfer."
-            )
 
         return (
             True,


### PR DESCRIPTION
### Summary

HL is migrating every user to unified accounts. The SDK already calls `ensure_unified_account(address)` at the top of every order-placing method (`place_market_order`, `place_limit_order`, `withdraw`, `deposit`), so the very first action after a user updates the image flips them to unified if they weren't already. In unified mode, spot + perp share a single collateral pool and `usdClassTransfer` is a no-op.

This PR rips out the dead transfer plumbing and the surrounding "compute split → transfer → wait → verify" orchestration in basis_trading_strategy and boros_hype_strategy. Net **−709 lines**.

**Removed:**
- `HyperliquidAdapter._usd_class_transfer`, `.transfer_spot_to_perp`, `.transfer_perp_to_spot`
- Abstract methods from `HyperliquidClient` protocol
- MCP actions `spot_to_perp_transfer` / `perp_to_spot_transfer` (preview branches + handler)
- `basis_trading_strategy._rebalance_usdc_between_perp_and_spot` and both call sites
- `basis_trading_strategy`: spot→perp transfer loop + 2s settle sleep in the exit flow
- `boros_hype_strategy.withdraw_mixin` STEP 7 (poll-until-spot-cleared transfer loop) + downstream `did_transfer_spot_usdc_to_perp` / `remaining_spot_usdc` checks
- `boros_hype_strategy.risk_ops_mixin`: two spot→perp sweep blocks + one perp→spot prep before spot buy
- `boros_hype_strategy.hyperliquid_ops_mixin`: `_sweep_hl_spot_usdc_to_perp` helper + 2 callers; perp→spot transfer in `_deploy_excess_hl_margin`; perp→spot transfer + margin-split math in `_bridge_to_hyperevm` (simplified `deployable_usd` calc)
- One obsolete test (`test_update_spot_usdc_only_rebalances_before_open`); mock setup for the dropped methods.

**Rollover safety:** Users on the old image with pre-unified state get auto-migrated by `ensure_unified_account` on their next order. No data migration needed.