### PR TITLE
AGENTS.md - UnifiedAccount migration note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,8 +98,6 @@ Hyperliquid minimums:
 
 Hyperliquid surfaces in the adapter/MCP: perp, spot, HIP-3 builder-deployed perp dexes (`xyz`/`flx`/`vntl`/`hyna`/`km`...), and HIP-4 outcome markets (binary/multi-outcome prediction contracts). Outcomes use a separate asset-id space (`100_000_000 + 10*outcome_id + side`) and integer contract sizes; **settle in USDH** (token 360), not USDC; settle daily at 06:00 UTC; written via `hyperliquid_execute(action="place_outcome_order", ...)`. See `/using-hyperliquid-adapter` rules for details.
 
-Hyperliquid spot_to_perp_transfer and perp_to_spot_transfer only work with USDC spot to/from USDC perps. Other USD stables will need to be converted first.
-
 **Outcome / prediction markets — search both venues, let the user pick.** When a user mentions "outcome market" or "prediction market" without naming the platform, **search both venues in parallel** and present candidates side-by-side so the user can choose. Two venues:
 
 - **Hyperliquid HIP-4** — daily binary price contracts settled in USDH on the HL L1; rotating daily lineup. Search via `mcp__wayfinder__hyperliquid_search_market(query=...)` (read the `outcomes` bucket).
@@ -197,6 +195,10 @@ On Wayfinder Shells instances (`OPENCODE_INSTANCE_ID` set), the runner daemon au
 The frontend shows synced jobs and runs in the "Scheduled" tab of the shells sidebar.
 
 **Don't silence `job_result` notifications.** When a scheduled job posts a `job_result` into the conversation, treat it as an event you must respond to — read the result, decide whether action is needed, and reply (act, escalate via `notify`, or acknowledge). Never skip past it silently or fold it into an unrelated turn.
+
+## Migration notes
+
+- Hyperliquid UnifiedAccount is the preferred account mode. If the user is on a legacy split spot/perp account, migrating may require closing all open positions, moving balances to spot, then enabling UnifiedAccountMode. `ensure_unified_account` runs before every order placement, but the flip can fail mid-state if open positions or stuck spot balances prevent the switch — you may need to edit code and write a custom script to unblock the user.
 
 ## User Suggestions (always emit)
 


### PR DESCRIPTION
### Summary

Adds a Migration notes section to AGENTS.md flagging that legacy split spot/perp HL accounts may need positions closed and balances moved to spot before the UnifiedAccountMode flip succeeds — follow-up to #321 which dropped the spot↔perp transfer functions. Also removes the now-stale line about `spot_to_perp_transfer` / `perp_to_spot_transfer` since those functions no longer exist.