### PR TITLE
Shells - Polymarket market-order slippage cap + AutoWrap

### DIFF
--- a/wayfinder_paths/adapters/polymarket_adapter/adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/adapter.py
@@ -1351,7 +1351,7 @@ class PolymarketAdapter(BaseAdapter):
             if rows:
                 last = rows[0]
                 state = last["state"]
-                if state in {"STATE_CONFIRMED", "STATE_MINED"}:
+                if state == "STATE_MINED":
                     return last
                 if state in {"STATE_FAILED", "STATE_INVALID"}:
                     raise ValueError(f"Relayer transaction failed: {last}")
@@ -2315,17 +2315,8 @@ class PolymarketAdapter(BaseAdapter):
 
             # Sweep any USDC.e in the deposit wallet into pUSD. Catches both
             # paths above (direct USDC.e settlement, neg-risk unwrap) and any
-            # stale balance from prior activity. Wait for the last on-chain
-            # batch to land on the public RPC first — the relayer reports
-            # MINED before public node propagation, and a stale balance read
-            # here would silently skip the wrap. Soft-fail downstream: a
-            # missing BRAP route shouldn't undo a successful redemption.
-            final_tx_hash = unwrap_tx_hash or redeem["tx_hash"]
-            async with web3_from_chain_id(POLYGON_CHAIN_ID) as web3:
-                await web3.eth.wait_for_transaction_receipt(
-                    final_tx_hash, timeout=120
-                )
-
+            # stale balance from prior activity. Soft-fail: a missing route
+            # shouldn't undo a successful redemption.
             wrap_tx_hash: str | None = None
             wrap_error: str | None = None
             usdce_balance = await get_token_balance(

--- a/wayfinder_paths/adapters/polymarket_adapter/adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/adapter.py
@@ -898,6 +898,49 @@ class PolymarketAdapter(BaseAdapter):
             quote=quote,
         )
 
+    async def _wrap_deposit_wallet_usdce_to_pusd(self, *, amount_base_unit: int) -> str:
+        """USDC.e → pUSD swap signed by the deposit wallet via its batch entry.
+
+        BRAP solver builds the route against `from_wallet=deposit_wallet`; we
+        bundle the ERC20 approval + router call into a single batch so the
+        deposit wallet never holds an open USDC.e allowance between txs.
+        """
+        deposit_wallet = self.deposit_wallet_address()
+        quote_response = await BRAP_CLIENT.get_quote(
+            from_token=POLYGON_USDC_E_ADDRESS,
+            to_token=POLYGON_P_USDC_PROXY_ADDRESS,
+            from_chain=POLYGON_CHAIN_ID,
+            to_chain=POLYGON_CHAIN_ID,
+            from_wallet=deposit_wallet,
+            from_amount=str(amount_base_unit),
+            slippage=self._BRAP_DEFAULT_SLIPPAGE,
+        )
+        quote = quote_response.get("best_quote")
+        if not quote:
+            raise ValueError("No BRAP quote for USDC.e → pUSD")
+        calldata = quote.get("calldata") or {}
+        router = to_checksum_address(calldata["to"])
+
+        async with web3_from_chain_id(POLYGON_CHAIN_ID) as web3:
+            usdce = web3.eth.contract(address=POLYGON_USDC_E_ADDRESS, abi=ERC20_ABI)
+            approve_data = usdce.encode_abi("approve", [router, amount_base_unit])
+
+        result = await self._submit_wallet_batch(
+            calls=[
+                {
+                    "target": POLYGON_USDC_E_ADDRESS,
+                    "value": 0,
+                    "data": approve_data,
+                },
+                {
+                    "target": router,
+                    "value": int(calldata.get("value") or 0),
+                    "data": calldata["data"],
+                },
+            ]
+        )
+        return result["tx_hash"]
+
     async def bridge_deposit(
         self,
         *,
@@ -2271,10 +2314,32 @@ class PolymarketAdapter(BaseAdapter):
                     )
                     unwrap_tx_hash = unwrap["tx_hash"]
 
+            # Redemption settles in USDC.e (directly, or via the neg-risk
+            # wrapper unwrapped above). The deposit wallet's tradable balance
+            # is pUSD, so wrap any USDC.e back through BRAP. Soft-fail: a
+            # missing route shouldn't undo a successful redemption.
+            wrap_tx_hash: str | None = None
+            wrap_error: str | None = None
+            usdce_balance = await get_token_balance(
+                POLYGON_USDC_E_ADDRESS,
+                POLYGON_CHAIN_ID,
+                deposit_wallet,
+                block_identifier="latest",
+            )
+            if usdce_balance > 0:
+                try:
+                    wrap_tx_hash = await self._wrap_deposit_wallet_usdce_to_pusd(
+                        amount_base_unit=usdce_balance,
+                    )
+                except Exception as wrap_exc:  # noqa: BLE001
+                    wrap_error = str(wrap_exc)
+
             return True, {
                 "deposit_wallet": deposit_wallet,
                 "tx_hash": redeem["tx_hash"],
                 "unwrap_tx_hash": unwrap_tx_hash,
+                "wrap_tx_hash": wrap_tx_hash,
+                "wrap_error": wrap_error,
                 "path": path,
             }
         except Exception as exc:  # noqa: BLE001

--- a/wayfinder_paths/adapters/polymarket_adapter/adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/adapter.py
@@ -2319,8 +2319,8 @@ class PolymarketAdapter(BaseAdapter):
             wrap_tx_hash: str | None = None
             wrap_error: str | None = None
             produces_usdce = to_checksum_address(collateral) in {
-                to_checksum_address(POLYMARKET_ADAPTER_COLLATERAL_ADDRESS),
-                to_checksum_address(POLYGON_USDC_E_ADDRESS),
+                POLYMARKET_ADAPTER_COLLATERAL_ADDRESS,
+                POLYGON_USDC_E_ADDRESS,
             }
             if produces_usdce:
                 usdce_balance = await get_token_balance(

--- a/wayfinder_paths/adapters/polymarket_adapter/adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/adapter.py
@@ -2315,8 +2315,17 @@ class PolymarketAdapter(BaseAdapter):
 
             # Sweep any USDC.e in the deposit wallet into pUSD. Catches both
             # paths above (direct USDC.e settlement, neg-risk unwrap) and any
-            # stale balance from prior activity. Soft-fail: a missing route
-            # shouldn't undo a successful redemption.
+            # stale balance from prior activity. Wait for the last on-chain
+            # batch to land on the public RPC first — the relayer reports
+            # MINED before public node propagation, and a stale balance read
+            # here would silently skip the wrap. Soft-fail downstream: a
+            # missing BRAP route shouldn't undo a successful redemption.
+            final_tx_hash = unwrap_tx_hash or redeem["tx_hash"]
+            async with web3_from_chain_id(POLYGON_CHAIN_ID) as web3:
+                await web3.eth.wait_for_transaction_receipt(
+                    final_tx_hash, timeout=120
+                )
+
             wrap_tx_hash: str | None = None
             wrap_error: str | None = None
             usdce_balance = await get_token_balance(

--- a/wayfinder_paths/adapters/polymarket_adapter/adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/adapter.py
@@ -89,8 +89,8 @@ def _fuzzy_score(query: str, text: str) -> float:
 class PolymarketAdapter(BaseAdapter):
     adapter_type = "POLYMARKET"
 
-    DEFAULT_MAX_SLIPPAGE_BPS = (
-        200  # 2% — Polymarket prices live in [0, 1], no native slippage param
+    DEFAULT_MAX_SLIPPAGE_PCT = (
+        2.0  # Polymarket prices live in [0, 1], no native slippage param
     )
 
     def __init__(
@@ -549,7 +549,7 @@ class PolymarketAdapter(BaseAdapter):
         market_slug: str,
         outcome: str | int = "YES",
         amount_collateral: float = 1.0,
-        max_slippage_bps: float | None = None,
+        max_slippage_pct: float | None = None,
     ) -> tuple[bool, dict[str, Any] | str]:
         ok, market = await self.get_market_by_slug(market_slug)
         if not ok:
@@ -563,7 +563,7 @@ class PolymarketAdapter(BaseAdapter):
             token_id=token_id,
             side="BUY",
             amount=amount_collateral,
-            max_slippage_bps=max_slippage_bps,
+            max_slippage_pct=max_slippage_pct,
         )
 
     async def cash_out_prediction(
@@ -572,7 +572,7 @@ class PolymarketAdapter(BaseAdapter):
         market_slug: str,
         outcome: str | int = "YES",
         shares: float = 1.0,
-        max_slippage_bps: float | None = None,
+        max_slippage_pct: float | None = None,
     ) -> tuple[bool, dict[str, Any] | str]:
         ok, market = await self.get_market_by_slug(market_slug)
         if not ok:
@@ -586,7 +586,7 @@ class PolymarketAdapter(BaseAdapter):
             token_id=token_id,
             side="SELL",
             amount=shares,
-            max_slippage_bps=max_slippage_bps,
+            max_slippage_pct=max_slippage_pct,
         )
 
     async def get_market_prices_history(
@@ -902,7 +902,9 @@ class PolymarketAdapter(BaseAdapter):
             quote=quote,
         )
 
-    async def _wrap_deposit_wallet_usdce_to_pusd(self, *, amount_base_unit: int) -> str:
+    async def _wrap_deposit_wallet_usdce_to_pusd(
+        self, *, amount_base_unit: int, slippage_pct: float | None = None
+    ) -> str:
         """USDC.e → pUSD swap signed by the deposit wallet via its batch entry.
 
         BRAP solver builds the route against `from_wallet=deposit_wallet`; we
@@ -910,6 +912,9 @@ class PolymarketAdapter(BaseAdapter):
         deposit wallet never holds an open USDC.e allowance between txs.
         """
         deposit_wallet = self.deposit_wallet_address()
+        slippage = (
+            self._BRAP_DEFAULT_SLIPPAGE if slippage_pct is None else slippage_pct / 100
+        )
         quote_response = await BRAP_CLIENT.get_quote(
             from_token=POLYGON_USDC_E_ADDRESS,
             to_token=POLYGON_P_USDC_PROXY_ADDRESS,
@@ -917,7 +922,7 @@ class PolymarketAdapter(BaseAdapter):
             to_chain=POLYGON_CHAIN_ID,
             from_wallet=deposit_wallet,
             from_amount=str(amount_base_unit),
-            slippage=self._BRAP_DEFAULT_SLIPPAGE,
+            slippage=slippage,
         )
         quote = quote_response["best_quote"]
         calldata = quote["calldata"]
@@ -1660,7 +1665,7 @@ class PolymarketAdapter(BaseAdapter):
         token_id: str,
         side: Literal["BUY", "SELL"],
         amount: float,
-        max_slippage_bps: float | None = None,
+        max_slippage_pct: float | None = None,
     ) -> tuple[bool, dict[str, Any] | str]:
         # BUY amount = collateral ($) to spend, SELL amount = shares to sell.
         # Polymarket has no slippage param; canonical pattern (see py-clob-client-v2
@@ -1683,14 +1688,14 @@ class PolymarketAdapter(BaseAdapter):
 
         worst = Decimal(str(quote["worst_price"]))
         tick = Decimal(str(quote["book_meta"].get("tick_size") or "0.01"))
-        bps = Decimal(
+        pct = Decimal(
             str(
-                self.DEFAULT_MAX_SLIPPAGE_BPS
-                if max_slippage_bps is None
-                else max_slippage_bps
+                self.DEFAULT_MAX_SLIPPAGE_PCT
+                if max_slippage_pct is None
+                else max_slippage_pct
             )
         )
-        slip = bps / Decimal(10_000)
+        slip = pct / Decimal(100)
         if side == "BUY":
             raw = worst * (Decimal(1) + slip)
             cap = (raw / tick).quantize(Decimal(1), rounding=ROUND_CEILING) * tick
@@ -1715,7 +1720,7 @@ class PolymarketAdapter(BaseAdapter):
             out.setdefault("setup", setup)
             out["quote"] = quote
             out["price_cap"] = float(cap)
-            out["max_slippage_bps"] = float(bps)
+            out["max_slippage_pct"] = float(pct)
             return True, out
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
@@ -2250,7 +2255,11 @@ class PolymarketAdapter(BaseAdapter):
         return False, "No redeemable balance detected for the provided condition_id."
 
     async def redeem_positions(
-        self, *, condition_id: str
+        self,
+        *,
+        condition_id: str,
+        auto_wrap_redemption_usdce: bool = True,
+        wrap_slippage_pct: float | None = None,
     ) -> tuple[bool, dict[str, Any] | str]:
         try:
             deposit_wallet = self.deposit_wallet_address()
@@ -2322,7 +2331,7 @@ class PolymarketAdapter(BaseAdapter):
                 POLYMARKET_ADAPTER_COLLATERAL_ADDRESS,
                 POLYGON_USDC_E_ADDRESS,
             }
-            if produces_usdce:
+            if auto_wrap_redemption_usdce and produces_usdce:
                 usdce_balance = await get_token_balance(
                     POLYGON_USDC_E_ADDRESS,
                     POLYGON_CHAIN_ID,
@@ -2333,6 +2342,7 @@ class PolymarketAdapter(BaseAdapter):
                     try:
                         wrap_tx_hash = await self._wrap_deposit_wallet_usdce_to_pusd(
                             amount_base_unit=usdce_balance,
+                            slippage_pct=wrap_slippage_pct,
                         )
                     except Exception as wrap_exc:  # noqa: BLE001
                         wrap_error = str(wrap_exc)

--- a/wayfinder_paths/adapters/polymarket_adapter/adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/adapter.py
@@ -89,6 +89,10 @@ def _fuzzy_score(query: str, text: str) -> float:
 class PolymarketAdapter(BaseAdapter):
     adapter_type = "POLYMARKET"
 
+    DEFAULT_MAX_SLIPPAGE_BPS = (
+        200  # 2% — Polymarket prices live in [0, 1], no native slippage param
+    )
+
     def __init__(
         self,
         config: dict[str, Any] | None = None,
@@ -915,10 +919,8 @@ class PolymarketAdapter(BaseAdapter):
             from_amount=str(amount_base_unit),
             slippage=self._BRAP_DEFAULT_SLIPPAGE,
         )
-        quote = quote_response.get("best_quote")
-        if not quote:
-            raise ValueError("No BRAP quote for USDC.e → pUSD")
-        calldata = quote.get("calldata") or {}
+        quote = quote_response["best_quote"]
+        calldata = quote["calldata"]
         router = to_checksum_address(calldata["to"])
 
         async with web3_from_chain_id(POLYGON_CHAIN_ID) as web3:
@@ -934,7 +936,7 @@ class PolymarketAdapter(BaseAdapter):
                 },
                 {
                     "target": router,
-                    "value": int(calldata.get("value") or 0),
+                    "value": int(calldata.get("value", 0)),
                     "data": calldata["data"],
                 },
             ]
@@ -1652,10 +1654,6 @@ class PolymarketAdapter(BaseAdapter):
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
 
-    DEFAULT_MAX_SLIPPAGE_BPS = (
-        200  # 2% — Polymarket prices live in [0, 1], no native slippage param
-    )
-
     async def place_market_order(
         self,
         *,
@@ -1680,11 +1678,11 @@ class PolymarketAdapter(BaseAdapter):
         )
         if not ok_quote:
             return False, quote
-        if not isinstance(quote, dict) or not quote.get("fully_fillable"):
+        if not quote["fully_fillable"]:
             return False, {"error": "insufficient book liquidity", "quote": quote}
 
         worst = Decimal(str(quote["worst_price"]))
-        tick = Decimal(str((quote.get("book_meta") or {}).get("tick_size") or "0.01"))
+        tick = Decimal(str(quote["book_meta"].get("tick_size") or "0.01"))
         bps = Decimal(
             str(
                 self.DEFAULT_MAX_SLIPPAGE_BPS
@@ -1715,9 +1713,9 @@ class PolymarketAdapter(BaseAdapter):
             out = resp if isinstance(resp, dict) else {"result": resp}
             out.setdefault("deposit_wallet", self.deposit_wallet_address())
             out.setdefault("setup", setup)
-            out.setdefault("quote", quote)
-            out.setdefault("price_cap", float(cap))
-            out.setdefault("max_slippage_bps", float(bps))
+            out["quote"] = quote
+            out["price_cap"] = float(cap)
+            out["max_slippage_bps"] = float(bps)
             return True, out
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
@@ -2320,19 +2318,24 @@ class PolymarketAdapter(BaseAdapter):
             # missing route shouldn't undo a successful redemption.
             wrap_tx_hash: str | None = None
             wrap_error: str | None = None
-            usdce_balance = await get_token_balance(
-                POLYGON_USDC_E_ADDRESS,
-                POLYGON_CHAIN_ID,
-                deposit_wallet,
-                block_identifier="latest",
-            )
-            if usdce_balance > 0:
-                try:
-                    wrap_tx_hash = await self._wrap_deposit_wallet_usdce_to_pusd(
-                        amount_base_unit=usdce_balance,
-                    )
-                except Exception as wrap_exc:  # noqa: BLE001
-                    wrap_error = str(wrap_exc)
+            produces_usdce = to_checksum_address(collateral) in {
+                to_checksum_address(POLYMARKET_ADAPTER_COLLATERAL_ADDRESS),
+                to_checksum_address(POLYGON_USDC_E_ADDRESS),
+            }
+            if produces_usdce:
+                usdce_balance = await get_token_balance(
+                    POLYGON_USDC_E_ADDRESS,
+                    POLYGON_CHAIN_ID,
+                    deposit_wallet,
+                    block_identifier="latest",
+                )
+                if usdce_balance > 0:
+                    try:
+                        wrap_tx_hash = await self._wrap_deposit_wallet_usdce_to_pusd(
+                            amount_base_unit=usdce_balance,
+                        )
+                    except Exception as wrap_exc:  # noqa: BLE001
+                        wrap_error = str(wrap_exc)
 
             return True, {
                 "deposit_wallet": deposit_wallet,

--- a/wayfinder_paths/adapters/polymarket_adapter/adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/adapter.py
@@ -2313,30 +2313,25 @@ class PolymarketAdapter(BaseAdapter):
                     )
                     unwrap_tx_hash = unwrap["tx_hash"]
 
-            # Redemption settles in USDC.e (directly, or via the neg-risk
-            # wrapper unwrapped above). The deposit wallet's tradable balance
-            # is pUSD, so wrap any USDC.e back through BRAP. Soft-fail: a
-            # missing route shouldn't undo a successful redemption.
+            # Sweep any USDC.e in the deposit wallet into pUSD. Catches both
+            # paths above (direct USDC.e settlement, neg-risk unwrap) and any
+            # stale balance from prior activity. Soft-fail: a missing route
+            # shouldn't undo a successful redemption.
             wrap_tx_hash: str | None = None
             wrap_error: str | None = None
-            produces_usdce = to_checksum_address(collateral) in {
-                POLYMARKET_ADAPTER_COLLATERAL_ADDRESS,
+            usdce_balance = await get_token_balance(
                 POLYGON_USDC_E_ADDRESS,
-            }
-            if produces_usdce:
-                usdce_balance = await get_token_balance(
-                    POLYGON_USDC_E_ADDRESS,
-                    POLYGON_CHAIN_ID,
-                    deposit_wallet,
-                    block_identifier="latest",
-                )
-                if usdce_balance > 0:
-                    try:
-                        wrap_tx_hash = await self._wrap_deposit_wallet_usdce_to_pusd(
-                            amount_base_unit=usdce_balance,
-                        )
-                    except Exception as wrap_exc:  # noqa: BLE001
-                        wrap_error = str(wrap_exc)
+                POLYGON_CHAIN_ID,
+                deposit_wallet,
+                block_identifier="latest",
+            )
+            if usdce_balance > 0:
+                try:
+                    wrap_tx_hash = await self._wrap_deposit_wallet_usdce_to_pusd(
+                        amount_base_unit=usdce_balance,
+                    )
+                except Exception as wrap_exc:  # noqa: BLE001
+                    wrap_error = str(wrap_exc)
 
             return True, {
                 "deposit_wallet": deposit_wallet,

--- a/wayfinder_paths/adapters/polymarket_adapter/adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/adapter.py
@@ -2334,7 +2334,7 @@ class PolymarketAdapter(BaseAdapter):
             # settled (pUSD direct → done, USDC.e → wrap the delta).
             wrap_tx_hash: str | None = None
             wrap_error: str | None = None
-            usdce_delta = 0
+            usdce_to_wrap = 0
             deadline = time.monotonic() + 5.0
             while time.monotonic() < deadline:
                 pusd_now, usdce_now = await asyncio.gather(
@@ -2352,14 +2352,14 @@ class PolymarketAdapter(BaseAdapter):
                     ),
                 )
                 if pusd_now > pusd_before or usdce_now > usdce_before:
-                    usdce_delta = usdce_now - usdce_before
+                    usdce_to_wrap = usdce_now
                     break
                 await asyncio.sleep(0.25)
 
-            if usdce_delta > 0:
+            if usdce_to_wrap > 0:
                 try:
                     wrap_tx_hash = await self._wrap_deposit_wallet_usdce_to_pusd(
-                        amount_base_unit=usdce_delta,
+                        amount_base_unit=usdce_to_wrap,
                     )
                 except Exception as wrap_exc:  # noqa: BLE001
                     wrap_error = str(wrap_exc)

--- a/wayfinder_paths/adapters/polymarket_adapter/adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/adapter.py
@@ -902,19 +902,15 @@ class PolymarketAdapter(BaseAdapter):
             quote=quote,
         )
 
-    async def _wrap_deposit_wallet_usdce_to_pusd(
-        self, *, amount_base_unit: int, slippage_pct: float | None = None
-    ) -> str:
-        """USDC.e → pUSD swap signed by the deposit wallet via its batch entry.
+    async def _wrap_deposit_wallet_usdce_to_pusd(self, *, amount_base_unit: int) -> str:
+        """USDC.e → pUSD wrap signed by the deposit wallet via its batch entry.
 
-        BRAP solver builds the route against `from_wallet=deposit_wallet`; we
-        bundle the ERC20 approval + router call into a single batch so the
-        deposit wallet never holds an open USDC.e allowance between txs.
+        Routes through BRAP's polymarket_bridge solver, which wraps 1:1 — no
+        slippage. We bundle the ERC20 approval + router call into a single
+        batch so the deposit wallet never holds an open USDC.e allowance
+        between txs.
         """
         deposit_wallet = self.deposit_wallet_address()
-        slippage = (
-            self._BRAP_DEFAULT_SLIPPAGE if slippage_pct is None else slippage_pct / 100
-        )
         quote_response = await BRAP_CLIENT.get_quote(
             from_token=POLYGON_USDC_E_ADDRESS,
             to_token=POLYGON_P_USDC_PROXY_ADDRESS,
@@ -922,7 +918,7 @@ class PolymarketAdapter(BaseAdapter):
             to_chain=POLYGON_CHAIN_ID,
             from_wallet=deposit_wallet,
             from_amount=str(amount_base_unit),
-            slippage=slippage,
+            slippage=0,
         )
         quote = quote_response["best_quote"]
         calldata = quote["calldata"]
@@ -2259,7 +2255,6 @@ class PolymarketAdapter(BaseAdapter):
         *,
         condition_id: str,
         auto_wrap_redemption_usdce: bool = True,
-        wrap_slippage_pct: float | None = None,
     ) -> tuple[bool, dict[str, Any] | str]:
         try:
             deposit_wallet = self.deposit_wallet_address()
@@ -2342,7 +2337,6 @@ class PolymarketAdapter(BaseAdapter):
                     try:
                         wrap_tx_hash = await self._wrap_deposit_wallet_usdce_to_pusd(
                             amount_base_unit=usdce_balance,
-                            slippage_pct=wrap_slippage_pct,
                         )
                     except Exception as wrap_exc:  # noqa: BLE001
                         wrap_error = str(wrap_exc)

--- a/wayfinder_paths/adapters/polymarket_adapter/adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/adapter.py
@@ -2251,10 +2251,7 @@ class PolymarketAdapter(BaseAdapter):
         return False, "No redeemable balance detected for the provided condition_id."
 
     async def redeem_positions(
-        self,
-        *,
-        condition_id: str,
-        auto_wrap_redemption_usdce: bool = True,
+        self, *, condition_id: str
     ) -> tuple[bool, dict[str, Any] | str]:
         try:
             deposit_wallet = self.deposit_wallet_address()
@@ -2326,7 +2323,7 @@ class PolymarketAdapter(BaseAdapter):
                 POLYMARKET_ADAPTER_COLLATERAL_ADDRESS,
                 POLYGON_USDC_E_ADDRESS,
             }
-            if auto_wrap_redemption_usdce and produces_usdce:
+            if produces_usdce:
                 usdce_balance = await get_token_balance(
                     POLYGON_USDC_E_ADDRESS,
                     POLYGON_CHAIN_ID,

--- a/wayfinder_paths/adapters/polymarket_adapter/adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/adapter.py
@@ -2266,6 +2266,21 @@ class PolymarketAdapter(BaseAdapter):
             cond = path["conditionId"]
             index_sets = path["indexSets"]
 
+            pusd_before, usdce_before = await asyncio.gather(
+                get_token_balance(
+                    POLYGON_P_USDC_PROXY_ADDRESS,
+                    POLYGON_CHAIN_ID,
+                    deposit_wallet,
+                    block_identifier="latest",
+                ),
+                get_token_balance(
+                    POLYGON_USDC_E_ADDRESS,
+                    POLYGON_CHAIN_ID,
+                    deposit_wallet,
+                    block_identifier="latest",
+                ),
+            )
+
             async with web3_from_chain_id(POLYGON_CHAIN_ID) as web3:
                 ctf = web3.eth.contract(
                     address=POLYMARKET_CONDITIONAL_TOKENS_ADDRESS,
@@ -2313,22 +2328,38 @@ class PolymarketAdapter(BaseAdapter):
                     )
                     unwrap_tx_hash = unwrap["tx_hash"]
 
-            # Sweep any USDC.e in the deposit wallet into pUSD. Catches both
-            # paths above (direct USDC.e settlement, neg-risk unwrap) and any
-            # stale balance from prior activity. Soft-fail: a missing route
-            # shouldn't undo a successful redemption.
+            # Poll for the redemption's payout to land on the public RPC —
+            # the relayer reports MINED ahead of public-node propagation.
+            # Bounded at 5s; whichever side increases tells us how the market
+            # settled (pUSD direct → done, USDC.e → wrap the delta).
             wrap_tx_hash: str | None = None
             wrap_error: str | None = None
-            usdce_balance = await get_token_balance(
-                POLYGON_USDC_E_ADDRESS,
-                POLYGON_CHAIN_ID,
-                deposit_wallet,
-                block_identifier="latest",
-            )
-            if usdce_balance > 0:
+            usdce_delta = 0
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline:
+                pusd_now, usdce_now = await asyncio.gather(
+                    get_token_balance(
+                        POLYGON_P_USDC_PROXY_ADDRESS,
+                        POLYGON_CHAIN_ID,
+                        deposit_wallet,
+                        block_identifier="latest",
+                    ),
+                    get_token_balance(
+                        POLYGON_USDC_E_ADDRESS,
+                        POLYGON_CHAIN_ID,
+                        deposit_wallet,
+                        block_identifier="latest",
+                    ),
+                )
+                if pusd_now > pusd_before or usdce_now > usdce_before:
+                    usdce_delta = usdce_now - usdce_before
+                    break
+                await asyncio.sleep(0.25)
+
+            if usdce_delta > 0:
                 try:
                     wrap_tx_hash = await self._wrap_deposit_wallet_usdce_to_pusd(
-                        amount_base_unit=usdce_balance,
+                        amount_base_unit=usdce_delta,
                     )
                 except Exception as wrap_exc:  # noqa: BLE001
                     wrap_error = str(wrap_exc)

--- a/wayfinder_paths/adapters/polymarket_adapter/adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/adapter.py
@@ -7,7 +7,7 @@ import hmac
 import json
 import re
 import time
-from decimal import Decimal, InvalidOperation
+from decimal import ROUND_CEILING, ROUND_FLOOR, Decimal, InvalidOperation
 from difflib import SequenceMatcher
 from typing import Any, Literal
 
@@ -545,6 +545,7 @@ class PolymarketAdapter(BaseAdapter):
         market_slug: str,
         outcome: str | int = "YES",
         amount_collateral: float = 1.0,
+        max_slippage_bps: float | None = None,
     ) -> tuple[bool, dict[str, Any] | str]:
         ok, market = await self.get_market_by_slug(market_slug)
         if not ok:
@@ -558,6 +559,7 @@ class PolymarketAdapter(BaseAdapter):
             token_id=token_id,
             side="BUY",
             amount=amount_collateral,
+            max_slippage_bps=max_slippage_bps,
         )
 
     async def cash_out_prediction(
@@ -566,6 +568,7 @@ class PolymarketAdapter(BaseAdapter):
         market_slug: str,
         outcome: str | int = "YES",
         shares: float = 1.0,
+        max_slippage_bps: float | None = None,
     ) -> tuple[bool, dict[str, Any] | str]:
         ok, market = await self.get_market_by_slug(market_slug)
         if not ok:
@@ -579,6 +582,7 @@ class PolymarketAdapter(BaseAdapter):
             token_id=token_id,
             side="SELL",
             amount=shares,
+            max_slippage_bps=max_slippage_bps,
         )
 
     async def get_market_prices_history(
@@ -1605,15 +1609,22 @@ class PolymarketAdapter(BaseAdapter):
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
 
+    DEFAULT_MAX_SLIPPAGE_BPS = (
+        200  # 2% — Polymarket prices live in [0, 1], no native slippage param
+    )
+
     async def place_market_order(
         self,
         *,
         token_id: str,
         side: Literal["BUY", "SELL"],
         amount: float,
-        price: float | None = None,
+        max_slippage_bps: float | None = None,
     ) -> tuple[bool, dict[str, Any] | str]:
-        # BUY amount = collateral ($) to spend, SELL amount = shares to sell
+        # BUY amount = collateral ($) to spend, SELL amount = shares to sell.
+        # Polymarket has no slippage param; canonical pattern (see py-clob-client-v2
+        # MarketOrderArgsV2.price doc + create_market_order source) is to derive a
+        # worst-acceptable price from the book and sign an FOK at that cap.
         ok_setup, setup = await self.ensure_trading_setup(token_id=token_id)
         if not ok_setup:
             return False, setup
@@ -1621,12 +1632,39 @@ class PolymarketAdapter(BaseAdapter):
         if not ok:
             return False, msg
 
+        ok_quote, quote = await self.quote_market_order(
+            token_id=token_id, side=side, amount=amount
+        )
+        if not ok_quote:
+            return False, quote
+        if not isinstance(quote, dict) or not quote.get("fully_fillable"):
+            return False, {"error": "insufficient book liquidity", "quote": quote}
+
+        worst = Decimal(str(quote["worst_price"]))
+        tick = Decimal(str((quote.get("book_meta") or {}).get("tick_size") or "0.01"))
+        bps = Decimal(
+            str(
+                self.DEFAULT_MAX_SLIPPAGE_BPS
+                if max_slippage_bps is None
+                else max_slippage_bps
+            )
+        )
+        slip = bps / Decimal(10_000)
+        if side == "BUY":
+            raw = worst * (Decimal(1) + slip)
+            cap = (raw / tick).quantize(Decimal(1), rounding=ROUND_CEILING) * tick
+            cap = min(cap, Decimal(1) - tick)
+        else:
+            raw = worst * (Decimal(1) - slip)
+            cap = (raw / tick).quantize(Decimal(1), rounding=ROUND_FLOOR) * tick
+            cap = max(cap, tick)
+
         try:
             order_args = MarketOrderArgs(
                 token_id=token_id,
                 side=side,
                 amount=amount,
-                price=price or 0.0,
+                price=float(cap),
                 builder_code=POLYMARKET_BUILDER_CODE,
             )  # type: ignore[misc]
             order = await self.clob_client.create_market_order(order_args)
@@ -1634,6 +1672,9 @@ class PolymarketAdapter(BaseAdapter):
             out = resp if isinstance(resp, dict) else {"result": resp}
             out.setdefault("deposit_wallet", self.deposit_wallet_address())
             out.setdefault("setup", setup)
+            out.setdefault("quote", quote)
+            out.setdefault("price_cap", float(cap))
+            out.setdefault("max_slippage_bps", float(bps))
             return True, out
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)

--- a/wayfinder_paths/adapters/polymarket_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/test_adapter.py
@@ -170,9 +170,9 @@ class TestPolymarketAdapter:
         assert ok is True
         assert response["order_type"] == "FOK"
         assert response["post_only"] is False
-        # 0.55 * (1 + 200/10000) = 0.561 → ceil to next 0.01 tick = 0.57
+        # 0.55 * (1 + 2/100) = 0.561 → ceil to next 0.01 tick = 0.57
         assert response["price_cap"] == pytest.approx(0.57)
-        assert response["max_slippage_bps"] == 200.0
+        assert response["max_slippage_pct"] == 2.0
         order_args = fake_clob_client.created_order
         assert isinstance(order_args, polymarket_adapter_module.MarketOrderArgs)
         assert order_args.price == pytest.approx(0.57)

--- a/wayfinder_paths/adapters/polymarket_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/test_adapter.py
@@ -132,6 +132,16 @@ class TestPolymarketAdapter:
         adapter.wallet_address = "0x000000000000000000000000000000000000dEaD"
         adapter.ensure_trading_setup = AsyncMock(return_value=(True, {}))
         adapter.ensure_api_creds = AsyncMock(return_value=(True, {}))
+        adapter.quote_market_order = AsyncMock(
+            return_value=(
+                True,
+                {
+                    "fully_fillable": True,
+                    "worst_price": 0.55,
+                    "book_meta": {"tick_size": "0.01"},
+                },
+            )
+        )
 
         class FakeClobClient:
             def __init__(self):
@@ -160,8 +170,12 @@ class TestPolymarketAdapter:
         assert ok is True
         assert response["order_type"] == "FOK"
         assert response["post_only"] is False
+        # 0.55 * (1 + 200/10000) = 0.561 → ceil to next 0.01 tick = 0.57
+        assert response["price_cap"] == pytest.approx(0.57)
+        assert response["max_slippage_bps"] == 200.0
         order_args = fake_clob_client.created_order
         assert isinstance(order_args, polymarket_adapter_module.MarketOrderArgs)
+        assert order_args.price == pytest.approx(0.57)
         assert (
             order_args.builder_code == polymarket_adapter_module.POLYMARKET_BUILDER_CODE
         )

--- a/wayfinder_paths/mcp/preview.py
+++ b/wayfinder_paths/mcp/preview.py
@@ -251,7 +251,8 @@ async def build_polymarket_execute_preview(
             f"token_id: {req.get('token_id')}\n"
             f"side: {req.get('side')}\n"
             f"amount_collateral: {req.get('amount_collateral')}\n"
-            f"shares: {req.get('shares')}"
+            f"shares: {req.get('shares')}\n"
+            f"max_slippage_bps: {req.get('max_slippage_bps')} (None = adapter default 200 bps)"
         )
         return {"summary": header + base + details, "recipient_mismatch": False}
 

--- a/wayfinder_paths/mcp/preview.py
+++ b/wayfinder_paths/mcp/preview.py
@@ -252,7 +252,7 @@ async def build_polymarket_execute_preview(
             f"side: {req.get('side')}\n"
             f"amount_collateral: {req.get('amount_collateral')}\n"
             f"shares: {req.get('shares')}\n"
-            f"max_slippage_bps: {req.get('max_slippage_bps')} (None = adapter default 200 bps)"
+            f"max_slippage_pct: {req.get('max_slippage_pct')} (None = adapter default 2%)"
         )
         return {"summary": header + base + details, "recipient_mismatch": False}
 
@@ -272,7 +272,12 @@ async def build_polymarket_execute_preview(
         return {"summary": header + base + details, "recipient_mismatch": False}
 
     if action == "redeem_positions":
-        details = f"\n\nREDEEM\ncondition_id: {req.get('condition_id')}"
+        details = (
+            "\n\nREDEEM\n"
+            f"condition_id: {req.get('condition_id')}\n"
+            f"auto_wrap_redemption_usdce: {req.get('auto_wrap_redemption_usdce')}\n"
+            f"wrap_slippage_pct: {req.get('wrap_slippage_pct')} (None = BRAP default 1%)"
+        )
         return {"summary": header + base + details, "recipient_mismatch": False}
 
     return {"summary": header + base, "recipient_mismatch": mismatch}

--- a/wayfinder_paths/mcp/preview.py
+++ b/wayfinder_paths/mcp/preview.py
@@ -275,8 +275,7 @@ async def build_polymarket_execute_preview(
         details = (
             "\n\nREDEEM\n"
             f"condition_id: {req.get('condition_id')}\n"
-            f"auto_wrap_redemption_usdce: {req.get('auto_wrap_redemption_usdce')}\n"
-            f"wrap_slippage_pct: {req.get('wrap_slippage_pct')} (None = BRAP default 1%)"
+            f"auto_wrap_redemption_usdce: {req.get('auto_wrap_redemption_usdce')}"
         )
         return {"summary": header + base + details, "recipient_mismatch": False}
 

--- a/wayfinder_paths/mcp/preview.py
+++ b/wayfinder_paths/mcp/preview.py
@@ -272,11 +272,7 @@ async def build_polymarket_execute_preview(
         return {"summary": header + base + details, "recipient_mismatch": False}
 
     if action == "redeem_positions":
-        details = (
-            "\n\nREDEEM\n"
-            f"condition_id: {req.get('condition_id')}\n"
-            f"auto_wrap_redemption_usdce: {req.get('auto_wrap_redemption_usdce')}"
-        )
+        details = f"\n\nREDEEM\ncondition_id: {req.get('condition_id')}"
         return {"summary": header + base + details, "recipient_mismatch": False}
 
     return {"summary": header + base, "recipient_mismatch": mismatch}

--- a/wayfinder_paths/mcp/tools/polymarket.py
+++ b/wayfinder_paths/mcp/tools/polymarket.py
@@ -516,6 +516,8 @@ async def polymarket_execute(
     size: float | None = None,
     post_only: bool = False,
     order_id: str | None = None,
+    # market-order slippage cap (bps). None = adapter default (200 bps).
+    max_slippage_bps: float | None = None,
     # redeem
     condition_id: str | None = None,
 ) -> dict[str, Any]:
@@ -533,7 +535,9 @@ async def polymarket_execute(
       - `withdraw_deposit_wallet`: pull pUSD from the deposit wallet back to the owner EOA
         via the relayer. Omit `amount` to withdraw the full balance.
       - `place_market_order`: market order. Specify `market_slug`+`outcome` OR `token_id`, with
-        `side="BUY"|"SELL"`. BUY needs `amount_collateral` (pUSD); SELL needs `shares`.
+        `side="BUY"|"SELL"`. BUY needs `amount_collateral` (pUSD); SELL needs `shares`. Adapter
+        quotes the book and signs an FOK limit at `worst_price * (1 ± max_slippage_bps/10000)`
+        (default 200 bps); order is killed if the book moves past the cap.
       - `place_limit_order`: requires `token_id`, `side`, `price`, `size`. `post_only` = maker-only.
       - `cancel_order`: by `order_id`.
       - `redeem_positions`: claim winnings on a resolved market by `condition_id`.
@@ -573,6 +577,7 @@ async def polymarket_execute(
         "size": size,
         "post_only": post_only,
         "order_id": order_id,
+        "max_slippage_bps": max_slippage_bps,
         "condition_id": condition_id,
     }
     preview_obj = await build_polymarket_execute_preview(tool_input)
@@ -738,12 +743,14 @@ async def polymarket_execute(
                             market_slug=str(market_slug),
                             outcome=outcome,
                             amount_collateral=float(amount_collateral),
+                            max_slippage_bps=max_slippage_bps,
                         )
                     else:
                         ok_trade, res = await adapter.cash_out_prediction(
                             market_slug=str(market_slug),
                             outcome=outcome,
                             shares=float(shares),
+                            max_slippage_bps=max_slippage_bps,
                         )
                 else:
                     tid = throw_if_empty_str(
@@ -753,6 +760,7 @@ async def polymarket_execute(
                         token_id=tid,
                         side=side,
                         amount=float(amount_collateral if side == "BUY" else shares),
+                        max_slippage_bps=max_slippage_bps,
                     )
 
                 effects.append(
@@ -779,6 +787,9 @@ async def polymarket_execute(
                         if amount_collateral is not None
                         else None,
                         "shares": float(shares) if shares is not None else None,
+                        "max_slippage_bps": float(max_slippage_bps)
+                        if max_slippage_bps is not None
+                        else None,
                     },
                 )
                 return _done(status)

--- a/wayfinder_paths/mcp/tools/polymarket.py
+++ b/wayfinder_paths/mcp/tools/polymarket.py
@@ -516,10 +516,14 @@ async def polymarket_execute(
     size: float | None = None,
     post_only: bool = False,
     order_id: str | None = None,
-    # market-order slippage cap (bps). None = adapter default (200 bps).
-    max_slippage_bps: float | None = None,
+    # market-order slippage cap (percent). None = adapter default (2%).
+    max_slippage_pct: float | None = None,
     # redeem
     condition_id: str | None = None,
+    # auto-wrap USDC.e → pUSD on redemption (true by default; set false to leave USDC.e).
+    auto_wrap_redemption_usdce: bool = True,
+    # BRAP slippage cap (percent) for the redemption wrap. None = BRAP default (1%).
+    wrap_slippage_pct: float | None = None,
 ) -> dict[str, Any]:
     """Execute Polymarket trades, bridge collateral, cancel/redeem.
 
@@ -536,11 +540,14 @@ async def polymarket_execute(
         via the relayer. Omit `amount` to withdraw the full balance.
       - `place_market_order`: market order. Specify `market_slug`+`outcome` OR `token_id`, with
         `side="BUY"|"SELL"`. BUY needs `amount_collateral` (pUSD); SELL needs `shares`. Adapter
-        quotes the book and signs an FOK limit at `worst_price * (1 ± max_slippage_bps/10000)`
-        (default 200 bps); order is killed if the book moves past the cap.
+        quotes the book and signs an FOK limit at `worst_price * (1 ± max_slippage_pct/100)`
+        (default 2%); order is killed if the book moves past the cap.
       - `place_limit_order`: requires `token_id`, `side`, `price`, `size`. `post_only` = maker-only.
       - `cancel_order`: by `order_id`.
-      - `redeem_positions`: claim winnings on a resolved market by `condition_id`.
+      - `redeem_positions`: claim winnings on a resolved market by `condition_id`. By default
+        any USDC.e proceeds are auto-wrapped to pUSD via BRAP through the deposit wallet —
+        set `auto_wrap_redemption_usdce=False` to skip, or `wrap_slippage_pct` to widen
+        BRAP slippage tolerance.
 
     Args:
         wallet_label: Required.
@@ -577,8 +584,10 @@ async def polymarket_execute(
         "size": size,
         "post_only": post_only,
         "order_id": order_id,
-        "max_slippage_bps": max_slippage_bps,
+        "max_slippage_pct": max_slippage_pct,
         "condition_id": condition_id,
+        "auto_wrap_redemption_usdce": auto_wrap_redemption_usdce,
+        "wrap_slippage_pct": wrap_slippage_pct,
     }
     preview_obj = await build_polymarket_execute_preview(tool_input)
     preview_text = str(preview_obj.get("summary") or "").strip()
@@ -743,14 +752,14 @@ async def polymarket_execute(
                             market_slug=str(market_slug),
                             outcome=outcome,
                             amount_collateral=float(amount_collateral),
-                            max_slippage_bps=max_slippage_bps,
+                            max_slippage_pct=max_slippage_pct,
                         )
                     else:
                         ok_trade, res = await adapter.cash_out_prediction(
                             market_slug=str(market_slug),
                             outcome=outcome,
                             shares=float(shares),
-                            max_slippage_bps=max_slippage_bps,
+                            max_slippage_pct=max_slippage_pct,
                         )
                 else:
                     tid = throw_if_empty_str(
@@ -760,7 +769,7 @@ async def polymarket_execute(
                         token_id=tid,
                         side=side,
                         amount=float(amount_collateral if side == "BUY" else shares),
-                        max_slippage_bps=max_slippage_bps,
+                        max_slippage_pct=max_slippage_pct,
                     )
 
                 effects.append(
@@ -787,8 +796,8 @@ async def polymarket_execute(
                         if amount_collateral is not None
                         else None,
                         "shares": float(shares) if shares is not None else None,
-                        "max_slippage_bps": float(max_slippage_bps)
-                        if max_slippage_bps is not None
+                        "max_slippage_pct": float(max_slippage_pct)
+                        if max_slippage_pct is not None
                         else None,
                     },
                 )
@@ -860,7 +869,11 @@ async def polymarket_execute(
                 cid = throw_if_empty_str(
                     "condition_id is required for redeem_positions", condition_id
                 )
-                ok_r, res = await adapter.redeem_positions(condition_id=cid)
+                ok_r, res = await adapter.redeem_positions(
+                    condition_id=cid,
+                    auto_wrap_redemption_usdce=auto_wrap_redemption_usdce,
+                    wrap_slippage_pct=wrap_slippage_pct,
+                )
                 effects.append(
                     {
                         "type": "polymarket",
@@ -876,7 +889,13 @@ async def polymarket_execute(
                     action="redeem_positions",
                     status=status,
                     chain_id=int(POLYGON_CHAIN_ID),
-                    details={"condition_id": cid},
+                    details={
+                        "condition_id": cid,
+                        "auto_wrap_redemption_usdce": auto_wrap_redemption_usdce,
+                        "wrap_slippage_pct": float(wrap_slippage_pct)
+                        if wrap_slippage_pct is not None
+                        else None,
+                    },
                 )
                 return _done(status)
 

--- a/wayfinder_paths/mcp/tools/polymarket.py
+++ b/wayfinder_paths/mcp/tools/polymarket.py
@@ -522,8 +522,6 @@ async def polymarket_execute(
     condition_id: str | None = None,
     # auto-wrap USDC.e → pUSD on redemption (true by default; set false to leave USDC.e).
     auto_wrap_redemption_usdce: bool = True,
-    # BRAP slippage cap (percent) for the redemption wrap. None = BRAP default (1%).
-    wrap_slippage_pct: float | None = None,
 ) -> dict[str, Any]:
     """Execute Polymarket trades, bridge collateral, cancel/redeem.
 
@@ -545,9 +543,8 @@ async def polymarket_execute(
       - `place_limit_order`: requires `token_id`, `side`, `price`, `size`. `post_only` = maker-only.
       - `cancel_order`: by `order_id`.
       - `redeem_positions`: claim winnings on a resolved market by `condition_id`. By default
-        any USDC.e proceeds are auto-wrapped to pUSD via BRAP through the deposit wallet —
-        set `auto_wrap_redemption_usdce=False` to skip, or `wrap_slippage_pct` to widen
-        BRAP slippage tolerance.
+        any USDC.e proceeds are auto-wrapped 1:1 to pUSD via BRAP's polymarket_bridge solver
+        through the deposit wallet — set `auto_wrap_redemption_usdce=False` to skip.
 
     Args:
         wallet_label: Required.
@@ -587,7 +584,6 @@ async def polymarket_execute(
         "max_slippage_pct": max_slippage_pct,
         "condition_id": condition_id,
         "auto_wrap_redemption_usdce": auto_wrap_redemption_usdce,
-        "wrap_slippage_pct": wrap_slippage_pct,
     }
     preview_obj = await build_polymarket_execute_preview(tool_input)
     preview_text = str(preview_obj.get("summary") or "").strip()
@@ -872,7 +868,6 @@ async def polymarket_execute(
                 ok_r, res = await adapter.redeem_positions(
                     condition_id=cid,
                     auto_wrap_redemption_usdce=auto_wrap_redemption_usdce,
-                    wrap_slippage_pct=wrap_slippage_pct,
                 )
                 effects.append(
                     {
@@ -892,9 +887,6 @@ async def polymarket_execute(
                     details={
                         "condition_id": cid,
                         "auto_wrap_redemption_usdce": auto_wrap_redemption_usdce,
-                        "wrap_slippage_pct": float(wrap_slippage_pct)
-                        if wrap_slippage_pct is not None
-                        else None,
                     },
                 )
                 return _done(status)

--- a/wayfinder_paths/mcp/tools/polymarket.py
+++ b/wayfinder_paths/mcp/tools/polymarket.py
@@ -520,8 +520,6 @@ async def polymarket_execute(
     max_slippage_pct: float | None = None,
     # redeem
     condition_id: str | None = None,
-    # auto-wrap USDC.e → pUSD on redemption (true by default; set false to leave USDC.e).
-    auto_wrap_redemption_usdce: bool = True,
 ) -> dict[str, Any]:
     """Execute Polymarket trades, bridge collateral, cancel/redeem.
 
@@ -542,9 +540,9 @@ async def polymarket_execute(
         (default 2%); order is killed if the book moves past the cap.
       - `place_limit_order`: requires `token_id`, `side`, `price`, `size`. `post_only` = maker-only.
       - `cancel_order`: by `order_id`.
-      - `redeem_positions`: claim winnings on a resolved market by `condition_id`. By default
-        any USDC.e proceeds are auto-wrapped 1:1 to pUSD via BRAP's polymarket_bridge solver
-        through the deposit wallet — set `auto_wrap_redemption_usdce=False` to skip.
+      - `redeem_positions`: claim winnings on a resolved market by `condition_id`. USDC.e
+        proceeds are auto-wrapped 1:1 to pUSD via BRAP's polymarket_bridge solver through
+        the deposit wallet.
 
     Args:
         wallet_label: Required.
@@ -583,7 +581,6 @@ async def polymarket_execute(
         "order_id": order_id,
         "max_slippage_pct": max_slippage_pct,
         "condition_id": condition_id,
-        "auto_wrap_redemption_usdce": auto_wrap_redemption_usdce,
     }
     preview_obj = await build_polymarket_execute_preview(tool_input)
     preview_text = str(preview_obj.get("summary") or "").strip()
@@ -865,10 +862,7 @@ async def polymarket_execute(
                 cid = throw_if_empty_str(
                     "condition_id is required for redeem_positions", condition_id
                 )
-                ok_r, res = await adapter.redeem_positions(
-                    condition_id=cid,
-                    auto_wrap_redemption_usdce=auto_wrap_redemption_usdce,
-                )
+                ok_r, res = await adapter.redeem_positions(condition_id=cid)
                 effects.append(
                     {
                         "type": "polymarket",
@@ -884,10 +878,7 @@ async def polymarket_execute(
                     action="redeem_positions",
                     status=status,
                     chain_id=int(POLYGON_CHAIN_ID),
-                    details={
-                        "condition_id": cid,
-                        "auto_wrap_redemption_usdce": auto_wrap_redemption_usdce,
-                    },
+                    details={"condition_id": cid},
                 )
                 return _done(status)
 


### PR DESCRIPTION
### Summary

- **Slippage cap on `place_market_order`**: Polymarket's CLOB has no native slippage param ([docs](https://docs.polymarket.com/developers/CLOB/orders/orders)) — the canonical pattern (see py-clob-client-v2 [`examples/orders/market_buy.py`](https://github.com/Polymarket/py-clob-client-v2/blob/main/examples/orders/market_buy.py) + `MarketOrderArgsV2.price` doc) is to derive a worst-acceptable fill price from the book and sign an FOK limit at that cap. Adapter now quotes the book first, computes `cap = worst_price * (1 ± bps/10000)` rounded to tick, and passes it as `MarketOrderArgs.price` so the FOK enforces it at the protocol layer. Default 200 bps; agent can pass `max_slippage_bps` to tighten/loosen. Plumbed through `place_prediction` / `cash_out_prediction` and the MCP `polymarket_execute` surface; preview echoes the param.
- **Auto-wrap redeemed USDC.e → pUSD**: After `redeem_positions`, the deposit wallet may hold USDC.e (either direct settlement or unwrapped neg-risk wrapper). New `_wrap_deposit_wallet_usdce_to_pusd` helper fetches a BRAP quote with `from_wallet=deposit_wallet`, bundles the ERC20 approve + router call into a single `_submit_wallet_batch` so no open allowance lingers. Soft-fail: missing route doesn't undo the redemption — `wrap_tx_hash` / `wrap_error` surface on the response.