### PR TITLE
WAYST-252: Update Aerodrome Sugar and Slipstream deployments

### DIFF
--- a/.claude/skills/using-aerodrome-adapter/SKILL.md
+++ b/.claude/skills/using-aerodrome-adapter/SKILL.md
@@ -14,6 +14,9 @@ Use this skill when you are:
 - Inspecting wallet LP balances, staked LP balances, veAERO NFTs, or vote claimables
 - Managing veAERO locks, lock extensions, permanent locks, votes, and reward claims
 
+Use the Slipstream skill instead when the pool is a concentrated-liquidity pool,
+has a `CL...` symbol, requires a tick spacing, or involves an NFPM token id.
+
 ## How to use
 
 - [rules/high-value-reads.md](rules/high-value-reads.md) - Market discovery, Sugar analytics, wallet reads, and shared veAERO read helpers

--- a/.claude/skills/using-aerodrome-adapter/rules/execution-opportunities.md
+++ b/.claude/skills/using-aerodrome-adapter/rules/execution-opportunities.md
@@ -14,6 +14,9 @@ Use quote surfaces before building a transaction:
 - `quote_remove_liquidity(...)` for LP removals
 
 These help you inspect route choice, expected token amounts, and slippage bounds before broadcast. The classic adapter does **not** implement swap execution; route helpers are quoting-only.
+For actual swaps, use an adapter/tool that explicitly exposes a swap execution
+capability and approval preview. Do not treat a route quote from this adapter as
+a transaction plan.
 
 ## Liquidity management
 
@@ -22,6 +25,8 @@ These help you inspect route choice, expected token amounts, and slippage bounds
 - `await adapter.add_liquidity(...)`
 - Supports classic ERC20-ERC20 and ERC20-native pool adds on Base.
 - Use `quote_add_liquidity(...)` first to inspect expected minting and minimum amounts.
+- This is for classic stable/volatile pools only. If the pool has a tick
+  spacing or NFPM position manager, use the Slipstream adapter instead.
 
 ### Remove liquidity
 

--- a/.claude/skills/using-aerodrome-adapter/rules/gotchas.md
+++ b/.claude/skills/using-aerodrome-adapter/rules/gotchas.md
@@ -12,6 +12,16 @@
 - Set `limit=None` only when you intentionally want a full scan.
 - `get_full_user_state(account=..., start=..., limit=...)` is also paginated across voter pools.
 - `include_vote_claimables=True` can add extra work because the adapter resolves vote reward contracts and claimables.
+- `sugar_all(...)` calls current LP Sugar as `all(limit, offset, filter)`;
+  keep `pool_filter=0` for all pools unless you intentionally need listed,
+  unlisted, emerging, listed-or-emerging, or neither-listed-nor-emerging rows.
+
+## Sugar rows can include CL pools
+
+- Current LP Sugar can return classic and concentrated-liquidity pools.
+- Use `pool.is_v2` before classic LP APR/TVL assumptions.
+- Use `pool.is_cl` and the Slipstream adapter when a row has tick spacing,
+  NFPM, ALM, or root-pool metadata.
 
 ## Zero-address gauge is normal
 
@@ -34,6 +44,8 @@
 - `quote_best_route`, `get_amounts_out`, `quote_add_liquidity`, and `quote_remove_liquidity` do not move funds.
 - `add_liquidity`, `remove_liquidity`, `stake_lp`, `create_lock`, `vote`, and the claim methods do.
 - The adapter does **not** implement swap execution even though it can quote routes.
+- Sugar/Swapper deployments are tracked in constants for audit context, but
+  this adapter does not build UniversalRouter/Swapper execution payloads.
 
 ## Native token handling is limited
 

--- a/.claude/skills/using-aerodrome-adapter/rules/high-value-reads.md
+++ b/.claude/skills/using-aerodrome-adapter/rules/high-value-reads.md
@@ -12,6 +12,10 @@
 - Shared helpers: `wayfinder_paths/adapters/aerodrome_common.py`
 - README: `wayfinder_paths/adapters/aerodrome_adapter/README.md`
 - Chain: Base only (`CHAIN_ID_BASE = 8453`)
+- Current Sugar reads: LP Sugar for pool rows, Rewards Sugar for epoch rows.
+- Current Sugar pool rows can include launcher, cap, NFPM, ALM, and root-pool
+  metadata. Do not assume every row is a classic V2 pool; check `pool.is_v2`
+  before using classic LP helpers.
 
 ## High-value reads
 
@@ -26,7 +30,10 @@ Use this for the adapter-facing market list, not `list_pools()`. It enumerates `
 
 ### Sugar pool and epoch analytics
 
-- `await adapter.sugar_all(limit=500, offset=0)` returns raw `SugarPool` rows.
+- `await adapter.sugar_all(limit=500, offset=0, pool_filter=0)` returns raw
+  `SugarPool` rows. The filter follows the deployed LP Sugar categories: `0`
+  all, `1` listed, `2` unlisted, `3` emerging, `4` listed or emerging, `5`
+  neither listed nor emerging.
 - `await adapter.list_pools(page_size=500, max_pools=None)` is the easiest broad pool scan.
 - `await adapter.pools_by_lp()` maps LP token address to `SugarPool`.
 - `await adapter.sugar_epochs_latest(limit=...)` returns recent `SugarEpoch` rows.
@@ -38,6 +45,8 @@ Use this for the adapter-facing market list, not `list_pools()`. It enumerates `
 - `await adapter.rank_v2_pools_by_emissions_apr(top_n=..., candidate_count=...)` ranks classic pools by emissions APR.
 
 Use these when you need broader pool analytics, including pools that are easier to reason about through Sugar than through the voter-driven `get_all_markets()` surface.
+Filter or branch on `pool.is_v2` before using classic TVL or emissions helpers;
+concentrated-liquidity rows belong in the Slipstream adapter.
 
 ### Route quotes and single-pool resolution
 

--- a/.claude/skills/using-aerodrome-slipstream-adapter/SKILL.md
+++ b/.claude/skills/using-aerodrome-slipstream-adapter/SKILL.md
@@ -15,6 +15,10 @@ Use this skill when you are:
 - Staking LP NFT positions into gauges and claiming position rewards
 - Managing veAERO locks, votes, and reward-claim flows that also apply to Slipstream gauges
 
+Use the classic Aerodrome skill instead when the pool is a stable/volatile V2
+pool, the position is an ERC20 LP balance, or the workflow is classic LP
+add/remove/stake without a tick range or NFPM token id.
+
 ## How to use
 
 - [rules/high-value-reads.md](rules/high-value-reads.md) - Deployment-aware market discovery, pool analytics, position reads, and shared veAERO reads

--- a/.claude/skills/using-aerodrome-slipstream-adapter/rules/execution-opportunities.md
+++ b/.claude/skills/using-aerodrome-slipstream-adapter/rules/execution-opportunities.md
@@ -12,6 +12,11 @@
 - `await adapter.mint_position(token0=..., token1=..., tick_spacing=..., tick_lower=..., tick_upper=..., amount0_desired=..., amount1_desired=..., deployment_variant=None, position_manager=None, amount0_min=None, amount1_min=None, slippage_bps=50, recipient=None, deadline=None, sqrt_price_x96=0)`
 - Use this to create a new concentrated-liquidity NFT position.
 - Inputs include tick range, desired token amounts, deployment selection, and optional slippage bounds.
+- New writes default to the `gauges_v3` deployment. Pass
+  `deployment_variant` or `position_manager` when interacting with older
+  deployments or when the target pool exists in multiple deployments.
+- Tick bounds must align with the pool tick spacing. Deadlines and slippage
+  mins are enforced on the NFPM call.
 
 ### Increase liquidity
 
@@ -42,6 +47,9 @@
 Treat staking and reward claiming as separate steps from fee collection:
 - fees come from `collect_fees(...)`
 - gauge emissions for a staked token id come from `claim_position_rewards(...)`
+- Gauges V3 can apply minimum stake time and early-unstake/getReward penalty
+  behavior. Read the pool and gauge state before claiming or withdrawing soon
+  after staking.
 
 ## Shared veAERO and reward actions
 

--- a/.claude/skills/using-aerodrome-slipstream-adapter/rules/gotchas.md
+++ b/.claude/skills/using-aerodrome-slipstream-adapter/rules/gotchas.md
@@ -7,7 +7,9 @@
 
 ## Deployment variants matter
 
-- Slipstream uses multiple deployment variants on Base.
+- Slipstream uses multiple deployment variants on Base: `initial`,
+  `gauge_caps`, and `gauges_v3`.
+- `gauges_v3` is the default write deployment for new positions.
 - `get_all_markets(...)` returns the deployment set it scanned.
 - Reads can accept `deployments=...`; writes use the adapter’s configured `write_deployment` unless a method resolves a manager from the token id.
 - `get_pool(...)` can fail with a multi-match error if the same pair and tick spacing exists across deployments and you do not pass `deployment_variant`.
@@ -34,6 +36,9 @@
 - A position can go out of range, which changes inventory composition and fee earning behavior.
 - Do not reuse classic Aerodrome assumptions for Slipstream positions.
 - Analytics like `slipstream_fee_apr_percent(...)` and `slipstream_prob_in_range_week(...)` are adapter-level estimates based on current state and swap logs, not protocol-guaranteed outputs.
+- Tick spacing is part of pool identity. Common docs examples include 1, 50,
+  200, and 2000, but always read the actual pool or pass the exact spacing.
+- The adapter does not execute swaps; swap logs are used only for analytics.
 
 ## veAERO vote timing
 
@@ -45,6 +50,16 @@
 
 - Token amounts and liquidity values are raw on-chain integers.
 - Explicit min amounts must be non-negative raw values.
+- When explicit mins are omitted, the adapter derives mins from current pool
+  price and `slippage_bps`. If current pool price cannot be resolved, pass
+  explicit `amount0_min` and `amount1_min`.
+
+## Gauges V3 penalties
+
+- Gauges V3 adds minimum stake time and early-unstake/getReward penalty logic
+  at the gauge layer.
+- Claiming `claim_position_rewards(...)` or calling `unstake_position(...)`
+  too soon after staking can be economically different from older gauges.
 
 ## Burn requires a cleared position
 

--- a/.claude/skills/using-aerodrome-slipstream-adapter/rules/high-value-reads.md
+++ b/.claude/skills/using-aerodrome-slipstream-adapter/rules/high-value-reads.md
@@ -12,6 +12,9 @@
 - Shared helpers: `wayfinder_paths/adapters/aerodrome_common.py`
 - Manifest: `wayfinder_paths/adapters/aerodrome_slipstream_adapter/manifest.yaml`
 - Chain: Base only (`CHAIN_ID_BASE = 8453`)
+- Deployments scanned by default: `initial`, `gauge_caps`, and `gauges_v3`.
+  Gauges V3 is the current latest deployment for new pools/gauges, while
+  older deployments can still hold live pools and positions.
 
 ## High-value reads
 
@@ -30,6 +33,8 @@ Use this as the repo-convention market list for Slipstream.
 - `await adapter.slipstream_best_pool_for_pair(tokenA=..., tokenB=..., deployments=...)`
 
 Use these when you know the pair and need to resolve the pool set, a single pool, a gauge, or the deepest-liquidity pool across deployments.
+Pass `deployment_variant` when a pair/tick spacing exists in more than one
+deployment and you need a deterministic pool or position-manager target.
 
 ### Pool and range analytics
 
@@ -41,6 +46,7 @@ Use these when you know the pair and need to resolve the pool set, a single pool
 - `ok, data = await adapter.slipstream_prob_in_range_week(pool=..., tick_lower=..., tick_upper=..., sigma_annual=...)`
 
 These are analytics helpers implemented in the adapter itself. They rely on on-chain pool state, swap logs, and token metadata from the shared helpers.
+They are not swap execution helpers.
 
 ### Position and wallet reads
 

--- a/wayfinder_paths/adapters/aerodrome_adapter/README.md
+++ b/wayfinder_paths/adapters/aerodrome_adapter/README.md
@@ -7,12 +7,27 @@ This adapter supports Aerodrome’s classic **Pool / Gauge / veAERO** stack on *
 - Enumerate gauge-enabled pools via `Voter.length()` + `Voter.pools(i)`
 - Sugar pool + epoch reads for analytics (`list_pools()`, `sugar_epochs_latest()`)
 - Pool ranking by latest epoch fees/bribes per veAERO vote (`rank_pools_by_usdc_per_ve()`)
+- Router exact-in route quoting (`quote_best_route()`, `get_amounts_out()`)
 - LP add/remove liquidity (ERC20-ERC20 and ERC20-ETH)
 - Stake/unstake LP into gauges + claim emissions
 - veAERO: list NFTs, create lock, increase amount/time, withdraw, permanent lock/unlock
 - Voting: `Voter.vote()` / `Voter.reset()` (with optional epoch-window precheck)
 - Claim fees / bribes (build reward token lists dynamically)
 - Claim rebases via `RewardsDistributor`
+
+## Current protocol notes
+
+- Use this adapter for classic stable/volatile Aerodrome pools. Use
+  `aerodrome_slipstream_adapter` for concentrated-liquidity pools and NFPM
+  positions.
+- Current Sugar reads use Base LP Sugar for pool rows and Rewards Sugar for
+  epoch rows. `sugar_all(..., pool_filter=0)` calls the current
+  `LpSugar.all(limit, offset, filter)` shape.
+- `SugarPool` includes current LP metadata such as `emissions_cap`, `locked`,
+  `emerging`, `created_at`, `nfpm`, `alm`, and `root` when the deployed Sugar
+  contract returns them.
+- The adapter quotes classic router routes but does not execute swaps. Fund
+  movement in this adapter is LP, gauge, veAERO, and reward-claim oriented.
 
 ## Quick usage
 

--- a/wayfinder_paths/adapters/aerodrome_adapter/adapter.py
+++ b/wayfinder_paths/adapters/aerodrome_adapter/adapter.py
@@ -105,7 +105,13 @@ class SugarPool:
     unstaked_fee_pips: int
     token0_fees: int
     token1_fees: int
-    created_at: int
+    emissions_cap: int = 0
+    locked: int = 0
+    emerging: int = 0
+    created_at: int = 0
+    nfpm: str = ZERO_ADDRESS
+    alm: str = ZERO_ADDRESS
+    root: str = ZERO_ADDRESS
 
     @property
     def is_cl(self) -> bool:
@@ -352,6 +358,36 @@ class AerodromeAdapter(
         if len(row) < 26:
             raise ValueError(f"Unexpected Sugar pool tuple length: {len(row)}")
 
+        emissions_cap = 0
+        pool_fee_pips = row[21]
+        unstaked_fee_pips = row[22]
+        token0_fees = row[23]
+        token1_fees = row[24]
+        locked = 0
+        emerging = 0
+        created_at = 0
+        nfpm = ZERO_ADDRESS
+        alm = ZERO_ADDRESS
+        root = ZERO_ADDRESS
+
+        if len(row) >= 32:
+            emissions_cap = row[21]
+            pool_fee_pips = row[22]
+            unstaked_fee_pips = row[23]
+            token0_fees = row[24]
+            token1_fees = row[25]
+            locked = row[26]
+            emerging = row[27]
+            created_at = row[28]
+            nfpm = to_checksum_address(row[29])
+            alm = to_checksum_address(row[30])
+            root = to_checksum_address(row[31])
+        elif len(row) >= 27:
+            nfpm = to_checksum_address(row[25])
+            alm = to_checksum_address(row[26])
+        else:
+            created_at = row[25]
+
         return SugarPool(
             lp=to_checksum_address(row[0]),
             symbol=row[1],
@@ -374,11 +410,17 @@ class AerodromeAdapter(
             factory=to_checksum_address(row[18]),
             emissions_per_sec=row[19],
             emissions_token=to_checksum_address(row[20]),
-            pool_fee_pips=row[21],
-            unstaked_fee_pips=row[22],
-            token0_fees=row[23],
-            token1_fees=row[24],
-            created_at=row[25],
+            pool_fee_pips=pool_fee_pips,
+            unstaked_fee_pips=unstaked_fee_pips,
+            token0_fees=token0_fees,
+            token1_fees=token1_fees,
+            emissions_cap=emissions_cap,
+            locked=locked,
+            emerging=emerging,
+            created_at=created_at,
+            nfpm=nfpm,
+            alm=alm,
+            root=root,
         )
 
     async def sugar_all(
@@ -386,6 +428,7 @@ class AerodromeAdapter(
         *,
         limit: int = _SUGAR_ALL_PAGE_SIZE,
         offset: int = 0,
+        pool_filter: int = 0,
     ) -> list[SugarPool]:
         async with web3_from_chain_id(CHAIN_ID_BASE) as web3:
             sugar = web3.eth.contract(
@@ -398,15 +441,17 @@ class AerodromeAdapter(
             # Not calling gather here, because each sugar call is heavy so we may hit limits
             while remaining > 0:
                 batch_limit = min(remaining, _SUGAR_ALL_PAGE_SIZE)
-                batch = await sugar.functions.all(batch_limit, next_offset).call(
-                    transaction={"gas": _SUGAR_CALL_GAS}, block_identifier="latest"
-                )
+                batch = await sugar.functions.all(
+                    batch_limit,
+                    next_offset,
+                    pool_filter,
+                ).call(transaction={"gas": _SUGAR_CALL_GAS}, block_identifier="latest")
                 out.extend(batch)
                 received = len(batch)
                 if received == 0:
                     break
                 remaining -= received
-                next_offset += received
+                next_offset += batch_limit
 
             return [self._parse_sugar_pool(row) for row in out]
 
@@ -465,7 +510,9 @@ class AerodromeAdapter(
     ) -> list[SugarEpoch]:
         async with web3_from_chain_id(CHAIN_ID_BASE) as web3:
             sugar = web3.eth.contract(
-                address=self.core_contracts["sugar"],
+                address=self.core_contracts.get(
+                    "rewards_sugar", self.core_contracts["sugar"]
+                ),
                 abi=AERODROME_SUGAR_ABI,
             )
             rows = await sugar.functions.epochsLatest(limit, offset).call(
@@ -483,7 +530,9 @@ class AerodromeAdapter(
         pool = to_checksum_address(pool)
         async with web3_from_chain_id(CHAIN_ID_BASE) as web3:
             sugar = web3.eth.contract(
-                address=self.core_contracts["sugar"],
+                address=self.core_contracts.get(
+                    "rewards_sugar", self.core_contracts["sugar"]
+                ),
                 abi=AERODROME_SUGAR_ABI,
             )
             rows = await sugar.functions.epochsByAddress(limit, offset, pool).call(

--- a/wayfinder_paths/adapters/aerodrome_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/aerodrome_adapter/test_adapter.py
@@ -1304,6 +1304,9 @@ def test_parse_sugar_pool():
     bribe = "0x" + "66" * 20
     factory = "0x" + "77" * 20
     emissions_token = "0x" + "88" * 20
+    nfpm = "0x" + "99" * 20
+    alm = "0x" + "aa" * 20
+    root = "0x" + "bb" * 20
 
     pool = AerodromeAdapter._parse_sugar_pool(
         [
@@ -1328,11 +1331,17 @@ def test_parse_sugar_pool():
             factory,
             123,
             emissions_token,
+            456,
             30,
             5,
             7,
             11,
+            13,
+            17,
             999,
+            nfpm,
+            alm,
+            root,
         ]
     )
 
@@ -1340,6 +1349,13 @@ def test_parse_sugar_pool():
     assert pool.symbol == "AERO/USDC"
     assert pool.gauge.lower() == gauge.lower()
     assert pool.emissions_token.lower() == emissions_token.lower()
+    assert pool.emissions_cap == 456
+    assert pool.locked == 13
+    assert pool.emerging == 17
+    assert pool.created_at == 999
+    assert pool.nfpm.lower() == nfpm.lower()
+    assert pool.alm.lower() == alm.lower()
+    assert pool.root.lower() == root.lower()
     assert pool.is_v2 is True
     assert pool.is_cl is False
     assert pool.stable is True
@@ -1552,24 +1568,30 @@ async def test_sugar_all_batches_large_limit():
             _addr(i + 6001),
             0,
             _addr(i + 7001),
+            0,
             30,
             5,
             0,
             0,
+            0,
+            0,
             1,
+            _addr(i + 8001),
+            ZERO_ADDRESS,
+            addr,
         )
 
     rows_page_1 = [_row(i) for i in range(300)]
     rows_page_2 = [_row(i) for i in range(300, 350)]
-    seen_calls: list[tuple[int, int]] = []
+    seen_calls: list[tuple[int, int, int]] = []
 
-    def _all(limit: int, offset: int):
-        seen_calls.append((limit, offset))
-        if (limit, offset) == (300, 10):
+    def _all(limit: int, offset: int, pool_filter: int):
+        seen_calls.append((limit, offset, pool_filter))
+        if (limit, offset, pool_filter) == (300, 10, 0):
             return _mock_call(rows_page_1)
-        if (limit, offset) == (50, 310):
+        if (limit, offset, pool_filter) == (50, 310, 0):
             return _mock_call(rows_page_2)
-        raise AssertionError(f"unexpected sugar.all({limit}, {offset})")
+        raise AssertionError(f"unexpected sugar.all({limit}, {offset}, {pool_filter})")
 
     sugar = MagicMock()
     sugar.functions.all = MagicMock(side_effect=_all)
@@ -1584,10 +1606,37 @@ async def test_sugar_all_batches_large_limit():
     ):
         pools = await adapter.sugar_all(limit=350, offset=10)
 
-    assert seen_calls == [(300, 10), (50, 310)]
+    assert seen_calls == [(300, 10, 0), (50, 310, 0)]
     assert len(pools) == 350
     assert pools[0].symbol == "pool-0"
     assert pools[-1].symbol == "pool-349"
+
+
+@pytest.mark.asyncio
+async def test_sugar_epochs_latest_uses_rewards_sugar_contract():
+    adapter = AerodromeAdapter()
+    rewards_sugar = MagicMock()
+    rewards_sugar.functions.epochsLatest = MagicMock(return_value=_mock_call([]))
+
+    seen_addresses: list[str] = []
+
+    def _contract(*, address: str, **_kwargs):
+        seen_addresses.append(address)
+        return rewards_sugar
+
+    mock_web3 = MagicMock()
+    mock_web3.eth.contract = MagicMock(side_effect=_contract)
+
+    with patch.object(
+        aerodrome_adapter_module,
+        "web3_from_chain_id",
+        _web3_ctx(mock_web3),
+    ):
+        rows = await adapter.sugar_epochs_latest(limit=2, offset=3)
+
+    assert rows == []
+    assert seen_addresses == [adapter.core_contracts["rewards_sugar"]]
+    rewards_sugar.functions.epochsLatest.assert_called_once_with(2, 3)
 
 
 @pytest.mark.asyncio

--- a/wayfinder_paths/adapters/aerodrome_slipstream_adapter/README.md
+++ b/wayfinder_paths/adapters/aerodrome_slipstream_adapter/README.md
@@ -1,0 +1,28 @@
+# Aerodrome Slipstream Adapter (Base)
+
+This adapter supports Aerodrome Slipstream concentrated-liquidity pools on Base.
+Slipstream positions are NFPM NFTs, not fungible classic LP tokens.
+
+## Supported flows
+
+- Deployment-aware pool discovery across the initial, gauge-caps, and Gauges V3
+  Slipstream deployments
+- Pool state, range sizing, fee APR, volume, volatility, and in-range
+  probability analytics
+- NFPM position lifecycle: mint, increase, decrease, collect, and burn
+- Gauge staking and unstaking for position NFTs, plus position reward claims
+- Shared veAERO lock, vote, fee, bribe, and rebase helpers
+
+## Current protocol notes
+
+- New write flows default to the current Gauges V3 deployment. Older
+  deployments remain scanned because existing pools and gauges are still live.
+- Tick spacing is part of the pool identity. Pass the exact tick spacing for
+  pool lookup and minting; common docs examples include 1, 50, 200, and 2000.
+- NPM-only actions require wallet ownership of the NFT. If the NFT is staked,
+  unstake it before increase, decrease, collect, or burn.
+- Gauges V3 introduces minimum stake time and early-unstake/getReward penalty
+  behavior at the gauge layer. Inspect pool/gauge terms before claiming or
+  withdrawing shortly after staking.
+- The adapter uses swap logs for analytics but does not execute swaps.
+

--- a/wayfinder_paths/adapters/aerodrome_slipstream_adapter/adapter.py
+++ b/wayfinder_paths/adapters/aerodrome_slipstream_adapter/adapter.py
@@ -25,6 +25,7 @@ from wayfinder_paths.core.constants.aerodrome_slipstream_abi import (
 from wayfinder_paths.core.constants.aerodrome_slipstream_contracts import (
     AERODROME_SLIPSTREAM_BY_CHAIN,
     AERODROME_SLIPSTREAM_DEPLOYMENT_GAUGE_CAPS,
+    AERODROME_SLIPSTREAM_DEPLOYMENT_GAUGES_V3,
     AERODROME_SLIPSTREAM_DEPLOYMENT_INITIAL,
 )
 from wayfinder_paths.core.constants.base import MAX_UINT256, SECONDS_PER_YEAR
@@ -133,11 +134,12 @@ class AerodromeSlipstreamAdapter(
             else [
                 AERODROME_SLIPSTREAM_DEPLOYMENT_INITIAL,
                 AERODROME_SLIPSTREAM_DEPLOYMENT_GAUGE_CAPS,
+                AERODROME_SLIPSTREAM_DEPLOYMENT_GAUGES_V3,
             ]
         )
         self.write_deployment = (config or {}).get(
             "write_deployment"
-        ) or AERODROME_SLIPSTREAM_DEPLOYMENT_INITIAL
+        ) or AERODROME_SLIPSTREAM_DEPLOYMENT_GAUGES_V3
         if self.write_deployment not in self.supported_deployments:
             raise ValueError(
                 f"Unknown Slipstream write deployment: {self.write_deployment}"

--- a/wayfinder_paths/adapters/aerodrome_slipstream_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/aerodrome_slipstream_adapter/test_adapter.py
@@ -11,6 +11,11 @@ from wayfinder_paths.adapters.aerodrome_slipstream_adapter.adapter import (
     AerodromeSlipstreamAdapter,
 )
 from wayfinder_paths.core.constants import ZERO_ADDRESS
+from wayfinder_paths.core.constants.aerodrome_slipstream_contracts import (
+    AERODROME_SLIPSTREAM_DEPLOYMENT_GAUGE_CAPS,
+    AERODROME_SLIPSTREAM_DEPLOYMENT_GAUGES_V3,
+    AERODROME_SLIPSTREAM_DEPLOYMENT_INITIAL,
+)
 from wayfinder_paths.core.constants.chains import CHAIN_ID_BASE
 from wayfinder_paths.core.utils.uniswap_v3_math import (
     amounts_for_liq_inrange,
@@ -58,6 +63,23 @@ def test_adapter_type():
 def test_constructor_is_base_only():
     adapter = AerodromeSlipstreamAdapter(config={"deployments": ("initial",)})
     assert adapter.chain_id == CHAIN_ID_BASE
+
+
+def test_constructor_defaults_to_all_current_deployments_and_v3_writes():
+    adapter = AerodromeSlipstreamAdapter()
+
+    assert adapter.default_deployments == [
+        AERODROME_SLIPSTREAM_DEPLOYMENT_INITIAL,
+        AERODROME_SLIPSTREAM_DEPLOYMENT_GAUGE_CAPS,
+        AERODROME_SLIPSTREAM_DEPLOYMENT_GAUGES_V3,
+    ]
+    assert adapter.write_deployment == AERODROME_SLIPSTREAM_DEPLOYMENT_GAUGES_V3
+    assert (
+        adapter._deployment(AERODROME_SLIPSTREAM_DEPLOYMENT_GAUGES_V3)[
+            "nonfungible_position_manager"
+        ]
+        == "0xe1f8cd9AC4e4A65F54f38a5CdAfCA44f6dD68b53"
+    )
 
 
 @pytest.mark.parametrize(

--- a/wayfinder_paths/core/constants/aerodrome_abi.py
+++ b/wayfinder_paths/core/constants/aerodrome_abi.py
@@ -708,6 +708,7 @@ AERODROME_SUGAR_ABI: list[dict[str, Any]] = [
         "inputs": [
             {"name": "_limit", "type": "uint256"},
             {"name": "_offset", "type": "uint256"},
+            {"name": "_filter", "type": "uint256"},
         ],
         "outputs": [
             {
@@ -735,11 +736,17 @@ AERODROME_SUGAR_ABI: list[dict[str, Any]] = [
                     {"name": "factory", "type": "address"},
                     {"name": "emissions", "type": "uint256"},
                     {"name": "emissions_token", "type": "address"},
+                    {"name": "emissions_cap", "type": "uint256"},
                     {"name": "pool_fee", "type": "uint256"},
                     {"name": "unstaked_fee", "type": "uint256"},
                     {"name": "token0_fees", "type": "uint256"},
                     {"name": "token1_fees", "type": "uint256"},
-                    {"name": "created_at", "type": "uint256"},
+                    {"name": "locked", "type": "uint256"},
+                    {"name": "emerging", "type": "uint256"},
+                    {"name": "created_at", "type": "uint32"},
+                    {"name": "nfpm", "type": "address"},
+                    {"name": "alm", "type": "address"},
+                    {"name": "root", "type": "address"},
                 ],
             }
         ],

--- a/wayfinder_paths/core/constants/aerodrome_contracts.py
+++ b/wayfinder_paths/core/constants/aerodrome_contracts.py
@@ -25,9 +25,7 @@ AERODROME_BY_CHAIN: dict[int, dict[str, str]] = {
             "0x227f65131A261548b057215bB1D5Ab2997964C7d"
         ),
         "sugar": to_checksum_address("0x69dD9db6d8f8E7d83887A704f447b1a584b599A1"),
-        "lp_sugar": to_checksum_address(
-            "0x69dD9db6d8f8E7d83887A704f447b1a584b599A1"
-        ),
+        "lp_sugar": to_checksum_address("0x69dD9db6d8f8E7d83887A704f447b1a584b599A1"),
         "rewards_sugar": to_checksum_address(
             "0x1b121EfDaF4ABb8785a315C51D29BCE0552A7678"
         ),

--- a/wayfinder_paths/core/constants/aerodrome_contracts.py
+++ b/wayfinder_paths/core/constants/aerodrome_contracts.py
@@ -24,7 +24,26 @@ AERODROME_BY_CHAIN: dict[int, dict[str, str]] = {
         "rewards_distributor": to_checksum_address(
             "0x227f65131A261548b057215bB1D5Ab2997964C7d"
         ),
-        "sugar": to_checksum_address("0x68c19e13618C41158fE4bAba1B8fb3A9c74bDb0A"),
+        "sugar": to_checksum_address("0x69dD9db6d8f8E7d83887A704f447b1a584b599A1"),
+        "lp_sugar": to_checksum_address(
+            "0x69dD9db6d8f8E7d83887A704f447b1a584b599A1"
+        ),
+        "rewards_sugar": to_checksum_address(
+            "0x1b121EfDaF4ABb8785a315C51D29BCE0552A7678"
+        ),
+        "token_sugar": to_checksum_address(
+            "0x910CD56277994B4970F49AEDA52c96aD620aE81D"
+        ),
+        "ve_sugar": to_checksum_address("0x4d6A741cEE6A8cC5632B2d948C050303F6246D24"),
+        "relay_sugar": to_checksum_address(
+            "0x3dd0849D66DBd63D06f11442502e200601c50790"
+        ),
+        "lp_helper": to_checksum_address("0x1a130fB30CEFc7465f796C9bc959E8402Ae46E8E"),
+        "swapper": to_checksum_address("0x91616a7B9CF6D23f8C17845581051EBdC4BcB916"),
+        "universal_router": to_checksum_address(
+            "0xC5b6786D7B64767D775877b0B6A319AD946B11B5"
+        ),
+        "permit2": to_checksum_address("0x494bbD8A3302AcA833D307D11838f18DbAdA9C25"),
         "minter": to_checksum_address("0xeB018363F0a9Af8f91F06FEe6613a751b2A33FE5"),
         "gauge_factory": to_checksum_address(
             "0x35f35cA5B132CaDf2916BaB57639128eAC5bbcb5"

--- a/wayfinder_paths/core/constants/aerodrome_slipstream_contracts.py
+++ b/wayfinder_paths/core/constants/aerodrome_slipstream_contracts.py
@@ -8,6 +8,7 @@ from wayfinder_paths.core.constants.contracts import BASE_WETH
 
 AERODROME_SLIPSTREAM_DEPLOYMENT_INITIAL = "initial"
 AERODROME_SLIPSTREAM_DEPLOYMENT_GAUGE_CAPS = "gauge_caps"
+AERODROME_SLIPSTREAM_DEPLOYMENT_GAUGES_V3 = "gauges_v3"
 
 AERODROME_SLIPSTREAM_BY_CHAIN: dict[int, dict[str, object]] = {
     CHAIN_ID_BASE: {
@@ -56,7 +57,7 @@ AERODROME_SLIPSTREAM_BY_CHAIN: dict[int, dict[str, object]] = {
                     "0x0AD09A66af0154a84e86F761313d02d0abB6edd5"
                 ),
                 "dynamic_swap_fee_module": to_checksum_address(
-                    "0xDB45818A6db280ecfeB33cbeBd445423d0216b5D"
+                    "0x090b2A6bb475c00e2256e2095A60887cD710803b"
                 ),
             },
             "gauge_caps": {
@@ -94,10 +95,54 @@ AERODROME_SLIPSTREAM_BY_CHAIN: dict[int, dict[str, object]] = {
                     "0xCCC21f4750E8B3E9C095BCB5d2fF59247A2CCD35"
                 ),
                 "dynamic_swap_fee_module": to_checksum_address(
-                    "0x00cB12a1c84dfC1b9c70734C0385E769Bc86e9Ef"
+                    "0xF4Ecd78EBEB6d36CF7f80B5B6B41453515fe2785"
                 ),
                 "redistributor": to_checksum_address(
                     "0x11a53f31Bf406de59fCf9613E1922bd3E283A4B4"
+                ),
+            },
+            "gauges_v3": {
+                "dynamic_swap_fee_module": to_checksum_address(
+                    "0x87D8f999BBa9343E8099552426775B51C338E8CB"
+                ),
+                "gauge_factory": to_checksum_address(
+                    "0x385293CaE378C813F16f0C1334d774AdDDf56AbB"
+                ),
+                "gauge_implementation": to_checksum_address(
+                    "0x434BCcaB043311a20b16021C137EA81702790f7B"
+                ),
+                "mixed_quoter": to_checksum_address(
+                    "0x9951FF0b830E46ef0e7Ce34d9117e3214B1F0b5a"
+                ),
+                "mixed_quoter_v2": to_checksum_address(
+                    "0xb4A9E5Fc0727BEF09D819fcfc5ece8CA9bCf09EB"
+                ),
+                "mixed_quoter_v3": to_checksum_address(
+                    "0xCd2A7D98e82D6107eac1828ce8DeAA6acB65b555"
+                ),
+                "nonfungible_position_manager": to_checksum_address(
+                    "0xe1f8cd9AC4e4A65F54f38a5CdAfCA44f6dD68b53"
+                ),
+                "nonfungible_token_position_descriptor": to_checksum_address(
+                    "0xc85C126442bb5B654792A70135805a9778C8e3fE"
+                ),
+                "pool_factory": to_checksum_address(
+                    "0xf8f2eB4940CFE7d13603DDDD87f123820Fc061Ef"
+                ),
+                "pool_implementation": to_checksum_address(
+                    "0xc770898522D2A9c8Da7A10D63989b6b58305B665"
+                ),
+                "quoter": to_checksum_address(
+                    "0x514c8B5f54112481E28028F1166Bd78501089259"
+                ),
+                "redistributor": to_checksum_address(
+                    "0xEe5b3C7b333e2870B746b3B2b168EF0958e55e15"
+                ),
+                "swap_router": to_checksum_address(
+                    "0x698Cb2b6dd822994581fEa6eA4Fc755d1363A92F"
+                ),
+                "unstaked_fee_module": to_checksum_address(
+                    "0xc2cc3256434AfbC36Bb5e815e1Bb2151310a1a0b"
                 ),
             },
         },


### PR DESCRIPTION
## Summary

- updates Aerodrome Sugar constants/ABI/read parsing for current LP Sugar and Rewards Sugar deployments
- adds current Slipstream Gauges V3 deployment constants, scans all live deployment generations by default, and defaults new writes to Gauges V3
- refreshes Aerodrome and Slipstream adapter docs/skills with classic vs CL boundaries, Sugar filter/read-model notes, NFPM/tick/deadline/slippage/reward gotchas, and swap capability boundaries

## Validation

- `POETRY_CACHE_DIR=/private/tmp/poetry-cache poetry run ruff format --check wayfinder_paths/adapters/aerodrome_adapter wayfinder_paths/adapters/aerodrome_slipstream_adapter .claude/skills/using-aerodrome-adapter .claude/skills/using-aerodrome-slipstream-adapter`
- `POETRY_CACHE_DIR=/private/tmp/poetry-cache poetry run ruff check wayfinder_paths/adapters/aerodrome_adapter wayfinder_paths/adapters/aerodrome_slipstream_adapter`
- `POETRY_CACHE_DIR=/private/tmp/poetry-cache poetry run pytest -o addopts= wayfinder_paths/adapters/aerodrome_adapter wayfinder_paths/adapters/aerodrome_slipstream_adapter -q` (`181 passed`)
- standalone Gorlami simulation files also passed (`6 passed`) before the final Sugar pagination cleanup; the final full adapter test command above re-ran both Gorlami files after that cleanup
- `git diff --check`

Linear: WAYST-252