### PR TITLE
Update Pendle market history endpoint

### DIFF
--- a/.claude/skills/using-pendle-adapter/rules/gotchas.md
+++ b/.claude/skills/using-pendle-adapter/rules/gotchas.md
@@ -46,6 +46,13 @@ The adapter accepts both forms:
 - Hosted SDK may omit `effectiveApy`/`impliedApy` depending on market state
 - Always handle missing fields with `.get()` defaults
 
+## Market history endpoint
+
+- Use `fetch_market_history()` for market time series. It calls Pendle's v3
+  historical-data endpoint; v2 is deprecated in current Pendle docs.
+- APY and fee breakdowns are optional and more expensive in computing units, so
+  request them only when the user needs those fields.
+
 ## Expired PT redemption (don't use `execute_swap`)
 
 - **`execute_swap` doesn't work for expired markets** — use `execute_convert` instead

--- a/.claude/skills/using-pendle-adapter/rules/high-value-reads.md
+++ b/.claude/skills/using-pendle-adapter/rules/high-value-reads.md
@@ -98,6 +98,10 @@ if __name__ == "__main__":
 
 ### Market history (time series)
 
+`fetch_market_history()` uses Pendle's current v3 market-history endpoint. It is
+backward-compatible with v2 and can request optional APY/fee breakdown payloads
+with `include_apy_breakdown=True` or `include_fee_breakdown=True`.
+
 ```python
 """Fetch historical data for a market."""
 import asyncio

--- a/wayfinder_paths/adapters/pendle_adapter/README.md
+++ b/wayfinder_paths/adapters/pendle_adapter/README.md
@@ -10,7 +10,7 @@ Adapter for Pendle API + Hosted SDK endpoints to support:
 
 - `pendle.markets.read`: Fetch whitelisted markets (`/v2/markets/all`)
 - `pendle.market.snapshot`: Fetch a market snapshot (`/v2/{chainId}/markets/{market}/data`)
-- `pendle.market.history`: Fetch market historical data (`/v2/{chainId}/markets/{market}/historical-data`)
+- `pendle.market.history`: Fetch market historical data (`/v3/{chainId}/markets/{market}/historical-data`)
 - `pendle.prices.ohlcv`: Fetch token OHLCV (`/v4/{chainId}/prices/{token}/ohlcv`)
 - `pendle.prices.assets`: Fetch all asset prices (`/v1/prices/assets`)
 - `pendle.swap.quote`: Build Hosted SDK swap payload (`/v2/sdk/{chainId}/markets/{market}/swap`)
@@ -264,6 +264,9 @@ ok, res = await adapter.execute_convert(
 
 - Market discovery uses `GET /v2/markets/all` with pagination. The raw endpoint
   returns `results`; the adapter normalizes this to `markets` for compatibility.
+- Market history uses `GET /v3/{chainId}/markets/{market}/historical-data`.
+  Pendle documents v3 as backward-compatible with v2 and adds optional APY/fee
+  breakdown flags.
 - “Fixed APY” proxy is `details.impliedApy` from `/v2/markets/all`.
 - Pendle docs recommend `POST /v3/sdk/{chainId}/convert` for new integrations.
   This adapter currently uses the v2 convert endpoint for compatibility.

--- a/wayfinder_paths/adapters/pendle_adapter/adapter.py
+++ b/wayfinder_paths/adapters/pendle_adapter/adapter.py
@@ -558,6 +558,8 @@ class PendleAdapter(BaseAdapter):
         timestamp_start: str | None = None,
         timestamp_end: str | None = None,
         fields: str | None = None,
+        include_apy_breakdown: bool | None = None,
+        include_fee_breakdown: bool | None = None,
     ) -> dict[str, Any]:
         params: dict[str, Any] = {
             "time_frame": time_frame,
@@ -567,9 +569,13 @@ class PendleAdapter(BaseAdapter):
             params["timestamp_start"] = timestamp_start
         if timestamp_end:
             params["timestamp_end"] = timestamp_end
+        if include_apy_breakdown is not None:
+            params["includeApyBreakdown"] = self._bool_q(include_apy_breakdown)
+        if include_fee_breakdown is not None:
+            params["includeFeeBreakdown"] = self._bool_q(include_fee_breakdown)
 
         data = await self._get(
-            f"/v2/{int(chain_id)}/markets/{market_address}/historical-data",
+            f"/v3/{int(chain_id)}/markets/{market_address}/historical-data",
             params=params,
         )
         return data if isinstance(data, dict) else {"data": data}

--- a/wayfinder_paths/adapters/pendle_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/pendle_adapter/test_adapter.py
@@ -269,6 +269,38 @@ class TestPendleAdapter:
         assert captured_skips == ["0", "100"]
 
     @pytest.mark.asyncio
+    async def test_fetch_market_history_uses_v3_and_breakdown_flags(self):
+        captured: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["path"] = request.url.path
+            captured["params"] = dict(request.url.params)
+            return httpx.Response(200, json={"total": 0, "results": []})
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        adapter = PendleAdapter(config={}, client=client)
+
+        resp = await adapter.fetch_market_history(
+            chain_id=42161,
+            market_address="0xMarket",
+            time_frame="week",
+            fields="all",
+            include_apy_breakdown=True,
+            include_fee_breakdown=False,
+        )
+
+        await client.aclose()
+
+        assert captured["path"] == "/core/v3/42161/markets/0xMarket/historical-data"
+        assert captured["params"] == {
+            "time_frame": "week",
+            "fields": "all",
+            "includeApyBreakdown": "true",
+            "includeFeeBreakdown": "false",
+        }
+        assert resp["results"] == []
+
+    @pytest.mark.asyncio
     async def test_pendle_api_get_helper_sets_user_agent_and_rate_limit(self):
         captured: dict[str, Any] = {}
 


### PR DESCRIPTION
## Summary
- validated PR #352 Pendle limit-order and market-discovery behavior against current Pendle docs/API
- moved `fetch_market_history()` to Pendle current v3 historical-data endpoint
- added optional APY/fee breakdown query flags and updated Pendle adapter docs/skill guidance

## Research outcome
PR #352 remains current for limit orders: the live limit-order OpenAPI still exposes `/v1/takers/limit-orders`, `/v1/makers/generate-limit-order-data`, and `/v1/makers/limit-orders`, with the same sort fields, order type ids, maker payload fields, and 1% `netFromTaker` fill-buffer guidance.

The only drift found was read-only market history: Pendle now documents `GET /v3/{chainId}/markets/{address}/historical-data` as the current endpoint and marks v2 history as deprecated. Live checks showed v2 and v3 both still respond, and docs say v3 is backward-compatible, so this PR makes only that focused update. Hosted SDK convert remains unchanged because the adapter method is explicitly `sdk_convert_v2()` and the README already documents the compatibility choice.

No Hyperliquid or Polymarket adapters were touched.

## Validation
- `poetry run ruff format --check wayfinder_paths/adapters/pendle_adapter .claude/skills/using-pendle-adapter`
- `poetry run ruff check wayfinder_paths/adapters/pendle_adapter`
- `poetry run pytest -o addopts= wayfinder_paths/adapters/pendle_adapter/test_adapter.py wayfinder_paths/adapters/pendle_adapter/test_gorlami_simulation.py -q`
- `git diff --check`

Linear: WAYST-255