### PR TITLE
Audit Aave V3 adapter coverage

### DIFF
--- a/.claude/skills/using-aave-v3-adapter/SKILL.md
+++ b/.claude/skills/using-aave-v3-adapter/SKILL.md
@@ -10,10 +10,12 @@ metadata:
 Use this skill when you are:
 - Fetching Aave V3 market data (APYs, caps, LTVs, rewards emissions)
 - Reading user positions/snapshots on Aave V3
-- Writing scripts that supply/withdraw/borrow/repay, manage collateral, or claim rewards
+- Reading or setting eMode categories
+- Reading or transacting with Aave Earn ERC-4626 vaults
+- Writing scripts that supply/withdraw/borrow/repay, manage collateral, set eMode, use Earn vaults, or claim rewards
 
 ## How to use
 
-- [rules/high-value-reads.md](rules/high-value-reads.md) - Markets + user snapshots
-- [rules/execution-opportunities.md](rules/execution-opportunities.md) - Supply/withdraw/borrow/repay/collateral/rewards
-- [rules/gotchas.md](rules/gotchas.md) - Rate mode, native wrapping, rewards asset list
+- [rules/high-value-reads.md](rules/high-value-reads.md) - Markets, user snapshots, eMode, Earn vaults
+- [rules/execution-opportunities.md](rules/execution-opportunities.md) - Supply/withdraw/borrow/repay/collateral/eMode/Earn/rewards
+- [rules/gotchas.md](rules/gotchas.md) - Rate mode, native wrapping, risk modes, Earn vaults, rewards asset list

--- a/.claude/skills/using-aave-v3-adapter/rules/execution-opportunities.md
+++ b/.claude/skills/using-aave-v3-adapter/rules/execution-opportunities.md
@@ -1,4 +1,4 @@
-# Aave V3 execution (supply/withdraw/borrow/repay/collateral/rewards)
+# Aave V3 execution (supply/withdraw/borrow/repay/collateral/eMode/Earn/rewards)
 
 ## Safety
 
@@ -50,4 +50,55 @@ ok, tx = await adapter.unlend(chain_id=CHAIN_ID_ARBITRUM, underlying_token=ARBIT
 ```python
 # If assets is omitted, the adapter derives incentivized aToken/debt-token addresses via UiIncentiveDataProviderV3.
 ok, tx = await adapter.claim_all_rewards(chain_id=CHAIN_ID_ARBITRUM)
+```
+
+### Set or disable eMode
+
+```python
+ok, categories = await adapter.get_emode_categories(chain_id=CHAIN_ID_ARBITRUM)
+if not ok:
+    raise RuntimeError(categories)
+
+# category_id=0 disables eMode. Non-zero IDs must be valid for the market and
+# compatible with the user's collateral/debt, or Aave will revert.
+ok, tx = await adapter.set_emode(chain_id=CHAIN_ID_ARBITRUM, category_id=1)
+ok, tx = await adapter.disable_emode(chain_id=CHAIN_ID_ARBITRUM)
+```
+
+### Use Aave Earn vaults
+
+```python
+VAULT = "0x..."
+
+# Read first; confirm the underlying reserve is active and not paused/frozen.
+ok, vault = await adapter.get_earn_vault_state(
+    chain_id=CHAIN_ID_ARBITRUM,
+    vault_address=VAULT,
+)
+if not ok:
+    raise RuntimeError(vault)
+
+# Underlying token deposit / share mint.
+ok, tx = await adapter.earn_vault_deposit(
+    chain_id=CHAIN_ID_ARBITRUM,
+    vault_address=VAULT,
+    assets=1_000_000,
+)
+ok, tx = await adapter.earn_vault_mint(
+    chain_id=CHAIN_ID_ARBITRUM,
+    vault_address=VAULT,
+    shares=1_000_000,
+)
+
+# aToken variants avoid unwrapping an existing Aave supply position.
+ok, tx = await adapter.earn_vault_deposit_atokens(
+    chain_id=CHAIN_ID_ARBITRUM,
+    vault_address=VAULT,
+    assets=1_000_000,
+)
+ok, tx = await adapter.earn_vault_redeem_as_atokens(
+    chain_id=CHAIN_ID_ARBITRUM,
+    vault_address=VAULT,
+    shares=1_000_000,
+)
 ```

--- a/.claude/skills/using-aave-v3-adapter/rules/gotchas.md
+++ b/.claude/skills/using-aave-v3-adapter/rules/gotchas.md
@@ -3,6 +3,11 @@
 - **Chain matters:** always pass the correct `chain_id`. Aave V3 deployments are per-chain.
 - **Variable rate mode:** borrowing/repaying uses variable rate mode (`interestRateMode=2`).
 - **Collateral toggle:** supplying an asset doesn't always mean it's enabled as collateral; use `set_collateral(...)`.
+- **Risk modes:** check `emode_category_id`, `borrowable_in_isolation`, `is_siloed_borrowing`, `debt_ceiling`, and `account_data.health_factor` before suggesting a borrow, collateral change, or eMode change.
+- **eMode:** `set_emode(...)` only accepts IDs `0..255`; `0` disables eMode. Aave can still revert if the wallet has incompatible collateral or debt.
 - **Rewards inputs:** rewards are incentivized on **aTokens and debt tokens**, not the underlying. `claim_all_rewards(...)` can auto-derive the asset list.
+- **Aave Earn vaults:** Earn vaults are ERC-4626 vaults over Aave V3 supply positions. Use `get_earn_vault_state(...)` first, and use the `*_atokens` methods only when the wallet holds the reserve aToken.
+- **UiPoolDataProvider variants:** live Aave V3 deployments do not all expose the same reserve tuple shape. The adapter handles current compact, Origin, and legacy periphery shapes; do not hand-roll tuple indexes in scripts.
+- **V4 scope:** Aave V4 uses a different hub/spoke model. Do not mix V4 behavior into this V3 adapter; document it as follow-up work instead.
 - **Native token handling:** `native=True` wraps/unwraps the chain's wrapped native token and may return multiple tx hashes for a single call.
 - **repay_full:** `repay_full=True` uses `MAX_UINT256` repayment semantics; ensure you have enough balance (and native gas if wrapping).

--- a/.claude/skills/using-aave-v3-adapter/rules/high-value-reads.md
+++ b/.claude/skills/using-aave-v3-adapter/rules/high-value-reads.md
@@ -12,6 +12,8 @@
 - Reads:
   - `get_all_markets(chain_id, include_rewards=...)`
   - `get_full_user_state_per_chain(chain_id, account, include_rewards=...)`
+  - `get_emode_categories(chain_id)`
+  - `get_earn_vault_state(chain_id, vault_address, account=...)`
 
 ## Ad-hoc read scripts
 
@@ -35,6 +37,8 @@ async def main():
         print(
             m.get("symbol"),
             "ltv_bps=", m.get("ltv_bps"),
+            "emode=", m.get("emode_category_id"),
+            "borrowable_in_isolation=", m.get("borrowable_in_isolation"),
             "supply_apy=", m.get("supply_apy"),
             "reward_supply_apr=", m.get("reward_supply_apr"),
         )
@@ -59,6 +63,8 @@ async def main():
     ok, state = await adapter.get_full_user_state_per_chain(chain_id=CHAIN_ID_ARBITRUM, account=USER, include_rewards=True)
     if not ok:
         raise RuntimeError(state)
+    print("health_factor=", (state.get("account_data") or {}).get("health_factor"))
+    print("user_emode_category_id=", state.get("user_emode_category_id"))
     for p in state.get("positions", []):
         if int(p.get("supply_raw") or 0) or int(p.get("variable_borrow_raw") or 0):
             print(p.get("symbol"), "supply_usd=", p.get("supply_usd"), "borrow_usd=", p.get("variable_borrow_usd"))
@@ -74,3 +80,11 @@ if __name__ == "__main__":
 | `get_all_markets(chain_id, include_rewards?)` | Market list + point-in-time rates/rewards | No |
 | `get_full_user_state_per_chain(chain_id, account, include_rewards?, include_zero_positions?)` | Positions snapshot on one chain | No (if you pass `account`) |
 | `get_full_user_state(account, include_rewards?, include_zero_positions?)` | Positions snapshot across supported chains | No (if you pass `account`) |
+| `get_emode_categories(chain_id)` | Available eMode categories from the UI data provider | No |
+| `get_earn_vault_state(chain_id, vault_address, account?)` | Aave Earn ERC-4626 vault state and optional user shares | No |
+
+## Fields worth checking
+
+- Market rows: `ltv_bps`, `liquidation_threshold_bps`, `liquidation_bonus_bps`, `reserve_factor_bps`, `emode_category_id`, `borrowable_in_isolation`, `debt_ceiling`, `flash_loan_enabled`, `virtual_underlying_balance`, `deficit`.
+- User state: `account_data.health_factor`, `account_data.available_borrows_base`, `user_emode_category_id`, `emode_categories`, and per-position collateral/risk fields.
+- Earn vault state: `asset`, `asset_decimals`, `total_assets_raw`, `assets_per_share_unit_raw`, `max_deposit_raw`, `max_mint_raw`, `fee_raw`, and `user.max_withdraw_raw` / `user.max_redeem_raw`.

--- a/wayfinder_paths/adapters/aave_v3_adapter/README.md
+++ b/wayfinder_paths/adapters/aave_v3_adapter/README.md
@@ -11,6 +11,8 @@ Adapter for Aave v3 pools across supported chains.
 
 Fetch reserve snapshots via `UiPoolDataProvider.getReservesData(...)` and (optionally)
 incentives via `UiIncentiveDataProviderV3.getReservesIncentivesData(...)`.
+The adapter supports the compact current UI data provider shape, Aave Origin
+deployments, and legacy Aave V3 periphery deployments used by existing markets.
 
 ```python
 from wayfinder_paths.adapters.aave_v3_adapter import AaveV3Adapter
@@ -18,6 +20,12 @@ from wayfinder_paths.adapters.aave_v3_adapter import AaveV3Adapter
 adapter = AaveV3Adapter(config={})
 ok, markets = await adapter.get_all_markets(chain_id=42161, include_rewards=True)
 ```
+
+Market rows include current risk and liquidity fields such as `ltv_bps`,
+`liquidation_threshold_bps`, `liquidation_bonus_bps`, `reserve_factor_bps`,
+`emode_category_id`, `borrowable_in_isolation`, `debt_ceiling`,
+`flash_loan_enabled`, `virtual_underlying_balance`, and `deficit` when the
+deployed UI provider exposes it.
 
 ### get_full_user_state (all chains)
 
@@ -32,6 +40,9 @@ ok, state = await adapter.get_full_user_state(account="0x...")
 
 Fetch user supplies/borrows via `UiPoolDataProvider.getUserReservesData(...)` and
 (optionally) claimable incentives via `UiIncentiveDataProviderV3.getUserReservesIncentivesData(...)`.
+The response includes `account_data` from `Pool.getUserAccountData(...)`,
+`user_emode_category_id`, and available `emode_categories` where the deployed UI
+provider exposes `getEModes(...)`.
 
 When `include_rewards=True` (default), each position includes market-level APY and reward data
 computed from `UiPoolDataProvider.getReservesData(...)` and `UiIncentiveDataProviderV3.getReservesIncentivesData(...)`:
@@ -72,10 +83,44 @@ ok, tx = await adapter.set_collateral(chain_id=42161, underlying_token="0x...")
 ok, tx = await adapter.remove_collateral(chain_id=42161, underlying_token="0x...")
 ```
 
+### get_emode_categories / set_emode / disable_emode
+
+Read available eMode categories and switch the strategy wallet into or out of
+eMode. `category_id=0` disables eMode.
+
+```python
+ok, categories = await adapter.get_emode_categories(chain_id=42161)
+ok, tx = await adapter.set_emode(chain_id=42161, category_id=1)
+ok, tx = await adapter.disable_emode(chain_id=42161)
+```
+
 ### claim_all_rewards
 
 Claims all rewards via the per-chain RewardsController.
 
 ```python
 ok, tx = await adapter.claim_all_rewards(chain_id=42161)
+```
+
+### Aave Earn vaults
+
+Earn vault helpers cover ERC-4626 vault reads and the Aave aToken variants.
+Pass an explicit vault address; the adapter resolves the underlying asset via
+`asset()` and the aToken through the configured Aave V3 market.
+
+```python
+ok, vault = await adapter.get_earn_vault_state(
+    chain_id=42161,
+    vault_address="0x...",
+    account="0x...",
+)
+
+ok, tx = await adapter.earn_vault_deposit(chain_id=42161, vault_address="0x...", assets=123)
+ok, tx = await adapter.earn_vault_deposit_atokens(chain_id=42161, vault_address="0x...", assets=123)
+ok, tx = await adapter.earn_vault_mint(chain_id=42161, vault_address="0x...", shares=123)
+ok, tx = await adapter.earn_vault_mint_with_atokens(chain_id=42161, vault_address="0x...", shares=123)
+ok, tx = await adapter.earn_vault_withdraw(chain_id=42161, vault_address="0x...", assets=123)
+ok, tx = await adapter.earn_vault_withdraw_atokens(chain_id=42161, vault_address="0x...", assets=123)
+ok, tx = await adapter.earn_vault_redeem(chain_id=42161, vault_address="0x...", shares=123)
+ok, tx = await adapter.earn_vault_redeem_as_atokens(chain_id=42161, vault_address="0x...", shares=123)
 ```

--- a/wayfinder_paths/adapters/aave_v3_adapter/adapter.py
+++ b/wayfinder_paths/adapters/aave_v3_adapter/adapter.py
@@ -6,17 +6,25 @@ from eth_utils import to_checksum_address
 
 from wayfinder_paths.core.adapters.BaseAdapter import BaseAdapter
 from wayfinder_paths.core.constants.aave_v3_abi import (
+    AAVE_EARN_VAULT_ABI,
     POOL_ABI,
     REWARDS_CONTROLLER_ABI,
     UI_INCENTIVE_DATA_PROVIDER_V3_ABI,
     UI_POOL_DATA_PROVIDER_ABI,
+    UI_POOL_DATA_PROVIDER_LEGACY_ABI,
+    UI_POOL_DATA_PROVIDER_ORIGIN_ABI,
     UI_POOL_RESERVE_KEYS,
+    UI_POOL_RESERVE_KEYS_LEGACY,
+    UI_POOL_RESERVE_KEYS_ORIGIN,
+    UI_POOL_USER_RESERVE_KEYS,
+    UI_POOL_USER_RESERVE_KEYS_LEGACY,
     WETH_ABI,
     WRAPPED_TOKEN_GATEWAY_V3_ABI,
 )
 from wayfinder_paths.core.constants.aave_v3_contracts import AAVE_V3_BY_CHAIN
 from wayfinder_paths.core.constants.base import MAX_UINT256, SECONDS_PER_YEAR
 from wayfinder_paths.core.constants.contracts import ZERO_ADDRESS
+from wayfinder_paths.core.constants.erc20_abi import ERC20_ABI
 from wayfinder_paths.core.utils import web3 as web3_utils
 from wayfinder_paths.core.utils.interest import RAY, apr_to_apy, ray_to_apr
 from wayfinder_paths.core.utils.symbols import is_stable_symbol, normalize_symbol
@@ -79,6 +87,72 @@ def _base_currency_to_ref(base_currency: Any) -> tuple[int, float]:
         else float(ref_usd_raw)
     )
     return (ref_unit, float(ref_usd))
+
+
+def _account_data_to_dict(account_data: Any) -> dict[str, int]:
+    keys = [
+        "total_collateral_base",
+        "total_debt_base",
+        "available_borrows_base",
+        "current_liquidation_threshold_bps",
+        "ltv_bps",
+        "health_factor",
+    ]
+    if isinstance(account_data, dict):
+        raw = {
+            "total_collateral_base": account_data.get("totalCollateralBase"),
+            "total_debt_base": account_data.get("totalDebtBase"),
+            "available_borrows_base": account_data.get("availableBorrowsBase"),
+            "current_liquidation_threshold_bps": account_data.get(
+                "currentLiquidationThreshold"
+            ),
+            "ltv_bps": account_data.get("ltv"),
+            "health_factor": account_data.get("healthFactor"),
+        }
+        return {k: int(v or 0) for k, v in raw.items()}
+    return {k: int(v or 0) for k, v in zip(keys, account_data or (), strict=False)}
+
+
+def _emode_category_to_dict(category: Any) -> dict[str, Any] | None:
+    if isinstance(category, dict):
+        category_id = int(category.get("id") or 0)
+        emode = category.get("eMode") or category.get("emode") or {}
+    else:
+        try:
+            category_id = int(category[0] or 0)
+            emode = category[1]
+        except (IndexError, TypeError, ValueError):
+            return None
+
+    if isinstance(emode, dict):
+        ltv = emode.get("ltv")
+        liquidation_threshold = emode.get("liquidationThreshold")
+        liquidation_bonus = emode.get("liquidationBonus")
+        collateral_bitmap = emode.get("collateralBitmap")
+        label = emode.get("label")
+        borrowable_bitmap = emode.get("borrowableBitmap")
+    else:
+        try:
+            (
+                ltv,
+                liquidation_threshold,
+                liquidation_bonus,
+                collateral_bitmap,
+                label,
+                borrowable_bitmap,
+            ) = emode
+        except (TypeError, ValueError):
+            return None
+
+    return {
+        "id": int(category_id),
+        "ltv_bps": int(ltv or 0),
+        "liquidation_threshold_bps": int(liquidation_threshold or 0),
+        "liquidation_bonus_bps": int(liquidation_bonus or 0),
+        "collateral_bitmap": int(collateral_bitmap or 0),
+        "borrowable_bitmap": int(borrowable_bitmap or 0),
+        "label": str(label or ""),
+    }
 
 
 def _reward_rows(rewards_info: Any) -> list[Any]:
@@ -228,6 +302,107 @@ class AaveV3Adapter(BaseAdapter):
             f"could not resolve variable debt token for asset={asset} on chain_id={chain_id}"
         )
 
+    async def _read_emode_categories(
+        self, ui_pool: Any, provider_addr: str
+    ) -> list[dict[str, Any]]:
+        rows = await ui_pool.functions.getEModes(provider_addr).call(
+            block_identifier="pending"
+        )
+        categories: list[dict[str, Any]] = []
+        for row in rows or []:
+            category = _emode_category_to_dict(row)
+            if category is not None:
+                categories.append(category)
+        return categories
+
+    async def _read_reserves_data(
+        self, web3: Any, ui_pool_addr: str, provider_addr: str
+    ) -> tuple[Any, list[str], list[str], Any, Any]:
+        last_error: Exception | None = None
+        variants = (
+            (
+                UI_POOL_DATA_PROVIDER_ABI,
+                UI_POOL_RESERVE_KEYS,
+                UI_POOL_USER_RESERVE_KEYS,
+            ),
+            (
+                UI_POOL_DATA_PROVIDER_ORIGIN_ABI,
+                UI_POOL_RESERVE_KEYS_ORIGIN,
+                UI_POOL_USER_RESERVE_KEYS,
+            ),
+            (
+                UI_POOL_DATA_PROVIDER_LEGACY_ABI,
+                UI_POOL_RESERVE_KEYS_LEGACY,
+                UI_POOL_USER_RESERVE_KEYS_LEGACY,
+            ),
+        )
+
+        for abi, reserve_keys, user_reserve_keys in variants:
+            ui_pool = web3.eth.contract(address=ui_pool_addr, abi=abi)
+            try:
+                reserves, base_currency = await ui_pool.functions.getReservesData(
+                    provider_addr
+                ).call(block_identifier="pending")
+                return (
+                    ui_pool,
+                    reserve_keys,
+                    user_reserve_keys,
+                    reserves,
+                    base_currency,
+                )
+            except Exception as exc:  # noqa: BLE001
+                last_error = exc
+
+        if last_error:
+            raise last_error
+        raise ValueError("no UiPoolDataProvider ABI variants configured")
+
+    async def get_emode_categories(
+        self, *, chain_id: int
+    ) -> tuple[bool, list[dict[str, Any]] | str]:
+        try:
+            entry = self._entry(int(chain_id))
+            async with web3_utils.web3_from_chain_id(int(chain_id)) as web3:
+                ui_pool = web3.eth.contract(
+                    address=entry["ui_pool_data_provider"],
+                    abi=UI_POOL_DATA_PROVIDER_ABI,
+                )
+                categories = await self._read_emode_categories(
+                    ui_pool, entry["pool_addresses_provider"]
+                )
+            return True, categories
+        except Exception as exc:  # noqa: BLE001
+            return False, str(exc)
+
+    async def _a_token_for_underlying(
+        self, *, chain_id: int, underlying_token: str
+    ) -> str:
+        asset = to_checksum_address(underlying_token)
+        ok, markets = await self.get_all_markets(
+            chain_id=int(chain_id), include_rewards=False
+        )
+        if not ok or not isinstance(markets, list):
+            raise ValueError(f"failed to resolve reserves for chain_id={chain_id}")
+
+        for market in markets:
+            if str(market.get("underlying") or "").lower() == asset.lower():
+                a_token = str(market.get("a_token") or "")
+                if a_token:
+                    return to_checksum_address(a_token)
+
+        raise ValueError(
+            f"could not resolve aToken for asset={asset} on chain_id={chain_id}"
+        )
+
+    async def _earn_vault_asset(self, *, chain_id: int, vault_address: str) -> str:
+        async with web3_utils.web3_from_chain_id(int(chain_id)) as web3:
+            vault = web3.eth.contract(
+                address=to_checksum_address(str(vault_address)),
+                abi=AAVE_EARN_VAULT_ABI,
+            )
+            asset = await vault.functions.asset().call(block_identifier="pending")
+            return to_checksum_address(str(asset))
+
     async def get_all_markets(
         self,
         *,
@@ -261,16 +436,16 @@ class AaveV3Adapter(BaseAdapter):
                     except Exception:  # noqa: BLE001
                         reserves_incentives = {}
 
-                ui_pool = web3.eth.contract(
-                    address=ui_pool_addr, abi=UI_POOL_DATA_PROVIDER_ABI
-                )
-                reserves, base_currency = await ui_pool.functions.getReservesData(
-                    provider_addr
-                ).call(block_identifier="pending")
+                (
+                    _ui_pool,
+                    reserve_keys,
+                    _user_reserve_keys,
+                    reserves,
+                    base_currency,
+                ) = await self._read_reserves_data(web3, ui_pool_addr, provider_addr)
 
                 ref_unit, ref_usd = _base_currency_to_ref(base_currency)
 
-                reserve_keys = UI_POOL_RESERVE_KEYS
                 markets: list[dict[str, Any]] = []
 
                 for reserve in reserves or []:
@@ -339,6 +514,53 @@ class AaveV3Adapter(BaseAdapter):
                         "liquidation_threshold_bps": int(
                             r.get("reserveLiquidationThreshold") or 0
                         ),
+                        "liquidation_bonus_bps": int(
+                            r.get("reserveLiquidationBonus") or 0
+                        ),
+                        "reserve_factor_bps": int(r.get("reserveFactor") or 0),
+                        "emode_category_id": int(r.get("eModeCategoryId") or 0),
+                        "emode_ltv_bps": int(r.get("eModeLtv") or 0),
+                        "emode_liquidation_threshold_bps": int(
+                            r.get("eModeLiquidationThreshold") or 0
+                        ),
+                        "emode_liquidation_bonus_bps": int(
+                            r.get("eModeLiquidationBonus") or 0
+                        ),
+                        "emode_label": str(r.get("eModeLabel") or ""),
+                        "emode_price_source": to_checksum_address(
+                            str(r.get("eModePriceSource"))
+                        )
+                        if r.get("eModePriceSource")
+                        else None,
+                        "borrowable_in_isolation": bool(r.get("borrowableInIsolation")),
+                        "debt_ceiling": int(r.get("debtCeiling") or 0),
+                        "debt_ceiling_decimals": int(r.get("debtCeilingDecimals") or 0),
+                        "isolation_mode_total_debt": int(
+                            r.get("isolationModeTotalDebt") or 0
+                        ),
+                        "flash_loan_enabled": bool(r.get("flashLoanEnabled")),
+                        "virtual_accounting_active": bool(r.get("virtualAccActive")),
+                        "virtual_underlying_balance": int(
+                            r.get("virtualUnderlyingBalance") or 0
+                        ),
+                        "accrued_to_treasury": int(r.get("accruedToTreasury") or 0),
+                        "unbacked": int(r.get("unbacked") or 0),
+                        "deficit": int(r.get("deficit") or 0),
+                        "last_update_timestamp": int(r.get("lastUpdateTimestamp") or 0),
+                        "price_oracle": to_checksum_address(str(r.get("priceOracle")))
+                        if r.get("priceOracle")
+                        else None,
+                        "interest_rate_strategy": to_checksum_address(
+                            str(r.get("interestRateStrategyAddress"))
+                        )
+                        if r.get("interestRateStrategyAddress")
+                        else None,
+                        "variable_rate_slope1": int(r.get("variableRateSlope1") or 0),
+                        "variable_rate_slope2": int(r.get("variableRateSlope2") or 0),
+                        "base_variable_borrow_rate": int(
+                            r.get("baseVariableBorrowRate") or 0
+                        ),
+                        "optimal_usage_ratio": int(r.get("optimalUsageRatio") or 0),
                         "price_usd": float(price_usd),
                         "supply_apr": float(supply_apr),
                         "supply_apy": float(base_supply_apy),
@@ -437,6 +659,10 @@ class AaveV3Adapter(BaseAdapter):
                         "chain_id": cid,
                         "pool": chain_data.get("pool"),
                         "userEmodeCategoryId": chain_data.get("userEmodeCategoryId", 0),
+                        "user_emode_category_id": chain_data.get(
+                            "user_emode_category_id", 0
+                        ),
+                        "account_data": chain_data.get("account_data"),
                     }
                 )
             else:
@@ -469,19 +695,41 @@ class AaveV3Adapter(BaseAdapter):
             account = to_checksum_address(account)
 
             async with web3_utils.web3_from_chain_id(int(chain_id)) as web3:
-                ui_pool = web3.eth.contract(
-                    address=ui_pool_addr, abi=UI_POOL_DATA_PROVIDER_ABI
-                )
-                reserves, base_currency = await ui_pool.functions.getReservesData(
-                    provider_addr
-                ).call(block_identifier="pending")
+                (
+                    ui_pool,
+                    reserve_keys,
+                    user_reserve_keys,
+                    reserves,
+                    base_currency,
+                ) = await self._read_reserves_data(web3, ui_pool_addr, provider_addr)
                 user_reserves, user_emode = await ui_pool.functions.getUserReservesData(
                     provider_addr, account
                 ).call(block_identifier="pending")
 
                 ref_unit, ref_usd = _base_currency_to_ref(base_currency)
+                account_data: dict[str, int] | None = None
+                account_data_error: str | None = None
+                try:
+                    pool_contract = web3.eth.contract(
+                        address=entry["pool"], abi=POOL_ABI
+                    )
+                    account_data = _account_data_to_dict(
+                        await pool_contract.functions.getUserAccountData(account).call(
+                            block_identifier="pending"
+                        )
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    account_data_error = str(exc)
 
-                reserve_keys = UI_POOL_RESERVE_KEYS
+                emode_categories: list[dict[str, Any]] = []
+                emode_categories_error: str | None = None
+                try:
+                    emode_categories = await self._read_emode_categories(
+                        ui_pool, provider_addr
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    emode_categories_error = str(exc)
+
                 by_underlying: dict[str, dict[str, Any]] = {}
                 for reserve in reserves or []:
                     r = _reserve_to_dict(reserve, reserve_keys)
@@ -566,8 +814,11 @@ class AaveV3Adapter(BaseAdapter):
 
             positions: list[dict[str, Any]] = []
             for row in user_reserves or []:
+                user_reserve = _reserve_to_dict(row, user_reserve_keys)
                 try:
-                    underlying = to_checksum_address(str(row[0]))
+                    underlying = to_checksum_address(
+                        str(user_reserve.get("underlyingAsset"))
+                    )
                 except Exception:  # noqa: BLE001
                     continue
 
@@ -581,10 +832,10 @@ class AaveV3Adapter(BaseAdapter):
                 liquidity_index = int(reserve.get("liquidityIndex") or 0)
                 variable_borrow_index = int(reserve.get("variableBorrowIndex") or 0)
 
-                scaled_supply = int(row[1] or 0)
-                scaled_var_debt = int(row[3] or 0)
-                stable_debt = 0
-                is_collateral = bool(row[2])
+                scaled_supply = int(user_reserve.get("scaledATokenBalance") or 0)
+                scaled_var_debt = int(user_reserve.get("scaledVariableDebt") or 0)
+                stable_debt = int(user_reserve.get("principalStableDebt") or 0)
+                is_collateral = bool(user_reserve.get("usageAsCollateralEnabledOnUser"))
 
                 supply_raw = (
                     (scaled_supply * liquidity_index) // RAY if scaled_supply else 0
@@ -690,6 +941,39 @@ class AaveV3Adapter(BaseAdapter):
                             str(reserve.get("variableDebtTokenAddress"))
                         ),
                         "usage_as_collateral": is_collateral,
+                        "usage_as_collateral_enabled": bool(
+                            reserve.get("usageAsCollateralEnabled")
+                        ),
+                        "is_frozen": bool(reserve.get("isFrozen")),
+                        "is_paused": bool(reserve.get("isPaused")),
+                        "is_siloed_borrowing": bool(reserve.get("isSiloedBorrowing")),
+                        "borrowable_in_isolation": bool(
+                            reserve.get("borrowableInIsolation")
+                        ),
+                        "ltv_bps": int(reserve.get("baseLTVasCollateral") or 0),
+                        "liquidation_threshold_bps": int(
+                            reserve.get("reserveLiquidationThreshold") or 0
+                        ),
+                        "liquidation_bonus_bps": int(
+                            reserve.get("reserveLiquidationBonus") or 0
+                        ),
+                        "emode_category_id": int(reserve.get("eModeCategoryId") or 0),
+                        "emode_ltv_bps": int(reserve.get("eModeLtv") or 0),
+                        "emode_liquidation_threshold_bps": int(
+                            reserve.get("eModeLiquidationThreshold") or 0
+                        ),
+                        "emode_liquidation_bonus_bps": int(
+                            reserve.get("eModeLiquidationBonus") or 0
+                        ),
+                        "emode_label": str(reserve.get("eModeLabel") or ""),
+                        "debt_ceiling": int(reserve.get("debtCeiling") or 0),
+                        "debt_ceiling_decimals": int(
+                            reserve.get("debtCeilingDecimals") or 0
+                        ),
+                        "isolation_mode_total_debt": int(
+                            reserve.get("isolationModeTotalDebt") or 0
+                        ),
+                        "deficit": int(reserve.get("deficit") or 0),
                         "supply_raw": int(supply_raw),
                         "variable_borrow_raw": int(variable_debt_raw),
                         "stable_borrow_raw": int(stable_debt),
@@ -709,14 +993,23 @@ class AaveV3Adapter(BaseAdapter):
                     }
                 )
 
-            return True, {
+            state: dict[str, Any] = {
                 "protocol": "aave_v3",
                 "chain_id": int(chain_id),
                 "pool": entry["pool"],
                 "account": account,
                 "userEmodeCategoryId": int(user_emode or 0),
+                "user_emode_category_id": int(user_emode or 0),
+                "emode_categories": emode_categories,
+                "account_data": account_data,
                 "positions": positions,
             }
+            if account_data_error:
+                state["account_data_error"] = account_data_error
+            if emode_categories_error:
+                state["emode_categories_error"] = emode_categories_error
+
+            return True, state
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
 
@@ -1102,6 +1395,38 @@ class AaveV3Adapter(BaseAdapter):
             use_as_collateral=False,
         )
 
+    async def set_emode(
+        self,
+        *,
+        chain_id: int,
+        category_id: int,
+    ) -> tuple[bool, Any]:
+        strategy = self.wallet_address
+        if not strategy:
+            return False, "strategy wallet address not configured"
+
+        category_id = int(category_id)
+        if category_id < 0 or category_id > 255:
+            return False, "category_id must be between 0 and 255"
+
+        try:
+            pool = self._entry(int(chain_id))["pool"]
+            tx = await encode_call(
+                target=pool,
+                abi=POOL_ABI,
+                fn_name="setUserEMode",
+                args=[category_id],
+                from_address=strategy,
+                chain_id=int(chain_id),
+            )
+            txn_hash = await send_transaction(tx, self.sign_callback)
+            return True, txn_hash
+        except Exception as exc:  # noqa: BLE001
+            return False, str(exc)
+
+    async def disable_emode(self, *, chain_id: int) -> tuple[bool, Any]:
+        return await self.set_emode(chain_id=int(chain_id), category_id=0)
+
     async def claim_all_rewards(
         self,
         *,
@@ -1153,6 +1478,477 @@ class AaveV3Adapter(BaseAdapter):
                 abi=REWARDS_CONTROLLER_ABI,
                 fn_name="claimAllRewards",
                 args=[[to_checksum_address(a) for a in assets], to_addr],
+                from_address=strategy,
+                chain_id=int(chain_id),
+            )
+            txn_hash = await send_transaction(tx, self.sign_callback)
+            return True, txn_hash
+        except Exception as exc:  # noqa: BLE001
+            return False, str(exc)
+
+    async def get_earn_vault_state(
+        self,
+        *,
+        chain_id: int,
+        vault_address: str,
+        account: str | None = None,
+    ) -> tuple[bool, dict[str, Any] | str]:
+        try:
+            vault_addr = to_checksum_address(str(vault_address))
+            acct = to_checksum_address(account) if account else None
+
+            async with web3_utils.web3_from_chain_id(int(chain_id)) as web3:
+                vault = web3.eth.contract(
+                    address=vault_addr,
+                    abi=AAVE_EARN_VAULT_ABI,
+                )
+                asset = to_checksum_address(
+                    str(await vault.functions.asset().call(block_identifier="pending"))
+                )
+                asset_token = web3.eth.contract(address=asset, abi=ERC20_ABI)
+                name = str(
+                    await vault.functions.name().call(block_identifier="pending") or ""
+                )
+                symbol = str(
+                    await vault.functions.symbol().call(block_identifier="pending")
+                    or ""
+                )
+                decimals = int(
+                    await vault.functions.decimals().call(block_identifier="pending")
+                    or 18
+                )
+                asset_decimals = int(
+                    await asset_token.functions.decimals().call(
+                        block_identifier="pending"
+                    )
+                    or decimals
+                )
+                total_supply = int(
+                    await vault.functions.totalSupply().call(block_identifier="pending")
+                    or 0
+                )
+                total_assets = int(
+                    await vault.functions.totalAssets().call(block_identifier="pending")
+                    or 0
+                )
+                unit_shares = 10 ** max(0, decimals)
+                unit_assets = 10 ** max(0, asset_decimals)
+                assets_per_share_unit = int(
+                    await vault.functions.convertToAssets(unit_shares).call(
+                        block_identifier="pending"
+                    )
+                    or 0
+                )
+                shares_per_asset_unit = int(
+                    await vault.functions.convertToShares(unit_assets).call(
+                        block_identifier="pending"
+                    )
+                    or 0
+                )
+                max_deposit = int(
+                    await vault.functions.maxDeposit(acct or ZERO_ADDRESS).call(
+                        block_identifier="pending"
+                    )
+                    or 0
+                )
+                max_mint = int(
+                    await vault.functions.maxMint(acct or ZERO_ADDRESS).call(
+                        block_identifier="pending"
+                    )
+                    or 0
+                )
+
+                fee_raw: int | None = None
+                claimable_fees_raw: int | None = None
+                last_vault_balance_raw: int | None = None
+                try:
+                    fee_raw = int(
+                        await vault.functions.getFee().call(block_identifier="pending")
+                        or 0
+                    )
+                    claimable_fees_raw = int(
+                        await vault.functions.getClaimableFees().call(
+                            block_identifier="pending"
+                        )
+                        or 0
+                    )
+                    last_vault_balance_raw = int(
+                        await vault.functions.getLastVaultBalance().call(
+                            block_identifier="pending"
+                        )
+                        or 0
+                    )
+                except Exception:  # noqa: BLE001
+                    pass
+
+                user: dict[str, Any] | None = None
+                if acct:
+                    shares = int(
+                        await vault.functions.balanceOf(acct).call(
+                            block_identifier="pending"
+                        )
+                        or 0
+                    )
+                    assets = int(
+                        await vault.functions.convertToAssets(shares).call(
+                            block_identifier="pending"
+                        )
+                        or 0
+                    )
+                    max_withdraw = int(
+                        await vault.functions.maxWithdraw(acct).call(
+                            block_identifier="pending"
+                        )
+                        or 0
+                    )
+                    max_redeem = int(
+                        await vault.functions.maxRedeem(acct).call(
+                            block_identifier="pending"
+                        )
+                        or 0
+                    )
+                    user = {
+                        "account": acct,
+                        "shares_raw": shares,
+                        "assets_raw": assets,
+                        "max_withdraw_raw": max_withdraw,
+                        "max_redeem_raw": max_redeem,
+                    }
+
+            return True, {
+                "protocol": "aave_v3",
+                "type": "earn_vault",
+                "chain_id": int(chain_id),
+                "vault": vault_addr,
+                "asset": asset,
+                "name": name,
+                "symbol": symbol,
+                "decimals": decimals,
+                "asset_decimals": asset_decimals,
+                "total_supply_raw": total_supply,
+                "total_assets_raw": total_assets,
+                "assets_per_share_unit_raw": assets_per_share_unit,
+                "shares_per_asset_unit_raw": shares_per_asset_unit,
+                "max_deposit_raw": max_deposit,
+                "max_mint_raw": max_mint,
+                "fee_raw": fee_raw,
+                "claimable_fees_raw": claimable_fees_raw,
+                "last_vault_balance_raw": last_vault_balance_raw,
+                "user": user,
+            }
+        except Exception as exc:  # noqa: BLE001
+            return False, str(exc)
+
+    async def earn_vault_deposit(
+        self,
+        *,
+        chain_id: int,
+        vault_address: str,
+        assets: int,
+        receiver: str | None = None,
+    ) -> tuple[bool, Any]:
+        strategy = self.wallet_address
+        if not strategy:
+            return False, "strategy wallet address not configured"
+        assets = int(assets)
+        if assets <= 0:
+            return False, "assets must be positive"
+
+        try:
+            vault = to_checksum_address(str(vault_address))
+            recv = to_checksum_address(receiver) if receiver else strategy
+            asset = await self._earn_vault_asset(
+                chain_id=int(chain_id), vault_address=vault
+            )
+
+            approved = await ensure_allowance(
+                token_address=asset,
+                owner=strategy,
+                spender=vault,
+                amount=assets,
+                chain_id=int(chain_id),
+                signing_callback=self.sign_callback,
+                approval_amount=MAX_UINT256,
+            )
+            if not approved[0]:
+                return approved
+
+            tx = await encode_call(
+                target=vault,
+                abi=AAVE_EARN_VAULT_ABI,
+                fn_name="deposit",
+                args=[assets, recv],
+                from_address=strategy,
+                chain_id=int(chain_id),
+            )
+            txn_hash = await send_transaction(tx, self.sign_callback)
+            return True, txn_hash
+        except Exception as exc:  # noqa: BLE001
+            return False, str(exc)
+
+    async def earn_vault_deposit_atokens(
+        self,
+        *,
+        chain_id: int,
+        vault_address: str,
+        assets: int,
+        receiver: str | None = None,
+    ) -> tuple[bool, Any]:
+        strategy = self.wallet_address
+        if not strategy:
+            return False, "strategy wallet address not configured"
+        assets = int(assets)
+        if assets <= 0:
+            return False, "assets must be positive"
+
+        try:
+            vault = to_checksum_address(str(vault_address))
+            recv = to_checksum_address(receiver) if receiver else strategy
+            asset = await self._earn_vault_asset(
+                chain_id=int(chain_id), vault_address=vault
+            )
+            a_token = await self._a_token_for_underlying(
+                chain_id=int(chain_id), underlying_token=asset
+            )
+
+            approved = await ensure_allowance(
+                token_address=a_token,
+                owner=strategy,
+                spender=vault,
+                amount=assets,
+                chain_id=int(chain_id),
+                signing_callback=self.sign_callback,
+                approval_amount=MAX_UINT256,
+            )
+            if not approved[0]:
+                return approved
+
+            tx = await encode_call(
+                target=vault,
+                abi=AAVE_EARN_VAULT_ABI,
+                fn_name="depositATokens",
+                args=[assets, recv],
+                from_address=strategy,
+                chain_id=int(chain_id),
+            )
+            txn_hash = await send_transaction(tx, self.sign_callback)
+            return True, txn_hash
+        except Exception as exc:  # noqa: BLE001
+            return False, str(exc)
+
+    async def earn_vault_mint(
+        self,
+        *,
+        chain_id: int,
+        vault_address: str,
+        shares: int,
+        receiver: str | None = None,
+    ) -> tuple[bool, Any]:
+        strategy = self.wallet_address
+        if not strategy:
+            return False, "strategy wallet address not configured"
+        shares = int(shares)
+        if shares <= 0:
+            return False, "shares must be positive"
+
+        try:
+            vault = to_checksum_address(str(vault_address))
+            recv = to_checksum_address(receiver) if receiver else strategy
+            asset = await self._earn_vault_asset(
+                chain_id=int(chain_id), vault_address=vault
+            )
+
+            approved = await ensure_allowance(
+                token_address=asset,
+                owner=strategy,
+                spender=vault,
+                amount=MAX_UINT256,
+                chain_id=int(chain_id),
+                signing_callback=self.sign_callback,
+                approval_amount=MAX_UINT256,
+            )
+            if not approved[0]:
+                return approved
+
+            tx = await encode_call(
+                target=vault,
+                abi=AAVE_EARN_VAULT_ABI,
+                fn_name="mint",
+                args=[shares, recv],
+                from_address=strategy,
+                chain_id=int(chain_id),
+            )
+            txn_hash = await send_transaction(tx, self.sign_callback)
+            return True, txn_hash
+        except Exception as exc:  # noqa: BLE001
+            return False, str(exc)
+
+    async def earn_vault_withdraw(
+        self,
+        *,
+        chain_id: int,
+        vault_address: str,
+        assets: int,
+        receiver: str | None = None,
+    ) -> tuple[bool, Any]:
+        strategy = self.wallet_address
+        if not strategy:
+            return False, "strategy wallet address not configured"
+        assets = int(assets)
+        if assets <= 0:
+            return False, "assets must be positive"
+
+        try:
+            vault = to_checksum_address(str(vault_address))
+            recv = to_checksum_address(receiver) if receiver else strategy
+            tx = await encode_call(
+                target=vault,
+                abi=AAVE_EARN_VAULT_ABI,
+                fn_name="withdraw",
+                args=[assets, recv, strategy],
+                from_address=strategy,
+                chain_id=int(chain_id),
+            )
+            txn_hash = await send_transaction(tx, self.sign_callback)
+            return True, txn_hash
+        except Exception as exc:  # noqa: BLE001
+            return False, str(exc)
+
+    async def earn_vault_mint_with_atokens(
+        self,
+        *,
+        chain_id: int,
+        vault_address: str,
+        shares: int,
+        receiver: str | None = None,
+    ) -> tuple[bool, Any]:
+        strategy = self.wallet_address
+        if not strategy:
+            return False, "strategy wallet address not configured"
+        shares = int(shares)
+        if shares <= 0:
+            return False, "shares must be positive"
+
+        try:
+            vault = to_checksum_address(str(vault_address))
+            recv = to_checksum_address(receiver) if receiver else strategy
+            asset = await self._earn_vault_asset(
+                chain_id=int(chain_id), vault_address=vault
+            )
+            a_token = await self._a_token_for_underlying(
+                chain_id=int(chain_id), underlying_token=asset
+            )
+
+            approved = await ensure_allowance(
+                token_address=a_token,
+                owner=strategy,
+                spender=vault,
+                amount=MAX_UINT256,
+                chain_id=int(chain_id),
+                signing_callback=self.sign_callback,
+                approval_amount=MAX_UINT256,
+            )
+            if not approved[0]:
+                return approved
+
+            tx = await encode_call(
+                target=vault,
+                abi=AAVE_EARN_VAULT_ABI,
+                fn_name="mintWithATokens",
+                args=[shares, recv],
+                from_address=strategy,
+                chain_id=int(chain_id),
+            )
+            txn_hash = await send_transaction(tx, self.sign_callback)
+            return True, txn_hash
+        except Exception as exc:  # noqa: BLE001
+            return False, str(exc)
+
+    async def earn_vault_withdraw_atokens(
+        self,
+        *,
+        chain_id: int,
+        vault_address: str,
+        assets: int,
+        receiver: str | None = None,
+    ) -> tuple[bool, Any]:
+        strategy = self.wallet_address
+        if not strategy:
+            return False, "strategy wallet address not configured"
+        assets = int(assets)
+        if assets <= 0:
+            return False, "assets must be positive"
+
+        try:
+            vault = to_checksum_address(str(vault_address))
+            recv = to_checksum_address(receiver) if receiver else strategy
+            tx = await encode_call(
+                target=vault,
+                abi=AAVE_EARN_VAULT_ABI,
+                fn_name="withdrawATokens",
+                args=[assets, recv, strategy],
+                from_address=strategy,
+                chain_id=int(chain_id),
+            )
+            txn_hash = await send_transaction(tx, self.sign_callback)
+            return True, txn_hash
+        except Exception as exc:  # noqa: BLE001
+            return False, str(exc)
+
+    async def earn_vault_redeem(
+        self,
+        *,
+        chain_id: int,
+        vault_address: str,
+        shares: int,
+        receiver: str | None = None,
+    ) -> tuple[bool, Any]:
+        strategy = self.wallet_address
+        if not strategy:
+            return False, "strategy wallet address not configured"
+        shares = int(shares)
+        if shares <= 0:
+            return False, "shares must be positive"
+
+        try:
+            vault = to_checksum_address(str(vault_address))
+            recv = to_checksum_address(receiver) if receiver else strategy
+            tx = await encode_call(
+                target=vault,
+                abi=AAVE_EARN_VAULT_ABI,
+                fn_name="redeem",
+                args=[shares, recv, strategy],
+                from_address=strategy,
+                chain_id=int(chain_id),
+            )
+            txn_hash = await send_transaction(tx, self.sign_callback)
+            return True, txn_hash
+        except Exception as exc:  # noqa: BLE001
+            return False, str(exc)
+
+    async def earn_vault_redeem_as_atokens(
+        self,
+        *,
+        chain_id: int,
+        vault_address: str,
+        shares: int,
+        receiver: str | None = None,
+    ) -> tuple[bool, Any]:
+        strategy = self.wallet_address
+        if not strategy:
+            return False, "strategy wallet address not configured"
+        shares = int(shares)
+        if shares <= 0:
+            return False, "shares must be positive"
+
+        try:
+            vault = to_checksum_address(str(vault_address))
+            recv = to_checksum_address(receiver) if receiver else strategy
+            tx = await encode_call(
+                target=vault,
+                abi=AAVE_EARN_VAULT_ABI,
+                fn_name="redeemAsATokens",
+                args=[shares, recv, strategy],
                 from_address=strategy,
                 chain_id=int(chain_id),
             )

--- a/wayfinder_paths/adapters/aave_v3_adapter/manifest.yaml
+++ b/wayfinder_paths/adapters/aave_v3_adapter/manifest.yaml
@@ -8,6 +8,12 @@ capabilities:
   - "lending.borrow"
   - "lending.repay"
   - "collateral.toggle"
+  - "emode.read"
+  - "emode.set"
   - "rewards.claim"
+  - "vault.read"
+  - "vault.deposit"
+  - "vault.withdraw"
+  - "vault.mint"
+  - "vault.redeem"
 dependencies: []
-

--- a/wayfinder_paths/adapters/aave_v3_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/aave_v3_adapter/test_adapter.py
@@ -4,11 +4,21 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from wayfinder_paths.adapters.aave_v3_adapter.adapter import AaveV3Adapter
-from wayfinder_paths.core.constants.aave_v3_abi import UI_POOL_RESERVE_KEYS
+from wayfinder_paths.core.constants.aave_v3_abi import (
+    UI_POOL_RESERVE_KEYS,
+    UI_POOL_RESERVE_KEYS_LEGACY,
+    UI_POOL_RESERVE_KEYS_ORIGIN,
+)
 from wayfinder_paths.core.constants.contracts import ZERO_ADDRESS
 
 FAKE_ADDR = "0x1234567890123456789012345678901234567890"
 FAKE_ASSET = "0x0000000000000000000000000000000000000001"
+FAKE_VAULT = "0x0000000000000000000000000000000000000002"
+FAKE_ATOKEN = "0x0000000000000000000000000000000000000003"
+
+
+def _async_call(value):
+    return MagicMock(call=AsyncMock(return_value=value))
 
 
 class TestAaveV3Adapter:
@@ -25,6 +35,44 @@ class TestAaveV3Adapter:
     def test_strategy_address_optional(self):
         adapter = AaveV3Adapter(config={})
         assert adapter.wallet_address is None
+
+    def test_ui_pool_reserve_keys_match_current_v3_tail_order(self):
+        assert UI_POOL_RESERVE_KEYS[-10:] == [
+            "isolationModeTotalDebt",
+            "flashLoanEnabled",
+            "debtCeiling",
+            "debtCeilingDecimals",
+            "eModeCategoryId",
+            "borrowCap",
+            "supplyCap",
+            "borrowableInIsolation",
+            "virtualAccActive",
+            "virtualUnderlyingBalance",
+        ]
+        assert UI_POOL_RESERVE_KEYS_ORIGIN[-10:] == [
+            "accruedToTreasury",
+            "isolationModeTotalDebt",
+            "flashLoanEnabled",
+            "debtCeiling",
+            "debtCeilingDecimals",
+            "borrowCap",
+            "supplyCap",
+            "borrowableInIsolation",
+            "virtualUnderlyingBalance",
+            "deficit",
+        ]
+        assert UI_POOL_RESERVE_KEYS_LEGACY[-10:] == [
+            "debtCeilingDecimals",
+            "eModeCategoryId",
+            "borrowCap",
+            "supplyCap",
+            "eModeLtv",
+            "eModeLiquidationThreshold",
+            "eModeLiquidationBonus",
+            "eModePriceSource",
+            "eModeLabel",
+            "borrowableInIsolation",
+        ]
 
     @pytest.mark.asyncio
     async def test_get_all_markets_basic(self, adapter):
@@ -56,6 +104,25 @@ class TestAaveV3Adapter:
                     "borrowCap": 0,
                     "baseLTVasCollateral": 8000,
                     "reserveLiquidationThreshold": 8500,
+                    "reserveLiquidationBonus": 10500,
+                    "reserveFactor": 1000,
+                    "flashLoanEnabled": True,
+                    "debtCeiling": 12345,
+                    "debtCeilingDecimals": 2,
+                    "eModeCategoryId": 1,
+                    "borrowableInIsolation": True,
+                    "virtualAccActive": True,
+                    "virtualUnderlyingBalance": 1_000_000,
+                    "isolationModeTotalDebt": 234,
+                    "unbacked": 345,
+                    "accruedToTreasury": 456,
+                    "lastUpdateTimestamp": 1_700_000_000,
+                    "priceOracle": "0x00000000000000000000000000000000000000c1",
+                    "interestRateStrategyAddress": "0x00000000000000000000000000000000000000d1",
+                    "variableRateSlope1": 111,
+                    "variableRateSlope2": 222,
+                    "baseVariableBorrowRate": 333,
+                    "optimalUsageRatio": 444,
                 }
             )
             base.update(overrides)
@@ -114,6 +181,23 @@ class TestAaveV3Adapter:
         assert usol["supply_cap_headroom"] == 85_000_000
         assert usol["ltv_bps"] == 8000
         assert usol["liquidation_threshold_bps"] == 8500
+        assert usol["liquidation_bonus_bps"] == 10500
+        assert usol["reserve_factor_bps"] == 1000
+        assert usol["flash_loan_enabled"] is True
+        assert usol["debt_ceiling"] == 12345
+        assert usol["debt_ceiling_decimals"] == 2
+        assert usol["emode_category_id"] == 1
+        assert usol["borrowable_in_isolation"] is True
+        assert usol["virtual_accounting_active"] is True
+        assert usol["virtual_underlying_balance"] == 1_000_000
+        assert usol["isolation_mode_total_debt"] == 234
+        assert usol["unbacked"] == 345
+        assert usol["accrued_to_treasury"] == 456
+        assert usol["last_update_timestamp"] == 1_700_000_000
+        assert usol["variable_rate_slope1"] == 111
+        assert usol["variable_rate_slope2"] == 222
+        assert usol["base_variable_borrow_rate"] == 333
+        assert usol["optimal_usage_ratio"] == 444
 
     @pytest.mark.asyncio
     async def test_get_all_markets_includes_rewards(self, adapter):
@@ -300,6 +384,137 @@ class TestAaveV3Adapter:
         pos = state["positions"][0]
         assert pos["supply_raw"] == 2_000_000
         assert pos["variable_borrow_raw"] == 1_000_000
+
+    @pytest.mark.asyncio
+    async def test_get_full_user_state_includes_account_data_and_emodes(self, adapter):
+        reserve_keys = UI_POOL_RESERVE_KEYS
+
+        def build_reserve(**overrides):
+            base = dict.fromkeys(reserve_keys, 0)
+            base.update(
+                {
+                    "underlyingAsset": "0x0000000000000000000000000000000000000011",
+                    "name": "",
+                    "symbol": "USDC",
+                    "decimals": 6,
+                    "usageAsCollateralEnabled": True,
+                    "borrowingEnabled": True,
+                    "isActive": True,
+                    "isFrozen": False,
+                    "isPaused": False,
+                    "isSiloedBorrowing": True,
+                    "borrowableInIsolation": True,
+                    "aTokenAddress": "0x00000000000000000000000000000000000000a1",
+                    "variableDebtTokenAddress": "0x00000000000000000000000000000000000000b1",
+                    "priceInMarketReferenceCurrency": 100000000,
+                    "liquidityIndex": 10**27,
+                    "variableBorrowIndex": 10**27,
+                    "baseLTVasCollateral": 8000,
+                    "reserveLiquidationThreshold": 8500,
+                    "reserveLiquidationBonus": 10500,
+                    "eModeCategoryId": 1,
+                    "debtCeiling": 1000,
+                    "debtCeilingDecimals": 2,
+                    "isolationModeTotalDebt": 12,
+                }
+            )
+            base.update(overrides)
+            return tuple(base[k] for k in reserve_keys)
+
+        mock_ui_pool = MagicMock()
+        mock_ui_pool.functions.getReservesData = MagicMock(
+            return_value=_async_call(([build_reserve()], (100000000, 100000000, 0, 8)))
+        )
+        mock_ui_pool.functions.getUserReservesData = MagicMock(
+            return_value=_async_call(
+                (
+                    [
+                        (
+                            "0x0000000000000000000000000000000000000011",
+                            2_000_000,
+                            True,
+                            1_000_000,
+                        )
+                    ],
+                    1,
+                )
+            )
+        )
+        mock_ui_pool.functions.getEModes = MagicMock(
+            return_value=_async_call(
+                [
+                    (
+                        1,
+                        (
+                            9300,
+                            9500,
+                            10100,
+                            7,
+                            "Stablecoins",
+                            3,
+                        ),
+                    )
+                ]
+            )
+        )
+
+        mock_pool = MagicMock()
+        mock_pool.functions.getUserAccountData = MagicMock(
+            return_value=_async_call((500, 100, 300, 8500, 8000, 2 * 10**18))
+        )
+
+        mock_web3 = MagicMock()
+
+        def contract_side_effect(*, address, abi):  # noqa: ARG001
+            if (
+                abi
+                and isinstance(abi, list)
+                and any(
+                    x.get("name") == "getUserAccountData"
+                    for x in abi
+                    if isinstance(x, dict)
+                )
+            ):
+                return mock_pool
+            return mock_ui_pool
+
+        mock_web3.eth.contract = MagicMock(side_effect=contract_side_effect)
+
+        @asynccontextmanager
+        async def mock_web3_ctx(_chain_id):
+            yield mock_web3
+
+        with patch(
+            "wayfinder_paths.adapters.aave_v3_adapter.adapter.web3_utils.web3_from_chain_id",
+            mock_web3_ctx,
+        ):
+            ok, state = await adapter.get_full_user_state_per_chain(
+                chain_id=42161,
+                account="0x1234567890123456789012345678901234567890",
+                include_rewards=False,
+            )
+
+        assert ok is True
+        assert isinstance(state, dict)
+        assert state["user_emode_category_id"] == 1
+        assert state["account_data"]["health_factor"] == 2 * 10**18
+        assert state["account_data"]["available_borrows_base"] == 300
+        assert state["emode_categories"] == [
+            {
+                "id": 1,
+                "ltv_bps": 9300,
+                "liquidation_threshold_bps": 9500,
+                "liquidation_bonus_bps": 10100,
+                "collateral_bitmap": 7,
+                "borrowable_bitmap": 3,
+                "label": "Stablecoins",
+            }
+        ]
+        pos = state["positions"][0]
+        assert pos["emode_category_id"] == 1
+        assert pos["is_siloed_borrowing"] is True
+        assert pos["borrowable_in_isolation"] is True
+        assert pos["debt_ceiling"] == 1000
 
     @pytest.mark.asyncio
     async def test_claim_all_rewards_encodes_tx(self, adapter):
@@ -534,3 +749,268 @@ class TestAaveV3Adapter:
         assert ok is True
         assert result["wrap_tx"] == "0xabc"
         assert result["repay_tx"] == "0xabc"
+
+    @pytest.mark.asyncio
+    @patch(
+        "wayfinder_paths.adapters.aave_v3_adapter.adapter.send_transaction",
+        new_callable=AsyncMock,
+        return_value="0xabc",
+    )
+    @patch(
+        "wayfinder_paths.adapters.aave_v3_adapter.adapter.encode_call",
+        new_callable=AsyncMock,
+        return_value={"to": FAKE_ADDR},
+    )
+    async def test_set_emode_encodes_tx(self, mock_encode, _mock_send, adapter):
+        ok, result = await adapter.set_emode(chain_id=42161, category_id=1)
+
+        assert ok is True
+        assert result == "0xabc"
+        assert mock_encode.await_args.kwargs["fn_name"] == "setUserEMode"
+        assert mock_encode.await_args.kwargs["args"] == [1]
+
+    @pytest.mark.asyncio
+    async def test_set_emode_validates_category(self, adapter):
+        ok, result = await adapter.set_emode(chain_id=42161, category_id=256)
+
+        assert ok is False
+        assert "category_id must be between 0 and 255" in result
+
+    @pytest.mark.asyncio
+    async def test_get_earn_vault_state_reads_vault_and_user(self, adapter):
+        mock_vault = MagicMock()
+        mock_vault.functions.asset = MagicMock(return_value=_async_call(FAKE_ASSET))
+        mock_vault.functions.name = MagicMock(
+            return_value=_async_call("Aave USDC Vault")
+        )
+        mock_vault.functions.symbol = MagicMock(return_value=_async_call("avUSDC"))
+        mock_vault.functions.decimals = MagicMock(return_value=_async_call(6))
+        mock_vault.functions.totalSupply = MagicMock(
+            return_value=_async_call(1_000_000)
+        )
+        mock_vault.functions.totalAssets = MagicMock(
+            return_value=_async_call(2_000_000)
+        )
+        mock_vault.functions.convertToAssets = MagicMock(
+            side_effect=[_async_call(2_000_000), _async_call(200_000)]
+        )
+        mock_vault.functions.convertToShares = MagicMock(
+            return_value=_async_call(500_000)
+        )
+        mock_vault.functions.maxDeposit = MagicMock(return_value=_async_call(3_000_000))
+        mock_vault.functions.maxMint = MagicMock(return_value=_async_call(1_500_000))
+        mock_vault.functions.getFee = MagicMock(return_value=_async_call(1000))
+        mock_vault.functions.getClaimableFees = MagicMock(return_value=_async_call(50))
+        mock_vault.functions.getLastVaultBalance = MagicMock(
+            return_value=_async_call(1_900_000)
+        )
+        mock_vault.functions.balanceOf = MagicMock(return_value=_async_call(100_000))
+        mock_vault.functions.maxWithdraw = MagicMock(return_value=_async_call(200_000))
+        mock_vault.functions.maxRedeem = MagicMock(return_value=_async_call(100_000))
+
+        mock_web3 = MagicMock()
+        mock_web3.eth.contract = MagicMock(return_value=mock_vault)
+
+        @asynccontextmanager
+        async def mock_web3_ctx(_chain_id):
+            yield mock_web3
+
+        with patch(
+            "wayfinder_paths.adapters.aave_v3_adapter.adapter.web3_utils.web3_from_chain_id",
+            mock_web3_ctx,
+        ):
+            ok, state = await adapter.get_earn_vault_state(
+                chain_id=42161, vault_address=FAKE_VAULT, account=FAKE_ADDR
+            )
+
+        assert ok is True
+        assert isinstance(state, dict)
+        assert state["type"] == "earn_vault"
+        assert state["asset"] == "0x0000000000000000000000000000000000000001"
+        assert state["symbol"] == "avUSDC"
+        assert state["asset_decimals"] == 6
+        assert state["total_assets_raw"] == 2_000_000
+        assert state["assets_per_share_unit_raw"] == 2_000_000
+        assert state["shares_per_asset_unit_raw"] == 500_000
+        assert state["max_deposit_raw"] == 3_000_000
+        assert state["max_mint_raw"] == 1_500_000
+        assert state["fee_raw"] == 1000
+        assert state["claimable_fees_raw"] == 50
+        assert state["last_vault_balance_raw"] == 1_900_000
+        assert state["user"]["shares_raw"] == 100_000
+        assert state["user"]["assets_raw"] == 200_000
+
+    @pytest.mark.asyncio
+    @patch(
+        "wayfinder_paths.adapters.aave_v3_adapter.adapter.send_transaction",
+        new_callable=AsyncMock,
+        return_value="0xvault",
+    )
+    @patch(
+        "wayfinder_paths.adapters.aave_v3_adapter.adapter.ensure_allowance",
+        new_callable=AsyncMock,
+        return_value=(True, "ok"),
+    )
+    @patch(
+        "wayfinder_paths.adapters.aave_v3_adapter.adapter.encode_call",
+        new_callable=AsyncMock,
+        return_value={"to": FAKE_VAULT},
+    )
+    async def test_earn_vault_deposit_approves_asset_and_encodes(
+        self, mock_encode, mock_allowance, _mock_send, adapter
+    ):
+        adapter._earn_vault_asset = AsyncMock(return_value=FAKE_ASSET)
+
+        ok, tx = await adapter.earn_vault_deposit(
+            chain_id=42161, vault_address=FAKE_VAULT, assets=123
+        )
+
+        assert ok is True
+        assert tx == "0xvault"
+        assert mock_allowance.await_args.kwargs["token_address"] == FAKE_ASSET
+        assert mock_allowance.await_args.kwargs["spender"] == FAKE_VAULT
+        assert mock_encode.await_args.kwargs["fn_name"] == "deposit"
+        assert mock_encode.await_args.kwargs["args"] == [123, FAKE_ADDR]
+
+    @pytest.mark.asyncio
+    @patch(
+        "wayfinder_paths.adapters.aave_v3_adapter.adapter.send_transaction",
+        new_callable=AsyncMock,
+        return_value="0xvault",
+    )
+    @patch(
+        "wayfinder_paths.adapters.aave_v3_adapter.adapter.ensure_allowance",
+        new_callable=AsyncMock,
+        return_value=(True, "ok"),
+    )
+    @patch(
+        "wayfinder_paths.adapters.aave_v3_adapter.adapter.encode_call",
+        new_callable=AsyncMock,
+        return_value={"to": FAKE_VAULT},
+    )
+    async def test_earn_vault_deposit_atokens_approves_atoken_and_encodes(
+        self, mock_encode, mock_allowance, _mock_send, adapter
+    ):
+        adapter._earn_vault_asset = AsyncMock(return_value=FAKE_ASSET)
+        adapter._a_token_for_underlying = AsyncMock(return_value=FAKE_ATOKEN)
+
+        ok, tx = await adapter.earn_vault_deposit_atokens(
+            chain_id=42161, vault_address=FAKE_VAULT, assets=123
+        )
+
+        assert ok is True
+        assert tx == "0xvault"
+        assert mock_allowance.await_args.kwargs["token_address"] == FAKE_ATOKEN
+        assert mock_allowance.await_args.kwargs["spender"] == FAKE_VAULT
+        assert mock_encode.await_args.kwargs["fn_name"] == "depositATokens"
+        assert mock_encode.await_args.kwargs["args"] == [123, FAKE_ADDR]
+
+    @pytest.mark.asyncio
+    @patch(
+        "wayfinder_paths.adapters.aave_v3_adapter.adapter.send_transaction",
+        new_callable=AsyncMock,
+        return_value="0xvault",
+    )
+    @patch(
+        "wayfinder_paths.adapters.aave_v3_adapter.adapter.ensure_allowance",
+        new_callable=AsyncMock,
+        return_value=(True, "ok"),
+    )
+    @patch(
+        "wayfinder_paths.adapters.aave_v3_adapter.adapter.encode_call",
+        new_callable=AsyncMock,
+        return_value={"to": FAKE_VAULT},
+    )
+    async def test_earn_vault_mint_with_atokens_approves_atoken_and_encodes(
+        self, mock_encode, mock_allowance, _mock_send, adapter
+    ):
+        adapter._earn_vault_asset = AsyncMock(return_value=FAKE_ASSET)
+        adapter._a_token_for_underlying = AsyncMock(return_value=FAKE_ATOKEN)
+
+        ok, tx = await adapter.earn_vault_mint_with_atokens(
+            chain_id=42161, vault_address=FAKE_VAULT, shares=456
+        )
+
+        assert ok is True
+        assert tx == "0xvault"
+        assert mock_allowance.await_args.kwargs["token_address"] == FAKE_ATOKEN
+        assert mock_allowance.await_args.kwargs["spender"] == FAKE_VAULT
+        assert mock_encode.await_args.kwargs["fn_name"] == "mintWithATokens"
+        assert mock_encode.await_args.kwargs["args"] == [456, FAKE_ADDR]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method_name", "kwargs", "fn_name", "expected_args"),
+        [
+            (
+                "earn_vault_mint",
+                {"shares": 456},
+                "mint",
+                [456, FAKE_ADDR],
+            ),
+            (
+                "earn_vault_withdraw",
+                {"assets": 123},
+                "withdraw",
+                [123, FAKE_ADDR, FAKE_ADDR],
+            ),
+            (
+                "earn_vault_withdraw_atokens",
+                {"assets": 123},
+                "withdrawATokens",
+                [123, FAKE_ADDR, FAKE_ADDR],
+            ),
+            (
+                "earn_vault_redeem",
+                {"shares": 456},
+                "redeem",
+                [456, FAKE_ADDR, FAKE_ADDR],
+            ),
+            (
+                "earn_vault_redeem_as_atokens",
+                {"shares": 456},
+                "redeemAsATokens",
+                [456, FAKE_ADDR, FAKE_ADDR],
+            ),
+        ],
+    )
+    @patch(
+        "wayfinder_paths.adapters.aave_v3_adapter.adapter.send_transaction",
+        new_callable=AsyncMock,
+        return_value="0xvault",
+    )
+    @patch(
+        "wayfinder_paths.adapters.aave_v3_adapter.adapter.ensure_allowance",
+        new_callable=AsyncMock,
+        return_value=(True, "ok"),
+    )
+    @patch(
+        "wayfinder_paths.adapters.aave_v3_adapter.adapter.encode_call",
+        new_callable=AsyncMock,
+        return_value={"to": FAKE_VAULT},
+    )
+    async def test_earn_vault_share_and_withdraw_ops_encode(
+        self,
+        mock_encode,
+        mock_allowance,
+        _mock_send,
+        adapter,
+        method_name,
+        kwargs,
+        fn_name,
+        expected_args,
+    ):
+        adapter._earn_vault_asset = AsyncMock(return_value=FAKE_ASSET)
+
+        ok, tx = await getattr(adapter, method_name)(
+            chain_id=42161, vault_address=FAKE_VAULT, **kwargs
+        )
+
+        assert ok is True
+        assert tx == "0xvault"
+        assert mock_encode.await_args.kwargs["fn_name"] == fn_name
+        assert mock_encode.await_args.kwargs["args"] == expected_args
+        if method_name == "earn_vault_mint":
+            assert mock_allowance.await_count == 1
+        else:
+            mock_allowance.assert_not_awaited()

--- a/wayfinder_paths/core/constants/aave_v3_abi.py
+++ b/wayfinder_paths/core/constants/aave_v3_abi.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from wayfinder_paths.core.constants.erc4626_abi import ERC4626_ABI
+
 # Minimal ABIs for Aave v3 pool operations + UI periphery helpers.
 
 POOL_ABI = [
@@ -61,6 +63,27 @@ POOL_ABI = [
         ],
         "outputs": [],
     },
+    {
+        "name": "setUserEMode",
+        "type": "function",
+        "stateMutability": "nonpayable",
+        "inputs": [{"name": "categoryId", "type": "uint8"}],
+        "outputs": [],
+    },
+    {
+        "name": "getUserAccountData",
+        "type": "function",
+        "stateMutability": "view",
+        "inputs": [{"name": "user", "type": "address"}],
+        "outputs": [
+            {"name": "totalCollateralBase", "type": "uint256"},
+            {"name": "totalDebtBase", "type": "uint256"},
+            {"name": "availableBorrowsBase", "type": "uint256"},
+            {"name": "currentLiquidationThreshold", "type": "uint256"},
+            {"name": "ltv", "type": "uint256"},
+            {"name": "healthFactor", "type": "uint256"},
+        ],
+    },
 ]
 
 
@@ -107,14 +130,16 @@ UI_POOL_DATA_PROVIDER_ABI = [
                     {"name": "isSiloedBorrowing", "type": "bool"},
                     {"name": "accruedToTreasury", "type": "uint128"},
                     {"name": "unbacked", "type": "uint128"},
+                    {"name": "isolationModeTotalDebt", "type": "uint128"},
                     {"name": "flashLoanEnabled", "type": "bool"},
                     {"name": "debtCeiling", "type": "uint256"},
                     {"name": "debtCeilingDecimals", "type": "uint256"},
+                    {"name": "eModeCategoryId", "type": "uint8"},
                     {"name": "borrowCap", "type": "uint256"},
                     {"name": "supplyCap", "type": "uint256"},
                     {"name": "borrowableInIsolation", "type": "bool"},
+                    {"name": "virtualAccActive", "type": "bool"},
                     {"name": "virtualUnderlyingBalance", "type": "uint128"},
-                    {"name": "isolationModeTotalDebt", "type": "uint128"},
                 ],
             },
             {
@@ -151,6 +176,33 @@ UI_POOL_DATA_PROVIDER_ABI = [
             {"name": "", "type": "uint8"},
         ],
     },
+    {
+        "name": "getEModes",
+        "type": "function",
+        "stateMutability": "view",
+        "inputs": [{"name": "provider", "type": "address"}],
+        "outputs": [
+            {
+                "name": "",
+                "type": "tuple[]",
+                "components": [
+                    {"name": "id", "type": "uint8"},
+                    {
+                        "name": "eMode",
+                        "type": "tuple",
+                        "components": [
+                            {"name": "ltv", "type": "uint16"},
+                            {"name": "liquidationThreshold", "type": "uint16"},
+                            {"name": "liquidationBonus", "type": "uint16"},
+                            {"name": "collateralBitmap", "type": "uint128"},
+                            {"name": "label", "type": "string"},
+                            {"name": "borrowableBitmap", "type": "uint128"},
+                        ],
+                    },
+                ],
+            }
+        ],
+    },
 ]
 
 UI_POOL_RESERVE_KEYS = [
@@ -159,6 +211,185 @@ UI_POOL_RESERVE_KEYS = [
         UI_POOL_DATA_PROVIDER_ABI[0].get("outputs", [{}])[0].get("components") or []
     )
     if c.get("name")
+]
+
+UI_POOL_USER_RESERVE_KEYS = [
+    c.get("name")
+    for c in (
+        UI_POOL_DATA_PROVIDER_ABI[1].get("outputs", [{}])[0].get("components") or []
+    )
+    if c.get("name")
+]
+
+UI_POOL_RESERVE_COMPONENTS_ORIGIN = [
+    {"name": "underlyingAsset", "type": "address"},
+    {"name": "name", "type": "string"},
+    {"name": "symbol", "type": "string"},
+    {"name": "decimals", "type": "uint256"},
+    {"name": "baseLTVasCollateral", "type": "uint256"},
+    {"name": "reserveLiquidationThreshold", "type": "uint256"},
+    {"name": "reserveLiquidationBonus", "type": "uint256"},
+    {"name": "reserveFactor", "type": "uint256"},
+    {"name": "usageAsCollateralEnabled", "type": "bool"},
+    {"name": "borrowingEnabled", "type": "bool"},
+    {"name": "isActive", "type": "bool"},
+    {"name": "isFrozen", "type": "bool"},
+    {"name": "liquidityIndex", "type": "uint128"},
+    {"name": "variableBorrowIndex", "type": "uint128"},
+    {"name": "liquidityRate", "type": "uint128"},
+    {"name": "variableBorrowRate", "type": "uint128"},
+    {"name": "lastUpdateTimestamp", "type": "uint40"},
+    {"name": "aTokenAddress", "type": "address"},
+    {"name": "variableDebtTokenAddress", "type": "address"},
+    {"name": "interestRateStrategyAddress", "type": "address"},
+    {"name": "availableLiquidity", "type": "uint256"},
+    {"name": "totalScaledVariableDebt", "type": "uint256"},
+    {"name": "priceInMarketReferenceCurrency", "type": "uint256"},
+    {"name": "priceOracle", "type": "address"},
+    {"name": "variableRateSlope1", "type": "uint256"},
+    {"name": "variableRateSlope2", "type": "uint256"},
+    {"name": "baseVariableBorrowRate", "type": "uint256"},
+    {"name": "optimalUsageRatio", "type": "uint256"},
+    {"name": "isPaused", "type": "bool"},
+    {"name": "isSiloedBorrowing", "type": "bool"},
+    {"name": "accruedToTreasury", "type": "uint128"},
+    {"name": "isolationModeTotalDebt", "type": "uint128"},
+    {"name": "flashLoanEnabled", "type": "bool"},
+    {"name": "debtCeiling", "type": "uint256"},
+    {"name": "debtCeilingDecimals", "type": "uint256"},
+    {"name": "borrowCap", "type": "uint256"},
+    {"name": "supplyCap", "type": "uint256"},
+    {"name": "borrowableInIsolation", "type": "bool"},
+    {"name": "virtualUnderlyingBalance", "type": "uint128"},
+    {"name": "deficit", "type": "uint128"},
+]
+
+UI_POOL_DATA_PROVIDER_ORIGIN_ABI = [
+    {
+        "name": "getReservesData",
+        "type": "function",
+        "stateMutability": "view",
+        "inputs": [{"name": "provider", "type": "address"}],
+        "outputs": [
+            {
+                "name": "",
+                "type": "tuple[]",
+                "components": UI_POOL_RESERVE_COMPONENTS_ORIGIN,
+            },
+            UI_POOL_DATA_PROVIDER_ABI[0]["outputs"][1],
+        ],
+    },
+    UI_POOL_DATA_PROVIDER_ABI[1],
+    UI_POOL_DATA_PROVIDER_ABI[2],
+]
+
+UI_POOL_RESERVE_KEYS_ORIGIN = [c["name"] for c in UI_POOL_RESERVE_COMPONENTS_ORIGIN]
+
+
+UI_POOL_RESERVE_COMPONENTS_LEGACY = [
+    {"name": "underlyingAsset", "type": "address"},
+    {"name": "name", "type": "string"},
+    {"name": "symbol", "type": "string"},
+    {"name": "decimals", "type": "uint256"},
+    {"name": "baseLTVasCollateral", "type": "uint256"},
+    {"name": "reserveLiquidationThreshold", "type": "uint256"},
+    {"name": "reserveLiquidationBonus", "type": "uint256"},
+    {"name": "reserveFactor", "type": "uint256"},
+    {"name": "usageAsCollateralEnabled", "type": "bool"},
+    {"name": "borrowingEnabled", "type": "bool"},
+    {"name": "stableBorrowRateEnabled", "type": "bool"},
+    {"name": "isActive", "type": "bool"},
+    {"name": "isFrozen", "type": "bool"},
+    {"name": "liquidityIndex", "type": "uint128"},
+    {"name": "variableBorrowIndex", "type": "uint128"},
+    {"name": "liquidityRate", "type": "uint128"},
+    {"name": "variableBorrowRate", "type": "uint128"},
+    {"name": "stableBorrowRate", "type": "uint128"},
+    {"name": "lastUpdateTimestamp", "type": "uint40"},
+    {"name": "aTokenAddress", "type": "address"},
+    {"name": "stableDebtTokenAddress", "type": "address"},
+    {"name": "variableDebtTokenAddress", "type": "address"},
+    {"name": "interestRateStrategyAddress", "type": "address"},
+    {"name": "availableLiquidity", "type": "uint256"},
+    {"name": "totalPrincipalStableDebt", "type": "uint256"},
+    {"name": "averageStableRate", "type": "uint256"},
+    {"name": "stableDebtLastUpdateTimestamp", "type": "uint256"},
+    {"name": "totalScaledVariableDebt", "type": "uint256"},
+    {"name": "priceInMarketReferenceCurrency", "type": "uint256"},
+    {"name": "priceOracle", "type": "address"},
+    {"name": "variableRateSlope1", "type": "uint256"},
+    {"name": "variableRateSlope2", "type": "uint256"},
+    {"name": "stableRateSlope1", "type": "uint256"},
+    {"name": "stableRateSlope2", "type": "uint256"},
+    {"name": "baseStableBorrowRate", "type": "uint256"},
+    {"name": "baseVariableBorrowRate", "type": "uint256"},
+    {"name": "optimalUsageRatio", "type": "uint256"},
+    {"name": "isPaused", "type": "bool"},
+    {"name": "isSiloedBorrowing", "type": "bool"},
+    {"name": "accruedToTreasury", "type": "uint128"},
+    {"name": "unbacked", "type": "uint128"},
+    {"name": "isolationModeTotalDebt", "type": "uint128"},
+    {"name": "flashLoanEnabled", "type": "bool"},
+    {"name": "debtCeiling", "type": "uint256"},
+    {"name": "debtCeilingDecimals", "type": "uint256"},
+    {"name": "eModeCategoryId", "type": "uint8"},
+    {"name": "borrowCap", "type": "uint256"},
+    {"name": "supplyCap", "type": "uint256"},
+    {"name": "eModeLtv", "type": "uint16"},
+    {"name": "eModeLiquidationThreshold", "type": "uint16"},
+    {"name": "eModeLiquidationBonus", "type": "uint16"},
+    {"name": "eModePriceSource", "type": "address"},
+    {"name": "eModeLabel", "type": "string"},
+    {"name": "borrowableInIsolation", "type": "bool"},
+]
+
+UI_POOL_USER_RESERVE_COMPONENTS_LEGACY = [
+    {"name": "underlyingAsset", "type": "address"},
+    {"name": "scaledATokenBalance", "type": "uint256"},
+    {"name": "usageAsCollateralEnabledOnUser", "type": "bool"},
+    {"name": "stableBorrowRate", "type": "uint256"},
+    {"name": "scaledVariableDebt", "type": "uint256"},
+    {"name": "principalStableDebt", "type": "uint256"},
+    {"name": "stableBorrowLastUpdateTimestamp", "type": "uint256"},
+]
+
+UI_POOL_DATA_PROVIDER_LEGACY_ABI = [
+    {
+        "name": "getReservesData",
+        "type": "function",
+        "stateMutability": "view",
+        "inputs": [{"name": "provider", "type": "address"}],
+        "outputs": [
+            {
+                "name": "",
+                "type": "tuple[]",
+                "components": UI_POOL_RESERVE_COMPONENTS_LEGACY,
+            },
+            UI_POOL_DATA_PROVIDER_ABI[0]["outputs"][1],
+        ],
+    },
+    {
+        "name": "getUserReservesData",
+        "type": "function",
+        "stateMutability": "view",
+        "inputs": [
+            {"name": "provider", "type": "address"},
+            {"name": "user", "type": "address"},
+        ],
+        "outputs": [
+            {
+                "name": "",
+                "type": "tuple[]",
+                "components": UI_POOL_USER_RESERVE_COMPONENTS_LEGACY,
+            },
+            {"name": "", "type": "uint8"},
+        ],
+    },
+]
+
+UI_POOL_RESERVE_KEYS_LEGACY = [c["name"] for c in UI_POOL_RESERVE_COMPONENTS_LEGACY]
+UI_POOL_USER_RESERVE_KEYS_LEGACY = [
+    c["name"] for c in UI_POOL_USER_RESERVE_COMPONENTS_LEGACY
 ]
 
 
@@ -447,5 +678,73 @@ CHAINLINK_AGGREGATOR_ABI = [
         "name": "latestAnswer",
         "inputs": [],
         "outputs": [{"type": "int256"}],
+    },
+]
+
+
+AAVE_EARN_VAULT_ABI = [
+    *ERC4626_ABI,
+    {
+        "type": "function",
+        "stateMutability": "nonpayable",
+        "name": "depositATokens",
+        "inputs": [
+            {"name": "assets", "type": "uint256"},
+            {"name": "receiver", "type": "address"},
+        ],
+        "outputs": [{"name": "shares", "type": "uint256"}],
+    },
+    {
+        "type": "function",
+        "stateMutability": "nonpayable",
+        "name": "withdrawATokens",
+        "inputs": [
+            {"name": "assets", "type": "uint256"},
+            {"name": "receiver", "type": "address"},
+            {"name": "owner", "type": "address"},
+        ],
+        "outputs": [{"name": "shares", "type": "uint256"}],
+    },
+    {
+        "type": "function",
+        "stateMutability": "nonpayable",
+        "name": "mintWithATokens",
+        "inputs": [
+            {"name": "shares", "type": "uint256"},
+            {"name": "receiver", "type": "address"},
+        ],
+        "outputs": [{"name": "assets", "type": "uint256"}],
+    },
+    {
+        "type": "function",
+        "stateMutability": "nonpayable",
+        "name": "redeemAsATokens",
+        "inputs": [
+            {"name": "shares", "type": "uint256"},
+            {"name": "receiver", "type": "address"},
+            {"name": "owner", "type": "address"},
+        ],
+        "outputs": [{"name": "assets", "type": "uint256"}],
+    },
+    {
+        "type": "function",
+        "stateMutability": "view",
+        "name": "getClaimableFees",
+        "inputs": [],
+        "outputs": [{"name": "", "type": "uint256"}],
+    },
+    {
+        "type": "function",
+        "stateMutability": "view",
+        "name": "getLastVaultBalance",
+        "inputs": [],
+        "outputs": [{"name": "", "type": "uint256"}],
+    },
+    {
+        "type": "function",
+        "stateMutability": "view",
+        "name": "getFee",
+        "inputs": [],
+        "outputs": [{"name": "", "type": "uint256"}],
     },
 ]

--- a/wayfinder_paths/core/constants/erc4626_abi.py
+++ b/wayfinder_paths/core/constants/erc4626_abi.py
@@ -76,9 +76,37 @@ ERC4626_ABI = [
     {
         "type": "function",
         "stateMutability": "view",
+        "name": "previewMint",
+        "inputs": [{"name": "shares", "type": "uint256"}],
+        "outputs": [{"name": "assets", "type": "uint256"}],
+    },
+    {
+        "type": "function",
+        "stateMutability": "view",
+        "name": "previewWithdraw",
+        "inputs": [{"name": "assets", "type": "uint256"}],
+        "outputs": [{"name": "shares", "type": "uint256"}],
+    },
+    {
+        "type": "function",
+        "stateMutability": "view",
         "name": "previewRedeem",
         "inputs": [{"name": "shares", "type": "uint256"}],
         "outputs": [{"name": "assets", "type": "uint256"}],
+    },
+    {
+        "type": "function",
+        "stateMutability": "view",
+        "name": "maxDeposit",
+        "inputs": [{"name": "receiver", "type": "address"}],
+        "outputs": [{"name": "", "type": "uint256"}],
+    },
+    {
+        "type": "function",
+        "stateMutability": "view",
+        "name": "maxMint",
+        "inputs": [{"name": "receiver", "type": "address"}],
+        "outputs": [{"name": "", "type": "uint256"}],
     },
     {
         "type": "function",


### PR DESCRIPTION
## Summary

- Updates the Aave V3 adapter against current Aave docs for market risk data, user account state, eMode reads/transactions, and Aave Earn ERC-4626 vaults.
- Adds UiPoolDataProvider ABI handling for current compact, Aave Origin, and legacy deployed tuple shapes so existing Gorlami/live markets remain readable.
- Extends adapter tests, Gorlami coverage, README, manifest capabilities, and the local `using-aave-v3-adapter` skill docs.

Linear: WAYST-250

## Gap matrix

| Area | Local adapter before | Current Aave V3 docs / deployed contracts | Change in this PR | Notes |
| --- | --- | --- | --- | --- |
| Supply / withdraw / borrow / repay | Existing fund-moving pool flows with variable rate mode and native gateway helpers | Pool operations still use V3 Pool / WrappedTokenGateway semantics | Kept existing execution paths and tests intact | No V4 behavior mixed into V3 abstractions |
| Market data | Basic reserve rows, caps, LTV/liquidation threshold, APY, optional incentives | Current docs/deployments expose additional risk, cap, isolation, flash loan, virtual accounting, deficit, oracle, and slope fields | Adds normalized risk/current fields to `get_all_markets(...)` | Supports current compact, Origin, and legacy UI provider tuple shapes |
| User positions | User reserve balances from `getUserReservesData(...)`; no account-level summary | Docs/contracts expose `Pool.getUserAccountData(...)` and user eMode category | Adds `account_data`, `user_emode_category_id`, eMode categories when available, stable legacy debt fields, and per-position risk fields | Account/eMode read failures are reported without breaking the rest of the snapshot |
| Incentives | Market/user incentives and reward claiming already existed | Incentives remain via UiIncentiveDataProviderV3 / RewardsController | Preserved reward reads/claims and covered regressions in tests | No duplicate incentive math added |
| Risk modes | Limited LTV/cap view; no eMode transaction helper | V3 includes eMode, isolation, siloed borrowing, debt ceilings, collateral risk fields | Adds `get_emode_categories(...)`, `set_emode(...)`, `disable_emode(...)`, plus risk fields in market/user state | `set_emode` validates uint8 range; Aave still enforces collateral/debt compatibility on-chain |
| Aave Earn vaults | No Earn-specific helper | Earn vaults are ERC-4626 vaults over Aave V3 supply positions, with aToken entry/exit variants | Adds vault state reads and deposit/mint/withdraw/redeem helpers for underlying and aToken variants | Vault addresses stay explicit; no registry added |
| Advanced features | Rewards and native gateway supported; no flash loan/credit delegation/sGHO execution | Docs include flash loans, credit delegation, sGHO, testing/debugging | Captured as out of scope for this V3 adapter audit | These need separate design because they are not simple extensions of current strategy-wallet flows |
| V4 | Not represented | Aave V4 docs now exist with a different hub/spoke model | Documented as out of scope/follow-up | Do not blend V4 into V3 adapter contracts |

## Research sources

- https://aave.com/docs/developers/
- https://aave.com/docs/aave-v3/overview
- https://aave.com/docs/developers/aave-v3/markets/operations
- https://aave.com/docs/developers/aave-v3/markets/advanced
- https://aave.com/docs/developers/smart-contracts/pool
- https://aave.com/docs/developers/smart-contracts/view-contracts
- https://aave.com/docs/developers/aave-v3/markets/incentives
- https://aave.com/docs/developers/aave-v3/markets/positions
- https://aave.com/docs/developers/aave-vaults/overview
- https://aave.com/docs/developers/aave-v4/overview

## Validation

- `POETRY_VIRTUALENVS_IN_PROJECT=true poetry run ruff format --check wayfinder_paths/adapters/aave_v3_adapter .claude/skills/using-aave-v3-adapter`
- `POETRY_VIRTUALENVS_IN_PROJECT=true poetry run ruff check wayfinder_paths/adapters/aave_v3_adapter`
- `POETRY_VIRTUALENVS_IN_PROJECT=true poetry run pytest -o addopts= wayfinder_paths/adapters/aave_v3_adapter -q`
- `POETRY_VIRTUALENVS_IN_PROJECT=true poetry run pytest -o addopts= wayfinder_paths/adapters/aave_v3_adapter/test_gorlami_simulation.py -q`
- `git diff --check`
