### PR TITLE
Polymarket - Unknown wallet_label surfaces as 404

### DIFF
--- a/wayfinder_paths/mcp/utils.py
+++ b/wayfinder_paths/mcp/utils.py
@@ -198,9 +198,12 @@ async def resolve_wallet_address(
 
     w = await find_wallet_by_label(want)
     if not w:
-        return None, None
+        # Preserve `want` so callers can distinguish "no label given" from
+        # "label not found" — the latter should surface as a 404 instead of
+        # the generic "account required" error.
+        return None, want
 
-    return normalize_address(w.get("address")), want
+    return normalize_address(w["address"]), want
 
 
 def parse_amount_to_raw(amount: str, decimals: int) -> int:

--- a/wayfinder_paths/tests/test_mcp_wallets.py
+++ b/wayfinder_paths/tests/test_mcp_wallets.py
@@ -19,6 +19,23 @@ async def test_resolve_wallet_address_prefers_explicit_address():
 
 
 @pytest.mark.asyncio
+async def test_resolve_wallet_address_unknown_label_preserves_label():
+    # An unknown label must come back as (None, label) so callers can emit a
+    # "Unknown wallet_label: X" 404 instead of a misleading generic error.
+    with patch("wayfinder_paths.mcp.utils.find_wallet_by_label", return_value=None):
+        addr, lbl = await resolve_wallet_address(wallet_label="not-a-real-label")
+    assert addr is None
+    assert lbl == "not-a-real-label"
+
+
+@pytest.mark.asyncio
+async def test_resolve_wallet_address_missing_label_returns_double_none():
+    addr, lbl = await resolve_wallet_address()
+    assert addr is None
+    assert lbl is None
+
+
+@pytest.mark.asyncio
 async def test_wallets_discover_portfolio_requires_confirmation_when_many_protocols():
     store = SimpleNamespace(
         get_protocols_for_wallet=lambda _addr: ["hyperliquid", "pendle", "moonwell"]


### PR DESCRIPTION
### Summary
`resolve_wallet_address` collapsed "no label given" and "label not found" into the same `(None, None)` return, so the 404 branch in `polymarket_get_state` (and `polymarket_read`) was dead code: agents passing a wrong label got the misleading `"account (or wallet_label/wallet_address) is required"` error. Caught in a `cosmic-nebula` session where the agent took 2 extra tool calls to discover the real wallet label was `"free-seeking-moon primary wallet"`. Preserve `want` when the lookup misses so callers can return `"Unknown wallet_label: X"`.