### PR TITLE
[codex] Add Derive options adapter

### DIFF
--- a/.claude/skills/using-derive-adapter/SKILL.md
+++ b/.claude/skills/using-derive-adapter/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: using-derive-adapter
-description: How to use the Derive adapter in Wayfinder Paths for options discovery, ticker quotes, authenticated account reads, margin checks, and signed order/cancel workflows.
+description: How to use the Derive adapter in Wayfinder Paths for options discovery, ticker quotes, authenticated account reads, account/subaccount lifecycle, collateral deposit/withdraw/transfer, margin checks, and signed order/cancel workflows.
 metadata:
-  tags: wayfinder, derive, options, perps, spot, orderbook, quotes, margin, positions, signed-orders
+  tags: wayfinder, derive, options, perps, spot, orderbook, quotes, margin, positions, signed-orders, deposits, withdrawals, subaccounts
 ---
 
 ## When to use
@@ -12,6 +12,8 @@ Use this skill when you are:
 - Discovering Derive options by currency, expiry, strike, or option type.
 - Reading Derive best bid/ask, mark, index, option greeks, or open interest from ticker data.
 - Reading Derive subaccounts, positions, open orders, or margin state.
+- Ensuring a Derive account/subaccount exists before trading.
+- Depositing, withdrawing, or transferring collateral with explicit wallet signing.
 - Preparing or validating a signed Derive order payload.
 - Cancelling an existing Derive order.
 

--- a/.claude/skills/using-derive-adapter/SKILL.md
+++ b/.claude/skills/using-derive-adapter/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: using-derive-adapter
+description: How to use the Derive adapter in Wayfinder Paths for options discovery, ticker quotes, authenticated account reads, margin checks, and signed order/cancel workflows.
+metadata:
+  tags: wayfinder, derive, options, perps, spot, orderbook, quotes, margin, positions, signed-orders
+---
+
+## When to use
+
+Use this skill when you are:
+
+- Discovering Derive options by currency, expiry, strike, or option type.
+- Reading Derive best bid/ask, mark, index, option greeks, or open interest from ticker data.
+- Reading Derive subaccounts, positions, open orders, or margin state.
+- Preparing or validating a signed Derive order payload.
+- Cancelling an existing Derive order.
+
+## How to use
+
+- `wayfinder_paths/adapters/derive_adapter/README.md` - Adapter overview, auth, examples, and source docs.
+- [rules/high-value-reads.md](rules/high-value-reads.md) - Market discovery, quotes, and account reads.
+- [rules/execution.md](rules/execution.md) - Signed order debug/submit and cancel workflows.
+- [rules/gotchas.md](rules/gotchas.md) - Derive wallet auth, signing boundaries, orderbook/WebSocket scope, and simulation limits.

--- a/.claude/skills/using-derive-adapter/rules/execution.md
+++ b/.claude/skills/using-derive-adapter/rules/execution.md
@@ -5,29 +5,110 @@ Derive order submission is a trading action. It is not just an HTTP request.
 Derive requires two signatures for sensitive workflows:
 
 - Endpoint authentication: `X-LyraWallet`, `X-LyraTimestamp`, `X-LyraSignature`.
-- Action signature: the signed order payload fields sent to `private/order` or `private/order_debug`.
+- Action signature: the signed payload fields sent to create/deposit/withdraw/transfer/order endpoints.
 
-The adapter handles endpoint auth when a signing callback is configured. It does not build or sign Derive action payloads.
+The adapter handles endpoint auth when a signing callback is configured. For account lifecycle, collateral lifecycle, and simple order helpers, it also builds the documented Derive `SignedAction` hash and signs it with Wayfinder's `sign_hash_callback`. You still must verify instrument constraints, fees, amount, side, and user intent before asking the adapter to sign.
 
-## Signed Order Dry-Run
+## Ensure Or Create A Subaccount
+
+Start with a read. Only create if the user explicitly wants a new subaccount.
+
+```python
+ok, account_state = await adapter.ensure_subaccount()
+
+if not ok:
+    ok, account_state = await adapter.ensure_subaccount(
+        create_if_missing=True,
+        amount="0",
+        asset_name="USDC",
+        margin_type="SM",
+    )
+```
+
+`create_if_missing=True` calls `private/create_subaccount`. It changes account state and requires admin/session-key permission. `amount="0"` creates an empty Standard Margin subaccount. A positive amount also initiates a deposit and requires the wallet to have collateral and allowance available on Derive Chain.
+
+If the Derive account itself is missing, the adapter can run Derive's `public/create_account_with_secret` flow first when the user has a current invite secret:
+
+```python
+ok, account_state = await adapter.ensure_subaccount(
+    create_account_if_missing=True,
+    account_secret="invite-secret",
+    create_if_missing=True,
+    amount="0",
+    asset_name="USDC",
+    margin_type="SM",
+)
+```
+
+Without `account_secret`, do not guess onboarding details. Ask the user to create/onboard the Derive account through Derive's current interface or provide the documented secret/code.
+
+## Deposit And Withdraw Collateral
+
+Deposit collateral into a subaccount:
+
+```python
+ok, deposit = await adapter.deposit_collateral(
+    subaccount_id=12345,
+    amount="100",
+    asset_name="USDC",
+)
+```
+
+Withdraw collateral back to the Derive wallet:
+
+```python
+ok, withdrawal = await adapter.withdraw_collateral(
+    subaccount_id=12345,
+    amount="25",
+    asset_name="USDC",
+)
+```
+
+Then poll history:
+
+```python
+ok, deposits = await adapter.get_deposit_history(subaccount_id=12345)
+ok, withdrawals = await adapter.get_withdrawal_history(subaccount_id=12345)
+```
+
+Do not assume a `requested` response is final settlement. Check `tx_status` until it is `settled` or a terminal failure.
+
+## Transfer Collateral Between Subaccounts
+
+Use `transfer_erc20(...)` for ERC20 collateral transfers between Derive subaccounts owned by the same Derive wallet.
+
+```python
+ok, transfer = await adapter.transfer_erc20(
+    subaccount_id=12345,
+    recipient_subaccount_id=67890,
+    amount="10",
+    asset_name="USDC",
+)
+```
+
+This signs both sender and recipient action details. Position transfers use separate Derive endpoints and are not part of this adapter surface.
+
+## Callback-Signed Order Dry-Run
 
 Use `dry_run=True` first. This calls `private/order_debug`, which Derive documents as read-only.
 
 ```python
-order = {
+unsigned_order = {
     "subaccount_id": 12345,
     "instrument_name": "ETH-20260522-2500-C",
     "direction": "buy",
     "amount": "0.1",
     "limit_price": "20",
     "max_fee": "2",
-    "nonce": DeriveAdapter.new_order_nonce(),
-    "signature_expiry_sec": 1779327600,
-    "signer": "0xSignerOrSessionKey",
-    "signature": "0xSignedOrderPayload",
     "order_type": "limit",
     "time_in_force": "gtc",
 }
+
+ok, order = await adapter.sign_order(
+    unsigned_order,
+    asset_address="0xInstrumentBaseAssetAddress",
+    asset_sub_id=123456789,
+)
 
 ok, debug = await adapter.submit_order(order, dry_run=True)
 ```
@@ -38,7 +119,32 @@ Only submit live after the user has reviewed the instrument, side, size, price, 
 ok, result = await adapter.submit_order(order)
 ```
 
-Required signed order fields:
+You can also combine signing and submission:
+
+```python
+ok, debug = await adapter.place_order(
+    unsigned_order,
+    asset_address="0xInstrumentBaseAssetAddress",
+    asset_sub_id=123456789,
+    dry_run=True,
+)
+```
+
+Required unsigned order fields for `sign_order(...)`:
+
+- `amount`
+- `direction`
+- `instrument_name`
+- `limit_price`
+- `max_fee`
+- `subaccount_id`
+
+Additional signing inputs:
+
+- `asset_address`: Derive instrument base asset address from instrument/ticker metadata.
+- `asset_sub_id`: Derive instrument sub ID from instrument/ticker metadata.
+
+Required signed order fields for raw `submit_order(...)`:
 
 - `amount`
 - `direction`

--- a/.claude/skills/using-derive-adapter/rules/execution.md
+++ b/.claude/skills/using-derive-adapter/rules/execution.md
@@ -1,0 +1,66 @@
+# Derive Execution
+
+Derive order submission is a trading action. It is not just an HTTP request.
+
+Derive requires two signatures for sensitive workflows:
+
+- Endpoint authentication: `X-LyraWallet`, `X-LyraTimestamp`, `X-LyraSignature`.
+- Action signature: the signed order payload fields sent to `private/order` or `private/order_debug`.
+
+The adapter handles endpoint auth when a signing callback is configured. It does not build or sign Derive action payloads.
+
+## Signed Order Dry-Run
+
+Use `dry_run=True` first. This calls `private/order_debug`, which Derive documents as read-only.
+
+```python
+order = {
+    "subaccount_id": 12345,
+    "instrument_name": "ETH-20260522-2500-C",
+    "direction": "buy",
+    "amount": "0.1",
+    "limit_price": "20",
+    "max_fee": "2",
+    "nonce": DeriveAdapter.new_order_nonce(),
+    "signature_expiry_sec": 1779327600,
+    "signer": "0xSignerOrSessionKey",
+    "signature": "0xSignedOrderPayload",
+    "order_type": "limit",
+    "time_in_force": "gtc",
+}
+
+ok, debug = await adapter.submit_order(order, dry_run=True)
+```
+
+Only submit live after the user has reviewed the instrument, side, size, price, max fee, margin impact, expiry, and account/subaccount.
+
+```python
+ok, result = await adapter.submit_order(order)
+```
+
+Required signed order fields:
+
+- `amount`
+- `direction`
+- `instrument_name`
+- `limit_price`
+- `max_fee`
+- `nonce`
+- `signature`
+- `signature_expiry_sec`
+- `signer`
+- `subaccount_id`
+
+## Cancel
+
+Cancelling is an admin-scoped private endpoint.
+
+```python
+ok, result = await adapter.cancel_order(
+    instrument_name="ETH-20260522-2500-C",
+    order_id="...",
+    subaccount_id=12345,
+)
+```
+
+Confirm the order belongs to the intended subaccount and instrument before cancelling. Use `get_open_orders(subaccount_id=...)` first.

--- a/.claude/skills/using-derive-adapter/rules/gotchas.md
+++ b/.claude/skills/using-derive-adapter/rules/gotchas.md
@@ -24,9 +24,25 @@ Derive session-key scopes matter:
 
 If an order or cancel fails with an auth/scope error, do not retry blindly. Check the key scope.
 
-## Signed Order Payloads Are Caller-Owned
+## Deposit Is Not A Bridge
 
-The adapter requires a complete signed order payload for `debug_order(...)` and `submit_order(...)`. It does not derive `max_fee`, build EIP-712/action signing payloads, or sign orders. Use Derive's current signing SDK/client docs for that payload and verify all fields against the current instrument constraints.
+`deposit_collateral(...)` calls Derive `private/deposit`, which moves collateral from the Derive wallet into a Derive subaccount. It does not bridge assets from Ethereum, Arbitrum, Optimism, or Base to Derive Chain, and it does not submit ERC20 approval transactions.
+
+Before depositing a positive amount, confirm the wallet has the asset on Derive Chain and that the Derive DepositModule has allowance to spend it. Use Derive bridge/approval docs for those steps.
+
+## Lifecycle Writes Are Signed Actions
+
+The adapter builds Derive SignedAction hashes for `create_subaccount`, `deposit_collateral`, `withdraw_collateral`, and `transfer_erc20`, then asks `sign_hash_callback` to sign them. If `sign_hash_callback` is missing, do not fall back to a raw signature string unless the user already has a verified Derive action signature from current docs/client tooling.
+
+`ensure_subaccount(create_if_missing=True, amount="0")` creates an empty subaccount. A positive amount also initiates a deposit.
+
+`ensure_subaccount(create_account_if_missing=True, ...)` can call `public/create_account_with_secret` first, but only when the user provides the current Derive account secret/code details. Do not silently invent onboarding secrets or assume an EOA is already a Derive smart contract wallet.
+
+## Signed Orders Still Need Instrument Metadata
+
+`sign_order(...)` and `place_order(...)` sign through Wayfinder's wallet callback, but they do not derive `max_fee`, choose side/size, or infer Derive asset metadata. Use current instrument/ticker data to provide `asset_address` and `asset_sub_id`, and verify all order fields against Derive constraints before signing.
+
+`submit_order(...)` still accepts a complete pre-signed order payload for callers using Derive's own SDK/client tooling.
 
 ## Ticker Versus Orderbook
 
@@ -42,7 +58,7 @@ The adapter currently builds this channel name but does not maintain WebSocket s
 
 Gorlami tests in this repo simulate EVM contract calls on forked chains. Derive option discovery, account reads, order debug, order submission, and cancel are Derive API/CLOB workflows, with settlement handled by Derive's matching/protocol pipeline. There is no current repo helper that can fork-simulate those API workflows on Derive Chain 957.
 
-Use adapter unit tests and `submit_order(..., dry_run=True)` as deterministic validation before any live submit.
+Use adapter unit tests, lifecycle history reads, and `submit_order(..., dry_run=True)` as deterministic validation before any live submit.
 
 ## Settlement And Margin
 

--- a/.claude/skills/using-derive-adapter/rules/gotchas.md
+++ b/.claude/skills/using-derive-adapter/rules/gotchas.md
@@ -1,0 +1,49 @@
+# Derive Gotchas
+
+## Derive Wallet Is Not Always The EOA
+
+Derive private REST auth uses `X-LyraWallet`, which the docs describe as the Derive wallet/account address, not necessarily the original owner EOA. Session keys can sign private requests, but the header wallet should still identify the Derive account.
+
+When in doubt, pass both:
+
+```python
+adapter = await get_adapter(
+    DeriveAdapter,
+    "session-key-label",
+    derive_wallet_address="0xDeriveAccountWallet",
+)
+```
+
+## Read-Only Session Keys Cannot Trade
+
+Derive session-key scopes matter:
+
+- `read_only`: account info, orders, positions, history.
+- `account`: account-level settings and RFQs, but not trading.
+- `admin`: orders, cancel, deposit, withdraw, transfer, and other sensitive actions.
+
+If an order or cancel fails with an auth/scope error, do not retry blindly. Check the key scope.
+
+## Signed Order Payloads Are Caller-Owned
+
+The adapter requires a complete signed order payload for `debug_order(...)` and `submit_order(...)`. It does not derive `max_fee`, build EIP-712/action signing payloads, or sign orders. Use Derive's current signing SDK/client docs for that payload and verify all fields against the current instrument constraints.
+
+## Ticker Versus Orderbook
+
+REST `public/get_tickers` gives best bid/ask, mark, index, stats, and option pricing fields. Full orderbook depth is a WebSocket channel named like:
+
+```text
+orderbook.{instrument_name}.{group}.{depth}
+```
+
+The adapter currently builds this channel name but does not maintain WebSocket subscriptions.
+
+## Gorlami Limitation
+
+Gorlami tests in this repo simulate EVM contract calls on forked chains. Derive option discovery, account reads, order debug, order submission, and cancel are Derive API/CLOB workflows, with settlement handled by Derive's matching/protocol pipeline. There is no current repo helper that can fork-simulate those API workflows on Derive Chain 957.
+
+Use adapter unit tests and `submit_order(..., dry_run=True)` as deterministic validation before any live submit.
+
+## Settlement And Margin
+
+Derive options are European and settle to a 30 minute TWAP. Standard margin is centered around zero, and maintenance margin below zero is liquidatable. Portfolio margin can reduce margin requirements but is constrained to one denominated base asset per portfolio margin account.

--- a/.claude/skills/using-derive-adapter/rules/high-value-reads.md
+++ b/.claude/skills/using-derive-adapter/rules/high-value-reads.md
@@ -64,10 +64,33 @@ adapter = await get_adapter(
 )
 
 ok, subaccounts = await adapter.get_subaccounts()
+ok, account = await adapter.get_account()
 ok, subaccount = await adapter.get_subaccount(subaccount_id=12345)
 ok, positions = await adapter.get_positions(subaccount_id=12345)
 ok, orders = await adapter.get_open_orders(subaccount_id=12345)
 ok, margin = await adapter.get_margin(subaccount_id=12345)
 ```
 
+Useful account fields:
+
+- `subaccount_ids`: Derive subaccounts owned by the authenticated wallet.
+- `fee_info`: current fee configuration for options/perps/spot/RFQ.
+- `cancel_on_disconnect`: account-level cancellation behavior.
+- `websocket_*_tps`: current account WebSocket rate-limit tiers.
+
 For trade previews, prefer `get_margin(..., simulated_position_changes=[...])` before considering any order submission.
+
+## Deposit And Withdrawal History
+
+Use history reads after a lifecycle write returns `status="requested"` and a `transaction_id`.
+
+```python
+ok, deposits = await adapter.get_deposit_history(
+    subaccount_id=12345,
+    start_timestamp=0,
+)
+
+ok, withdrawals = await adapter.get_withdrawal_history(subaccount_id=12345)
+```
+
+Watch `tx_status` for `requested`, `pending`, `settled`, `reverted`, `ignored`, or `timed_out`. Check `error_log` before retrying a failed deposit or withdrawal.

--- a/.claude/skills/using-derive-adapter/rules/high-value-reads.md
+++ b/.claude/skills/using-derive-adapter/rules/high-value-reads.md
@@ -1,0 +1,73 @@
+# Derive Reads
+
+## Public Options Discovery
+
+Use the adapter for live Derive data. Do not invent expiries, strikes, fees, quotes, funding, or margin values.
+
+```python
+from wayfinder_paths.adapters.derive_adapter import DeriveAdapter
+
+adapter = DeriveAdapter()
+
+ok, options = await adapter.list_options(currency="ETH", expired=False)
+ok, expiries = await adapter.list_option_expiries(currency="ETH")
+ok, tickers = await adapter.get_option_tickers(
+    currency="ETH",
+    expiry_date=expiries[0]["expiry_date"],
+)
+```
+
+Useful fields from `list_options(...)`:
+
+- `instrument_name`: Derive instrument name, for example `ETH-20260522-2500-C`.
+- `option_details.expiry`: Unix expiry timestamp in seconds.
+- `option_details.strike`: strike as a decimal string.
+- `option_details.option_type`: `C` or `P`.
+- `tick_size`, `minimum_amount`, `amount_step`: order sizing constraints.
+- `maker_fee_rate`, `taker_fee_rate`, `base_fee`, `max_fee`: fee inputs for order signing and risk review.
+
+Useful fields from `get_option_tickers(...)`:
+
+- `b` / `B`: best bid price and amount.
+- `a` / `A`: best ask price and amount.
+- `M`: mark price.
+- `I`: index price.
+- `stats.oi`: open interest.
+- `option_pricing`: greeks and model fields exposed by Derive.
+
+## Orderbook Channel
+
+Full orderbook snapshots are exposed as WebSocket channels, not REST.
+
+```python
+channel = DeriveAdapter.orderbook_channel(
+    "ETH-20260522-2500-C",
+    group="1",
+    depth="10",
+)
+```
+
+The adapter currently builds the documented channel name and reads REST ticker quotes. It does not run a WebSocket subscription loop.
+
+## Authenticated Reads
+
+Private reads require Derive REST auth. If the signing wallet/session key differs from the Derive account wallet, pass `derive_wallet_address`.
+
+```python
+from wayfinder_paths.adapters.derive_adapter import DeriveAdapter
+from wayfinder_paths.mcp.scripting import get_adapter
+
+adapter = await get_adapter(
+    DeriveAdapter,
+    "main",
+    derive_wallet_address="0xYourDeriveWallet",
+)
+
+ok, subaccounts = await adapter.get_subaccounts()
+ok, subaccount = await adapter.get_subaccount(subaccount_id=12345)
+ok, positions = await adapter.get_positions(subaccount_id=12345)
+ok, orders = await adapter.get_open_orders(subaccount_id=12345)
+ok, margin = await adapter.get_margin(subaccount_id=12345)
+```
+
+For trade previews, prefer `get_margin(..., simulated_position_changes=[...])` before considering any order submission.

--- a/wayfinder_paths/adapters/derive_adapter/README.md
+++ b/wayfinder_paths/adapters/derive_adapter/README.md
@@ -14,9 +14,11 @@ This adapter emphasizes Derive options workflows:
 - Public discovery: active option instruments, expiries, strikes, fee/tick constraints.
 - Public quote reads: `public/get_tickers` and `public/get_ticker`.
 - Account reads: subaccounts, subaccount aggregate state, positions, open orders, margin simulation.
+- Account lifecycle: account/subaccount detection, optional account creation with invite secret, and signed subaccount creation.
+- Collateral lifecycle: signed deposit, signed withdraw, deposit/withdraw history reads, and signed ERC20 collateral transfer between subaccounts.
 - Order workflows: signed order debug and signed order submission pass-through, plus cancel.
 
-Full WebSocket streaming, deposits, withdrawals, collateral transfers, position transfers, RFQs, liquidation actions, session-key management, and on-chain Derive Chain contract calls are intentionally out of scope for the first adapter.
+Full WebSocket streaming, position transfers, RFQs, liquidation actions, session-key management, bridge flows into Derive Chain, ERC20 approval transaction construction, and direct on-chain Derive Chain contract calls are intentionally out of scope.
 
 ## Auth And Signing
 
@@ -28,7 +30,11 @@ Derive private REST endpoints require these headers:
 
 When constructed through `get_adapter(DeriveAdapter, "main")`, Wayfinder can auto-wire `sign_hash_callback` and `wallet_address`. If your Derive wallet differs from the signing wallet/session key, pass `derive_wallet_address` explicitly.
 
-Order submission is self-custodial. Derive requires endpoint authentication plus a signed order payload. This adapter does **not** recreate Derive's EIP-712/action-signing SDK. Callers must provide `signature`, `signer`, `nonce`, `max_fee`, `signature_expiry_sec`, and the other required order fields.
+Account creation, deposits, withdrawals, transfers, and order submission are self-custodial. Derive requires endpoint authentication plus a signed action payload.
+
+For account/collateral lifecycle methods, the adapter builds the documented Derive `SignedAction` hash and asks Wayfinder's `sign_hash_callback` to sign it. For order submission, use `sign_order(...)` or `place_order(...)` when you have verified the instrument asset address/sub-id, max fee, direction, amount, and user intent. `submit_order(...)` also accepts a complete pre-signed Derive order payload for callers using Derive's own SDK.
+
+Deposits may require the wallet to already hold collateral on Derive Chain and to have approved the Derive DepositModule to spend the asset. Derive bridging and ERC20 approval transactions are documented separately by Derive and are not hidden inside this REST adapter.
 
 ## Usage
 
@@ -58,27 +64,87 @@ adapter = await get_adapter(
 )
 
 ok, subaccounts = await adapter.get_subaccounts()
+ok, account = await adapter.get_account()
 ok, positions = await adapter.get_positions(subaccount_id=12345)
 ok, margin = await adapter.get_margin(subaccount_id=12345)
 ```
 
-Signed order dry-run before live submit:
+Ensure/create a usable account and subaccount:
 
 ```python
-order = {
+ok, account_state = await adapter.ensure_subaccount()
+if not ok:
+    ok, account_state = await adapter.ensure_subaccount(
+        create_if_missing=True,
+        amount="0",
+        asset_name="USDC",
+        margin_type="SM",
+    )
+```
+
+If the Derive account itself is missing and the user has a current Derive invite secret, the same flow can create the account first:
+
+```python
+ok, account_state = await adapter.ensure_subaccount(
+    create_account_if_missing=True,
+    account_secret="invite-secret",
+    create_if_missing=True,
+    amount="0",
+    asset_name="USDC",
+    margin_type="SM",
+)
+```
+
+Deposit, withdraw, and inspect lifecycle status:
+
+```python
+ok, deposit = await adapter.deposit_collateral(
+    subaccount_id=12345,
+    amount="100",
+    asset_name="USDC",
+)
+
+ok, deposit_history = await adapter.get_deposit_history(subaccount_id=12345)
+
+ok, withdrawal = await adapter.withdraw_collateral(
+    subaccount_id=12345,
+    amount="25",
+    asset_name="USDC",
+)
+
+ok, withdrawal_history = await adapter.get_withdrawal_history(subaccount_id=12345)
+```
+
+Transfer collateral between Derive subaccounts:
+
+```python
+ok, transfer = await adapter.transfer_erc20(
+    subaccount_id=12345,
+    recipient_subaccount_id=67890,
+    amount="10",
+    asset_name="USDC",
+)
+```
+
+Callback-signed order dry-run before live submit:
+
+```python
+unsigned_order = {
     "subaccount_id": 12345,
     "instrument_name": "ETH-20260522-2500-C",
     "direction": "buy",
     "amount": "0.1",
     "limit_price": "20",
     "max_fee": "2",
-    "nonce": DeriveAdapter.new_order_nonce(),
-    "signature_expiry_sec": 1779327600,
-    "signer": "0xSignerOrSessionKey",
-    "signature": "0xSignedOrderPayload",
     "order_type": "limit",
     "time_in_force": "gtc",
 }
+
+ok, order = await adapter.sign_order(
+    unsigned_order,
+    asset_address="0xInstrumentBaseAssetAddress",
+    asset_sub_id=123456789,
+)
 
 ok, debug = await adapter.submit_order(order, dry_run=True)
 if ok:
@@ -99,6 +165,21 @@ if ok:
 - https://docs.derive.xyz/reference/authentication.md
 - https://docs.derive.xyz/reference/session-keys.md
 - https://docs.derive.xyz/reference/rate-limits.md
+- https://docs.derive.xyz/reference/protocol-constants.md
+- https://docs.derive.xyz/reference/create-or-deposit-to-subaccount.md
+- https://docs.derive.xyz/reference/deposit-to-lyra-chain.md
+- https://docs.derive.xyz/reference/on-chain-withdraw.md
+- https://docs.derive.xyz/reference/post_private-get-account.md
+- https://docs.derive.xyz/reference/public-create_account_with_secret-1.md
+- https://docs.derive.xyz/reference/post_private-create-subaccount.md
+- https://docs.derive.xyz/reference/post_private-deposit.md
+- https://docs.derive.xyz/reference/post_private-withdraw.md
+- https://docs.derive.xyz/reference/post_private-get-deposit-history.md
+- https://docs.derive.xyz/reference/post_private-get-withdrawal-history.md
+- https://docs.derive.xyz/reference/post_private-transfer-erc20.md
+- https://docs.derive.xyz/reference/transfer-collateral.md
+- https://pypi.org/project/derive_action_signing/
+- https://github.com/derivexyz/v2-action-signing-python
 - https://docs.derive.xyz/reference/post_public-get-instruments.md
 - https://docs.derive.xyz/reference/post_public-get-tickers.md
 - https://docs.derive.xyz/reference/orderbook-instrument_name-group-depth.md

--- a/wayfinder_paths/adapters/derive_adapter/README.md
+++ b/wayfinder_paths/adapters/derive_adapter/README.md
@@ -1,0 +1,113 @@
+# DeriveAdapter
+
+Derive options, perps, and spot REST adapter for Wayfinder Paths.
+
+- **Type**: `DERIVE`
+- **Module**: `wayfinder_paths.adapters.derive_adapter.adapter.DeriveAdapter`
+- **Default API**: `https://api.lyra.finance`
+- **Demo API**: `https://api-demo.lyra.finance`
+
+## Scope
+
+This adapter emphasizes Derive options workflows:
+
+- Public discovery: active option instruments, expiries, strikes, fee/tick constraints.
+- Public quote reads: `public/get_tickers` and `public/get_ticker`.
+- Account reads: subaccounts, subaccount aggregate state, positions, open orders, margin simulation.
+- Order workflows: signed order debug and signed order submission pass-through, plus cancel.
+
+Full WebSocket streaming, deposits, withdrawals, collateral transfers, position transfers, RFQs, liquidation actions, session-key management, and on-chain Derive Chain contract calls are intentionally out of scope for the first adapter.
+
+## Auth And Signing
+
+Derive private REST endpoints require these headers:
+
+- `X-LyraWallet`: the Derive wallet/account address.
+- `X-LyraTimestamp`: current UTC timestamp in milliseconds.
+- `X-LyraSignature`: standard Ethereum message signature of the timestamp.
+
+When constructed through `get_adapter(DeriveAdapter, "main")`, Wayfinder can auto-wire `sign_hash_callback` and `wallet_address`. If your Derive wallet differs from the signing wallet/session key, pass `derive_wallet_address` explicitly.
+
+Order submission is self-custodial. Derive requires endpoint authentication plus a signed order payload. This adapter does **not** recreate Derive's EIP-712/action-signing SDK. Callers must provide `signature`, `signer`, `nonce`, `max_fee`, `signature_expiry_sec`, and the other required order fields.
+
+## Usage
+
+```python
+from wayfinder_paths.adapters.derive_adapter import DeriveAdapter
+
+adapter = DeriveAdapter()
+
+ok, options = await adapter.list_options(currency="ETH")
+ok, expiries = await adapter.list_option_expiries(currency="ETH")
+ok, tickers = await adapter.get_option_tickers(
+    currency="ETH",
+    expiry_date=expiries[0]["expiry_date"],
+)
+```
+
+Authenticated reads:
+
+```python
+from wayfinder_paths.adapters.derive_adapter import DeriveAdapter
+from wayfinder_paths.mcp.scripting import get_adapter
+
+adapter = await get_adapter(
+    DeriveAdapter,
+    "main",
+    derive_wallet_address="0xYourDeriveWallet",
+)
+
+ok, subaccounts = await adapter.get_subaccounts()
+ok, positions = await adapter.get_positions(subaccount_id=12345)
+ok, margin = await adapter.get_margin(subaccount_id=12345)
+```
+
+Signed order dry-run before live submit:
+
+```python
+order = {
+    "subaccount_id": 12345,
+    "instrument_name": "ETH-20260522-2500-C",
+    "direction": "buy",
+    "amount": "0.1",
+    "limit_price": "20",
+    "max_fee": "2",
+    "nonce": DeriveAdapter.new_order_nonce(),
+    "signature_expiry_sec": 1779327600,
+    "signer": "0xSignerOrSessionKey",
+    "signature": "0xSignedOrderPayload",
+    "order_type": "limit",
+    "time_in_force": "gtc",
+}
+
+ok, debug = await adapter.submit_order(order, dry_run=True)
+if ok:
+    ok, result = await adapter.submit_order(order)
+```
+
+## Derive Docs Used
+
+- https://docs.derive.xyz/llms.txt
+- https://docs.derive.xyz/docs/about-derive.md
+- https://docs.derive.xyz/docs/supported-products-1.md
+- https://docs.derive.xyz/docs/standard-margin-1.md
+- https://docs.derive.xyz/docs/portfolio-margin-1.md
+- https://docs.derive.xyz/docs/settlements.md
+- https://docs.derive.xyz/docs/lyra-chain.md
+- https://docs.derive.xyz/reference/overview.md
+- https://docs.derive.xyz/reference/json-rpc.md
+- https://docs.derive.xyz/reference/authentication.md
+- https://docs.derive.xyz/reference/session-keys.md
+- https://docs.derive.xyz/reference/rate-limits.md
+- https://docs.derive.xyz/reference/post_public-get-instruments.md
+- https://docs.derive.xyz/reference/post_public-get-tickers.md
+- https://docs.derive.xyz/reference/orderbook-instrument_name-group-depth.md
+- https://docs.derive.xyz/reference/post_private-order-debug.md
+- https://docs.derive.xyz/reference/post_private-order.md
+- https://docs.derive.xyz/reference/post_private-cancel.md
+
+## Testing
+
+```bash
+poetry run pytest -o addopts= wayfinder_paths/adapters/derive_adapter -q
+```

--- a/wayfinder_paths/adapters/derive_adapter/__init__.py
+++ b/wayfinder_paths/adapters/derive_adapter/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import DeriveAdapter
+
+__all__ = ["DeriveAdapter"]

--- a/wayfinder_paths/adapters/derive_adapter/adapter.py
+++ b/wayfinder_paths/adapters/derive_adapter/adapter.py
@@ -4,10 +4,13 @@ import secrets
 import time
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation
 from typing import Any, Literal
 
 import httpx
+from eth_abi import encode as abi_encode
 from eth_account.messages import defunct_hash_message
+from web3 import Web3
 
 from wayfinder_paths.core.adapters.BaseAdapter import BaseAdapter
 
@@ -17,6 +20,7 @@ DERIVE_MAINNET_WS_URL = "wss://api.lyra.finance/ws"
 DERIVE_TESTNET_WS_URL = "wss://api-demo.lyra.finance/ws"
 
 InstrumentType = Literal["option", "perp", "erc20"]
+MarginType = Literal["PM", "SM", "PM2"]
 
 DERIVE_ORDER_REQUIRED_FIELDS = frozenset(
     {
@@ -32,9 +36,78 @@ DERIVE_ORDER_REQUIRED_FIELDS = frozenset(
         "subaccount_id",
     }
 )
+DERIVE_ORDER_UNSIGNED_FIELDS = frozenset(
+    {
+        "amount",
+        "direction",
+        "instrument_name",
+        "limit_price",
+        "max_fee",
+        "subaccount_id",
+    }
+)
 
+DERIVE_ACTION_DETAIL_FIELDS = frozenset(
+    {"nonce", "signature", "signature_expiry_sec", "signer"}
+)
 DERIVE_ORDERBOOK_GROUPS = frozenset({"1", "10", "100"})
 DERIVE_ORDERBOOK_DEPTHS = frozenset({"1", "10", "20", "100"})
+DERIVE_ACTION_SIGNATURE_EXPIRY_BUFFER_SEC = 600
+DERIVE_DEFAULT_TRANSFER_MANAGER = "0x0000000000000000000000000000000000000000"
+DERIVE_DEFAULT_ASSET_DECIMALS = {
+    "USDC": 6,
+    "USDC.E": 6,
+    "ETH": 18,
+    "WETH": 18,
+    "BTC": 8,
+    "WBTC": 8,
+}
+
+DERIVE_PROTOCOL_CONSTANTS: dict[str, dict[str, Any]] = {
+    "mainnet": {
+        "domain_separator": (
+            "0xd96e5f90797da7ec8dc4e276260c7f3f87fedf68775fbe1ef116e996fc60441b"
+        ),
+        "action_typehash": (
+            "0x4d7a9f27c403ff9c0f19bce61d76d82f9aa29f8d6d4b0c5474607d9770d1af17"
+        ),
+        "deposit_module_address": "0x9B3FE5E5a3bcEa5df4E08c41Ce89C4e3Ff01Ace3",
+        "trade_module_address": "0xB8D20c2B7a1Ad2EE33Bc50eF10876eD3035b5e7b",
+        "withdrawal_module_address": "0x9d0E8f5b25384C7310CB8C6aE32C8fbeb645d083",
+        "transfer_module_address": "0x01259207A40925b794C8ac320456F7F6c8FE2636",
+        "cash_asset_address": "0x57B03E14d409ADC7fAb6CFc44b5886CAD2D5f02b",
+        "standard_risk_manager_address": ("0x28c9ddF9A3B29c2E6a561c1BC520954e5A33de5D"),
+        "portfolio_risk_manager_addresses": {
+            "ETH": "0xe7cD9370CdE6C9b5eAbCe8f86d01822d3de205A0",
+            "BTC": "0x45DA02B9cCF384d7DbDD7b2b13e705BADB43Db0D",
+        },
+        "portfolio_risk_manager_v2_addresses": {
+            "ETH": "0xc755DAe3fd295A687adf3e192387163f813F0598",
+            "BTC": "0xC7adAB7A2b92019098dA55Ba4C5A8C65Ae7e52DC",
+        },
+        "chain_id": 957,
+    },
+    "testnet": {
+        "domain_separator": (
+            "0x9bcf4dc06df5d8bf23af818d5716491b995020f377d3b7b64c29ed14e3dd1105"
+        ),
+        "action_typehash": (
+            "0x4d7a9f27c403ff9c0f19bce61d76d82f9aa29f8d6d4b0c5474607d9770d1af17"
+        ),
+        "deposit_module_address": "0x43223Db33AdA0575D2E100829543f8B04A37a1ec",
+        "trade_module_address": "0x87F2863866D85E3192a35A73b388BD625D83f2be",
+        "withdrawal_module_address": "0xe850641C5207dc5E9423fB15f89ae6031A05fd92",
+        "transfer_module_address": "0x0CFC1a4a90741aB242cAfaCD798b409E12e68926",
+        "cash_asset_address": "0x6caf294DaC985ff653d5aE75b4FF8E0A66025928",
+        "standard_risk_manager_address": ("0x28bE681F7bEa6f465cbcA1D25A2125fe7533391C"),
+        "portfolio_risk_manager_addresses": {
+            "ETH": "0xDF448056d7bf3f9Ca13d713114e17f1B7470DeBF",
+            "BTC": "0xbaC0328cd4Af53d52F9266Cdbd5bf46720320A20",
+        },
+        "portfolio_risk_manager_v2_addresses": {},
+        "chain_id": 901,
+    },
+}
 
 
 class DeriveAdapter(BaseAdapter):
@@ -62,6 +135,7 @@ class DeriveAdapter(BaseAdapter):
 
         network = str(derive_config.get("network", "mainnet")).lower()
         use_testnet = network in {"testnet", "demo", "api-demo"}
+        self.network = "testnet" if use_testnet else "mainnet"
 
         self.api_base_url = (
             api_base_url
@@ -90,6 +164,7 @@ class DeriveAdapter(BaseAdapter):
             base_url=self.api_base_url,
             timeout=httpx.Timeout(http_timeout_s),
         )
+        self.protocol_constants = self._protocol_constants(derive_config)
 
     async def close(self) -> None:
         await self._http.aclose()
@@ -100,10 +175,11 @@ class DeriveAdapter(BaseAdapter):
         payload: dict[str, Any],
         *,
         private: bool = False,
+        auth_wallet: str | None = None,
     ) -> tuple[bool, Any]:
         headers: dict[str, str] | None = None
         if private:
-            ok, auth_headers = await self._auth_headers()
+            ok, auth_headers = await self._auth_headers(wallet=auth_wallet)
             if not ok:
                 return False, auth_headers
             headers = auth_headers
@@ -123,11 +199,14 @@ class DeriveAdapter(BaseAdapter):
             return False, f"Derive response missing result: {data}"
         return True, data["result"]
 
-    async def _auth_headers(self) -> tuple[bool, dict[str, str] | str]:
-        if not self.derive_wallet_address:
+    async def _auth_headers(
+        self, *, wallet: str | None = None
+    ) -> tuple[bool, dict[str, str] | str]:
+        target_wallet = wallet or self.derive_wallet_address
+        if not target_wallet:
             return (
                 False,
-                "derive_wallet_address is required for Derive private endpoints",
+                "wallet or derive_wallet_address is required for Derive private endpoints",
             )
 
         timestamp = str(int(time.time() * 1000))
@@ -145,7 +224,7 @@ class DeriveAdapter(BaseAdapter):
         return (
             True,
             {
-                "X-LyraWallet": str(self.derive_wallet_address),
+                "X-LyraWallet": str(target_wallet),
                 "X-LyraTimestamp": timestamp,
                 "X-LyraSignature": str(signature),
             },
@@ -263,6 +342,38 @@ class DeriveAdapter(BaseAdapter):
             return False, f"Unexpected get_ticker result: {type(result).__name__}"
         return True, result
 
+    async def create_account_with_secret(
+        self,
+        *,
+        secret: str,
+        wallet: str | None = None,
+        code: str | int | None = None,
+        scw_owner: str | None = None,
+    ) -> tuple[bool, dict[str, Any] | str]:
+        target_wallet = wallet or self.derive_wallet_address or self.wallet_address
+        if not target_wallet:
+            return False, "wallet, derive_wallet_address, or wallet_address is required"
+
+        payload: dict[str, Any] = {"secret": secret, "wallet": target_wallet}
+        if code is not None:
+            payload["code"] = code
+        if scw_owner is not None:
+            payload["scw_owner"] = scw_owner
+        return await self._post("/public/create_account_with_secret", payload)
+
+    async def get_account(
+        self, *, wallet: str | None = None
+    ) -> tuple[bool, dict[str, Any] | str]:
+        target_wallet = wallet or self.derive_wallet_address
+        if not target_wallet:
+            return False, "wallet or derive_wallet_address is required"
+        return await self._post(
+            "/private/get_account",
+            {"wallet": target_wallet},
+            private=True,
+            auth_wallet=target_wallet,
+        )
+
     async def get_subaccounts(
         self, *, wallet: str | None = None
     ) -> tuple[bool, dict[str, Any] | str]:
@@ -273,6 +384,7 @@ class DeriveAdapter(BaseAdapter):
             "/private/get_subaccounts",
             {"wallet": target_wallet},
             private=True,
+            auth_wallet=target_wallet,
         )
 
     async def get_subaccount(
@@ -283,6 +395,118 @@ class DeriveAdapter(BaseAdapter):
             {"subaccount_id": subaccount_id},
             private=True,
         )
+
+    async def ensure_subaccount(
+        self,
+        *,
+        wallet: str | None = None,
+        preferred_subaccount_id: int | None = None,
+        create_account_if_missing: bool = False,
+        account_secret: str | None = None,
+        account_code: str | int | None = None,
+        scw_owner: str | None = None,
+        create_if_missing: bool = False,
+        amount: str | int | Decimal = "0",
+        asset_name: str = "USDC",
+        margin_type: MarginType = "SM",
+        currency: str | None = None,
+        asset_address: str | None = None,
+        manager_address: str | None = None,
+        asset_decimals: int | None = None,
+        signer: str | None = None,
+        nonce: int | None = None,
+        signature_expiry_sec: int | None = None,
+    ) -> tuple[bool, dict[str, Any] | str]:
+        target_wallet = wallet or self.derive_wallet_address
+        if not target_wallet:
+            return False, "wallet or derive_wallet_address is required"
+
+        ok, subaccounts = await self.get_subaccounts(wallet=target_wallet)
+        account_request: dict[str, Any] | None = None
+        if not ok:
+            if not create_account_if_missing:
+                return False, subaccounts
+            if not account_secret:
+                return (
+                    False,
+                    "account_secret is required when create_account_if_missing=True",
+                )
+            ok, created_account = await self.create_account_with_secret(
+                secret=account_secret,
+                wallet=target_wallet,
+                code=account_code,
+                scw_owner=scw_owner,
+            )
+            if not ok:
+                return False, created_account
+            account_request = created_account
+            ok, subaccounts = await self.get_subaccounts(wallet=target_wallet)
+            if not ok:
+                return False, {
+                    "error": subaccounts,
+                    "account": account_request,
+                    "wallet": target_wallet,
+                }
+        if not isinstance(subaccounts, dict):
+            return (
+                False,
+                f"Unexpected get_subaccounts result: {type(subaccounts).__name__}",
+            )
+
+        ids = subaccounts.get("subaccount_ids") or []
+        if not isinstance(ids, list):
+            return False, "Unexpected get_subaccounts subaccount_ids"
+
+        if preferred_subaccount_id is not None and preferred_subaccount_id in ids:
+            return True, {
+                "status": "exists",
+                "created": False,
+                "subaccount_id": preferred_subaccount_id,
+                "subaccount_ids": ids,
+                "wallet": target_wallet,
+                **({"account": account_request} if account_request else {}),
+            }
+        if preferred_subaccount_id is None and ids:
+            return True, {
+                "status": "exists",
+                "created": False,
+                "subaccount_id": ids[0],
+                "subaccount_ids": ids,
+                "wallet": target_wallet,
+                **({"account": account_request} if account_request else {}),
+            }
+        if not create_if_missing:
+            return False, {
+                "error": "No matching Derive subaccount found",
+                "subaccount_ids": ids,
+                "wallet": target_wallet,
+                **({"account": account_request} if account_request else {}),
+            }
+
+        ok, created = await self.create_subaccount(
+            wallet=target_wallet,
+            amount=amount,
+            asset_name=asset_name,
+            margin_type=margin_type,
+            currency=currency,
+            asset_address=asset_address,
+            manager_address=manager_address,
+            asset_decimals=asset_decimals,
+            signer=signer,
+            nonce=nonce,
+            signature_expiry_sec=signature_expiry_sec,
+        )
+        if not ok:
+            return False, created
+        return True, {
+            "status": "create_requested",
+            "created": True,
+            "subaccount_id": None,
+            "subaccount_ids": ids,
+            "wallet": target_wallet,
+            "request": created,
+            **({"account": account_request} if account_request else {}),
+        }
 
     async def get_positions(
         self, *, subaccount_id: int
@@ -302,6 +526,42 @@ class DeriveAdapter(BaseAdapter):
             private=True,
         )
 
+    async def get_deposit_history(
+        self,
+        *,
+        subaccount_id: int,
+        start_timestamp: int | None = None,
+        end_timestamp: int | None = None,
+    ) -> tuple[bool, dict[str, Any] | str]:
+        payload = self._history_payload(
+            subaccount_id=subaccount_id,
+            start_timestamp=start_timestamp,
+            end_timestamp=end_timestamp,
+        )
+        return await self._post(
+            "/private/get_deposit_history",
+            payload,
+            private=True,
+        )
+
+    async def get_withdrawal_history(
+        self,
+        *,
+        subaccount_id: int,
+        start_timestamp: int | None = None,
+        end_timestamp: int | None = None,
+    ) -> tuple[bool, dict[str, Any] | str]:
+        payload = self._history_payload(
+            subaccount_id=subaccount_id,
+            start_timestamp=start_timestamp,
+            end_timestamp=end_timestamp,
+        )
+        return await self._post(
+            "/private/get_withdrawal_history",
+            payload,
+            private=True,
+        )
+
     async def get_margin(
         self,
         *,
@@ -315,6 +575,339 @@ class DeriveAdapter(BaseAdapter):
         if simulated_collateral_changes is not None:
             payload["simulated_collateral_changes"] = simulated_collateral_changes
         return await self._post("/private/get_margin", payload, private=True)
+
+    async def create_subaccount(
+        self,
+        *,
+        amount: str | int | Decimal = "0",
+        asset_name: str = "USDC",
+        margin_type: MarginType = "SM",
+        wallet: str | None = None,
+        currency: str | None = None,
+        asset_address: str | None = None,
+        manager_address: str | None = None,
+        asset_decimals: int | None = None,
+        signer: str | None = None,
+        nonce: int | None = None,
+        signature_expiry_sec: int | None = None,
+        signature: str | None = None,
+    ) -> tuple[bool, dict[str, Any] | str]:
+        target_wallet = wallet or self.derive_wallet_address
+        if not target_wallet:
+            return False, "wallet or derive_wallet_address is required"
+
+        ok, signed = await self._deposit_action_details(
+            amount=amount,
+            asset_name=asset_name,
+            subaccount_id=0,
+            asset_address=asset_address,
+            manager_address=manager_address,
+            asset_decimals=asset_decimals,
+            margin_type=margin_type,
+            currency=currency,
+            owner=target_wallet,
+            signer=signer,
+            nonce=nonce,
+            signature_expiry_sec=signature_expiry_sec,
+            signature=signature,
+        )
+        if not ok:
+            return False, signed
+
+        payload: dict[str, Any] = {
+            "amount": self._amount_to_string(amount),
+            "asset_name": asset_name.upper(),
+            "margin_type": margin_type,
+            "wallet": target_wallet,
+            **signed,
+        }
+        if currency is not None:
+            payload["currency"] = currency.upper()
+        return await self._post(
+            "/private/create_subaccount",
+            payload,
+            private=True,
+            auth_wallet=target_wallet,
+        )
+
+    async def deposit_collateral(
+        self,
+        *,
+        subaccount_id: int,
+        amount: str | int | Decimal,
+        asset_name: str = "USDC",
+        asset_address: str | None = None,
+        manager_address: str | None = None,
+        asset_decimals: int | None = None,
+        margin_type: MarginType = "SM",
+        currency: str | None = None,
+        owner: str | None = None,
+        signer: str | None = None,
+        nonce: int | None = None,
+        signature_expiry_sec: int | None = None,
+        signature: str | None = None,
+        is_atomic_signing: bool = False,
+    ) -> tuple[bool, dict[str, Any] | str]:
+        target_owner = owner or self.derive_wallet_address
+        ok, signed = await self._deposit_action_details(
+            amount=amount,
+            asset_name=asset_name,
+            subaccount_id=subaccount_id,
+            asset_address=asset_address,
+            manager_address=manager_address,
+            asset_decimals=asset_decimals,
+            margin_type=margin_type,
+            currency=currency,
+            owner=target_owner,
+            signer=signer,
+            nonce=nonce,
+            signature_expiry_sec=signature_expiry_sec,
+            signature=signature,
+        )
+        if not ok:
+            return False, signed
+
+        payload: dict[str, Any] = {
+            "amount": self._amount_to_string(amount),
+            "asset_name": asset_name.upper(),
+            "subaccount_id": subaccount_id,
+            **signed,
+        }
+        if is_atomic_signing:
+            payload["is_atomic_signing"] = True
+        return await self._post(
+            "/private/deposit",
+            payload,
+            private=True,
+            auth_wallet=target_owner,
+        )
+
+    async def withdraw_collateral(
+        self,
+        *,
+        subaccount_id: int,
+        amount: str | int | Decimal,
+        asset_name: str = "USDC",
+        asset_address: str | None = None,
+        asset_decimals: int | None = None,
+        owner: str | None = None,
+        signer: str | None = None,
+        nonce: int | None = None,
+        signature_expiry_sec: int | None = None,
+        signature: str | None = None,
+        is_atomic_signing: bool = False,
+    ) -> tuple[bool, dict[str, Any] | str]:
+        target_owner = owner or self.derive_wallet_address
+        resolved_asset = self._asset_address(asset_name, asset_address)
+        if not resolved_asset:
+            return False, "asset_address is required for this Derive asset"
+        decimals = self._asset_decimals(asset_name, asset_decimals)
+
+        try:
+            module_data = self._withdraw_module_data(
+                amount=amount,
+                asset_address=resolved_asset,
+                asset_decimals=decimals,
+            )
+        except ValueError as exc:
+            return False, str(exc)
+
+        ok, signed = await self._action_details(
+            subaccount_id=subaccount_id,
+            module_address=self.protocol_constants["withdrawal_module_address"],
+            module_data=module_data,
+            owner=target_owner,
+            signer=signer,
+            nonce=nonce,
+            signature_expiry_sec=signature_expiry_sec,
+            signature=signature,
+        )
+        if not ok:
+            return False, signed
+
+        payload: dict[str, Any] = {
+            "amount": self._amount_to_string(amount),
+            "asset_name": asset_name.upper(),
+            "subaccount_id": subaccount_id,
+            **signed,
+        }
+        if is_atomic_signing:
+            payload["is_atomic_signing"] = True
+        return await self._post(
+            "/private/withdraw",
+            payload,
+            private=True,
+            auth_wallet=target_owner,
+        )
+
+    async def transfer_erc20(
+        self,
+        *,
+        subaccount_id: int,
+        recipient_subaccount_id: int,
+        amount: str | int | Decimal,
+        asset_name: str = "USDC",
+        asset_address: str | None = None,
+        asset_sub_id: int = 0,
+        owner: str | None = None,
+        signer: str | None = None,
+        recipient_signer: str | None = None,
+        nonce: int | None = None,
+        recipient_nonce: int | None = None,
+        signature_expiry_sec: int | None = None,
+        recipient_signature_expiry_sec: int | None = None,
+        sender_details: dict[str, Any] | None = None,
+        recipient_details: dict[str, Any] | None = None,
+        manager_if_new_account: str | None = None,
+    ) -> tuple[bool, dict[str, Any] | str]:
+        target_owner = owner or self.derive_wallet_address
+        resolved_asset = self._asset_address(asset_name, asset_address)
+        if not resolved_asset:
+            return False, "asset_address is required for this Derive asset"
+
+        if sender_details is None:
+            try:
+                sender_module_data = self._sender_transfer_erc20_module_data(
+                    recipient_subaccount_id=recipient_subaccount_id,
+                    asset_address=resolved_asset,
+                    asset_sub_id=asset_sub_id,
+                    amount=amount,
+                    manager_if_new_account=(
+                        manager_if_new_account or DERIVE_DEFAULT_TRANSFER_MANAGER
+                    ),
+                )
+            except ValueError as exc:
+                return False, str(exc)
+            ok, sender_details = await self._action_details(
+                subaccount_id=subaccount_id,
+                module_address=self.protocol_constants["transfer_module_address"],
+                module_data=sender_module_data,
+                owner=target_owner,
+                signer=signer,
+                nonce=nonce,
+                signature_expiry_sec=signature_expiry_sec,
+            )
+            if not ok:
+                return False, sender_details
+        else:
+            ok, error = self._validate_action_details(sender_details)
+            if not ok:
+                return False, error
+
+        if recipient_details is None:
+            ok, recipient_details = await self._action_details(
+                subaccount_id=recipient_subaccount_id,
+                module_address=self.protocol_constants["transfer_module_address"],
+                module_data=b"",
+                owner=target_owner,
+                signer=recipient_signer or signer,
+                nonce=recipient_nonce,
+                signature_expiry_sec=(
+                    recipient_signature_expiry_sec or signature_expiry_sec
+                ),
+            )
+            if not ok:
+                return False, recipient_details
+        else:
+            ok, error = self._validate_action_details(recipient_details)
+            if not ok:
+                return False, error
+
+        payload = {
+            "subaccount_id": subaccount_id,
+            "recipient_subaccount_id": recipient_subaccount_id,
+            "sender_details": sender_details,
+            "recipient_details": recipient_details,
+            "transfer": {
+                "address": Web3.to_checksum_address(resolved_asset),
+                "amount": self._amount_to_string(amount),
+                "sub_id": asset_sub_id,
+            },
+        }
+        return await self._post(
+            "/private/transfer_erc20",
+            payload,
+            private=True,
+            auth_wallet=target_owner,
+        )
+
+    async def sign_order(
+        self,
+        order: dict[str, Any],
+        *,
+        asset_address: str,
+        asset_sub_id: int,
+        owner: str | None = None,
+        signer: str | None = None,
+        recipient_id: int | None = None,
+        nonce: int | None = None,
+        signature_expiry_sec: int | None = None,
+    ) -> tuple[bool, dict[str, Any] | str]:
+        ok, error = self._validate_unsigned_order(order)
+        if not ok:
+            return False, error
+
+        direction = str(order["direction"]).lower()
+        if direction not in {"buy", "sell"}:
+            return False, "direction must be 'buy' or 'sell'"
+
+        subaccount_id = int(order["subaccount_id"])
+        try:
+            module_data = self._trade_module_data(
+                asset_address=asset_address,
+                asset_sub_id=asset_sub_id,
+                limit_price=order["limit_price"],
+                amount=order["amount"],
+                max_fee=order["max_fee"],
+                recipient_id=recipient_id or subaccount_id,
+                is_bid=direction == "buy",
+            )
+        except ValueError as exc:
+            return False, str(exc)
+
+        ok, signed = await self._action_details(
+            subaccount_id=subaccount_id,
+            module_address=self.protocol_constants["trade_module_address"],
+            module_data=module_data,
+            owner=owner or self.derive_wallet_address,
+            signer=signer,
+            nonce=nonce,
+            signature_expiry_sec=signature_expiry_sec,
+        )
+        if not ok:
+            return False, signed
+
+        signed_order = dict(order)
+        signed_order["direction"] = direction
+        signed_order.update(signed)
+        return True, signed_order
+
+    async def place_order(
+        self,
+        order: dict[str, Any],
+        *,
+        asset_address: str,
+        asset_sub_id: int,
+        dry_run: bool = True,
+        owner: str | None = None,
+        signer: str | None = None,
+        recipient_id: int | None = None,
+        nonce: int | None = None,
+        signature_expiry_sec: int | None = None,
+    ) -> tuple[bool, dict[str, Any] | str]:
+        ok, signed_order = await self.sign_order(
+            order,
+            asset_address=asset_address,
+            asset_sub_id=asset_sub_id,
+            owner=owner,
+            signer=signer,
+            recipient_id=recipient_id,
+            nonce=nonce,
+            signature_expiry_sec=signature_expiry_sec,
+        )
+        if not ok:
+            return False, signed_order
+        return await self.submit_order(signed_order, dry_run=dry_run)
 
     async def debug_order(
         self, order: dict[str, Any]
@@ -362,6 +955,13 @@ class DeriveAdapter(BaseAdapter):
         return True, ""
 
     @staticmethod
+    def _validate_unsigned_order(order: dict[str, Any]) -> tuple[bool, str]:
+        missing = sorted(DERIVE_ORDER_UNSIGNED_FIELDS.difference(order))
+        if missing:
+            return False, f"missing unsigned Derive order fields: {', '.join(missing)}"
+        return True, ""
+
+    @staticmethod
     def expiry_date(expiry_timestamp: int) -> str:
         return datetime.fromtimestamp(expiry_timestamp, UTC).strftime("%Y%m%d")
 
@@ -369,6 +969,10 @@ class DeriveAdapter(BaseAdapter):
     def new_order_nonce(now_ms: int | None = None) -> int:
         timestamp_ms = now_ms if now_ms is not None else int(time.time() * 1000)
         return timestamp_ms * 1000 + secrets.randbelow(1000)
+
+    @staticmethod
+    def new_action_nonce(now_ms: int | None = None) -> int:
+        return DeriveAdapter.new_order_nonce(now_ms=now_ms)
 
     @staticmethod
     def orderbook_channel(
@@ -382,3 +986,365 @@ class DeriveAdapter(BaseAdapter):
         if depth not in DERIVE_ORDERBOOK_DEPTHS:
             raise ValueError("depth must be one of: 1, 10, 20, 100")
         return f"orderbook.{instrument_name}.{group}.{depth}"
+
+    def _protocol_constants(self, derive_config: dict[str, Any]) -> dict[str, Any]:
+        constants = dict(DERIVE_PROTOCOL_CONSTANTS[self.network])
+        for key in (
+            "domain_separator",
+            "action_typehash",
+            "deposit_module_address",
+            "trade_module_address",
+            "withdrawal_module_address",
+            "transfer_module_address",
+            "cash_asset_address",
+            "standard_risk_manager_address",
+            "chain_id",
+        ):
+            if derive_config.get(key) is not None:
+                constants[key] = derive_config[key]
+
+        for key in (
+            "portfolio_risk_manager_addresses",
+            "portfolio_risk_manager_v2_addresses",
+        ):
+            merged = dict(constants.get(key) or {})
+            override = derive_config.get(key)
+            if isinstance(override, dict):
+                merged.update({str(k).upper(): v for k, v in override.items()})
+            constants[key] = merged
+        return constants
+
+    def _asset_address(self, asset_name: str, asset_address: str | None) -> str | None:
+        if asset_address:
+            return asset_address
+        if asset_name.upper() == "USDC":
+            return str(self.protocol_constants["cash_asset_address"])
+        asset_addresses = self.config.get("derive", {}).get("asset_addresses")
+        if isinstance(asset_addresses, dict):
+            configured = asset_addresses.get(asset_name.upper())
+            if isinstance(configured, str):
+                return configured
+        return None
+
+    @staticmethod
+    def _asset_decimals(asset_name: str, asset_decimals: int | None) -> int:
+        if asset_decimals is not None:
+            return asset_decimals
+        return DERIVE_DEFAULT_ASSET_DECIMALS.get(asset_name.upper(), 18)
+
+    def _manager_address(
+        self,
+        *,
+        margin_type: MarginType,
+        currency: str | None,
+        manager_address: str | None,
+    ) -> str | None:
+        if manager_address:
+            return manager_address
+        if margin_type == "SM":
+            return str(self.protocol_constants["standard_risk_manager_address"])
+        if not currency:
+            return None
+        manager_map_key = (
+            "portfolio_risk_manager_v2_addresses"
+            if margin_type == "PM2"
+            else "portfolio_risk_manager_addresses"
+        )
+        manager_map = self.protocol_constants.get(manager_map_key) or {}
+        return manager_map.get(currency.upper())
+
+    async def _deposit_action_details(
+        self,
+        *,
+        amount: str | int | Decimal,
+        asset_name: str,
+        subaccount_id: int,
+        asset_address: str | None,
+        manager_address: str | None,
+        asset_decimals: int | None,
+        margin_type: MarginType,
+        currency: str | None,
+        owner: str | None,
+        signer: str | None,
+        nonce: int | None,
+        signature_expiry_sec: int | None,
+        signature: str | None,
+    ) -> tuple[bool, dict[str, Any] | str]:
+        resolved_asset = self._asset_address(asset_name, asset_address)
+        if not resolved_asset:
+            return False, "asset_address is required for this Derive asset"
+        resolved_manager = self._manager_address(
+            margin_type=margin_type,
+            currency=currency,
+            manager_address=manager_address,
+        )
+        if not resolved_manager:
+            return False, "manager_address is required for this margin_type/currency"
+
+        try:
+            module_data = self._deposit_module_data(
+                amount=amount,
+                asset_address=resolved_asset,
+                manager_address=resolved_manager,
+                asset_decimals=self._asset_decimals(asset_name, asset_decimals),
+            )
+        except ValueError as exc:
+            return False, str(exc)
+
+        return await self._action_details(
+            subaccount_id=subaccount_id,
+            module_address=self.protocol_constants["deposit_module_address"],
+            module_data=module_data,
+            owner=owner,
+            signer=signer,
+            nonce=nonce,
+            signature_expiry_sec=signature_expiry_sec,
+            signature=signature,
+        )
+
+    async def _action_details(
+        self,
+        *,
+        subaccount_id: int,
+        module_address: str,
+        module_data: bytes,
+        owner: str | None,
+        signer: str | None,
+        nonce: int | None,
+        signature_expiry_sec: int | None,
+        signature: str | None = None,
+    ) -> tuple[bool, dict[str, Any] | str]:
+        target_owner = owner or self.derive_wallet_address
+        target_signer = signer or self.wallet_address or target_owner
+        if not target_owner:
+            return False, "owner or derive_wallet_address is required"
+        if not target_signer:
+            return False, "signer or wallet_address is required"
+
+        action_nonce = nonce if nonce is not None else self.new_action_nonce()
+        expiry = (
+            signature_expiry_sec
+            if signature_expiry_sec is not None
+            else int(time.time()) + DERIVE_ACTION_SIGNATURE_EXPIRY_BUFFER_SEC
+        )
+        if expiry <= int(time.time()) + 300:
+            return False, "signature_expiry_sec must be more than 5 minutes from now"
+
+        details = {
+            "nonce": action_nonce,
+            "signature_expiry_sec": expiry,
+            "signer": Web3.to_checksum_address(target_signer),
+        }
+        if signature is not None:
+            details["signature"] = self._ensure_0x(signature)
+            return True, details
+
+        if self.sign_hash_callback is None:
+            return False, "sign_hash_callback is required for Derive action signing"
+
+        try:
+            action_hash = self.signed_action_hash(
+                subaccount_id=subaccount_id,
+                nonce=action_nonce,
+                module_address=module_address,
+                module_data=module_data,
+                signature_expiry_sec=expiry,
+                owner=target_owner,
+                signer=target_signer,
+                domain_separator=self.protocol_constants["domain_separator"],
+                action_typehash=self.protocol_constants["action_typehash"],
+            )
+        except ValueError as exc:
+            return False, str(exc)
+
+        signature_value = await self.sign_hash_callback(action_hash)
+        details["signature"] = self._ensure_0x(signature_value)
+        return True, details
+
+    @staticmethod
+    def _validate_action_details(details: dict[str, Any]) -> tuple[bool, str]:
+        missing = sorted(DERIVE_ACTION_DETAIL_FIELDS.difference(details))
+        if missing:
+            return False, f"missing Derive action detail fields: {', '.join(missing)}"
+        return True, ""
+
+    @staticmethod
+    def _history_payload(
+        *,
+        subaccount_id: int,
+        start_timestamp: int | None,
+        end_timestamp: int | None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {"subaccount_id": subaccount_id}
+        if start_timestamp is not None:
+            payload["start_timestamp"] = start_timestamp
+        if end_timestamp is not None:
+            payload["end_timestamp"] = end_timestamp
+        return payload
+
+    @staticmethod
+    def _amount_to_string(amount: str | int | Decimal) -> str:
+        return str(amount)
+
+    @staticmethod
+    def _scale_amount(amount: str | int | Decimal, decimals: int) -> int:
+        try:
+            decimal_amount = Decimal(str(amount))
+        except (InvalidOperation, ValueError) as exc:
+            raise ValueError(f"invalid decimal amount: {amount}") from exc
+        scaled = decimal_amount.scaleb(decimals)
+        if scaled != scaled.to_integral_value():
+            raise ValueError(
+                f"amount {amount} has more precision than {decimals} decimals"
+            )
+        if scaled < 0:
+            raise ValueError("amount must be non-negative")
+        return int(scaled)
+
+    @classmethod
+    def _deposit_module_data(
+        cls,
+        *,
+        amount: str | int | Decimal,
+        asset_address: str,
+        manager_address: str,
+        asset_decimals: int,
+    ) -> bytes:
+        return abi_encode(
+            ["uint256", "address", "address"],
+            [
+                cls._scale_amount(amount, asset_decimals),
+                Web3.to_checksum_address(asset_address),
+                Web3.to_checksum_address(manager_address),
+            ],
+        )
+
+    @classmethod
+    def _withdraw_module_data(
+        cls,
+        *,
+        amount: str | int | Decimal,
+        asset_address: str,
+        asset_decimals: int,
+    ) -> bytes:
+        return abi_encode(
+            ["address", "uint"],
+            [
+                Web3.to_checksum_address(asset_address),
+                cls._scale_amount(amount, asset_decimals),
+            ],
+        )
+
+    @classmethod
+    def _trade_module_data(
+        cls,
+        *,
+        asset_address: str,
+        asset_sub_id: int,
+        limit_price: str | int | Decimal,
+        amount: str | int | Decimal,
+        max_fee: str | int | Decimal,
+        recipient_id: int,
+        is_bid: bool,
+    ) -> bytes:
+        return abi_encode(
+            ["address", "uint", "int", "int", "uint", "uint", "bool"],
+            [
+                Web3.to_checksum_address(asset_address),
+                asset_sub_id,
+                cls._scale_amount(limit_price, 18),
+                cls._scale_amount(amount, 18),
+                cls._scale_amount(max_fee, 18),
+                recipient_id,
+                is_bid,
+            ],
+        )
+
+    @classmethod
+    def _sender_transfer_erc20_module_data(
+        cls,
+        *,
+        recipient_subaccount_id: int,
+        asset_address: str,
+        asset_sub_id: int,
+        amount: str | int | Decimal,
+        manager_if_new_account: str,
+    ) -> bytes:
+        return abi_encode(
+            ["(uint,address,(address,uint,int)[])"],
+            [
+                (
+                    recipient_subaccount_id,
+                    Web3.to_checksum_address(manager_if_new_account),
+                    [
+                        (
+                            Web3.to_checksum_address(asset_address),
+                            asset_sub_id,
+                            cls._scale_amount(amount, 18),
+                        )
+                    ],
+                )
+            ],
+        )
+
+    @staticmethod
+    def signed_action_hash(
+        *,
+        subaccount_id: int,
+        nonce: int,
+        module_address: str,
+        module_data: bytes,
+        signature_expiry_sec: int,
+        owner: str,
+        signer: str,
+        domain_separator: str,
+        action_typehash: str,
+    ) -> str:
+        domain_separator_bytes = DeriveAdapter._bytes32(
+            domain_separator, "domain_separator"
+        )
+        action_typehash_bytes = DeriveAdapter._bytes32(
+            action_typehash, "action_typehash"
+        )
+        action_hash = Web3.keccak(
+            abi_encode(
+                [
+                    "bytes32",
+                    "uint",
+                    "uint",
+                    "address",
+                    "bytes32",
+                    "uint",
+                    "address",
+                    "address",
+                ],
+                [
+                    action_typehash_bytes,
+                    subaccount_id,
+                    nonce,
+                    Web3.to_checksum_address(module_address),
+                    Web3.keccak(module_data),
+                    signature_expiry_sec,
+                    Web3.to_checksum_address(owner),
+                    Web3.to_checksum_address(signer),
+                ],
+            )
+        )
+        typed_data_hash = Web3.keccak(
+            b"\x19\x01" + domain_separator_bytes + bytes(action_hash)
+        )
+        return "0x" + bytes(typed_data_hash).hex()
+
+    @staticmethod
+    def _bytes32(value: str, field_name: str) -> bytes:
+        try:
+            raw = bytes.fromhex(value.removeprefix("0x"))
+        except ValueError as exc:
+            raise ValueError(f"{field_name} must be 32 bytes hex") from exc
+        if len(raw) != 32:
+            raise ValueError(f"{field_name} must be 32 bytes hex")
+        return raw
+
+    @staticmethod
+    def _ensure_0x(value: str) -> str:
+        return value if value.startswith("0x") else f"0x{value}"

--- a/wayfinder_paths/adapters/derive_adapter/adapter.py
+++ b/wayfinder_paths/adapters/derive_adapter/adapter.py
@@ -1,0 +1,384 @@
+from __future__ import annotations
+
+import secrets
+import time
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+import httpx
+from eth_account.messages import defunct_hash_message
+
+from wayfinder_paths.core.adapters.BaseAdapter import BaseAdapter
+
+DERIVE_MAINNET_API_BASE_URL = "https://api.lyra.finance"
+DERIVE_TESTNET_API_BASE_URL = "https://api-demo.lyra.finance"
+DERIVE_MAINNET_WS_URL = "wss://api.lyra.finance/ws"
+DERIVE_TESTNET_WS_URL = "wss://api-demo.lyra.finance/ws"
+
+InstrumentType = Literal["option", "perp", "erc20"]
+
+DERIVE_ORDER_REQUIRED_FIELDS = frozenset(
+    {
+        "amount",
+        "direction",
+        "instrument_name",
+        "limit_price",
+        "max_fee",
+        "nonce",
+        "signature",
+        "signature_expiry_sec",
+        "signer",
+        "subaccount_id",
+    }
+)
+
+DERIVE_ORDERBOOK_GROUPS = frozenset({"1", "10", "100"})
+DERIVE_ORDERBOOK_DEPTHS = frozenset({"1", "10", "20", "100"})
+
+
+class DeriveAdapter(BaseAdapter):
+    adapter_type = "DERIVE"
+
+    def __init__(
+        self,
+        config: dict[str, Any] | None = None,
+        *,
+        sign_callback: Callable[[dict[str, Any]], Awaitable[bytes]] | None = None,
+        sign_hash_callback: Callable[[str], Awaitable[str]] | None = None,
+        sign_message_callback: Callable[[str], Awaitable[str]] | None = None,
+        wallet_address: str | None = None,
+        derive_wallet_address: str | None = None,
+        api_base_url: str | None = None,
+        ws_url: str | None = None,
+        http_client: httpx.AsyncClient | None = None,
+        http_timeout_s: float = 30.0,
+    ) -> None:
+        super().__init__("derive_adapter", config)
+
+        derive_config = self.config.get("derive") or {}
+        if not isinstance(derive_config, dict):
+            derive_config = {}
+
+        network = str(derive_config.get("network", "mainnet")).lower()
+        use_testnet = network in {"testnet", "demo", "api-demo"}
+
+        self.api_base_url = (
+            api_base_url
+            or derive_config.get("api_base_url")
+            or (
+                DERIVE_TESTNET_API_BASE_URL
+                if use_testnet
+                else DERIVE_MAINNET_API_BASE_URL
+            )
+        )
+        self.ws_url = (
+            ws_url
+            or derive_config.get("ws_url")
+            or (DERIVE_TESTNET_WS_URL if use_testnet else DERIVE_MAINNET_WS_URL)
+        )
+        self.wallet_address = wallet_address or derive_config.get("wallet_address")
+        self.derive_wallet_address = (
+            derive_wallet_address
+            or derive_config.get("derive_wallet_address")
+            or self.wallet_address
+        )
+        self.sign_callback = sign_callback
+        self.sign_hash_callback = sign_hash_callback
+        self.sign_message_callback = sign_message_callback
+        self._http = http_client or httpx.AsyncClient(
+            base_url=self.api_base_url,
+            timeout=httpx.Timeout(http_timeout_s),
+        )
+
+    async def close(self) -> None:
+        await self._http.aclose()
+
+    async def _post(
+        self,
+        path: str,
+        payload: dict[str, Any],
+        *,
+        private: bool = False,
+    ) -> tuple[bool, Any]:
+        headers: dict[str, str] | None = None
+        if private:
+            ok, auth_headers = await self._auth_headers()
+            if not ok:
+                return False, auth_headers
+            headers = auth_headers
+
+        try:
+            response = await self._http.post(path, json=payload, headers=headers)
+            response.raise_for_status()
+            data = response.json()
+        except Exception as exc:  # noqa: BLE001
+            return False, str(exc)
+
+        if not isinstance(data, dict):
+            return False, f"Unexpected Derive response: {type(data).__name__}"
+        if data.get("error") is not None:
+            return False, data["error"]
+        if "result" not in data:
+            return False, f"Derive response missing result: {data}"
+        return True, data["result"]
+
+    async def _auth_headers(self) -> tuple[bool, dict[str, str] | str]:
+        if not self.derive_wallet_address:
+            return (
+                False,
+                "derive_wallet_address is required for Derive private endpoints",
+            )
+
+        timestamp = str(int(time.time() * 1000))
+        if self.sign_message_callback is not None:
+            signature = await self.sign_message_callback(timestamp)
+        elif self.sign_hash_callback is not None:
+            digest = defunct_hash_message(text=timestamp)
+            signature = await self.sign_hash_callback(f"0x{bytes(digest).hex()}")
+        else:
+            return (
+                False,
+                "sign_message_callback or sign_hash_callback is required for Derive private endpoints",
+            )
+
+        return (
+            True,
+            {
+                "X-LyraWallet": str(self.derive_wallet_address),
+                "X-LyraTimestamp": timestamp,
+                "X-LyraSignature": str(signature),
+            },
+        )
+
+    async def get_time(self) -> tuple[bool, int | str]:
+        ok, result = await self._post("/public/get_time", {})
+        if not ok:
+            return False, result
+        if not isinstance(result, int):
+            return False, f"Unexpected get_time result: {result}"
+        return True, result
+
+    async def get_instruments(
+        self,
+        *,
+        currency: str,
+        instrument_type: InstrumentType = "option",
+        expired: bool = False,
+    ) -> tuple[bool, list[dict[str, Any]] | str]:
+        ok, result = await self._post(
+            "/public/get_instruments",
+            {
+                "currency": currency.upper(),
+                "instrument_type": instrument_type,
+                "expired": expired,
+            },
+        )
+        if not ok:
+            return False, result
+        if not isinstance(result, list):
+            return False, f"Unexpected get_instruments result: {type(result).__name__}"
+        return True, result
+
+    async def list_options(
+        self, *, currency: str, expired: bool = False
+    ) -> tuple[bool, list[dict[str, Any]] | str]:
+        return await self.get_instruments(
+            currency=currency,
+            instrument_type="option",
+            expired=expired,
+        )
+
+    async def list_option_expiries(
+        self, *, currency: str, expired: bool = False
+    ) -> tuple[bool, list[dict[str, Any]] | str]:
+        ok, instruments = await self.list_options(currency=currency, expired=expired)
+        if not ok:
+            return False, instruments
+
+        expiries: dict[int, int] = {}
+        for instrument in instruments:
+            details = instrument.get("option_details") or {}
+            expiry = details.get("expiry")
+            if isinstance(expiry, int):
+                expiries[expiry] = expiries.get(expiry, 0) + 1
+
+        return True, [
+            {
+                "expiry": expiry,
+                "expiry_date": self.expiry_date(expiry),
+                "instrument_count": count,
+            }
+            for expiry, count in sorted(expiries.items())
+        ]
+
+    async def get_tickers(
+        self,
+        *,
+        instrument_type: InstrumentType,
+        currency: str | None = None,
+        expiry_date: str | int | None = None,
+    ) -> tuple[bool, dict[str, Any] | str]:
+        if instrument_type == "option" and (currency is None or expiry_date is None):
+            return False, "currency and expiry_date are required for option tickers"
+
+        payload: dict[str, Any] = {"instrument_type": instrument_type}
+        if currency is not None:
+            payload["currency"] = currency.upper()
+        if expiry_date is not None:
+            payload["expiry_date"] = str(expiry_date)
+
+        ok, result = await self._post("/public/get_tickers", payload)
+        if not ok:
+            return False, result
+        if not isinstance(result, dict):
+            return False, f"Unexpected get_tickers result: {type(result).__name__}"
+        tickers = result.get("tickers")
+        if not isinstance(tickers, dict):
+            return False, f"Unexpected get_tickers tickers: {type(tickers).__name__}"
+        return True, tickers
+
+    async def get_option_tickers(
+        self,
+        *,
+        currency: str,
+        expiry_date: str | int,
+    ) -> tuple[bool, dict[str, Any] | str]:
+        return await self.get_tickers(
+            instrument_type="option",
+            currency=currency,
+            expiry_date=expiry_date,
+        )
+
+    async def get_ticker(
+        self, *, instrument_name: str
+    ) -> tuple[bool, dict[str, Any] | str]:
+        ok, result = await self._post(
+            "/public/get_ticker",
+            {"instrument_name": instrument_name},
+        )
+        if not ok:
+            return False, result
+        if not isinstance(result, dict):
+            return False, f"Unexpected get_ticker result: {type(result).__name__}"
+        return True, result
+
+    async def get_subaccounts(
+        self, *, wallet: str | None = None
+    ) -> tuple[bool, dict[str, Any] | str]:
+        target_wallet = wallet or self.derive_wallet_address
+        if not target_wallet:
+            return False, "wallet or derive_wallet_address is required"
+        return await self._post(
+            "/private/get_subaccounts",
+            {"wallet": target_wallet},
+            private=True,
+        )
+
+    async def get_subaccount(
+        self, *, subaccount_id: int
+    ) -> tuple[bool, dict[str, Any] | str]:
+        return await self._post(
+            "/private/get_subaccount",
+            {"subaccount_id": subaccount_id},
+            private=True,
+        )
+
+    async def get_positions(
+        self, *, subaccount_id: int
+    ) -> tuple[bool, dict[str, Any] | str]:
+        return await self._post(
+            "/private/get_positions",
+            {"subaccount_id": subaccount_id},
+            private=True,
+        )
+
+    async def get_open_orders(
+        self, *, subaccount_id: int
+    ) -> tuple[bool, dict[str, Any] | str]:
+        return await self._post(
+            "/private/get_open_orders",
+            {"subaccount_id": subaccount_id},
+            private=True,
+        )
+
+    async def get_margin(
+        self,
+        *,
+        subaccount_id: int,
+        simulated_position_changes: list[dict[str, Any]] | None = None,
+        simulated_collateral_changes: list[dict[str, Any]] | None = None,
+    ) -> tuple[bool, dict[str, Any] | str]:
+        payload: dict[str, Any] = {"subaccount_id": subaccount_id}
+        if simulated_position_changes is not None:
+            payload["simulated_position_changes"] = simulated_position_changes
+        if simulated_collateral_changes is not None:
+            payload["simulated_collateral_changes"] = simulated_collateral_changes
+        return await self._post("/private/get_margin", payload, private=True)
+
+    async def debug_order(
+        self, order: dict[str, Any]
+    ) -> tuple[bool, dict[str, Any] | str]:
+        ok, error = self._validate_signed_order(order)
+        if not ok:
+            return False, error
+        return await self._post("/private/order_debug", dict(order), private=True)
+
+    async def submit_order(
+        self,
+        order: dict[str, Any],
+        *,
+        dry_run: bool = False,
+    ) -> tuple[bool, dict[str, Any] | str]:
+        ok, error = self._validate_signed_order(order)
+        if not ok:
+            return False, error
+
+        path = "/private/order_debug" if dry_run else "/private/order"
+        return await self._post(path, dict(order), private=True)
+
+    async def cancel_order(
+        self,
+        *,
+        instrument_name: str,
+        order_id: str,
+        subaccount_id: int,
+    ) -> tuple[bool, dict[str, Any] | str]:
+        return await self._post(
+            "/private/cancel",
+            {
+                "instrument_name": instrument_name,
+                "order_id": order_id,
+                "subaccount_id": subaccount_id,
+            },
+            private=True,
+        )
+
+    @staticmethod
+    def _validate_signed_order(order: dict[str, Any]) -> tuple[bool, str]:
+        missing = sorted(DERIVE_ORDER_REQUIRED_FIELDS.difference(order))
+        if missing:
+            return False, f"missing signed Derive order fields: {', '.join(missing)}"
+        return True, ""
+
+    @staticmethod
+    def expiry_date(expiry_timestamp: int) -> str:
+        return datetime.fromtimestamp(expiry_timestamp, UTC).strftime("%Y%m%d")
+
+    @staticmethod
+    def new_order_nonce(now_ms: int | None = None) -> int:
+        timestamp_ms = now_ms if now_ms is not None else int(time.time() * 1000)
+        return timestamp_ms * 1000 + secrets.randbelow(1000)
+
+    @staticmethod
+    def orderbook_channel(
+        instrument_name: str,
+        *,
+        group: str = "1",
+        depth: str = "10",
+    ) -> str:
+        if group not in DERIVE_ORDERBOOK_GROUPS:
+            raise ValueError("group must be one of: 1, 10, 100")
+        if depth not in DERIVE_ORDERBOOK_DEPTHS:
+            raise ValueError("depth must be one of: 1, 10, 20, 100")
+        return f"orderbook.{instrument_name}.{group}.{depth}"

--- a/wayfinder_paths/adapters/derive_adapter/examples.json
+++ b/wayfinder_paths/adapters/derive_adapter/examples.json
@@ -13,6 +13,79 @@
       "expiry_date": "20260522"
     }
   },
+  "ensure_existing_subaccount": {
+    "method": "ensure_subaccount",
+    "kwargs": {}
+  },
+  "create_empty_standard_margin_subaccount": {
+    "method": "ensure_subaccount",
+    "kwargs": {
+      "create_if_missing": true,
+      "amount": "0",
+      "asset_name": "USDC",
+      "margin_type": "SM"
+    }
+  },
+  "create_account_and_empty_subaccount": {
+    "method": "ensure_subaccount",
+    "kwargs": {
+      "create_account_if_missing": true,
+      "account_secret": "invite-secret",
+      "create_if_missing": true,
+      "amount": "0",
+      "asset_name": "USDC",
+      "margin_type": "SM"
+    }
+  },
+  "deposit_usdc": {
+    "method": "deposit_collateral",
+    "kwargs": {
+      "subaccount_id": 12345,
+      "amount": "100",
+      "asset_name": "USDC"
+    }
+  },
+  "get_deposit_history": {
+    "method": "get_deposit_history",
+    "kwargs": {
+      "subaccount_id": 12345
+    }
+  },
+  "withdraw_usdc": {
+    "method": "withdraw_collateral",
+    "kwargs": {
+      "subaccount_id": 12345,
+      "amount": "25",
+      "asset_name": "USDC"
+    }
+  },
+  "transfer_usdc_between_subaccounts": {
+    "method": "transfer_erc20",
+    "kwargs": {
+      "subaccount_id": 12345,
+      "recipient_subaccount_id": 67890,
+      "amount": "10",
+      "asset_name": "USDC"
+    }
+  },
+  "callback_signed_order_dry_run": {
+    "method": "place_order",
+    "kwargs": {
+      "dry_run": true,
+      "asset_address": "0xInstrumentBaseAssetAddress",
+      "asset_sub_id": 123456789,
+      "order": {
+        "subaccount_id": 12345,
+        "instrument_name": "ETH-20260522-2500-C",
+        "direction": "buy",
+        "amount": "0.1",
+        "limit_price": "20",
+        "max_fee": "2",
+        "order_type": "limit",
+        "time_in_force": "gtc"
+      }
+    }
+  },
   "signed_order_dry_run": {
     "method": "submit_order",
     "kwargs": {

--- a/wayfinder_paths/adapters/derive_adapter/examples.json
+++ b/wayfinder_paths/adapters/derive_adapter/examples.json
@@ -1,0 +1,34 @@
+{
+  "list_eth_options": {
+    "method": "list_options",
+    "kwargs": {
+      "currency": "ETH",
+      "expired": false
+    }
+  },
+  "get_eth_option_tickers": {
+    "method": "get_option_tickers",
+    "kwargs": {
+      "currency": "ETH",
+      "expiry_date": "20260522"
+    }
+  },
+  "signed_order_dry_run": {
+    "method": "submit_order",
+    "kwargs": {
+      "dry_run": true,
+      "order": {
+        "subaccount_id": 12345,
+        "instrument_name": "ETH-20260522-2500-C",
+        "direction": "buy",
+        "amount": "0.1",
+        "limit_price": "20",
+        "max_fee": "2",
+        "nonce": 1779327000000001,
+        "signature_expiry_sec": 1779327600,
+        "signer": "0x0000000000000000000000000000000000000000",
+        "signature": "0x..."
+      }
+    }
+  }
+}

--- a/wayfinder_paths/adapters/derive_adapter/manifest.yaml
+++ b/wayfinder_paths/adapters/derive_adapter/manifest.yaml
@@ -5,8 +5,13 @@ capabilities:
   - "market.meta"
   - "market.orderbook"
   - "market.quote"
+  - "account.read"
+  - "account.create"
   - "position.read"
   - "margin.read"
+  - "collateral.deposit"
+  - "collateral.withdraw"
+  - "collateral.transfer"
   - "order.execute"
   - "order.cancel"
 dependencies: []

--- a/wayfinder_paths/adapters/derive_adapter/manifest.yaml
+++ b/wayfinder_paths/adapters/derive_adapter/manifest.yaml
@@ -1,0 +1,12 @@
+schema_version: "0.1"
+entrypoint: "adapters.derive_adapter.adapter.DeriveAdapter"
+capabilities:
+  - "market.read"
+  - "market.meta"
+  - "market.orderbook"
+  - "market.quote"
+  - "position.read"
+  - "margin.read"
+  - "order.execute"
+  - "order.cancel"
+dependencies: []

--- a/wayfinder_paths/adapters/derive_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/derive_adapter/test_adapter.py
@@ -59,6 +59,23 @@ def _signed_order() -> dict[str, Any]:
     }
 
 
+def _unsigned_order() -> dict[str, Any]:
+    return {
+        "subaccount_id": 12345,
+        "instrument_name": "ETH-20260522-2500-C",
+        "direction": "BUY",
+        "amount": "0.1",
+        "limit_price": "20",
+        "max_fee": "2",
+        "order_type": "limit",
+        "time_in_force": "gtc",
+    }
+
+
+async def _fixed_signature(_hash_hex: str) -> str:
+    return "0x" + "33" * 65
+
+
 def test_adapter_type_and_config_defaults() -> None:
     adapter = DeriveAdapter(config={}, http_client=FakeAsyncClient([]))
 
@@ -268,6 +285,468 @@ async def test_private_read_requires_signing_callback() -> None:
 
 
 @pytest.mark.asyncio
+async def test_create_account_with_secret_posts_public_payload() -> None:
+    http = FakeAsyncClient(
+        [{"id": "1", "result": {"status": "created", "wallet": "0xabc"}}]
+    )
+    adapter = DeriveAdapter(config={}, http_client=http)
+
+    ok, result = await adapter.create_account_with_secret(
+        secret="invite-secret",
+        wallet="0x1111111111111111111111111111111111111111",
+        scw_owner="0x2222222222222222222222222222222222222222",
+    )
+
+    assert ok is True
+    assert result == {"status": "created", "wallet": "0xabc"}
+    assert http.requests == [
+        {
+            "path": "/public/create_account_with_secret",
+            "json": {
+                "secret": "invite-secret",
+                "wallet": "0x1111111111111111111111111111111111111111",
+                "scw_owner": "0x2222222222222222222222222222222222222222",
+            },
+            "headers": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_account_uses_target_wallet_for_auth(monkeypatch) -> None:
+    monkeypatch.setattr("time.time", lambda: 1779327000.123)
+    http = FakeAsyncClient(
+        [
+            {
+                "id": "1",
+                "result": {
+                    "wallet": "0x2222222222222222222222222222222222222222",
+                    "subaccount_ids": [12345],
+                },
+            }
+        ]
+    )
+    adapter = DeriveAdapter(
+        config={},
+        sign_hash_callback=_fixed_signature,
+        wallet_address="0x1111111111111111111111111111111111111111",
+        derive_wallet_address="0x1111111111111111111111111111111111111111",
+        http_client=http,
+    )
+
+    ok, result = await adapter.get_account(
+        wallet="0x2222222222222222222222222222222222222222"
+    )
+
+    assert ok is True
+    assert result["subaccount_ids"] == [12345]
+    assert http.requests[0]["path"] == "/private/get_account"
+    assert http.requests[0]["json"] == {
+        "wallet": "0x2222222222222222222222222222222222222222"
+    }
+    assert http.requests[0]["headers"]["X-LyraWallet"] == (
+        "0x2222222222222222222222222222222222222222"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ensure_subaccount_returns_existing_preferred(monkeypatch) -> None:
+    monkeypatch.setattr("time.time", lambda: 1779327000.123)
+    http = FakeAsyncClient(
+        [
+            {
+                "id": "1",
+                "result": {
+                    "wallet": "0x1111111111111111111111111111111111111111",
+                    "subaccount_ids": [111, 222],
+                },
+            }
+        ]
+    )
+    adapter = DeriveAdapter(
+        config={},
+        sign_hash_callback=_fixed_signature,
+        derive_wallet_address="0x1111111111111111111111111111111111111111",
+        http_client=http,
+    )
+
+    ok, result = await adapter.ensure_subaccount(preferred_subaccount_id=222)
+
+    assert ok is True
+    assert result == {
+        "status": "exists",
+        "created": False,
+        "subaccount_id": 222,
+        "subaccount_ids": [111, 222],
+        "wallet": "0x1111111111111111111111111111111111111111",
+    }
+    assert len(http.requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_ensure_subaccount_creates_empty_subaccount(monkeypatch) -> None:
+    captured_hashes: list[str] = []
+
+    async def sign_hash(hash_hex: str) -> str:
+        captured_hashes.append(hash_hex)
+        return "0x" + "44" * 65
+
+    monkeypatch.setattr("time.time", lambda: 1779327000.123)
+    monkeypatch.setattr(
+        "wayfinder_paths.adapters.derive_adapter.adapter.secrets.randbelow",
+        lambda _upper: 7,
+    )
+    http = FakeAsyncClient(
+        [
+            {
+                "id": "1",
+                "result": {
+                    "wallet": "0x1111111111111111111111111111111111111111",
+                    "subaccount_ids": [],
+                },
+            },
+            {
+                "id": "2",
+                "result": {
+                    "status": "requested",
+                    "transaction_id": "00000000-0000-0000-0000-000000000001",
+                },
+            },
+        ]
+    )
+    adapter = DeriveAdapter(
+        config={"derive": {"network": "testnet"}},
+        sign_hash_callback=sign_hash,
+        wallet_address="0x1111111111111111111111111111111111111111",
+        derive_wallet_address="0x1111111111111111111111111111111111111111",
+        http_client=http,
+    )
+
+    ok, result = await adapter.ensure_subaccount(
+        create_if_missing=True,
+        amount="0",
+        nonce=1779327000123007,
+        signature_expiry_sec=1779327600,
+    )
+
+    assert ok is True
+    assert result["status"] == "create_requested"
+    assert result["request"]["transaction_id"].endswith("1")
+    assert http.requests[1]["path"] == "/private/create_subaccount"
+    assert http.requests[1]["json"] == {
+        "amount": "0",
+        "asset_name": "USDC",
+        "margin_type": "SM",
+        "wallet": "0x1111111111111111111111111111111111111111",
+        "nonce": 1779327000123007,
+        "signature_expiry_sec": 1779327600,
+        "signer": "0x1111111111111111111111111111111111111111",
+        "signature": "0x" + "44" * 65,
+    }
+    assert len(captured_hashes) == 3
+    assert all(item.startswith("0x") for item in captured_hashes)
+
+
+@pytest.mark.asyncio
+async def test_ensure_subaccount_can_create_account_then_subaccount(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr("time.time", lambda: 1779327000.123)
+    http = FakeAsyncClient(
+        [
+            {"id": "1", "error": {"code": -32000, "message": "account missing"}},
+            {
+                "id": "2",
+                "result": {
+                    "status": "created",
+                    "wallet": "0x1111111111111111111111111111111111111111",
+                },
+            },
+            {
+                "id": "3",
+                "result": {
+                    "wallet": "0x1111111111111111111111111111111111111111",
+                    "subaccount_ids": [],
+                },
+            },
+            {
+                "id": "4",
+                "result": {
+                    "status": "requested",
+                    "transaction_id": "00000000-0000-0000-0000-000000000005",
+                },
+            },
+        ]
+    )
+    adapter = DeriveAdapter(
+        config={"derive": {"network": "testnet"}},
+        sign_hash_callback=_fixed_signature,
+        wallet_address="0x1111111111111111111111111111111111111111",
+        derive_wallet_address="0x1111111111111111111111111111111111111111",
+        http_client=http,
+    )
+
+    ok, result = await adapter.ensure_subaccount(
+        create_account_if_missing=True,
+        account_secret="invite-secret",
+        scw_owner="0x2222222222222222222222222222222222222222",
+        create_if_missing=True,
+        amount="0",
+        nonce=1779327000123007,
+        signature_expiry_sec=1779327600,
+    )
+
+    assert ok is True
+    assert result["status"] == "create_requested"
+    assert result["account"] == {
+        "status": "created",
+        "wallet": "0x1111111111111111111111111111111111111111",
+    }
+    assert [request["path"] for request in http.requests] == [
+        "/private/get_subaccounts",
+        "/public/create_account_with_secret",
+        "/private/get_subaccounts",
+        "/private/create_subaccount",
+    ]
+    assert http.requests[1]["json"] == {
+        "secret": "invite-secret",
+        "wallet": "0x1111111111111111111111111111111111111111",
+        "scw_owner": "0x2222222222222222222222222222222222222222",
+    }
+
+
+@pytest.mark.asyncio
+async def test_ensure_subaccount_requires_secret_for_account_creation(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr("time.time", lambda: 1779327000.123)
+    http = FakeAsyncClient(
+        [{"id": "1", "error": {"code": -32000, "message": "account missing"}}]
+    )
+    adapter = DeriveAdapter(
+        config={},
+        sign_hash_callback=_fixed_signature,
+        derive_wallet_address="0x1111111111111111111111111111111111111111",
+        http_client=http,
+    )
+
+    ok, error = await adapter.ensure_subaccount(create_account_if_missing=True)
+
+    assert ok is False
+    assert "account_secret is required" in error
+    assert len(http.requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_deposit_collateral_signs_action_payload(monkeypatch) -> None:
+    captured_hashes: list[str] = []
+
+    async def sign_hash(hash_hex: str) -> str:
+        captured_hashes.append(hash_hex)
+        return "0x" + "55" * 65
+
+    monkeypatch.setattr("time.time", lambda: 1779327000.123)
+    http = FakeAsyncClient(
+        [
+            {
+                "id": "1",
+                "result": {
+                    "status": "requested",
+                    "transaction_id": "00000000-0000-0000-0000-000000000002",
+                },
+            }
+        ]
+    )
+    adapter = DeriveAdapter(
+        config={"derive": {"network": "testnet"}},
+        sign_hash_callback=sign_hash,
+        wallet_address="0x1111111111111111111111111111111111111111",
+        derive_wallet_address="0x2222222222222222222222222222222222222222",
+        http_client=http,
+    )
+
+    ok, result = await adapter.deposit_collateral(
+        subaccount_id=12345,
+        amount="12.5",
+        nonce=1779327000123007,
+        signature_expiry_sec=1779327600,
+    )
+
+    assert ok is True
+    assert result["status"] == "requested"
+    assert http.requests[0]["path"] == "/private/deposit"
+    assert http.requests[0]["json"] == {
+        "amount": "12.5",
+        "asset_name": "USDC",
+        "subaccount_id": 12345,
+        "nonce": 1779327000123007,
+        "signature_expiry_sec": 1779327600,
+        "signer": "0x1111111111111111111111111111111111111111",
+        "signature": "0x" + "55" * 65,
+    }
+    assert http.requests[0]["headers"]["X-LyraWallet"] == (
+        "0x2222222222222222222222222222222222222222"
+    )
+    assert len(captured_hashes) == 2
+
+
+@pytest.mark.asyncio
+async def test_withdraw_collateral_signs_action_payload(monkeypatch) -> None:
+    monkeypatch.setattr("time.time", lambda: 1779327000.123)
+    http = FakeAsyncClient(
+        [
+            {
+                "id": "1",
+                "result": {
+                    "status": "requested",
+                    "transaction_id": "00000000-0000-0000-0000-000000000003",
+                },
+            }
+        ]
+    )
+    adapter = DeriveAdapter(
+        config={"derive": {"network": "testnet"}},
+        sign_hash_callback=_fixed_signature,
+        wallet_address="0x1111111111111111111111111111111111111111",
+        derive_wallet_address="0x1111111111111111111111111111111111111111",
+        http_client=http,
+    )
+
+    ok, result = await adapter.withdraw_collateral(
+        subaccount_id=12345,
+        amount="1.25",
+        nonce=1779327000123008,
+        signature_expiry_sec=1779327600,
+        is_atomic_signing=True,
+    )
+
+    assert ok is True
+    assert result["transaction_id"].endswith("3")
+    assert http.requests[0]["path"] == "/private/withdraw"
+    assert http.requests[0]["json"] == {
+        "amount": "1.25",
+        "asset_name": "USDC",
+        "subaccount_id": 12345,
+        "nonce": 1779327000123008,
+        "signature_expiry_sec": 1779327600,
+        "signer": "0x1111111111111111111111111111111111111111",
+        "signature": "0x" + "33" * 65,
+        "is_atomic_signing": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_action_requires_hash_callback() -> None:
+    adapter = DeriveAdapter(
+        config={},
+        derive_wallet_address="0x1111111111111111111111111111111111111111",
+        http_client=FakeAsyncClient([]),
+    )
+
+    ok, error = await adapter.deposit_collateral(subaccount_id=12345, amount="1")
+
+    assert ok is False
+    assert "sign_hash_callback is required" in error
+
+
+@pytest.mark.asyncio
+async def test_deposit_and_withdrawal_history_payloads(monkeypatch) -> None:
+    monkeypatch.setattr("time.time", lambda: 1779327000.123)
+    http = FakeAsyncClient(
+        [
+            {"id": "1", "result": {"events": [{"tx_status": "settled"}]}},
+            {"id": "2", "result": {"events": [{"tx_status": "pending"}]}},
+        ]
+    )
+    adapter = DeriveAdapter(
+        config={},
+        sign_hash_callback=_fixed_signature,
+        derive_wallet_address="0x1111111111111111111111111111111111111111",
+        http_client=http,
+    )
+
+    ok, deposits = await adapter.get_deposit_history(
+        subaccount_id=12345,
+        start_timestamp=100,
+        end_timestamp=200,
+    )
+    assert ok is True
+    assert deposits["events"][0]["tx_status"] == "settled"
+
+    ok, withdrawals = await adapter.get_withdrawal_history(subaccount_id=12345)
+    assert ok is True
+    assert withdrawals["events"][0]["tx_status"] == "pending"
+    assert http.requests[0]["path"] == "/private/get_deposit_history"
+    assert http.requests[0]["json"] == {
+        "subaccount_id": 12345,
+        "start_timestamp": 100,
+        "end_timestamp": 200,
+    }
+    assert http.requests[1]["path"] == "/private/get_withdrawal_history"
+    assert http.requests[1]["json"] == {"subaccount_id": 12345}
+
+
+@pytest.mark.asyncio
+async def test_transfer_erc20_signs_sender_and_recipient(monkeypatch) -> None:
+    captured_hashes: list[str] = []
+
+    async def sign_hash(hash_hex: str) -> str:
+        captured_hashes.append(hash_hex)
+        return "0x" + str(len(captured_hashes)) * 130
+
+    monkeypatch.setattr("time.time", lambda: 1779327000.123)
+    http = FakeAsyncClient(
+        [
+            {
+                "id": "1",
+                "result": {
+                    "status": "requested",
+                    "transaction_id": "00000000-0000-0000-0000-000000000004",
+                },
+            }
+        ]
+    )
+    adapter = DeriveAdapter(
+        config={"derive": {"network": "testnet"}},
+        sign_hash_callback=sign_hash,
+        wallet_address="0x1111111111111111111111111111111111111111",
+        derive_wallet_address="0x1111111111111111111111111111111111111111",
+        http_client=http,
+    )
+
+    ok, result = await adapter.transfer_erc20(
+        subaccount_id=111,
+        recipient_subaccount_id=222,
+        amount="3.5",
+        nonce=1779327000123001,
+        recipient_nonce=1779327000123002,
+        signature_expiry_sec=1779327600,
+    )
+
+    assert ok is True
+    assert result["status"] == "requested"
+    assert http.requests[0]["path"] == "/private/transfer_erc20"
+    assert http.requests[0]["json"]["sender_details"] == {
+        "nonce": 1779327000123001,
+        "signature_expiry_sec": 1779327600,
+        "signer": "0x1111111111111111111111111111111111111111",
+        "signature": "0x" + "1" * 130,
+    }
+    assert http.requests[0]["json"]["recipient_details"] == {
+        "nonce": 1779327000123002,
+        "signature_expiry_sec": 1779327600,
+        "signer": "0x1111111111111111111111111111111111111111",
+        "signature": "0x" + "2" * 130,
+    }
+    assert http.requests[0]["json"]["transfer"] == {
+        "address": "0x6caf294DaC985ff653d5aE75b4FF8E0A66025928",
+        "amount": "3.5",
+        "sub_id": 0,
+    }
+    assert len(captured_hashes) == 3
+
+
+@pytest.mark.asyncio
 async def test_rpc_error_returns_false() -> None:
     http = FakeAsyncClient(
         [
@@ -293,6 +772,77 @@ async def test_submit_order_rejects_missing_signed_fields() -> None:
 
     assert ok is False
     assert "missing signed Derive order fields" in error
+
+
+@pytest.mark.asyncio
+async def test_sign_order_uses_wallet_hash_callback(monkeypatch) -> None:
+    captured_hashes: list[str] = []
+
+    async def sign_hash(hash_hex: str) -> str:
+        captured_hashes.append(hash_hex)
+        return "0x" + "66" * 65
+
+    monkeypatch.setattr("time.time", lambda: 1779327000.123)
+    adapter = DeriveAdapter(
+        config={"derive": {"network": "testnet"}},
+        sign_hash_callback=sign_hash,
+        wallet_address="0x1111111111111111111111111111111111111111",
+        derive_wallet_address="0x2222222222222222222222222222222222222222",
+        http_client=FakeAsyncClient([]),
+    )
+
+    ok, order = await adapter.sign_order(
+        _unsigned_order(),
+        asset_address="0xBcB494059969DAaB460E0B5d4f5c2366aab79aa1",
+        asset_sub_id=987654,
+        nonce=1779327000123009,
+        signature_expiry_sec=1779327600,
+    )
+
+    assert ok is True
+    assert order["direction"] == "buy"
+    assert order["signature"] == "0x" + "66" * 65
+    assert order["signer"] == "0x1111111111111111111111111111111111111111"
+    assert order["nonce"] == 1779327000123009
+    assert len(captured_hashes) == 1
+
+
+@pytest.mark.asyncio
+async def test_place_order_dry_run_signs_and_posts_order_debug(monkeypatch) -> None:
+    captured_hashes: list[str] = []
+
+    async def sign_hash(hash_hex: str) -> str:
+        captured_hashes.append(hash_hex)
+        return "0x" + "77" * 65
+
+    monkeypatch.setattr("time.time", lambda: 1779327000.123)
+    http = FakeAsyncClient([{"id": "1", "result": {"is_valid": True}}])
+    adapter = DeriveAdapter(
+        config={"derive": {"network": "testnet"}},
+        sign_hash_callback=sign_hash,
+        wallet_address="0x1111111111111111111111111111111111111111",
+        derive_wallet_address="0x2222222222222222222222222222222222222222",
+        http_client=http,
+    )
+
+    ok, result = await adapter.place_order(
+        _unsigned_order(),
+        asset_address="0xBcB494059969DAaB460E0B5d4f5c2366aab79aa1",
+        asset_sub_id=987654,
+        nonce=1779327000123010,
+        signature_expiry_sec=1779327600,
+        dry_run=True,
+    )
+
+    assert ok is True
+    assert result == {"is_valid": True}
+    assert http.requests[0]["path"] == "/private/order_debug"
+    assert http.requests[0]["json"]["signature"] == "0x" + "77" * 65
+    assert http.requests[0]["json"]["direction"] == "buy"
+    assert http.requests[0]["headers"]["X-LyraWallet"] == (
+        "0x2222222222222222222222222222222222222222"
+    )
+    assert len(captured_hashes) == 2
 
 
 @pytest.mark.asyncio

--- a/wayfinder_paths/adapters/derive_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/derive_adapter/test_adapter.py
@@ -1,0 +1,397 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from eth_account.messages import defunct_hash_message
+
+from wayfinder_paths.adapters.derive_adapter.adapter import (
+    DERIVE_MAINNET_API_BASE_URL,
+    DERIVE_TESTNET_API_BASE_URL,
+    DeriveAdapter,
+)
+from wayfinder_paths.mcp.scripting import get_adapter
+
+
+class FakeResponse:
+    def __init__(self, data: dict[str, Any]) -> None:
+        self.data = data
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return self.data
+
+
+class FakeAsyncClient:
+    def __init__(self, responses: list[dict[str, Any]]) -> None:
+        self.responses = [FakeResponse(item) for item in responses]
+        self.requests: list[dict[str, Any]] = []
+        self.closed = False
+
+    async def post(
+        self,
+        path: str,
+        *,
+        json: dict[str, Any],
+        headers: dict[str, str] | None = None,
+    ) -> FakeResponse:
+        self.requests.append({"path": path, "json": json, "headers": headers})
+        return self.responses.pop(0)
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def _signed_order() -> dict[str, Any]:
+    return {
+        "subaccount_id": 12345,
+        "instrument_name": "ETH-20260522-2500-C",
+        "direction": "buy",
+        "amount": "0.1",
+        "limit_price": "20",
+        "max_fee": "2",
+        "nonce": 1779327000000001,
+        "signature_expiry_sec": 1779327600,
+        "signer": "0x1111111111111111111111111111111111111111",
+        "signature": "0x" + "22" * 65,
+    }
+
+
+def test_adapter_type_and_config_defaults() -> None:
+    adapter = DeriveAdapter(config={}, http_client=FakeAsyncClient([]))
+
+    assert adapter.adapter_type == "DERIVE"
+    assert adapter.name == "derive_adapter"
+    assert adapter.api_base_url == DERIVE_MAINNET_API_BASE_URL
+    assert adapter.wallet_address is None
+
+
+def test_testnet_config_selects_demo_api() -> None:
+    adapter = DeriveAdapter(
+        config={"derive": {"network": "testnet"}},
+        http_client=FakeAsyncClient([]),
+    )
+
+    assert adapter.api_base_url == DERIVE_TESTNET_API_BASE_URL
+
+
+@pytest.mark.asyncio
+async def test_get_adapter_wires_wallet_and_hash_signer(monkeypatch) -> None:
+    wallet = {
+        "label": "derive",
+        "address": "0x1111111111111111111111111111111111111111",
+        "private_key_hex": "0x" + "11" * 32,
+    }
+
+    async def find_wallet_by_label(label: str) -> dict[str, Any] | None:
+        return wallet if label == "derive" else None
+
+    monkeypatch.setattr(
+        "wayfinder_paths.core.utils.wallets.find_wallet_by_label",
+        find_wallet_by_label,
+    )
+    monkeypatch.setattr("wayfinder_paths.mcp.scripting.CONFIG", {})
+
+    adapter = await get_adapter(
+        DeriveAdapter, "derive", http_client=FakeAsyncClient([])
+    )
+
+    assert adapter.wallet_address == wallet["address"]
+    assert adapter.derive_wallet_address == wallet["address"]
+    assert adapter.sign_callback is not None
+    assert adapter.sign_hash_callback is not None
+
+
+@pytest.mark.asyncio
+async def test_get_instruments_posts_public_payload() -> None:
+    http = FakeAsyncClient(
+        [
+            {
+                "id": "1",
+                "result": [
+                    {
+                        "instrument_name": "ETH-20260522-2500-C",
+                        "instrument_type": "option",
+                    }
+                ],
+            }
+        ]
+    )
+    adapter = DeriveAdapter(config={}, http_client=http)
+
+    ok, instruments = await adapter.get_instruments(
+        currency="eth",
+        instrument_type="option",
+        expired=False,
+    )
+
+    assert ok is True
+    assert instruments == [
+        {"instrument_name": "ETH-20260522-2500-C", "instrument_type": "option"}
+    ]
+    assert http.requests == [
+        {
+            "path": "/public/get_instruments",
+            "json": {
+                "currency": "ETH",
+                "instrument_type": "option",
+                "expired": False,
+            },
+            "headers": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_option_expiries_groups_option_instruments() -> None:
+    http = FakeAsyncClient(
+        [
+            {
+                "id": "1",
+                "result": [
+                    {"option_details": {"expiry": 1779408000}},
+                    {"option_details": {"expiry": 1779408000}},
+                    {"option_details": {"expiry": 1780012800}},
+                ],
+            }
+        ]
+    )
+    adapter = DeriveAdapter(config={}, http_client=http)
+
+    ok, expiries = await adapter.list_option_expiries(currency="ETH")
+
+    assert ok is True
+    assert expiries == [
+        {
+            "expiry": 1779408000,
+            "expiry_date": "20260522",
+            "instrument_count": 2,
+        },
+        {
+            "expiry": 1780012800,
+            "expiry_date": "20260529",
+            "instrument_count": 1,
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_option_tickers_requires_option_params() -> None:
+    adapter = DeriveAdapter(config={}, http_client=FakeAsyncClient([]))
+
+    ok, error = await adapter.get_tickers(instrument_type="option", currency="ETH")
+
+    assert ok is False
+    assert "currency and expiry_date" in error
+
+
+@pytest.mark.asyncio
+async def test_get_option_tickers_returns_tickers_map() -> None:
+    http = FakeAsyncClient(
+        [
+            {
+                "id": "1",
+                "result": {
+                    "tickers": {
+                        "ETH-20260522-2500-C": {
+                            "b": "10",
+                            "a": "11",
+                            "M": "10.5",
+                        }
+                    }
+                },
+            }
+        ]
+    )
+    adapter = DeriveAdapter(config={}, http_client=http)
+
+    ok, tickers = await adapter.get_option_tickers(
+        currency="eth",
+        expiry_date=20260522,
+    )
+
+    assert ok is True
+    assert tickers["ETH-20260522-2500-C"]["M"] == "10.5"
+    assert http.requests[0]["json"] == {
+        "instrument_type": "option",
+        "currency": "ETH",
+        "expiry_date": "20260522",
+    }
+
+
+@pytest.mark.asyncio
+async def test_private_read_builds_derive_auth_headers(monkeypatch) -> None:
+    captured_hashes: list[str] = []
+
+    async def sign_hash(hash_hex: str) -> str:
+        captured_hashes.append(hash_hex)
+        return "0x" + "33" * 65
+
+    monkeypatch.setattr("time.time", lambda: 1779327000.123)
+    http = FakeAsyncClient(
+        [{"id": "1", "result": {"subaccount_id": 12345, "positions": []}}]
+    )
+    adapter = DeriveAdapter(
+        config={},
+        sign_hash_callback=sign_hash,
+        derive_wallet_address="0x1111111111111111111111111111111111111111",
+        http_client=http,
+    )
+
+    ok, result = await adapter.get_positions(subaccount_id=12345)
+
+    assert ok is True
+    assert result == {"subaccount_id": 12345, "positions": []}
+    expected_digest = defunct_hash_message(text="1779327000123")
+    assert captured_hashes == [f"0x{bytes(expected_digest).hex()}"]
+    assert http.requests[0]["headers"] == {
+        "X-LyraWallet": "0x1111111111111111111111111111111111111111",
+        "X-LyraTimestamp": "1779327000123",
+        "X-LyraSignature": "0x" + "33" * 65,
+    }
+
+
+@pytest.mark.asyncio
+async def test_private_read_requires_signing_callback() -> None:
+    adapter = DeriveAdapter(
+        config={},
+        derive_wallet_address="0x1111111111111111111111111111111111111111",
+        http_client=FakeAsyncClient([]),
+    )
+
+    ok, error = await adapter.get_open_orders(subaccount_id=12345)
+
+    assert ok is False
+    assert "sign_message_callback or sign_hash_callback" in error
+
+
+@pytest.mark.asyncio
+async def test_rpc_error_returns_false() -> None:
+    http = FakeAsyncClient(
+        [
+            {
+                "id": "1",
+                "error": {"code": -32000, "message": "Rate limit exceeded"},
+            }
+        ]
+    )
+    adapter = DeriveAdapter(config={}, http_client=http)
+
+    ok, error = await adapter.get_time()
+
+    assert ok is False
+    assert error == {"code": -32000, "message": "Rate limit exceeded"}
+
+
+@pytest.mark.asyncio
+async def test_submit_order_rejects_missing_signed_fields() -> None:
+    adapter = DeriveAdapter(config={}, http_client=FakeAsyncClient([]))
+
+    ok, error = await adapter.submit_order({"instrument_name": "ETH-20260522-2500-C"})
+
+    assert ok is False
+    assert "missing signed Derive order fields" in error
+
+
+@pytest.mark.asyncio
+async def test_submit_order_dry_run_uses_order_debug(monkeypatch) -> None:
+    async def sign_hash(_hash_hex: str) -> str:
+        return "0x" + "33" * 65
+
+    monkeypatch.setattr("time.time", lambda: 1779327000.123)
+    http = FakeAsyncClient([{"id": "1", "result": {"is_valid": True}}])
+    adapter = DeriveAdapter(
+        config={},
+        sign_hash_callback=sign_hash,
+        derive_wallet_address="0x1111111111111111111111111111111111111111",
+        http_client=http,
+    )
+
+    ok, result = await adapter.submit_order(_signed_order(), dry_run=True)
+
+    assert ok is True
+    assert result == {"is_valid": True}
+    assert http.requests[0]["path"] == "/private/order_debug"
+    assert http.requests[0]["json"] == _signed_order()
+
+
+@pytest.mark.asyncio
+async def test_submit_order_live_uses_order_endpoint(monkeypatch) -> None:
+    async def sign_hash(_hash_hex: str) -> str:
+        return "0x" + "33" * 65
+
+    monkeypatch.setattr("time.time", lambda: 1779327000.123)
+    http = FakeAsyncClient([{"id": "1", "result": {"order_id": "order-123"}}])
+    adapter = DeriveAdapter(
+        config={},
+        sign_hash_callback=sign_hash,
+        derive_wallet_address="0x1111111111111111111111111111111111111111",
+        http_client=http,
+    )
+
+    ok, result = await adapter.submit_order(_signed_order())
+
+    assert ok is True
+    assert result == {"order_id": "order-123"}
+    assert http.requests[0]["path"] == "/private/order"
+
+
+@pytest.mark.asyncio
+async def test_cancel_order_posts_cancel_payload(monkeypatch) -> None:
+    async def sign_hash(_hash_hex: str) -> str:
+        return "0x" + "33" * 65
+
+    monkeypatch.setattr("time.time", lambda: 1779327000.123)
+    http = FakeAsyncClient([{"id": "1", "result": {"order_status": "cancelled"}}])
+    adapter = DeriveAdapter(
+        config={},
+        sign_hash_callback=sign_hash,
+        derive_wallet_address="0x1111111111111111111111111111111111111111",
+        http_client=http,
+    )
+
+    ok, result = await adapter.cancel_order(
+        instrument_name="ETH-20260522-2500-C",
+        order_id="order-123",
+        subaccount_id=12345,
+    )
+
+    assert ok is True
+    assert result == {"order_status": "cancelled"}
+    assert http.requests[0]["path"] == "/private/cancel"
+    assert http.requests[0]["json"] == {
+        "instrument_name": "ETH-20260522-2500-C",
+        "order_id": "order-123",
+        "subaccount_id": 12345,
+    }
+
+
+def test_orderbook_channel_builder() -> None:
+    assert (
+        DeriveAdapter.orderbook_channel("ETH-20260522-2500-C", group="10", depth="20")
+        == "orderbook.ETH-20260522-2500-C.10.20"
+    )
+
+    with pytest.raises(ValueError, match="group"):
+        DeriveAdapter.orderbook_channel("ETH-20260522-2500-C", group="5")
+
+
+def test_new_order_nonce_uses_three_digit_random_suffix(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "wayfinder_paths.adapters.derive_adapter.adapter.secrets.randbelow",
+        lambda _upper: 7,
+    )
+
+    assert DeriveAdapter.new_order_nonce(now_ms=1779327000123) == 1779327000123007
+
+
+@pytest.mark.asyncio
+async def test_close_closes_http_client() -> None:
+    http = FakeAsyncClient([])
+    adapter = DeriveAdapter(config={}, http_client=http)
+
+    await adapter.close()
+
+    assert http.closed is True

--- a/wayfinder_paths/adapters/derive_adapter/test_gorlami_simulation.py
+++ b/wayfinder_paths/adapters/derive_adapter/test_gorlami_simulation.py
@@ -6,14 +6,15 @@ from wayfinder_paths.adapters.derive_adapter.adapter import DeriveAdapter
 
 
 @pytest.mark.asyncio
-async def test_deterministic_order_smoke_covers_non_gorlami_surface() -> None:
-    """Derive order flows are API/CLOB actions, not local EVM fork calls.
+async def test_deterministic_smoke_covers_non_gorlami_surface() -> None:
+    """Derive lifecycle/order flows are API/CLOB actions, not local EVM fork calls.
 
     Gorlami fork tests in this repo exercise EVM contract transactions. Derive's
-    option discovery, account reads, and matching endpoints are REST/WebSocket API
-    flows, and signed orders settle through Derive's matching/protocol pipeline.
-    This smoke check keeps deterministic coverage near the adapter surface while
-    README/skill docs record the fork-simulation limitation.
+    option discovery, account reads, lifecycle writes, and matching endpoints are
+    REST/WebSocket API flows. Signed collateral/order actions settle through
+    Derive's matching/protocol pipeline. This smoke check keeps deterministic
+    coverage near the adapter surface while README/skill docs record the
+    fork-simulation limitation.
     """
     assert DeriveAdapter.orderbook_channel("ETH-20260522-2500-C") == (
         "orderbook.ETH-20260522-2500-C.1.10"

--- a/wayfinder_paths/adapters/derive_adapter/test_gorlami_simulation.py
+++ b/wayfinder_paths/adapters/derive_adapter/test_gorlami_simulation.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pytest
+
+from wayfinder_paths.adapters.derive_adapter.adapter import DeriveAdapter
+
+
+@pytest.mark.asyncio
+async def test_deterministic_order_smoke_covers_non_gorlami_surface() -> None:
+    """Derive order flows are API/CLOB actions, not local EVM fork calls.
+
+    Gorlami fork tests in this repo exercise EVM contract transactions. Derive's
+    option discovery, account reads, and matching endpoints are REST/WebSocket API
+    flows, and signed orders settle through Derive's matching/protocol pipeline.
+    This smoke check keeps deterministic coverage near the adapter surface while
+    README/skill docs record the fork-simulation limitation.
+    """
+    assert DeriveAdapter.orderbook_channel("ETH-20260522-2500-C") == (
+        "orderbook.ETH-20260522-2500-C.1.10"
+    )
+    assert DeriveAdapter.expiry_date(1779408000) == "20260522"


### PR DESCRIPTION
## Summary

Adds a new Derive REST adapter focused on options discovery, quote reads, authenticated account/subaccount reads, margin checks, account onboarding, collateral lifecycle, signed order debug/submit, and cancel. It also adds adapter docs, examples, tests, and `.claude/skills/using-derive-adapter/` usage guidance.

This rework addresses the account lifecycle feedback: callers can detect Derive accounts/subaccounts, optionally create a missing account through Derive's documented invite-secret flow, create an empty or funded subaccount, deposit collateral, inspect deposit/withdraw history, withdraw collateral, transfer ERC20 collateral between subaccounts, and use callback-signed order helpers.

## Gap / Design Matrix

| Derive product / area | Current docs/API checked | SDK adapter capability in this PR | Intentionally left out |
| --- | --- | --- | --- |
| Options instruments | `public/get_instruments`, Supported Products | `list_options`, `list_option_expiries`, raw instrument fields for expiry/strike/type/fees/tick sizing | Option pricing model reconstruction; custom chain contract reads |
| Options quotes | `public/get_tickers`, `public/get_ticker` | `get_option_tickers`, `get_ticker` for best bid/ask, mark, index, stats, option pricing fields | Live WebSocket ticker stream |
| Orderbook depth | WebSocket `orderbook.{instrument_name}.{group}.{depth}` channel | `orderbook_channel(...)` helper and docs identifying the channel | WebSocket subscription loop/client |
| Account onboarding | `public/create_account_with_secret`, Authentication | `create_account_with_secret(...)` and `ensure_subaccount(create_account_if_missing=True, account_secret=...)` | Issuing Derive invite secrets/codes; silent assumptions that an EOA is already the Derive smart contract wallet |
| Subaccount lifecycle | `private/get_account`, `private/get_subaccounts`, `private/create_subaccount`, Create or Deposit to Subaccount guide | `get_account`, `get_subaccounts`, `get_subaccount`, `ensure_subaccount(...)`, signed `create_subaccount(...)` with margin-type/manager selection | Manual session-key management; direct SubAccount contract calls |
| Collateral deposit/withdraw | `private/deposit`, `private/withdraw`, create/deposit guide, withdrawal guide, protocol constants | `deposit_collateral(...)`, `withdraw_collateral(...)`, Derive SignedAction hashing through existing `sign_hash_callback` | Bridge flows into Derive Chain; ERC20 approval tx construction; hiding required wallet approvals |
| Collateral status/history | `private/get_deposit_history`, `private/get_withdrawal_history` | `get_deposit_history`, `get_withdrawal_history` with timestamp filters | Background polling worker or settlement watchdog |
| ERC20 collateral transfer | `private/transfer_erc20`, Transfer Collateral guide, Derive action-signing reference | `transfer_erc20(...)` signs sender and recipient action details for ERC20 subaccount collateral transfer | Position transfer endpoints; RFQ transfer variants |
| Positions/orders | `private/get_positions`, `private/get_open_orders` | read-only position and open-order views | Historical archives/RFQ quoting surfaces |
| Margin/risk | `private/get_margin`, Standard Margin, Portfolio Margin, PM2 docs | read current/simulated margin through Derive API | Local margin engine or portfolio shock calculator |
| Order submit/debug | `private/order_debug`, `private/order`, Authentication, Session Keys, action-signing reference | `sign_order(...)`, `place_order(...)`, raw signed `submit_order(...)`; `dry_run=True` calls `order_debug`, live submit calls `order` | Deriving user intent, choosing size/side/max fee, RFQ, TWAP helpers |
| Cancel | `private/cancel` | authenticated cancel by instrument/order/subaccount | Batch cancel variants and cancel-on-disconnect |
| Perps/spot reads | Same public instrument/ticker API shape where `instrument_type` is `perp` or `erc20` | generic `get_instruments`/`get_tickers` can read them when the same API model applies | Perp/spot-specific strategy surface |
| Gorlami/simulation | Repo Gorlami guidance and Derive Chain/API docs | deterministic adapter unit/smoke coverage plus documented limitation | Fork simulation of Derive CLOB/API workflows on chain 957 |

## Safety Boundaries

- Public discovery is read-only.
- Private reads require Derive auth headers: `X-LyraWallet`, `X-LyraTimestamp`, `X-LyraSignature`.
- Account creation, subaccount creation, deposit, withdrawal, ERC20 transfer, order submit, and cancel are state-changing or fund-moving/trading actions.
- The adapter follows existing Wayfinder constructor conventions so `get_adapter(DeriveAdapter, "...")` wires wallet address and signing callbacks.
- Lifecycle/order helpers build Derive SignedAction hashes locally and ask Wayfinder's `sign_hash_callback` to sign them. Callers can still pass a verified pre-signed Derive payload when using Derive's own client/tooling.
- Deposits require collateral already available on Derive Chain and any required ERC20 allowance for the DepositModule. This REST adapter does not hide bridge or approval transactions.
- Session keys remain optional/scoped; docs call out read-only/account/admin permission boundaries instead of making manual session-key setup the only happy path.

## Derive Docs Cited

- https://docs.derive.xyz/llms.txt
- https://docs.derive.xyz/docs/about-derive.md
- https://docs.derive.xyz/docs/supported-products-1.md
- https://docs.derive.xyz/docs/standard-margin-1.md
- https://docs.derive.xyz/docs/portfolio-margin-1.md
- https://docs.derive.xyz/docs/pm2.md
- https://docs.derive.xyz/docs/settlements.md
- https://docs.derive.xyz/docs/lyra-chain.md
- https://docs.derive.xyz/reference/overview.md
- https://docs.derive.xyz/reference/json-rpc.md
- https://docs.derive.xyz/reference/authentication.md
- https://docs.derive.xyz/reference/session-keys.md
- https://docs.derive.xyz/reference/rate-limits.md
- https://docs.derive.xyz/reference/protocol-constants.md
- https://docs.derive.xyz/reference/public-create_account_with_secret.md
- https://docs.derive.xyz/reference/create-or-deposit-to-subaccount.md
- https://docs.derive.xyz/reference/deposit-to-lyra-chain.md
- https://docs.derive.xyz/reference/on-chain-withdraw.md
- https://docs.derive.xyz/reference/post_public-get-time.md
- https://docs.derive.xyz/reference/post_public-get-instruments.md
- https://docs.derive.xyz/reference/post_public-get-tickers.md
- https://docs.derive.xyz/reference/post_public-get-ticker.md
- https://docs.derive.xyz/reference/orderbook-instrument_name-group-depth.md
- https://docs.derive.xyz/reference/post_private-get-account.md
- https://docs.derive.xyz/reference/post_private-get-subaccounts.md
- https://docs.derive.xyz/reference/post_private-get-subaccount.md
- https://docs.derive.xyz/reference/post_private-create-subaccount.md
- https://docs.derive.xyz/reference/post_private-deposit.md
- https://docs.derive.xyz/reference/post_private-withdraw.md
- https://docs.derive.xyz/reference/post_private-get-deposit-history.md
- https://docs.derive.xyz/reference/post_private-get-withdrawal-history.md
- https://docs.derive.xyz/reference/post_private-transfer-erc20.md
- https://docs.derive.xyz/reference/transfer-collateral.md
- https://docs.derive.xyz/reference/post_private-get-positions.md
- https://docs.derive.xyz/reference/post_private-get-open-orders.md
- https://docs.derive.xyz/reference/post_private-get-margin.md
- https://docs.derive.xyz/reference/post_private-order-debug.md
- https://docs.derive.xyz/reference/post_private-order.md
- https://docs.derive.xyz/reference/post_private-cancel.md
- https://pypi.org/project/derive_action_signing/
- https://github.com/derivexyz/v2-action-signing-python

## Validation

The sandbox cannot write Poetry's default user cache, so dependency setup and commands were run with `POETRY_VIRTUALENVS_IN_PROJECT=true POETRY_CACHE_DIR=.poetry-cache`.

- `poetry install` passed with the in-project env/cache settings.
- `poetry run ruff format --check wayfinder_paths/adapters/derive_adapter .claude/skills/using-derive-adapter` passed (`4 files already formatted`).
- `poetry run ruff check wayfinder_paths/adapters/derive_adapter` passed.
- `poetry run pytest -o addopts= wayfinder_paths/adapters/derive_adapter -q` passed (`31 passed`; warnings are dependency/Python 3.14 deprecations).
- `poetry run pytest -o addopts= wayfinder_paths/tests/test_manifests.py -q` passed (`2 passed`).
- `git diff --check` passed.
- `git diff --check origin/main...HEAD` passed.

Gorlami note: Derive option discovery, account reads, lifecycle writes, order debug/submit, and cancel are Derive REST/WebSocket/CLOB workflows, with settlement through Derive's matching/protocol pipeline. The current repo Gorlami helpers cover EVM fork transaction simulation, so the PR adds deterministic adapter tests and a smoke test documenting this limitation instead of claiming fork simulation for Derive API workflows.
