### PR TITLE
Shells - Drop stale spot/perp transfer doc references

### DIFF
--- a/.claude/skills/developing-wayfinder-strategies/rules/reference-strategies.md
+++ b/.claude/skills/developing-wayfinder-strategies/rules/reference-strategies.md
@@ -154,8 +154,7 @@ Don't deviate on:
 
 [ ] Wallet exists with label == strategy.name and has USDC in HL PERP
     (not just spot). Use core_get_wallets(label="<name>") to verify both;
-    if spot-only, run hyperliquid_execute(action="spot_to_perp_transfer", ...)
-    before the first update.
+    if spot-only, move USDC into perp margin before the first update.
 
 [ ] CLI status returns clean StatusDict (no risk_warning):
     poetry run python -m wayfinder_paths.run_strategy <name> --action status \

--- a/.claude/skills/developing-wayfinder-strategies/rules/reference-strategies.md
+++ b/.claude/skills/developing-wayfinder-strategies/rules/reference-strategies.md
@@ -152,9 +152,8 @@ Don't deviate on:
     set to wallet-appropriate values. Verify it loads:
     poetry run python -c "from wayfinder_paths.core.strategies.risk_limits import RiskLimits; print(RiskLimits.load_optional('wayfinder_paths/strategies/<name>'))"
 
-[ ] Wallet exists with label == strategy.name and has USDC in HL PERP
-    (not just spot). Use core_get_wallets(label="<name>") to verify both;
-    if spot-only, move USDC into perp margin before the first update.
+[ ] Wallet exists with label == strategy.name and holds USDC. Use
+    core_get_wallets(label="<name>") to verify.
 
 [ ] CLI status returns clean StatusDict (no risk_warning):
     poetry run python -m wayfinder_paths.run_strategy <name> --action status \

--- a/.claude/skills/using-hyperliquid-adapter/rules/execution-opportunities.md
+++ b/.claude/skills/using-hyperliquid-adapter/rules/execution-opportunities.md
@@ -32,7 +32,6 @@ Account/risk:
 - `approve_builder_fee(builder, max_fee_rate, address)`
 
 Transfers:
-- `transfer_spot_to_perp(amount, address)` / `transfer_perp_to_spot(amount, address)`
 - `spot_transfer(amount, destination, token, address)`
 - `hypercore_to_hyperevm(amount, address, token_address=None)`
 
@@ -62,8 +61,8 @@ For interactive use in Claude Code, this repo exposes a small MCP surface:
   - `place_trigger_order` (stop-loss / take-profit, perp only — see below)
   - `cancel_order`
   - `update_leverage`
+  - `deposit`
   - `withdraw`
-  - `spot_to_perp_transfer` / `perp_to_spot_transfer` (move USDC between wallets)
 
 ### `place_trigger_order` via MCP
 

--- a/.claude/skills/using-hyperliquid-adapter/rules/gotchas.md
+++ b/.claude/skills/using-hyperliquid-adapter/rules/gotchas.md
@@ -13,14 +13,12 @@ Constants available in `wayfinder_paths.core.constants.hyperliquid`:
 - `MIN_DEPOSIT_USD = 5.0`
 - `MIN_ORDER_USD_NOTIONAL = 10.0`
 
-## HIP-3 collateral via UnifiedAccount
+## UnifiedAccount mode is the default
 
-Trading on HIP-3 dexes (xyz, flx, vntl, hyna, km, etc.) requires **UnifiedAccount mode** enabled on the account. Without it, orders on non-default dexes fail with "Insufficient margin" or similar errors.
+All accounts touched by this adapter run in **UnifiedAccount mode**, where spot tokens and perp margin share collateral. The adapter auto-enables this before any order (`place_market_order`, `place_limit_order`, `place_tp_sl_order`, `place_outcome_order`) via `ensure_unified_account(address)` — one-time on-chain action per account, stays enabled afterward. As a consequence:
 
-- The adapter auto-enables this before `place_market_order`, `place_limit_order`, `place_tp_sl_order`, and `place_outcome_order` via `ensure_unified_account(address)`.
-- One-time on-chain action per account — once enabled, it stays enabled.
-- HIP-3 asset IDs use offsets: first builder dex starts at 110000, then 120000, 130000, etc.
-- HIP-3 coin names are prefixed: `xyz:NVDA`, `vntl:SPACEX`, `hyna:BTC`, etc.
+- Deposits land in the unified balance; no spot ↔ perp transfers needed.
+- HIP-3 dexes (xyz, flx, vntl, hyna, km, …) are unlocked. HIP-3 asset IDs use offsets (first builder dex starts at 110000, then 120000, 130000, …) and coin names are prefixed (`xyz:NVDA`, `vntl:SPACEX`, `hyna:BTC`, …).
 
 ## Asset ID conventions
 
@@ -50,8 +48,6 @@ Spot "index" is usually: `spot_index = spot_asset_id - 10000`.
 
 - `usd_amount` is always treated as notional (no `usd_amount_kind` required)
 - `leverage` and `reduce_only` are ignored for spot
-
-**Spot balance location:** Spot tokens live in your spot wallet, separate from perp margin.
 
 ## Spot L2 naming quirks
 

--- a/.claude/skills/using-hyperliquid-adapter/rules/gotchas.md
+++ b/.claude/skills/using-hyperliquid-adapter/rules/gotchas.md
@@ -51,7 +51,7 @@ Spot "index" is usually: `spot_index = spot_asset_id - 10000`.
 - `usd_amount` is always treated as notional (no `usd_amount_kind` required)
 - `leverage` and `reduce_only` are ignored for spot
 
-**Spot balance location:** Spot tokens live in your spot wallet, separate from perp margin. Use `spot_to_perp_transfer` / `perp_to_spot_transfer` to move USDC between them.
+**Spot balance location:** Spot tokens live in your spot wallet, separate from perp margin.
 
 ## Spot L2 naming quirks
 

--- a/.claude/skills/using-hyperliquid-adapter/rules/outcomes.md
+++ b/.claude/skills/using-hyperliquid-adapter/rules/outcomes.md
@@ -2,7 +2,7 @@
 
 HIP-4 is a hypercore-native prediction-contract surface. Phase 1 ships **binary daily markets** (e.g. "BTC > $78,213 by 06:00 UTC"); the protocol generalizes to multi-outcome later. Outcomes settle daily at **06:00 UTC**, after which the `outcome_id` rolls and old ids stop trading.
 
-**Collateral / quote: USDH** (Hyperliquid's stablecoin, spot token id 360). All currently-live HIP-4 outcomes settle in USDH — `outcomeMeta` doesn't expose a per-market quote field, so treat the whole surface as USDH-only until HL deploys outcomes against another token. Fund the spot wallet with USDH before placing orders; a USDC balance won't be debited for outcome trades.
+**Collateral / quote: USDH** (Hyperliquid's stablecoin, token id 360). All currently-live HIP-4 outcomes settle in USDH — `outcomeMeta` doesn't expose a per-market quote field, so treat the whole surface as USDH-only until HL deploys outcomes against another token. You need a USDH balance to place orders; a USDC balance won't be debited.
 
 ## Asset id encoding
 
@@ -92,7 +92,7 @@ hyperliquid_execute(
 
 ## Gotchas
 
-- **Collateral is USDH, not USDC.** Outcome buys debit USDH (token 360) on the spot side. A USDC-only spot wallet will fail to place orders even with plenty of buying power. Use the existing spot pair `USDH/USDC` (or transfer in) to fund USDH first.
+- **Collateral is USDH, not USDC.** Outcome buys debit USDH (token 360). If you only hold USDC, orders fail even with plenty of buying power — swap USDC → USDH on the `USDH/USDC` spot pair first.
 - **Daily settlement rolls outcome ids.** A live `outcome_id=20` at 05:55 UTC may be expired by 06:05 UTC and a new id replaces it. Re-fetch `get_outcome_markets()` rather than caching ids across days.
 - **Sizes are integer contracts.** The adapter rejects non-integer `size` loudly; don't pass floats.
 - **Price decimals follow the spot rule** (`MAX_DECIMALS=8`, 5-sig-figs); for typical 0..1 outcome prices this means up to ~5 decimals.


### PR DESCRIPTION
### Summary
- \`hyperliquid_execute\` action \`Literal\` (\`place_order\`, \`place_trigger_order\`, \`cancel_order\`, \`update_leverage\`, \`deposit\`, \`withdraw\`) doesn't expose \`spot_to_perp_transfer\` / \`perp_to_spot_transfer\`, and the adapter no longer has \`transfer_spot_to_perp\` / \`transfer_perp_to_spot\` either. But three skill docs still told the agent to use them — fixed.
- Bonus: the MCP action list in \`execution-opportunities.md\` was also missing \`deposit\`; added.