### PR TITLE
[codex] Document Uniswap adapter scope and v4 gaps

### DIFF
--- a/.claude/skills/using-uniswap-adapter/SKILL.md
+++ b/.claude/skills/using-uniswap-adapter/SKILL.md
@@ -1,9 +1,20 @@
 ---
 name: using-uniswap-adapter
-description: How to use the Uniswap V3 adapter for concentrated liquidity on Base/Arbitrum/Ethereum (LP provisioning, position management, tick math, and common gotchas).
+description: How to use the Uniswap V3-only adapter for concentrated-liquidity NFT positions on Base/Arbitrum/Ethereum (LP provisioning, position management, tick math, and common gotchas).
 metadata:
   tags: wayfinder, uniswap, v3, liquidity, lp, base, arbitrum, tick, nft
 ---
+
+## Current support boundary
+
+This skill is for the SDK's `UniswapAdapter`, which is a **Uniswap V3
+NonfungiblePositionManager adapter**. It is not a swap router and does not
+support Universal Router command execution, Permit2 signatures/transfers, v2
+routes, or Uniswap v4 PoolManager/PositionManager flows.
+
+Use a separate design before adding Universal Router or v4 behavior. Current
+Uniswap docs recommend v4 for new integrations and Universal Router for
+programmatic swaps, but those are different protocol surfaces from this adapter.
 
 ## When to use
 
@@ -12,6 +23,12 @@ Use this skill when you are:
 - Reading LP positions, pool state, or uncollected fees
 - Writing scripts that add/remove liquidity or collect fees
 - Working with tick math, price ranges, or sqrtPriceX96
+
+Do not use this skill when you are:
+- Building token swaps through Universal Router or SwapRouter02
+- Building Permit2 signature-transfer or allowance-transfer flows
+- Building Uniswap v4 pools, hooks, swaps, or liquidity positions
+- Building v2 pair liquidity or constant-product router flows
 
 ## How to use
 

--- a/.claude/skills/using-uniswap-adapter/rules/execution-opportunities.md
+++ b/.claude/skills/using-uniswap-adapter/rules/execution-opportunities.md
@@ -1,11 +1,24 @@
 # Uniswap V3 execution (ad-hoc scripts)
 
+The current SDK adapter executes **V3 position manager** transactions only:
+mint, increase liquidity, decrease/remove liquidity, collect fees, and optional
+burns. It does not execute swaps through Universal Router, does not build
+Permit2 signatures, and does not handle Uniswap v4 PositionManager actions.
+
 ## Execution pattern
 
 All write operations use ad-hoc scripts under `.wayfinder_runs/`:
 
 1. Write script with `get_adapter(UniswapAdapter, "wallet_label")`
 2. Run via `mcp__wayfinder__core_run_script(script_path, wallet_label)`
+
+For fund-moving changes to this adapter, run the focused unit tests and the
+Gorlami fork simulation when configured:
+
+```bash
+poetry run pytest -o addopts= wayfinder_paths/adapters/uniswap_adapter -q
+poetry run pytest -o addopts= wayfinder_paths/adapters/uniswap_adapter/test_gorlami_simulation.py -q
+```
 
 ## Add liquidity (new position)
 

--- a/.claude/skills/using-uniswap-adapter/rules/gotchas.md
+++ b/.claude/skills/using-uniswap-adapter/rules/gotchas.md
@@ -1,5 +1,16 @@
 # Uniswap V3 gotchas
 
+## This adapter is V3 NPM-only
+
+The SDK's `UniswapAdapter` is not the Universal Router. It does not support V2
+routes, V3 swaps, Permit2 signatures/transfers, or Uniswap v4 pools/positions.
+Those flows require distinct command encoders, address maps, approval semantics,
+and safety checks.
+
+Current Uniswap docs describe Universal Router as the preferred programmatic
+swap entrypoint and v4 as recommended for new integrations. Treat that as a
+follow-up design boundary, not as behavior provided by this adapter.
+
 ## `price_to_tick_decimal` does NOT match on-chain ticks
 
 `price_to_tick_decimal(price, dec0, dec1)` and `tick_to_price_decimal()` are self-consistent

--- a/.claude/skills/using-uniswap-adapter/rules/high-value-reads.md
+++ b/.claude/skills/using-uniswap-adapter/rules/high-value-reads.md
@@ -9,11 +9,27 @@
 ## Primary data source
 
 - Adapter: `wayfinder_paths/adapters/uniswap_adapter/adapter.py`
+- Adapter README: `wayfinder_paths/adapters/uniswap_adapter/README.md`
 - Supported chains: Ethereum (1), Arbitrum (42161), Base (8453), Polygon (137), BSC (56), Avalanche (43114)
 - ABIs: `wayfinder_paths/core/constants/uniswap_v3_abi.py`
   - `NONFUNGIBLE_POSITION_MANAGER_ABI` — NPM (positions, mint, collect, etc.)
   - `UNISWAP_V3_POOL_ABI` — pool contract (`slot0`)
   - `UNISWAP_V3_FACTORY_ABI` — factory (`getPool`)
+
+## Unsupported surfaces
+
+Do not infer support from the wider Uniswap docs. The SDK adapter does **not**
+currently expose:
+
+- V2 pair/router reads
+- V3 swaps
+- Universal Router `execute(...)` command streams
+- Permit2 `SignatureTransfer` or `AllowanceTransfer`
+- V4 `PoolManager`, `StateView`, `Quoter`, hooks, native ETH pools, or
+  `PositionManager` action encoding
+
+If one of those surfaces is needed, design a separate adapter/helper instead of
+adding it to the V3 position abstraction.
 
 ## Ad-hoc read scripts
 

--- a/wayfinder_paths/adapters/uniswap_adapter/README.md
+++ b/wayfinder_paths/adapters/uniswap_adapter/README.md
@@ -1,0 +1,111 @@
+# Uniswap Adapter
+
+The Uniswap adapter currently supports Uniswap V3 concentrated-liquidity position
+management through the V3 `NonfungiblePositionManager` and V3 factory contracts.
+
+- **Type**: `UNISWAP`
+- **Module**: `wayfinder_paths.adapters.uniswap_adapter.adapter.UniswapAdapter`
+- **Scope**: V3 LP NFT positions only
+- **Not supported**: V2 swaps/liquidity, V3 swaps, Universal Router command
+  execution, Permit2 signature approvals/transfers, Uniswap v4 pools or positions
+
+## Supported Chains
+
+The adapter uses `UNISWAP_V3_NPM` and `UNISWAP_V3_FACTORY` from
+`wayfinder_paths.core.constants.contracts`:
+
+| Chain ID | Network |
+| --- | --- |
+| 1 | Ethereum |
+| 42161 | Arbitrum One |
+| 137 | Polygon |
+| 8453 | Base |
+| 56 | BNB Smart Chain |
+| 43114 | Avalanche C-Chain |
+
+The official Uniswap v3 docs warn that deployment addresses are chain-specific.
+Do not assume a new chain can reuse an address from another chain.
+
+## Usage
+
+```python
+from eth_account import Account
+from wayfinder_paths.adapters.uniswap_adapter import UniswapAdapter
+
+acct = Account.create()
+
+async def sign_cb(tx: dict) -> bytes:
+    return acct.sign_transaction(tx).raw_transaction
+
+adapter = UniswapAdapter(
+    config={"chain_id": 8453},
+    sign_callback=sign_cb,
+    wallet_address=acct.address,
+)
+```
+
+## Read Methods
+
+| Method | Purpose |
+| --- | --- |
+| `get_pool(token_a, token_b, fee)` | Read a V3 pool address from the V3 factory |
+| `get_position(token_id)` | Read one V3 LP NFT position |
+| `get_positions(owner=None)` | List V3 LP NFT positions for an owner |
+| `get_uncollected_fees(token_id)` | Simulate V3 fee collection amounts |
+| `get_full_user_state(account=...)` | Return a V3 position snapshot for an account |
+
+## Fund-Moving Methods
+
+| Method | On-chain action |
+| --- | --- |
+| `add_liquidity(...)` | ERC20 approvals when needed, then V3 NPM `mint` |
+| `increase_liquidity(...)` | ERC20 approvals when needed, then V3 NPM `increaseLiquidity` |
+| `remove_liquidity(...)` | V3 NPM `multicall` with `decreaseLiquidity`, optional `collect`, optional `burn` |
+| `collect_fees(token_id)` | V3 NPM `collect` |
+
+All write methods require a `sign_callback`. The adapter never silently approves
+or signs transactions. ERC20 approvals use the shared `ensure_allowance` helper,
+which includes the repo's reset-before-approve handling for tokens such as USDT.
+
+## Current Gap Matrix
+
+| Area | Current SDK adapter | Current Uniswap expectation | Decision |
+| --- | --- | --- | --- |
+| V2 swaps/liquidity | No V2 router or pair support | V2 is a legacy AMM surface, and swaps can be composed through Universal Router | Out of scope |
+| V3 LP positions | Supported through V3 NPM and factory | V3 remains valid for existing integrations and V3-specific workflows | Keep and test |
+| V3 swaps | No SwapRouter02 or Universal Router support | Uniswap docs identify Universal Router as the preferred ERC20/NFT swap entrypoint | Follow-up router design |
+| Universal Router | No `execute` command encoder, sub-plans, balance checks, or cleanup commands | Command stream composes v2/v3/v4 swaps, Permit2, wrapping, position-manager calls | Follow-up adapter/helper |
+| Permit2 | No Permit2 ABI, signatures, allowance expiration, or SignatureTransfer support | Permit2 is used by Universal Router and PositionManager workflows | Follow-up approval design |
+| V4 swaps/LP | No PoolManager, StateView, Quoter, v4 PositionManager, `PoolKey`, hooks, native ETH, or action encoding | v4 is recommended for new integrations; deployments are per-chain | Follow-up v4 adapter |
+
+The existing V3 adapter should not be extended by bolting v4 or Universal Router
+behavior onto `UniswapV3BaseAdapter`. Those are separate protocol surfaces with
+different address maps, calldata encodings, approval semantics, and safety checks.
+
+## Gorlami Simulation
+
+The fund-moving V3 mint path is covered by:
+
+```bash
+poetry run pytest -o addopts= wayfinder_paths/adapters/uniswap_adapter/test_gorlami_simulation.py -q
+```
+
+The test runs only when the Gorlami fork proxy is configured. It creates a Base
+fork, funds a temporary wallet with gas, WETH, and USDC, then exercises the
+adapter's ERC20 approval and V3 NPM mint flow against the Base WETH/USDC 0.05%
+pool.
+
+## Official Docs Checked
+
+- Uniswap protocols overview:
+  `https://developers.uniswap.org/docs/protocols/overview`
+- Universal Router overview and commands:
+  `https://developers.uniswap.org/docs/protocols/universal-router/overview`
+  and `https://developers.uniswap.org/docs/protocols/universal-router/concepts/commands`
+- Permit2 overview:
+  `https://developers.uniswap.org/docs/protocols/permit2/overview`
+- Uniswap v3 deployments:
+  `https://developers.uniswap.org/docs/protocols/v3/deployments`
+- Uniswap v4 deployments and liquidity guides:
+  `https://developers.uniswap.org/docs/protocols/v4/deployments`
+  and `https://developers.uniswap.org/docs/protocols/v4/guides/managing-liquidity/overview`

--- a/wayfinder_paths/adapters/uniswap_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/uniswap_adapter/test_adapter.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import yaml
 
 from wayfinder_paths.adapters.uniswap_adapter.adapter import UniswapAdapter
 from wayfinder_paths.core.utils.uniswap_v3_math import tick_to_price, ticks_for_range
@@ -114,6 +116,29 @@ class TestConstruction:
     def test_missing_wallet(self):
         with pytest.raises(ValueError, match="wallet_address is required"):
             UniswapAdapter({"chain_id": 8453})
+
+
+class TestManifestScope:
+    def test_manifest_advertises_v3_position_capabilities_only(self):
+        manifest_path = Path(__file__).with_name("manifest.yaml")
+        manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+
+        capabilities = set(manifest["capabilities"])
+        assert capabilities == {
+            "uniswap.liquidity.add",
+            "uniswap.liquidity.increase",
+            "uniswap.liquidity.remove",
+            "uniswap.fees.collect",
+            "uniswap.position.get",
+            "uniswap.positions.list",
+            "uniswap.fees.uncollected",
+            "uniswap.pool.get",
+        }
+        assert not any(
+            marker in capability
+            for capability in capabilities
+            for marker in (".swap", "router", "permit2", ".v2", ".v4")
+        )
 
 
 class TestAddLiquidity:

--- a/wayfinder_paths/adapters/uniswap_adapter/test_gorlami_simulation.py
+++ b/wayfinder_paths/adapters/uniswap_adapter/test_gorlami_simulation.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+from eth_account import Account
+
+from wayfinder_paths.adapters.uniswap_adapter.adapter import UniswapAdapter
+from wayfinder_paths.core.constants.chains import CHAIN_ID_BASE
+from wayfinder_paths.core.constants.contracts import BASE_USDC, BASE_WETH
+from wayfinder_paths.core.utils import web3 as web3_utils
+from wayfinder_paths.core.utils.uniswap_v3_math import get_pool_slot0, ticks_for_range
+from wayfinder_paths.testing.gorlami import gorlami_configured
+
+pytestmark = pytest.mark.skipif(
+    not gorlami_configured(),
+    reason="api_key not configured (needed for gorlami fork proxy)",
+)
+
+CHAIN_ID = CHAIN_ID_BASE
+FEE = 500
+TICK_SPACING = 10
+
+
+async def _ensure_base_fork(gorlami) -> str:
+    try:
+        async with web3_utils.web3_from_chain_id(CHAIN_ID) as web3:
+            assert await web3.eth.chain_id == int(CHAIN_ID)
+    except httpx.HTTPStatusError as exc:
+        status = exc.response.status_code if exc.response is not None else None
+        if status is not None and status >= 500:
+            pytest.skip(
+                f"gorlami could not create fork for chain_id={CHAIN_ID} (HTTP {status})"
+            )
+        raise
+    except Exception as exc:
+        pytest.skip(f"gorlami RPC unreachable for chain_id={CHAIN_ID}: {exc}")
+
+    fork_info = gorlami.forks.get(str(CHAIN_ID))
+    assert fork_info is not None
+    return fork_info["fork_id"]
+
+
+def _make_adapter(acct: Account) -> UniswapAdapter:
+    async def sign_cb(tx: dict) -> bytes:
+        signed = acct.sign_transaction(tx)
+        return signed.raw_transaction
+
+    return UniswapAdapter(
+        {"chain_id": CHAIN_ID},
+        sign_callback=sign_cb,
+        wallet_address=acct.address,
+    )
+
+
+@pytest.mark.asyncio
+async def test_gorlami_uniswap_v3_mints_base_weth_usdc_position(gorlami):
+    fork_id = await _ensure_base_fork(gorlami)
+    acct = Account.create()
+    adapter = _make_adapter(acct)
+
+    await gorlami.set_native_balance(fork_id, acct.address, 2 * 10**18)
+    await gorlami.set_erc20_balance(fork_id, BASE_WETH, acct.address, 10**16)
+    await gorlami.set_erc20_balance(fork_id, BASE_USDC, acct.address, 100 * 10**6)
+
+    ok, pool_address = await adapter.get_pool(BASE_WETH, BASE_USDC, FEE)
+    assert ok is True, pool_address
+    if pool_address is None:
+        pytest.skip("Base WETH/USDC 0.05% Uniswap V3 pool not found on fork")
+
+    slot0 = await get_pool_slot0(pool_address, CHAIN_ID, 18, 6)
+    tick_lower, tick_upper = ticks_for_range(
+        int(slot0["tick"]), bps=1_000, spacing=TICK_SPACING
+    )
+
+    weth_amount = 10**15
+    usdc_amount = max(1_000_000, int((weth_amount / 10**18) * slot0["price"] * 10**6))
+
+    ok, tx_hash = await adapter.add_liquidity(
+        token0=BASE_WETH,
+        token1=BASE_USDC,
+        fee=FEE,
+        tick_lower=tick_lower,
+        tick_upper=tick_upper,
+        amount0_desired=weth_amount,
+        amount1_desired=usdc_amount,
+        slippage_bps=3_000,
+    )
+    assert ok is True, tx_hash
+    assert isinstance(tx_hash, str) and tx_hash.startswith("0x")
+
+    ok, positions = await adapter.get_positions()
+    assert ok is True, positions
+    assert any(
+        str(pos["token0"]).lower() == BASE_WETH.lower()
+        and str(pos["token1"]).lower() == BASE_USDC.lower()
+        and int(pos["fee"]) == FEE
+        and int(pos["liquidity"]) > 0
+        for pos in positions
+    )


### PR DESCRIPTION

## Summary

- Document the current Uniswap adapter as a V3 NonfungiblePositionManager/factory adapter for LP NFT positions only.
- Add adapter README coverage for supported chains, read/write methods, signing and approval expectations, unsupported Universal Router/Permit2/v4 surfaces, and Gorlami simulation.
- Add focused tests for advertised manifest scope plus a Gorlami Base fork simulation that mints a WETH/USDC V3 position through the adapter.
- Update `.claude/skills/using-uniswap-adapter/` to make the V3-only support boundary and gotchas explicit.

Linear: WAYST-253

## Gap matrix

| Area | Current SDK adapter | Current Uniswap docs expectation | Decision |
| --- | --- | --- | --- |
| V2 swaps/liquidity | No V2 router or pair support | V2 remains a legacy AMM surface; swaps can be composed through Universal Router | Out of scope for this adapter |
| V3 LP positions | Supported through V3 NPM and factory | V3 remains valid for existing integrations and V3-specific workflows | Keep and test |
| V3 swaps | No SwapRouter02 or Universal Router support | Universal Router is the recommended ERC20/NFT swap entrypoint | Follow-up router design |
| Universal Router | No `execute` command encoder, sub-plans, balance checks, cleanup commands, or command byte model | Universal Router composes v2/v3/v4 swaps, Permit2, wrapping, and v3/v4 position-manager calls | Follow-up adapter/helper |
| Permit2 | No Permit2 ABI, signature-transfer handling, allowance expiration handling, or Permit2 transfer commands | Permit2 combines `SignatureTransfer` and `AllowanceTransfer` and is used by Universal Router and position workflows | Follow-up approval design |
| V4 swaps/LP | No PoolManager, StateView, Quoter, v4 PositionManager, `PoolKey`, hooks, native ETH, or action encoding | v4 is recommended for new integrations and v4 liquidity uses command/action encoding through PositionManager | Follow-up v4 adapter |

## Design note

This PR deliberately keeps the existing adapter V3-only. Universal Router, Permit2, and v4 liquidity are separate protocol surfaces with different address maps, calldata encoding, approval semantics, cleanup requirements, native ETH handling, and hook/pool-key concepts. Bolting them onto `UniswapV3BaseAdapter` would blur the SDK boundary; the follow-up should design either a dedicated Universal Router helper/adapter and/or a dedicated v4 position adapter.

## Docs checked

- https://developers.uniswap.org/docs/protocols/overview
- https://developers.uniswap.org/docs/protocols/universal-router/overview
- https://developers.uniswap.org/docs/protocols/universal-router/concepts/commands
- https://developers.uniswap.org/docs/protocols/permit2/overview
- https://developers.uniswap.org/docs/protocols/v3/deployments
- https://developers.uniswap.org/docs/protocols/v4/deployments
- https://developers.uniswap.org/docs/protocols/v4/guides/managing-liquidity/overview

## Validation

- `POETRY_VIRTUALENVS_IN_PROJECT=true POETRY_CACHE_DIR=/private/tmp/poetry-cache-wayst-253 poetry run ruff format --check wayfinder_paths/adapters/uniswap_adapter .claude/skills/using-uniswap-adapter`
- `POETRY_VIRTUALENVS_IN_PROJECT=true POETRY_CACHE_DIR=/private/tmp/poetry-cache-wayst-253 poetry run ruff check wayfinder_paths/adapters/uniswap_adapter`
- `POETRY_VIRTUALENVS_IN_PROJECT=true POETRY_CACHE_DIR=/private/tmp/poetry-cache-wayst-253 poetry run pytest -o addopts= wayfinder_paths/adapters/uniswap_adapter -q` (`21 passed`)
- `POETRY_VIRTUALENVS_IN_PROJECT=true POETRY_CACHE_DIR=/private/tmp/poetry-cache-wayst-253 poetry run pytest -o addopts= wayfinder_paths/adapters/uniswap_adapter/test_gorlami_simulation.py -q` (`1 passed`)
- `git diff --check`

## Maintainability pass

- Reuses existing V3 constants, ABI helpers, `ensure_allowance`, `encode_call`, `send_transaction`, tick math, and Gorlami fixture patterns.
- Adds no new production helper/client/type/serializer abstraction.
- Keeps Hyperliquid, Polymarket, backend, frontend, harness, and contracts untouched.
