### PR TITLE
OpenCode Agent - Collapse HIP-3 Collateral Tables

### DIFF
--- a/.opencode/agents/wayfinder.md
+++ b/.opencode/agents/wayfinder.md
@@ -133,26 +133,22 @@ Hyperliquid balances are separate from a user's EVM balances. To place transacti
 
 Before any order is placed, the Hyperliquid Adapter enforces [Unified Account mode](https://hyperliquid.gitbook.io/hyperliquid-docs/trading/account-abstraction-modes): collateral for perpetuals comes from the user's spot account. Before Unified Account, users had to manage balances between accounts using spotToPerp and perpToSpot transfers.
 
-| Type             | Collateral / Quote                                                        |
-| ---------------- | ------------------------------------------------------------------------- |
-| Perpetuals       | USDC in spot account (Unified Account Mode)                               |
-| HIP-3 Perpetuals | Per-dex collateral pool, NOT unified with spot. See table below.          |
-| Spot             | For market {A} - {B}, {B} is the quote asset, typically: USDC, USDH, USDT |
-| HIP-4 Outcome    | USDH in spot account                                                      |
+| Type          | Collateral / Quote                                                        |
+| ------------- | ------------------------------------------------------------------------- |
+| Perpetuals    | USDC in spot account (Unified Account Mode)                               |
+| HIP-3 `xyz`   | USDC                                                                      |
+| HIP-3 `para`  | USDC                                                                      |
+| HIP-3 `flx`   | USDH                                                                      |
+| HIP-3 `vntl`  | USDH                                                                      |
+| HIP-3 `km`    | USDH                                                                      |
+| HIP-3 `cash`  | USDT                                                                      |
+| HIP-3 `hyna`  | USDE                                                                      |
+| Spot          | For market {A} - {B}, {B} is the quote asset, typically: USDC, USDH, USDT |
+| HIP-4 Outcome | USDH in spot account                                                      |
 
 If a user is on a legacy split account, migration may require closing positions, moving balances to spot, then enabling UnifiedAccountMode. `ensure_unified_account` runs before order placement, but can fail mid-state if open positions or stuck spot balances block the switch.
 
-HIP-3 builder dexes each have their own collateral pool separate from spot / unified balance. Deposits go into the dex's own ledger; you cannot fund cross-dex from unified spot. To trade on a builder dex, USDC/USDT/USDH/USDE must be transferred into that specific dex's user ledger first.
-
-| Builder dex | Collateral |
-| ----------- | ---------- |
-| `xyz`       | USDC       |
-| `para`      | USDC       |
-| `flx`       | USDH       |
-| `vntl`      | USDH       |
-| `km`        | USDH       |
-| `cash`      | USDT       |
-| `hyna`      | USDE       |
+HIP-3 builder dexes each have their own collateral pool separate from spot / unified balance. Deposits go into the dex's own ledger; you cannot fund cross-dex from unified spot.
 
 #### Notes
 

--- a/.opencode/agents/wayfinder.md
+++ b/.opencode/agents/wayfinder.md
@@ -148,8 +148,6 @@ Before any order is placed, the Hyperliquid Adapter enforces [Unified Account mo
 
 If a user is on a legacy split account, migration may require closing positions, moving balances to spot, then enabling UnifiedAccountMode. `ensure_unified_account` runs before order placement, but can fail mid-state if open positions or stuck spot balances block the switch.
 
-Each HIP-3 dex holds its own collateral ledger — fund the specific dex, not unified spot.
-
 #### Notes
 
 Leveraged perp execution: before placing, call `hyperliquid_get_state(label=..., asset_name=...)` and build a trade ticket from its `trade_context`. For UnifiedAccount margin, use `trade_context.available_to_trade_long_usd` or `trade_context.available_to_trade_short_usd`; do not use wallet USDC balance, spot balance, withdrawable, account value, or `crossMarginSummary` as "available to trade". Show wallet/address label, asset, current position, margin mode, leverage, selected side, order type, requested notional/size, required initial margin (`notional / leverage`), available-to-trade margin, utilization, reduce/open/flip effect, and exact tool inputs before requesting approval. If leverage or margin mode is not explicit for a new position, ask or update leverage first, then verify state again.

--- a/.opencode/agents/wayfinder.md
+++ b/.opencode/agents/wayfinder.md
@@ -148,7 +148,7 @@ Before any order is placed, the Hyperliquid Adapter enforces [Unified Account mo
 
 If a user is on a legacy split account, migration may require closing positions, moving balances to spot, then enabling UnifiedAccountMode. `ensure_unified_account` runs before order placement, but can fail mid-state if open positions or stuck spot balances block the switch.
 
-HIP-3 builder dexes each have their own collateral pool separate from spot / unified balance. Deposits go into the dex's own ledger; you cannot fund cross-dex from unified spot.
+Each HIP-3 dex holds its own collateral ledger — fund the specific dex, not unified spot.
 
 #### Notes
 


### PR DESCRIPTION
### Summary
Inlines the standalone HIP-3 builder dex collateral table into the main Hyperliquid collateral table so each dex's settlement coin lives next to Perpetuals / Spot / HIP-4 Outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)