### PR TITLE
Shells - Drop bridge_deposit/bridge_withdraw MCP actions

### DIFF
--- a/.claude/skills/using-polymarket-adapter/rules/deposit-wallet.md
+++ b/.claude/skills/using-polymarket-adapter/rules/deposit-wallet.md
@@ -28,7 +28,7 @@ The deposit wallet is a smart contract — no private key — so every state cha
 | `withdraw_deposit_wallet` | Relayer | `POST /submit` type=`WALLET`, owner signs Batch |
 | `redeem_positions` (+ NegRisk unwrap) | Relayer | Same — owner signs, relayer broadcasts |
 | `fund_deposit_wallet` | **Owner EOA** | Direct `pUSD.transfer` from owner; needs POL |
-| `bridge_deposit` / `bridge_withdraw` (collateral conversion) | **Owner EOA** | wrap/unwrap + BRAP swaps; needs POL |
+| Collateral routing (BRAP swap into/out of pUSD) | **Owner EOA** | `onchain_quote_swap` + `core_execute(kind="swap")`; needs POL |
 | Order placement (CLOB market/limit) | Polymarket CLOB engine | Order signed POLY_1271, matched off-chain, settled on-chain by Polymarket |
 
 Net: the owner EOA needs Polygon POL **only for `fund_deposit_wallet` and the upstream collateral-prep flows**. Everything that touches the deposit wallet contract itself is free.
@@ -41,15 +41,15 @@ Trading collateral lives in **two places**, and the adapter has **two distinct f
 
 | Flow | From → To | Asset | Method |
 | --- | --- | --- | --- |
-| **Collateral preparation** | Polygon USDC/USDC.e ↔ pUSD on **owner EOA** | USDC ↔ pUSD | `bridge_deposit` / `bridge_withdraw` (see `rules/deposits-withdrawals.md`) |
+| **Collateral routing** | any token/chain ↔ pUSD on **owner EOA** | any ↔ pUSD | BRAP swap MCP tools (see `rules/deposits-withdrawals.md`) |
 | **Deposit wallet funding** | owner EOA pUSD ↔ deposit wallet pUSD | pUSD only | `fund_deposit_wallet` / `withdraw_deposit_wallet` |
 
 A full first-time flow looks like:
-1. `bridge_deposit` — Polygon USDC → pUSD (on owner EOA)
+1. `onchain_quote_swap` + `core_execute(kind="swap")` — any token → pUSD (on owner EOA)
 2. `fund_deposit_wallet` — pUSD owner EOA → pUSD deposit wallet
 3. trade — `place_market_order` / `place_limit_order`
 4. (optional) `withdraw_deposit_wallet` — pUSD deposit wallet → pUSD owner EOA
-5. (optional) `bridge_withdraw` — pUSD → Polygon USDC
+5. (optional) `onchain_quote_swap` + `core_execute(kind="swap")` — pUSD → any token
 
 ## Operational expectations
 

--- a/.claude/skills/using-polymarket-adapter/rules/deposits-withdrawals.md
+++ b/.claude/skills/using-polymarket-adapter/rules/deposits-withdrawals.md
@@ -11,9 +11,9 @@ This page covers **collateral routing** — moving between any token/chain and p
 - Native Polygon **USDC**:
   - `0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359`
 
-## MCP recipe — use the BRAP swap tools
+## MCP recipe — BRAP swap tools
 
-Polymarket-specific bridge actions no longer exist on `polymarket_execute`. Use the BRAP swap MCP tools — they pick the right solver automatically (`polymarket_bridge` for USDC.e ↔ pUSD 1:1 wraps; standard DEX routes for everything else; cross-chain bridges when source chain ≠ Polygon).
+Route into and out of pUSD with the BRAP swap MCP tools. They pick the right solver automatically (`polymarket_bridge` for USDC.e ↔ pUSD 1:1 wraps; standard DEX routes for everything else; cross-chain bridges when source chain ≠ Polygon).
 
 **In: any token → pUSD on Polygon**
 

--- a/.claude/skills/using-polymarket-adapter/rules/deposits-withdrawals.md
+++ b/.claude/skills/using-polymarket-adapter/rules/deposits-withdrawals.md
@@ -1,77 +1,40 @@
-# Polymarket collateral: pUSD (deposit / withdraw preparation)
+# Polymarket collateral: routing in and out of pUSD
 
-This page covers **collateral conversion** — moving between Polygon USDC / USDC.e and pUSD on the **owner EOA**. For funding the per-user **deposit wallet** (the actual trading address under V2), see `rules/deposit-wallet.md`. A full trade lifecycle uses both flows.
+This page covers **collateral routing** — moving between any token/chain and pUSD on the **owner EOA**. For funding the per-user **deposit wallet** (the actual trading address under V2), see `rules/deposit-wallet.md`. A full trade lifecycle uses both flows.
 
 ## Key requirement
 
 - Polymarket V2 CLOB trading collateral is **pUSD** on Polygon:
   - `0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB` (proxy, 6 decimals)
-- Polygon **USDC.e** is the direct wrap asset for pUSD:
+- Polygon **USDC.e** wraps 1:1 to pUSD:
   - `0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174` (6 decimals)
-- Native Polygon **USDC** must first be converted to **USDC.e** before wrapping.
+- Native Polygon **USDC**:
   - `0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359`
 
-## MCP shortcuts (Claude Code)
+## MCP recipe — use the BRAP swap tools
 
-- Prepare collateral for trading: `mcp__wayfinder__polymarket_execute(action="bridge_deposit", wallet_label="main", amount=10)`
-- Unwind collateral back to Polygon native USDC: `mcp__wayfinder__polymarket_execute(action="bridge_withdraw", wallet_label="main", amount_usdce=10)`
-- Monitor bridge status: `mcp__wayfinder__polymarket_read(action="bridge_status", wallet_label="main")`
+Polymarket-specific bridge actions no longer exist on `polymarket_execute`. Use the BRAP swap MCP tools — they pick the right solver automatically (`polymarket_bridge` for USDC.e ↔ pUSD 1:1 wraps; standard DEX routes for everything else; cross-chain bridges when source chain ≠ Polygon).
 
-## Adapter behavior
+**In: any token → pUSD on Polygon**
 
-The adapter prepares Polymarket V2 collateral like this:
-
-- Polygon **USDC.e** → **pUSD** via the Polymarket onramp
-- Polygon native **USDC** → **USDC.e** via BRAP, then wrap to **pUSD**
-- Other supported source assets / chains → Polymarket Bridge deposit flow (async)
-
-For withdrawals:
-
-- **pUSD** → **USDC.e** via the Polymarket offramp
-- **pUSD** → **USDC.e** → Polygon native **USDC** via BRAP
-- Other supported destination assets / chains → Polymarket Bridge withdraw flow (async)
-
-If BRAP quoting/execution fails (no route / API error), the adapter falls back to the **Polymarket Bridge** deposit/withdraw flow.
-
-### Polygon native USDC → pUSD (deposit)
-
-```python
-from wayfinder_paths.mcp.scripting import get_adapter
-from wayfinder_paths.adapters.polymarket_adapter.adapter import PolymarketAdapter
-from wayfinder_paths.core.constants.polymarket import POLYGON_CHAIN_ID, POLYGON_USDC_ADDRESS
-
-adapter = await get_adapter(PolymarketAdapter, wallet_label="main")
-ok, res = await adapter.bridge_deposit(
-    from_chain_id=POLYGON_CHAIN_ID,
-    from_token_address=POLYGON_USDC_ADDRESS,
-    amount=10.0,
-    recipient_address="0xYourWallet",  # usually the same wallet that is sending
+```
+mcp__wayfinder__onchain_quote_swap(
+    wallet_label="main",
+    from_token="<source token id>",          # e.g. "polygon_0x3c499c..." (Polygon USDC)
+    to_token="polygon_0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB",  # pUSD
+    amount="<wei>",                          # use to_erc20_raw(human, decimals)
+    slippage_bps=50,
 )
+# inspect the preview, then:
+mcp__wayfinder__core_execute(request=<suggested_execute_request>)
 ```
 
-### pUSD → Polygon native USDC (withdraw)
+**Out: pUSD → any token**
 
-`bridge_withdraw()` starts from Polymarket collateral (`pUSD`) and will unwrap to `USDC.e` internally before delivering the requested destination asset.
+Flip `from_token` and `to_token`. For pUSD → native Polygon USDC, BRAP routes via the polymarket_bridge unwrap + USDC.e/USDC swap. For pUSD → another chain, BRAP picks a cross-chain route.
 
-```python
-from wayfinder_paths.core.constants.polymarket import POLYGON_CHAIN_ID, POLYGON_USDC_ADDRESS
+**Important**: `from_token` / `to_token` accept `<chain_code>_<address>` ids, `<coingecko_id>-<chain_code>` ids, or symbol queries. `amount` is raw wei (use `to_erc20_raw(human, decimals)` to convert). See `onchain_quote_swap` for full arg docs.
 
-ok, res = await adapter.bridge_withdraw(
-    amount_usdce=10.0,
-    to_chain_id=POLYGON_CHAIN_ID,
-    to_token_address=POLYGON_USDC_ADDRESS,
-    recipient_addr="0xYourWallet",  # must match where you want USDC delivered
-)
-```
+## Already have pUSD?
 
-### Monitoring (important)
-
-- If the result has `method="pusd_wrap"`, `method="pusd_unwrap"`, `method="brap_then_wrap"`, or `method="unwrap_then_brap"`, the conversion completed through direct on-chain steps.
-- If the result has `method="polymarket_bridge"`, the conversion is **asynchronous**; use `bridge_status(address=...)` and/or poll balances until it completes.
-
-## Alternative: Polymarket Bridge (explicit)
-
-If you want to force the bridge-style flow (even when BRAP could work), use the Polymarket Bridge endpoints directly:
-
-- `bridge_deposit_addresses(...)` + ERC20 transfer (supported asset → deposit address)
-- `bridge_withdraw_addresses(...)` + ERC20 transfer (USDC.e → withdraw address)
+Skip routing entirely and call `polymarket_execute(action="fund_deposit_wallet", ...)` to move pUSD from the owner EOA into the deposit wallet (the actual trading address — see `rules/deposit-wallet.md`).

--- a/.claude/skills/using-polymarket-adapter/rules/gotchas.md
+++ b/.claude/skills/using-polymarket-adapter/rules/gotchas.md
@@ -3,7 +3,8 @@
 ## Read vs write surfaces (MCP)
 
 - Use `mcp__wayfinder__polymarket_read` for reads (search/markets/history) and `mcp__wayfinder__polymarket_get_state` for account state (positions/orders/activity/trades).
-- Use `mcp__wayfinder__polymarket_execute` for writes (bridge, approvals, buy/sell, limit/cancel, redeem). It should always require a confirmation in Claude Code.
+- Use `mcp__wayfinder__polymarket_execute` for writes (fund/withdraw deposit wallet, buy/sell, limit/cancel, redeem). It should always require a confirmation in Claude Code.
+- For collateral routing in/out of pUSD, use the BRAP swap MCP tools (`onchain_quote_swap` + `core_execute(kind="swap", ...)`) — see `rules/deposits-withdrawals.md`.
 - Use `mcp__wayfinder__polymarket_read(action="quote", ...)` before a sized buy/sell when you need average execution from the current book.
 
 ## `price` is not `quote`
@@ -22,7 +23,7 @@
 
 - The Polymarket relayer (`relayer-v2.polymarket.com`) is a third-party sponsored-tx service. It pays POL gas for **deposit wallet creation, approvals, withdraws, and redemptions** on user-signed batches.
 - If the relayer is degraded / down, those operations block. The adapter has **no escape-hatch path** that bypasses it.
-- Operations that do NOT depend on the relayer: `fund_deposit_wallet` (owner-EOA direct transfer), `bridge_deposit` / `bridge_withdraw` (collateral conversion on owner EOA), and order placement itself (CLOB engine matches/settles).
+- Operations that do NOT depend on the relayer: `fund_deposit_wallet` (owner-EOA direct transfer), BRAP swaps that route into/out of pUSD on the owner EOA, and order placement itself (CLOB engine matches/settles).
 - See `rules/deposit-wallet.md` for the full gas-payer matrix.
 
 ## Trading wallet ≠ owner EOA (V2 deposit wallet)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,17 +246,16 @@ Polymarket quick flows:
 
 - Search markets/events: `mcp__wayfinder__polymarket_read(action="search", query="bitcoin february 9", limit=10)`
 - Full status (positions + PnL + balances + open orders): `mcp__wayfinder__polymarket_get_state(wallet_label="main")`
-- Convert **native Polygon USDC (0x3c499c...) → pUSD (0xC011a7..., V2 collateral)**: `mcp__wayfinder__polymarket_execute(action="bridge_deposit", wallet_label="main", amount=10)` (adapter routes USDC → USDC.e → pUSD automatically; skip if you already have pUSD)
+- Convert **any token/chain → pUSD (0xC011a7..., V2 collateral)**: use the BRAP swap MCP tools. Quote first with `mcp__wayfinder__onchain_quote_swap(wallet_label="main", from_token="<source>", to_token="polygon_0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB", amount="<wei>", slippage_bps=50)`, then `mcp__wayfinder__core_execute(request=<suggested_execute_request>)`. BRAP picks the right solver automatically (USDC.e → pUSD goes through the 1:1 `polymarket_bridge` wrap; everything else routes via standard DEX / cross-chain bridges). Skip if you already have pUSD.
 - Buy shares (market order): `mcp__wayfinder__polymarket_execute(action="place_market_order", wallet_label="main", market_slug="bitcoin-above-70k-on-february-9", outcome="YES", side="BUY", amount_collateral=2)`
 - Sell shares (market order): `mcp__wayfinder__polymarket_execute(action="place_market_order", wallet_label="main", market_slug="bitcoin-above-70k-on-february-9", outcome="YES", side="SELL", shares=10)` (pass the full size from `polymarket_get_state` to close)
 - Redeem after resolution: `mcp__wayfinder__polymarket_execute(action="redeem_positions", wallet_label="main", condition_id="0x...")`
 
 Polymarket funding (pUSD collateral):
 
-- **Polygon USDC → pUSD:** `polymarket_execute(action="bridge_deposit", amount=10)` converts native USDC (0x3c499c...) → pUSD (0xC011a7...), routing through USDC.e automatically.
-- **Polygon USDC.e → pUSD:** same `bridge_deposit` call wraps USDC.e → pUSD in a single step (polymarket_bridge solver).
-- **Already have pUSD:** Trade immediately, skip `bridge_deposit`.
-- **Funds on other chains:** use `bridge_deposit` with `from_chain_id` + `from_token_address` — the adapter bridges to Polygon and wraps into pUSD end-to-end.
+- **Any token/chain → pUSD:** use the BRAP swap MCP tools (`onchain_quote_swap` + `core_execute(kind="swap", ...)`) with `to_token` = `polygon_0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB`. Works for Polygon USDC, Polygon USDC.e, or any supported asset on any supported chain — BRAP picks the route.
+- **Already have pUSD:** Trade immediately, skip routing.
+- **pUSD → any token/chain:** flip `from_token` / `to_token` in the same BRAP swap flow.
 
 Sizing note (avoid ambiguity): if a user says "$X at Y× leverage", confirm whether `$X`is **notional** or **margin** (use`usd_amount_kind="notional"|"margin"`on`mcp**wayfinder**hyperliquid_execute`).
 

--- a/wayfinder_paths/mcp/preview.py
+++ b/wayfinder_paths/mcp/preview.py
@@ -5,10 +5,6 @@ from pathlib import Path
 from typing import Any
 
 from wayfinder_paths.core.constants.hyperliquid import HYPE_FEE_WALLET
-from wayfinder_paths.core.constants.polymarket import (
-    POLYGON_USDC_ADDRESS,
-    POLYGON_USDC_E_ADDRESS,
-)
 from wayfinder_paths.mcp.utils import (
     find_wallet_by_label,
     normalize_address,
@@ -201,47 +197,12 @@ async def build_polymarket_execute_preview(
     w = await find_wallet_by_label(wallet_label) if wallet_label else None
     sender = normalize_address((w or {}).get("address")) if w else None
 
-    recipient = None
-    if action == "bridge_deposit":
-        recipient = normalize_address(req.get("recipient_address"))
-    if action == "bridge_withdraw":
-        recipient = normalize_address(req.get("recipient_addr"))
-
-    mismatch = bool(sender and recipient and sender.lower() != recipient.lower())
-
     header = "POLYMARKET_EXECUTE\n"
     base = (
         f"action: {action or '(missing)'}\n"
         f"wallet_label: {wallet_label or '(missing)'}\n"
         f"address: {sender or '(unknown)'}"
     )
-
-    if action == "bridge_deposit":
-        details = (
-            "\n\nCONVERT (token → USDC.e)\n"
-            "route: BRAP swap preferred; Polymarket Bridge fallback\n"
-            f"polymarket_collateral_usdce: {POLYGON_USDC_E_ADDRESS}\n"
-            f"polygon_native_usdc: {POLYGON_USDC_ADDRESS}\n"
-            f"from_chain_id: {req.get('from_chain_id')}\n"
-            f"from_token_address: {req.get('from_token_address')}\n"
-            f"amount: {req.get('amount')}\n"
-            f"recipient_address: {req.get('recipient_address')}\n"
-            "note: If you already have USDC.e on Polygon, you can trade without running bridge_deposit."
-        )
-        return {"summary": header + base + details, "recipient_mismatch": mismatch}
-
-    if action == "bridge_withdraw":
-        details = (
-            "\n\nCONVERT (USDC.e → token)\n"
-            "route: BRAP swap preferred; Polymarket Bridge fallback\n"
-            f"polymarket_collateral_usdce: {POLYGON_USDC_E_ADDRESS}\n"
-            f"polygon_native_usdc: {POLYGON_USDC_ADDRESS}\n"
-            f"amount_pusd: {req.get('amount_pusd')}\n"
-            f"to_chain_id: {req.get('to_chain_id')}\n"
-            f"to_token_address: {req.get('to_token_address')}\n"
-            f"recipient_addr: {req.get('recipient_addr')}"
-        )
-        return {"summary": header + base + details, "recipient_mismatch": mismatch}
 
     if action == "place_market_order":
         details = (
@@ -275,7 +236,7 @@ async def build_polymarket_execute_preview(
         details = f"\n\nREDEEM\ncondition_id: {req.get('condition_id')}"
         return {"summary": header + base + details, "recipient_mismatch": False}
 
-    return {"summary": header + base, "recipient_mismatch": mismatch}
+    return {"summary": header + base, "recipient_mismatch": False}
 
 
 async def build_contract_execute_preview(tool_input: dict[str, Any]) -> dict[str, Any]:

--- a/wayfinder_paths/mcp/tools/polymarket.py
+++ b/wayfinder_paths/mcp/tools/polymarket.py
@@ -6,10 +6,7 @@ from typing import Any, Literal
 
 from wayfinder_paths.adapters.polymarket_adapter.adapter import PolymarketAdapter
 from wayfinder_paths.core.config import CONFIG
-from wayfinder_paths.core.constants.polymarket import (
-    POLYGON_CHAIN_ID,
-    POLYGON_USDC_ADDRESS,
-)
+from wayfinder_paths.core.constants.polymarket import POLYGON_CHAIN_ID
 from wayfinder_paths.core.utils.wallets import (
     get_wallet_sign_hash_callback,
     get_wallet_sign_typed_data_callback,
@@ -483,8 +480,6 @@ async def polymarket_read(
 @catch_errors
 async def polymarket_execute(
     action: Literal[
-        "bridge_deposit",
-        "bridge_withdraw",
         "fund_deposit_wallet",
         "withdraw_deposit_wallet",
         "place_market_order",
@@ -494,16 +489,8 @@ async def polymarket_execute(
     ],
     *,
     wallet_label: str,
-    # bridge
-    from_chain_id: int = POLYGON_CHAIN_ID,
-    from_token_address: str = POLYGON_USDC_ADDRESS,
+    # deposit-wallet move
     amount: float | None = None,
-    recipient_address: str | None = None,
-    amount_pusd: float | None = None,
-    to_chain_id: int = POLYGON_CHAIN_ID,
-    to_token_address: str = POLYGON_USDC_ADDRESS,
-    recipient_addr: str | None = None,
-    token_decimals: int = 6,
     # trade
     market_slug: str | None = None,
     outcome: str | int = "YES",
@@ -521,15 +508,13 @@ async def polymarket_execute(
     # redeem
     condition_id: str | None = None,
 ) -> dict[str, Any]:
-    """Execute Polymarket trades, bridge collateral, cancel/redeem.
+    """Execute Polymarket trades on the owner EOA / deposit wallet.
 
-    Polymarket settles on Polygon in pUSD (post-V2 rollover). Bridging in/out goes through
-    the official bridge; trading uses the CLOB.
+    Polymarket V2 settles on Polygon in pUSD (`0xC011a7...`). This tool only handles the
+    deposit-wallet + CLOB surface — it does NOT convert collateral. To route in/out of pUSD,
+    use the BRAP swap MCP tools (see "Routing collateral" below).
 
     Actions:
-      - `bridge_deposit`: bridge `amount` of `from_token_address` from `from_chain_id` into
-        Polymarket pUSD. `recipient_address` defaults to sender. `token_decimals` defaults to 6.
-      - `bridge_withdraw`: bridge `amount_pusd` out to `to_chain_id` / `to_token_address`.
       - `fund_deposit_wallet`: move `amount` pUSD from the owner EOA into the derived deposit
         wallet (Polygon transfer). Required before trading.
       - `withdraw_deposit_wallet`: pull pUSD from the deposit wallet back to the owner EOA
@@ -543,6 +528,12 @@ async def polymarket_execute(
       - `redeem_positions`: claim winnings on a resolved market by `condition_id`. USDC.e
         proceeds are auto-wrapped 1:1 to pUSD via BRAP's polymarket_bridge solver through
         the deposit wallet.
+
+    Routing collateral (in/out of pUSD): use `onchain_quote_swap` then
+    `core_execute(kind="swap", ...)` with `to_token` or `from_token` set to pUSD
+    (`polygon_0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB`). BRAP picks the right solver
+    (`polymarket_bridge` for USDC.e ↔ pUSD 1:1 wraps; standard DEX routes for everything else)
+    and handles cross-chain. Works for any source token/chain; no Polymarket-specific call needed.
 
     Args:
         wallet_label: Required.
@@ -560,15 +551,7 @@ async def polymarket_execute(
     tool_input = {
         "action": action,
         "wallet_label": want,
-        "from_chain_id": from_chain_id,
-        "from_token_address": from_token_address,
         "amount": amount,
-        "recipient_address": recipient_address,
-        "amount_pusd": amount_pusd,
-        "to_chain_id": to_chain_id,
-        "to_token_address": to_token_address,
-        "recipient_addr": recipient_addr,
-        "token_decimals": token_decimals,
         "market_slug": market_slug,
         "outcome": outcome,
         "token_id": token_id,
@@ -614,75 +597,6 @@ async def polymarket_execute(
             )
 
         match action:
-            case "bridge_deposit":
-                throw_if_none("amount is required for bridge_deposit", amount)
-                rcpt = normalize_address(recipient_address) or sender
-                ok_dep, res = await adapter.bridge_deposit(
-                    from_chain_id=int(from_chain_id),
-                    from_token_address=str(from_token_address),
-                    amount=float(amount),
-                    recipient_address=str(rcpt),
-                    token_decimals=int(token_decimals),
-                )
-                effects.append(
-                    {
-                        "type": "polymarket",
-                        "label": "bridge_deposit",
-                        "ok": ok_dep,
-                        "result": res,
-                    }
-                )
-                status = "confirmed" if ok_dep else "failed"
-                _annotate(
-                    address=sender,
-                    label=want,
-                    action="bridge_deposit",
-                    status=status,
-                    chain_id=int(from_chain_id),
-                    details={
-                        "amount": float(amount),
-                        "from_token_address": str(from_token_address),
-                        "recipient_address": str(rcpt),
-                    },
-                )
-                return _done(status)
-
-            case "bridge_withdraw":
-                throw_if_none(
-                    "amount_pusd is required for bridge_withdraw", amount_pusd
-                )
-                rcpt = normalize_address(recipient_addr) or sender
-                ok_wd, res = await adapter.bridge_withdraw(
-                    amount_pusd=float(amount_pusd),
-                    to_chain_id=int(to_chain_id),
-                    to_token_address=str(to_token_address),
-                    recipient_addr=str(rcpt),
-                    token_decimals=int(token_decimals),
-                )
-                effects.append(
-                    {
-                        "type": "polymarket",
-                        "label": "bridge_withdraw",
-                        "ok": ok_wd,
-                        "result": res,
-                    }
-                )
-                status = "confirmed" if ok_wd else "failed"
-                _annotate(
-                    address=sender,
-                    label=want,
-                    action="bridge_withdraw",
-                    status=status,
-                    chain_id=int(POLYGON_CHAIN_ID),
-                    details={
-                        "amount_pusd": float(amount_pusd),
-                        "to_chain_id": int(to_chain_id),
-                        "to_token_address": str(to_token_address),
-                        "recipient_addr": str(rcpt),
-                    },
-                )
-                return _done(status)
-
             case "fund_deposit_wallet":
                 throw_if_none("amount is required for fund_deposit_wallet", amount)
                 ok_fund, res = await adapter.fund_deposit_wallet(

--- a/wayfinder_paths/mcp/tools/polymarket.py
+++ b/wayfinder_paths/mcp/tools/polymarket.py
@@ -510,9 +510,9 @@ async def polymarket_execute(
 ) -> dict[str, Any]:
     """Execute Polymarket trades on the owner EOA / deposit wallet.
 
-    Polymarket V2 settles on Polygon in pUSD (`0xC011a7...`). This tool only handles the
-    deposit-wallet + CLOB surface — it does NOT convert collateral. To route in/out of pUSD,
-    use the BRAP swap MCP tools (see "Routing collateral" below).
+    Polymarket V2 settles on Polygon in pUSD (`0xC011a7...`). This tool handles the
+    deposit-wallet + CLOB surface. For collateral routing in/out of pUSD, use the BRAP
+    swap MCP tools (see "Routing collateral" below).
 
     Actions:
       - `fund_deposit_wallet`: move `amount` pUSD from the owner EOA into the derived deposit

--- a/wayfinder_paths/tests/test_mcp_polymarket_tool.py
+++ b/wayfinder_paths/tests/test_mcp_polymarket_tool.py
@@ -163,33 +163,6 @@ async def test_polymarket_quote_surfaces_adapter_failure():
 
 
 @pytest.mark.asyncio
-async def test_polymarket_execute_bridge_deposit(tmp_path: Path, monkeypatch):
-    monkeypatch.setenv("WAYFINDER_RUNS_DIR", str(tmp_path / "runs"))
-
-    with (
-        patch(_FIND_WALLET, AsyncMock(return_value=_WALLET)),
-        patch(_GET_SIGN_CB, AsyncMock(return_value=(_SIGN_CB, _ADDR))),
-        patch(_GET_HASH_CB, AsyncMock(return_value=(_HASH_CB, _ADDR))),
-        patch(_GET_TYPED_CB, AsyncMock(return_value=(_TYPED_CB, _ADDR))),
-        patch("wayfinder_paths.mcp.tools.polymarket.CONFIG", {}),
-        patch(
-            "wayfinder_paths.mcp.tools.polymarket.PolymarketAdapter.bridge_deposit",
-            new=AsyncMock(return_value=(True, {"tx_hash": "0xabc"})),
-        ),
-    ):
-        out = await polymarket_execute(
-            "bridge_deposit",
-            wallet_label="main",
-            amount=1.0,
-        )
-        assert out["ok"] is True
-        assert out["result"]["status"] == "confirmed"
-        assert out["result"]["action"] == "bridge_deposit"
-        effects = out["result"]["effects"]
-        assert effects and effects[0]["label"] == "bridge_deposit"
-
-
-@pytest.mark.asyncio
 async def test_polymarket_execute_place_market_order(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("WAYFINDER_RUNS_DIR", str(tmp_path / "runs"))
 


### PR DESCRIPTION
### Summary
- Polymarket-specific bridge actions on `polymarket_execute` are redundant — BRAP's swap MCP tools (`onchain_quote_swap` + `core_execute(kind="swap")`) already route any token/chain into and out of pUSD, picking the `polymarket_bridge` solver automatically for the USDC.e ↔ pUSD 1:1 wrap.
- Drop `bridge_deposit` / `bridge_withdraw` from the action `Literal`, the param list, the `tool_input` dict, and the case branches in `wayfinder_paths/mcp/tools/polymarket.py`.
- Trim the matching preview branches in `wayfinder_paths/mcp/preview.py` and drop the unused USDC constant imports.
- Remove the MCP `test_polymarket_execute_bridge_deposit` test.
- Rewrite the agent-facing docs (`CLAUDE.md` Polymarket section + all three `.claude/skills/using-polymarket-adapter/rules/*.md` pages) to point at the BRAP swap recipe with the pUSD address (`polygon_0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB`).
- Adapter-level `adapter.bridge_deposit()` / `adapter.bridge_withdraw()` Python methods, library README, and `scripts/polymarket_smoketest.py` are unchanged.