### PR TITLE
Shells - HL search_market: market_type filter

### DIFF
--- a/wayfinder_paths/core/constants/hyperliquid.py
+++ b/wayfinder_paths/core/constants/hyperliquid.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Final, Literal
 
 from wayfinder_paths.core.constants.contracts import (
     ARBITRUM_USDC as ARBITRUM_USDC_ADDRESS,
@@ -20,6 +20,7 @@ __all__ = [
     "HYPERLIQUID_BRIDGE_ADDRESS",
     "DEFAULT_HYPERLIQUID_BUILDER_FEE_TENTHS_BP",
     "DEFAULT_HYPERLIQUID_BUILDER_FEE",
+    "HyperliquidMarketType",
     "MARKET_SEARCH_ALIASES",
     "MARKET_SEARCH_MIN_MATCH_SCORE",
     "MARKET_TYPE_HIP3",
@@ -52,10 +53,13 @@ WITHDRAW_FEE_USD: float = 1.0
 # At least $2 gross so something lands on Arbitrum after the $1 fee.
 MIN_WITHDRAW_USD: float = 2.0
 
-MARKET_TYPE_PERP: str = "perp"
-MARKET_TYPE_HIP3: str = "hip3"
-MARKET_TYPE_SPOT: str = "spot"
-MARKET_TYPE_HIP4: str = "hip4"
+MARKET_TYPE_PERP: Final = "perp"
+MARKET_TYPE_HIP3: Final = "hip3"
+MARKET_TYPE_SPOT: Final = "spot"
+MARKET_TYPE_HIP4: Final = "hip4"
+HyperliquidMarketType = Literal[
+    MARKET_TYPE_PERP, MARKET_TYPE_HIP3, MARKET_TYPE_SPOT, MARKET_TYPE_HIP4
+]
 
 # Min `matches/min(len)` score for hyperliquid_search_market to keep a candidate.
 MARKET_SEARCH_MIN_MATCH_SCORE: float = 0.9

--- a/wayfinder_paths/mcp/tools/hyperliquid.py
+++ b/wayfinder_paths/mcp/tools/hyperliquid.py
@@ -24,6 +24,7 @@ from wayfinder_paths.core.constants.hyperliquid import (
     MIN_ORDER_USD_NOTIONAL,
     MIN_WITHDRAW_USD,
     WITHDRAW_FEE_USD,
+    HyperliquidMarketType,
 )
 from wayfinder_paths.core.utils.tokens import build_send_transaction
 from wayfinder_paths.core.utils.transaction import send_transaction
@@ -1153,13 +1154,18 @@ async def hyperliquid_search_mid_prices(
 
 
 @catch_errors
-async def hyperliquid_search_market(query: str, limit: int = 10) -> dict[str, Any]:
+async def hyperliquid_search_market(
+    query: str,
+    limit: int = 10,
+    market_type: HyperliquidMarketType | None = None,
+) -> dict[str, Any]:
     """
     Search Hyperliquid perpetual, spot, hip3 perpetual and hip4 outcome markets by a simple query string. An empty
     query returns the first `limit` items from each bucket unfiltered.
 
     query: A simple string containing asset names, for example: btc, eth, oil. Prefer non empty queries for efficiency.
-    limit: Max number of results to return per category
+    limit: Max number of results to return per category.
+    market_type: optional filter — "perp", "hip3", "spot", or "hip4". Buckets the caller filters out come back empty.
 
     Returns a list of asset names to be used when executing Hyperliquid orders.
     """
@@ -1247,6 +1253,18 @@ async def hyperliquid_search_market(query: str, limit: int = 10) -> dict[str, An
         perp_hits = [{"name": p} for p in top(perps, lambda p: p)][:limit]
         spot_hits = [{"name": s} for s in top(spots, lambda s: s)][:limit]
         outcome_hits = top(outcome_data, outcome_text)[:limit]
+
+    match market_type:
+        case "perp":
+            perp_hits = [h for h in perp_hits if ":" not in h["name"]]
+            spot_hits, outcome_hits = [], []
+        case "hip3":
+            perp_hits = [h for h in perp_hits if ":" in h["name"]]
+            spot_hits, outcome_hits = [], []
+        case "spot":
+            perp_hits, outcome_hits = [], []
+        case "hip4":
+            perp_hits, spot_hits = [], []
 
     return ok(
         {

--- a/wayfinder_paths/tests/test_mcp_hyperliquid_search.py
+++ b/wayfinder_paths/tests/test_mcp_hyperliquid_search.py
@@ -58,6 +58,23 @@ async def test_search_kinetiq_resolves_to_kntq_spot():
 
 
 @pytest.mark.asyncio
+async def test_search_market_type_filter():
+    res_perp = await hyperliquid_search_market("bitcoin", limit=10, market_type="perp")
+    res_hip3 = await hyperliquid_search_market("bitcoin", limit=10, market_type="hip3")
+    res_hip4 = await hyperliquid_search_market("bitcoin", limit=10, market_type="hip4")
+
+    assert {"BTC-USDC"} <= _names(res_perp["result"]["perps"])
+    assert not any(":" in r["name"] for r in res_perp["result"]["perps"])
+    assert res_perp["result"]["spots"] == [] and res_perp["result"]["outcomes"] == []
+
+    assert {"flx:BTC"} <= _names(res_hip3["result"]["perps"])
+    assert all(":" in r["name"] for r in res_hip3["result"]["perps"])
+
+    assert res_hip4["result"]["perps"] == [] and res_hip4["result"]["spots"] == []
+    assert res_hip4["result"]["outcomes"]
+
+
+@pytest.mark.asyncio
 async def test_search_oil_futures():
     res = await hyperliquid_search_market("oil futures", limit=20)
     assert res["ok"]


### PR DESCRIPTION
### Summary

Adds a `HyperliquidMarketType` type alias (`Literal[MARKET_TYPE_PERP, MARKET_TYPE_HIP3, MARKET_TYPE_SPOT, MARKET_TYPE_HIP4]`) reusing the existing constants, and threads it through `hyperliquid_search_market` as an optional filter. Return shape is unchanged — `perps` / `spots` / `outcomes` — buckets the caller filters out come back empty. Perp vs HIP-3 is distinguished by `:` prefix in the entry's name (HIP-3 dex perps carry `<dex>:<base>`).