### PR TITLE
Shells - Expand ticker synonyms in Polymarket search

### DIFF
--- a/wayfinder_paths/adapters/polymarket_adapter/adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/adapter.py
@@ -31,6 +31,7 @@ from wayfinder_paths.core.adapters.BaseAdapter import BaseAdapter
 from wayfinder_paths.core.clients.BRAPClient import BRAP_CLIENT
 from wayfinder_paths.core.constants.erc20_abi import ERC20_ABI
 from wayfinder_paths.core.constants.polymarket import (
+    ASSET_NAME_SYNONYMS,
     MAX_UINT256,
     POLYGON_CHAIN_ID,
     POLYGON_P_USDC_PROXY_ADDRESS,
@@ -84,6 +85,27 @@ def _fuzzy_score(query: str, text: str) -> float:
     if q in t:
         return 1.0
     return SequenceMatcher(None, q, t).ratio()
+
+
+def _expand_query_synonyms(query: str) -> str | None:
+    """Swap any standalone asset ticker in `query` for its full name.
+
+    Returns the rewritten query if at least one substitution happened, else None.
+    """
+    normalized = _normalize_text(query)
+    if not normalized:
+        return None
+    tokens = normalized.split()
+    swapped = False
+    out: list[str] = []
+    for tok in tokens:
+        full = ASSET_NAME_SYNONYMS.get(tok)
+        if full:
+            out.append(full)
+            swapped = True
+        else:
+            out.append(tok)
+    return " ".join(out) if swapped else None
 
 
 class PolymarketAdapter(BaseAdapter):
@@ -277,29 +299,50 @@ class PolymarketAdapter(BaseAdapter):
         end_date_min: str | None = None,
         rerank: bool = True,
     ) -> tuple[bool, list[dict[str, Any]] | str]:
-        ok, data = await self.public_search(
-            q=query,
-            limit_per_type=max(limit, 1),
-            page=page,
-            keep_closed_markets=keep_closed_markets,
-            events_status=events_status,
-        )
-        if not ok:
-            return False, str(data)
+        # Polymarket titles short-duration markets with full asset names ("Bitcoin
+        # Up or Down"); ticker queries ("BTC 5m") miss them because Gamma matches
+        # the ticker literally and returns long-dated commentary markets instead.
+        # Fan out: original query + ticker-expanded query.
+        expanded = _expand_query_synonyms(query)
+        queries = [query] if expanded is None else [query, expanded]
 
-        markets: list[dict[str, Any]] = []
-        for event in data.get("events") or []:
-            for market in event.get("markets") or []:
-                markets.append(
-                    {
-                        **self._normalize_market(market),
-                        "_event": {
-                            "id": event.get("id"),
-                            "slug": event.get("slug"),
-                            "title": event.get("title"),
-                        },
-                    }
+        responses = await asyncio.gather(
+            *(
+                self.public_search(
+                    q=q,
+                    limit_per_type=max(limit, 1),
+                    page=page,
+                    keep_closed_markets=keep_closed_markets,
+                    events_status=events_status,
                 )
+                for q in queries
+            )
+        )
+
+        for ok, data in responses:
+            if not ok:
+                return False, str(data)
+
+        seen_market_ids: set[str] = set()
+        markets: list[dict[str, Any]] = []
+        for _, data in responses:
+            for event in data.get("events") or []:
+                for market in event.get("markets") or []:
+                    mid = str(market.get("id") or "")
+                    if mid and mid in seen_market_ids:
+                        continue
+                    if mid:
+                        seen_market_ids.add(mid)
+                    markets.append(
+                        {
+                            **self._normalize_market(market),
+                            "_event": {
+                                "id": event.get("id"),
+                                "slug": event.get("slug"),
+                                "title": event.get("title"),
+                            },
+                        }
+                    )
 
         if end_date_min:
             markets = [
@@ -312,10 +355,13 @@ class PolymarketAdapter(BaseAdapter):
             return True, markets[:limit]
 
         def score(m: dict[str, Any]) -> float:
+            question = str(m.get("question") or "")
+            slug = str(m.get("slug") or "")
+            event_title = str((m.get("_event") or {}).get("title") or "")
             return max(
-                _fuzzy_score(query, str(m.get("question") or "")),
-                _fuzzy_score(query, str(m.get("slug") or "")),
-                _fuzzy_score(query, str((m.get("_event") or {}).get("title") or "")),
+                _fuzzy_score(q, field)
+                for q in queries
+                for field in (question, slug, event_title)
             )
 
         markets.sort(key=score, reverse=True)

--- a/wayfinder_paths/adapters/polymarket_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/test_adapter.py
@@ -271,6 +271,70 @@ class TestPolymarketAdapter:
         assert "events" in data
 
     @pytest.mark.asyncio
+    async def test_search_markets_fuzzy_expands_ticker_synonyms(
+        self, adapter, monkeypatch
+    ):
+        ticker_response = {
+            "events": [
+                {
+                    "id": "ev-ticker",
+                    "slug": "anthropic-flip-btc",
+                    "title": "Will Anthropic flip BTC?",
+                    "markets": [
+                        {
+                            "id": "m-ticker",
+                            "question": "Will Anthropic flip BTC?",
+                            "slug": "anthropic-flip-btc",
+                            "outcomes": '["Yes","No"]',
+                            "outcomePrices": "[0.5,0.5]",
+                            "clobTokenIds": '["t1","t2"]',
+                        }
+                    ],
+                }
+            ]
+        }
+        fullname_response = {
+            "events": [
+                {
+                    "id": "ev-full",
+                    "slug": "btc-updown",
+                    "title": "Bitcoin Up or Down",
+                    "markets": [
+                        {
+                            "id": "m-full",
+                            "question": "Bitcoin Up or Down - 5m",
+                            "slug": "btc-updown-5m-1",
+                            "outcomes": '["Up","Down"]',
+                            "outcomePrices": "[0.5,0.5]",
+                            "clobTokenIds": '["t3","t4"]',
+                        }
+                    ],
+                }
+            ]
+        }
+        calls: list[str] = []
+
+        async def mock_get(_path, params=None, **_kwargs):
+            q = (params or {}).get("q", "")
+            calls.append(q)
+            resp = MagicMock()
+            resp.raise_for_status.return_value = None
+            resp.json.return_value = (
+                fullname_response if "bitcoin" in q.lower() else ticker_response
+            )
+            return resp
+
+        monkeypatch.setattr(adapter._gamma_http, "get", mock_get)
+
+        ok, rows = await adapter.search_markets_fuzzy(query="BTC 5 min", limit=5)
+        assert ok is True
+        assert isinstance(rows, list)
+        questions = [m["question"] for m in rows]
+        assert "Bitcoin Up or Down - 5m" in questions
+        assert any("BTC" in c for c in calls)
+        assert any("bitcoin" in c.lower() for c in calls)
+
+    @pytest.mark.asyncio
     async def test_get_price(self, adapter, monkeypatch):
         mock_resp = MagicMock()
         mock_resp.raise_for_status.return_value = None

--- a/wayfinder_paths/core/constants/polymarket.py
+++ b/wayfinder_paths/core/constants/polymarket.py
@@ -3,6 +3,23 @@ from __future__ import annotations
 from eth_abi import encode as abi_encode
 from eth_utils import keccak, to_bytes, to_checksum_address
 
+# Ticker → full name. Polymarket's high-volume short-duration markets
+# ("Bitcoin Up or Down", "Ethereum Up or Down", daily/hourly) are titled with
+# full asset names; ticker queries ("BTC 5m") miss them and only match
+# commentary markets that happen to contain the ticker literally.
+ASSET_NAME_SYNONYMS: dict[str, str] = {
+    "btc": "bitcoin",
+    "eth": "ethereum",
+    "sol": "solana",
+    "xrp": "ripple",
+    "doge": "dogecoin",
+    "ltc": "litecoin",
+    "ada": "cardano",
+    "avax": "avalanche",
+    "dot": "polkadot",
+    "link": "chainlink",
+}
+
 POLYMARKET_GAMMA_BASE_URL = "https://gamma-api.polymarket.com"
 POLYMARKET_CLOB_BASE_URL = "https://clob.polymarket.com"
 # v2 test url before crossover. once crossover is complete, v2 will use the original url


### PR DESCRIPTION
### Summary
- Ticker queries like \`BTC 5 min market\` returned El Salvador / MicroStrategy / Anthropic-flip-BTC instead of the actual Bitcoin Up or Down 5m markets. Polymarket titles short-duration markets with the full asset name (\`Bitcoin Up or Down\`), and Gamma's \`/public-search\` matches the ticker literally — so tickers only surface commentary markets that happen to contain the ticker in their slug.
- Add \`ASSET_NAME_SYNONYMS\` (BTC↔Bitcoin, ETH↔Ethereum, SOL↔Solana, XRP, DOGE, LTC, ADA, AVAX, DOT, LINK) in \`wayfinder_paths/core/constants/polymarket.py\`.
- \`search_markets_fuzzy\` now detects tickers in the query, fans out the original + the synonym-expanded query through \`asyncio.gather\`, dedupes events by market id, and reranks against both variants.
- Verified against live Gamma: \`BTC 5 min\`, \`ETH 5 min\`, \`SOL hourly\`, \`BTC daily\`, \`BTC up down\` all now return the matching Up-or-Down markets instead of long-dated commentary.