### PR TITLE
Research gateway - Lift per-request timeout to 120s

### DIFF
--- a/wayfinder_paths/core/clients/ResearchClient.py
+++ b/wayfinder_paths/core/clients/ResearchClient.py
@@ -174,6 +174,11 @@ class ResearchClient(WayfinderClient):
         )
         return await self._post_gateway("social/x-search", payload)
 
+    # Research endpoints fan out to upstream AI providers (Exa, Grok x_search)
+    # whose tail latency can exceed the 30s default. 120s covers deep-research
+    # / multi-keyword queries without locking up the agent forever on a bad day.
+    _GATEWAY_TIMEOUT_SECONDS = 120.0
+
     async def _post_gateway(
         self,
         path: str,
@@ -184,6 +189,7 @@ class ResearchClient(WayfinderClient):
                 "POST",
                 self._research_url(path),
                 json=payload,
+                timeout=self._GATEWAY_TIMEOUT_SECONDS,
             )
         except httpx.HTTPStatusError as exc:
             raise _gateway_error_from_response(exc.response) from exc


### PR DESCRIPTION
### Summary
Research endpoints fan out to AI providers (Exa for web search, Grok `x_search` for social/X) with tail latency that can exceed the 30s shared-client default. Multi-keyword queries (e.g. "Iran ceasefire nuclear deal military escalation May 2026") intermittently surface as `gateway_unavailable` (httpx.RequestError → timeout) even when the upstream eventually returns 200. The same query through curl with 120s timeout returns 200 in 1s, confirming it's the SDK timeout that bites.

Pass an explicit 120s timeout on the research `_post_gateway` path so only research gets the longer headroom; everything else on the shared `WayfinderClient` stays at 30s.