### PR TITLE
Shells - Polymarket search via vault-backend client

### DIFF
--- a/scripts/polymarket_smoketest.py
+++ b/scripts/polymarket_smoketest.py
@@ -43,27 +43,14 @@ async def _pick_tradable(
     *,
     outcome: str,
 ) -> tuple[dict[str, Any], str, dict[str, Any]]:
-    # Try open markets first, but fall back to any market whose token_id resolves on CLOB.
-    for attempt_open_only in (True, False):
-        for m in markets:
-            if not m.get("enableOrderBook") or not m.get("clobTokenIds"):
-                continue
-            if attempt_open_only and (
-                m.get("closed") is True or m.get("active") is False
-            ):
-                continue
-
-            ok_tid, token_id = adapter.resolve_clob_token_id(market=m, outcome=outcome)
-            if not ok_tid:
-                # Fallback: pick first outcome when the query isn't a YES/NO market.
-                ok_tid, token_id = adapter.resolve_clob_token_id(market=m, outcome=0)
-                if not ok_tid:
-                    continue
-
-            ok_price, price = await adapter.get_price(token_id=token_id, side="BUY")
-            if ok_price and isinstance(price, dict):
-                return m, token_id, price
-
+    want_yes = outcome.strip().lower() in {"yes", "up", "0"}
+    for m in markets:
+        token_id = m["yesTokenId"] if want_yes else m["noTokenId"]
+        if not token_id:
+            continue
+        ok_price, price = await adapter.get_price(token_id=token_id, side="BUY")
+        if ok_price and isinstance(price, dict):
+            return m, token_id, price
     raise RuntimeError("No tradable market found for query")
 
 
@@ -106,24 +93,13 @@ async def main() -> int:
             print(f"USDC.e: {usdce0 / 1e6:.6f}")
             print(f"pUSD:   {pusd0 / 1e6:.6f}")
 
-        ok, markets = await adapter.search_markets_fuzzy(query=args.query, limit=20)
+        ok, markets = await adapter.search_markets(query=args.query, limit=20)
         if not ok:
-            raise RuntimeError(f"search_markets_fuzzy failed: {markets}")
-        try:
-            market, token_id, price = await _pick_tradable(
-                adapter, markets, outcome=str(args.outcome)
-            )
-        except RuntimeError as err:
-            print("No tradable market in search results; falling back to trending...")
-            ok2, trending = await adapter.list_markets(
-                closed=False, limit=50, order="volume24hr", ascending=False
-            )
-            if not ok2:
-                raise RuntimeError(f"list_markets trending failed: {trending}") from err
-            market, token_id, price = await _pick_tradable(
-                adapter, trending, outcome=str(args.outcome)
-            )
-        slug = market.get("slug")
+            raise RuntimeError(f"search_markets failed: {markets}")
+        market, token_id, price = await _pick_tradable(
+            adapter, markets, outcome=str(args.outcome)
+        )
+        slug = market["slug"]
         print(f"Selected market: {slug}")
         print(f"Token: {token_id}")
         print(f"Price(BUY): {price.get('price')}")

--- a/wayfinder_paths/adapters/polymarket_adapter/adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/adapter.py
@@ -29,6 +29,12 @@ from py_clob_client_v2.config import (  # type: ignore[import-untyped]
 from wayfinder_paths.adapters.brap_adapter.adapter import BRAPAdapter
 from wayfinder_paths.core.adapters.BaseAdapter import BaseAdapter
 from wayfinder_paths.core.clients.BRAPClient import BRAP_CLIENT
+from wayfinder_paths.core.clients.PolymarketClient import (
+    POLYMARKET_CLIENT,
+    PolymarketMarket,
+    PolymarketSort,
+    PolymarketStatus,
+)
 from wayfinder_paths.core.constants.erc20_abi import ERC20_ABI
 from wayfinder_paths.core.constants.polymarket import (
     MAX_UINT256,
@@ -236,90 +242,22 @@ class PolymarketAdapter(BaseAdapter):
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
 
-    async def public_search(
+    async def search_markets(
         self,
         *,
-        q: str,
-        limit_per_type: int = 10,
-        page: int = 1,
-        keep_closed_markets: bool = False,
-        **kwargs: Any,
-    ) -> tuple[bool, dict[str, Any] | str]:
-        params: dict[str, Any] = {
-            "q": q,
-            "limit_per_type": limit_per_type,
-            "page": page,
-            "keep_closed_markets": "1" if keep_closed_markets else "0",
-        }
-        params.update({k: v for k, v in kwargs.items() if v is not None})
-
+        query: str | None = None,
+        limit: int = 20,
+        sort: PolymarketSort = "trending",
+        status: PolymarketStatus = "active",
+    ) -> tuple[bool, list[PolymarketMarket] | str]:
+        """Search via vault-backend, which handles tag resolution + ranking."""
         try:
-            res = await self._gamma_http.get("/public-search", params=params)
-            res.raise_for_status()
-            data = res.json()
-            if not isinstance(data, dict):
-                return (
-                    False,
-                    f"Unexpected /public-search response: {type(data).__name__}",
-                )
-            return True, data
+            rows = await POLYMARKET_CLIENT.search_markets(
+                query=query, limit=limit, sort=sort, status=status
+            )
+            return True, rows
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
-
-    async def search_markets_fuzzy(
-        self,
-        *,
-        query: str,
-        limit: int = 10,
-        page: int = 1,
-        keep_closed_markets: bool = False,
-        events_status: str | None = None,
-        end_date_min: str | None = None,
-        rerank: bool = True,
-    ) -> tuple[bool, list[dict[str, Any]] | str]:
-        ok, data = await self.public_search(
-            q=query,
-            limit_per_type=max(limit, 1),
-            page=page,
-            keep_closed_markets=keep_closed_markets,
-            events_status=events_status,
-        )
-        if not ok:
-            return False, str(data)
-
-        markets: list[dict[str, Any]] = []
-        for event in data.get("events") or []:
-            for market in event.get("markets") or []:
-                markets.append(
-                    {
-                        **self._normalize_market(market),
-                        "_event": {
-                            "id": event.get("id"),
-                            "slug": event.get("slug"),
-                            "title": event.get("title"),
-                        },
-                    }
-                )
-
-        if end_date_min:
-            markets = [
-                m
-                for m in markets
-                if (m.get("endDateIso") or m.get("endDate") or "") >= end_date_min
-            ]
-
-        if not rerank:
-            return True, markets[:limit]
-
-        def score(m: dict[str, Any]) -> float:
-            return max(
-                _fuzzy_score(query, str(m.get("question") or "")),
-                _fuzzy_score(query, str(m.get("slug") or "")),
-                _fuzzy_score(query, str((m.get("_event") or {}).get("title") or "")),
-            )
-
-        markets.sort(key=score, reverse=True)
-        return True, markets[:limit]
 
     async def get_market_by_condition_id(
         self, *, condition_id: str

--- a/wayfinder_paths/adapters/polymarket_adapter/adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/adapter.py
@@ -250,7 +250,6 @@ class PolymarketAdapter(BaseAdapter):
         sort: PolymarketSort = "trending",
         status: PolymarketStatus = "active",
     ) -> tuple[bool, list[PolymarketMarket] | str]:
-        """Search via vault-backend, which handles tag resolution + ranking."""
         try:
             rows = await POLYMARKET_CLIENT.search_markets(
                 query=query, limit=limit, sort=sort, status=status

--- a/wayfinder_paths/adapters/polymarket_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/test_adapter.py
@@ -256,19 +256,33 @@ class TestPolymarketAdapter:
         assert data[0]["slug"] == "test-market"
 
     @pytest.mark.asyncio
-    async def test_public_search(self, adapter, monkeypatch):
-        mock_resp = MagicMock()
-        mock_resp.raise_for_status.return_value = None
-        mock_resp.json.return_value = {"events": [], "pagination": {}}
+    async def test_search_markets_delegates_to_polymarket_client(
+        self, adapter, monkeypatch
+    ):
+        captured: dict = {}
 
-        async def mock_get(*_args, **_kwargs):
-            return mock_resp
+        async def fake_search_markets(**kwargs):
+            captured.update(kwargs)
+            return [{"slug": "btc-updown-5m-1", "symbol": "Bitcoin Up or Down — 5m"}]
 
-        monkeypatch.setattr(adapter._gamma_http, "get", mock_get)
-        ok, data = await adapter.public_search(q="bitcoin", limit_per_type=1)
+        monkeypatch.setattr(
+            polymarket_adapter_module.POLYMARKET_CLIENT,
+            "search_markets",
+            fake_search_markets,
+        )
+
+        ok, rows = await adapter.search_markets(
+            query="btc 5 min", limit=5, sort="trending", status="active"
+        )
         assert ok is True
-        assert isinstance(data, dict)
-        assert "events" in data
+        assert isinstance(rows, list)
+        assert rows[0]["slug"] == "btc-updown-5m-1"
+        assert captured == {
+            "query": "btc 5 min",
+            "limit": 5,
+            "sort": "trending",
+            "status": "active",
+        }
 
     @pytest.mark.asyncio
     async def test_get_price(self, adapter, monkeypatch):

--- a/wayfinder_paths/adapters/polymarket_adapter/test_adapter_live.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/test_adapter_live.py
@@ -25,27 +25,15 @@ async def live_adapter():
 class TestPolymarketLiveRead:
     @pytest.mark.asyncio
     async def test_search_and_market_data(self, live_adapter):
-        ok, markets = await live_adapter.search_markets_fuzzy(
-            query="super bowl", limit=10
-        )
+        ok, markets = await live_adapter.search_markets(query="super bowl", limit=10)
         assert ok
         assert isinstance(markets, list)
         assert len(markets) > 0
 
-        market = next(
-            (
-                m
-                for m in markets
-                if m.get("enableOrderBook")
-                and live_adapter._ensure_list(m.get("clobTokenIds"))
-            ),
-            markets[0],
-        )
+        market = next((m for m in markets if m.get("yesTokenId")), markets[0])
+        token_id = str(market["yesTokenId"])
+        assert token_id, "Expected yesTokenId on at least one market"
 
-        token_ids = live_adapter._ensure_list(market.get("clobTokenIds"))
-        assert token_ids, "Expected clobTokenIds on at least one market"
-
-        token_id = str(token_ids[0])
         ok, price = await live_adapter.get_price(token_id=token_id, side="BUY")
         assert ok
         assert isinstance(price, dict)

--- a/wayfinder_paths/core/clients/PolymarketClient.py
+++ b/wayfinder_paths/core/clients/PolymarketClient.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import Any, Literal, NotRequired, Required, TypedDict
 
-from loguru import logger
-
 from wayfinder_paths.core.clients.WayfinderClient import WayfinderClient
 from wayfinder_paths.core.config import get_api_base_url
 
@@ -45,13 +43,12 @@ class PolymarketClient(WayfinderClient):
         params: dict[str, Any] = {"limit": limit, "sort": sort, "status": status}
         if query:
             params["query"] = query
-        response = await self._authed_request("GET", url, params=params, headers={})
+        response = await self._authed_request("GET", url, params=params)
         data = response.json()
         if not isinstance(data, list):
-            logger.warning(
+            raise ValueError(
                 f"Unexpected polymarket markets response: {type(data).__name__}"
             )
-            return []
         return data
 
 

--- a/wayfinder_paths/core/clients/PolymarketClient.py
+++ b/wayfinder_paths/core/clients/PolymarketClient.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Any, Literal, NotRequired, Required, TypedDict
+
+from loguru import logger
+
+from wayfinder_paths.core.clients.WayfinderClient import WayfinderClient
+from wayfinder_paths.core.config import get_api_base_url
+
+PolymarketSort = Literal["trending", "volume24h", "liquidity", "fresh"]
+PolymarketStatus = Literal["active", "closed", "all"]
+
+
+class PolymarketMarket(TypedDict):
+    id: Required[str]
+    type: Required[str]
+    symbol: Required[str]
+    imageUrl: Required[str]
+    lastPrice: Required[float]
+    change24h: NotRequired[float | None]
+    volume24h: Required[float]
+    yesPrice: Required[float]
+    noPrice: Required[float]
+    yesLabel: Required[str]
+    noLabel: Required[str]
+    liquidity: Required[float]
+    resolvesAt: Required[str]
+    slug: Required[str]
+    eventSlug: Required[str]
+    conditionId: Required[str]
+    yesTokenId: Required[str]
+    noTokenId: Required[str]
+
+
+class PolymarketClient(WayfinderClient):
+    async def search_markets(
+        self,
+        *,
+        query: str | None = None,
+        limit: int = 20,
+        sort: PolymarketSort = "trending",
+        status: PolymarketStatus = "active",
+    ) -> list[PolymarketMarket]:
+        url = f"{get_api_base_url()}/blockchain/polymarket/markets/"
+        params: dict[str, Any] = {"limit": limit, "sort": sort, "status": status}
+        if query:
+            params["query"] = query
+        response = await self._authed_request("GET", url, params=params, headers={})
+        data = response.json()
+        if not isinstance(data, list):
+            logger.warning(
+                f"Unexpected polymarket markets response: {type(data).__name__}"
+            )
+            return []
+        return data
+
+
+POLYMARKET_CLIENT = PolymarketClient()

--- a/wayfinder_paths/mcp/tools/polymarket.py
+++ b/wayfinder_paths/mcp/tools/polymarket.py
@@ -4,6 +4,10 @@ from decimal import Decimal
 from typing import Any, Literal
 
 from wayfinder_paths.adapters.polymarket_adapter.adapter import PolymarketAdapter
+from wayfinder_paths.core.clients.PolymarketClient import (
+    PolymarketSort,
+    PolymarketStatus,
+)
 from wayfinder_paths.core.config import CONFIG
 from wayfinder_paths.core.constants.polymarket import POLYGON_CHAIN_ID
 from wayfinder_paths.core.utils.wallets import (
@@ -225,8 +229,8 @@ async def polymarket_read(
     # search/trending
     query: str | None = None,
     limit: int = 10,
-    sort: Literal["trending", "volume24h", "liquidity", "fresh"] = "trending",
-    status: Literal["active", "closed", "all"] = "active",
+    sort: PolymarketSort = "trending",
+    status: PolymarketStatus = "active",
     offset: int = 0,
     # market/event
     market_slug: str | None = None,

--- a/wayfinder_paths/mcp/tools/polymarket.py
+++ b/wayfinder_paths/mcp/tools/polymarket.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any, Literal
 
@@ -226,12 +225,9 @@ async def polymarket_read(
     # search/trending
     query: str | None = None,
     limit: int = 10,
-    page: int = 1,
-    keep_closed_markets: bool = False,
-    rerank: bool = True,
+    sort: Literal["trending", "volume24h", "liquidity", "fresh"] = "trending",
+    status: Literal["active", "closed", "all"] = "active",
     offset: int = 0,
-    events_status: str | None = "active",
-    end_date_min: str | None = datetime.now(UTC).strftime("%Y-%m-%d"),
     # market/event
     market_slug: str | None = None,
     event_slug: str | None = None,
@@ -251,8 +247,10 @@ async def polymarket_read(
     For account state (positions / orders / activity / trades) call `polymarket_get_state`.
 
     Actions:
-      - `search`: fuzzy market search by `query`. `events_status` filters active/closed/archived;
-        `end_date_min` (YYYY-MM-DD) filters out resolved markets; `rerank` re-scores results.
+      - `search`: market search via vault-backend. Backend handles tag resolution, ticker
+        synonyms (BTC↔Bitcoin), duration intent ("5 min" → 5-minute markets), ranking by
+        relevance + activity + freshness. `sort`: trending|volume24h|liquidity|fresh.
+        `status`: active|closed|all.
       - `trending`: list markets sorted by 24h volume (`limit`, `offset`).
       - `get_market` / `get_event`: fetch by `market_slug` / `event_slug`.
       - `quote`: market-order quote. BUY needs `amount_collateral` (USDC), SELL needs `shares`.
@@ -314,33 +312,15 @@ async def polymarket_read(
         match action:
             case "search":
                 q = throw_if_empty_str("query is required for search", query)
-                if events_status and events_status not in {
-                    "active",
-                    "closed",
-                    "archived",
-                }:
-                    raise ValueError(
-                        f"events_status must be one of: active, closed, archived (got {events_status!r})"
-                    )
-
-                ok_rows, rows = await adapter.search_markets_fuzzy(
+                ok_rows, rows = await adapter.search_markets(
                     query=q,
                     limit=int(limit),
-                    page=int(page),
-                    keep_closed_markets=bool(keep_closed_markets),
-                    events_status=events_status,
-                    end_date_min=end_date_min,
-                    rerank=bool(rerank),
+                    sort=sort,
+                    status=status,
                 )
                 if not ok_rows:
                     return err("error", str(rows))
-                return ok(
-                    {
-                        "action": action,
-                        "query": q,
-                        "markets": [_trim_market(m) for m in rows],
-                    }
-                )
+                return ok({"action": action, "query": q, "markets": rows})
 
             case "trending":
                 ok_rows, rows = await adapter.list_markets(

--- a/wayfinder_paths/tests/test_mcp_polymarket_tool.py
+++ b/wayfinder_paths/tests/test_mcp_polymarket_tool.py
@@ -53,7 +53,7 @@ async def test_polymarket_search_uses_adapter_search():
     with (
         patch("wayfinder_paths.mcp.tools.polymarket.CONFIG", {}),
         patch(
-            "wayfinder_paths.mcp.tools.polymarket.PolymarketAdapter.search_markets_fuzzy",
+            "wayfinder_paths.mcp.tools.polymarket.PolymarketAdapter.search_markets",
             new=AsyncMock(return_value=(True, [{"slug": "m1"}])),
         ),
     ):


### PR DESCRIPTION
### Summary
- Move Polymarket search out of the SDK adapter and into vault-backend's existing \`PolymarketDiscoveryService\`, which handles tag resolution (\`btc\` → bitcoin tag), ticker aliases, relevance + activity + freshness scoring, and event diversification. Pairs with vault-backend PR that adds duration-intent parsing so \`BTC 5 min market\` surfaces the actual 5m markets.
- Add \`wayfinder_paths/core/clients/PolymarketClient.py\` (singleton \`POLYMARKET_CLIENT\`) that hits \`GET /api/v1/blockchain/polymarket/markets/\` through the \`WayfinderClient\` base.
- Replace \`PolymarketAdapter.public_search\` + \`search_markets_fuzzy\` with a single \`search_markets(query, limit, sort, status)\` that delegates to the client. The adapter's local Gamma \`/public-search\` fetch and fuzzy rerank are gone.
- MCP \`polymarket_read(action=\"search\", ...)\` now exposes \`sort\` + \`status\` matching the backend, drops the local-only knobs (\`page\`, \`keep_closed_markets\`, \`rerank\`, \`events_status\`, \`end_date_min\`) that the backend handles internally, and returns backend rows directly — no \`_trim_market\` pass since the backend shape (\`yesTokenId\`/\`noTokenId\`/\`yesPrice\`/\`noPrice\`/\`slug\`/\`eventSlug\`/\`conditionId\`/...) is already agent-friendly.
- Smoketest + live test updated to pick token IDs straight off the backend rows instead of going through \`resolve_clob_token_id\` on Gamma-shaped data.