### PR TITLE
Shells - Wait For Bridge Execution On Cross-Chain Swap

### DIFF
--- a/wayfinder_paths/core/clients/BRAPClient.py
+++ b/wayfinder_paths/core/clients/BRAPClient.py
@@ -117,5 +117,30 @@ class BRAPClient(WayfinderClient):
             logger.error(f"BRAP quote request failed after {elapsed:.2f}s: {e}")
             raise
 
+    async def wait_for_bridge_execution(
+        self,
+        *,
+        bridge_tracking: dict[str, Any],
+        tx_hash: str | None = None,
+        poll_interval_seconds: float = 5.0,
+        timeout_seconds: float = 600.0,
+    ) -> dict[str, Any]:
+        url = f"{get_api_base_url()}/blockchain/braps/wait-bridge-execution/"
+        payload: dict[str, Any] = {
+            "bridge_tracking": bridge_tracking,
+            "poll_interval_seconds": poll_interval_seconds,
+            "timeout_seconds": timeout_seconds,
+        }
+        if tx_hash:
+            payload["tx_hash"] = tx_hash
+        response = await self._authed_request(
+            "POST",
+            url,
+            json=payload,
+            headers={},
+            timeout=timeout_seconds + 30.0,
+        )
+        return response.json()
+
 
 BRAP_CLIENT = BRAPClient()

--- a/wayfinder_paths/mcp/tools/execute.py
+++ b/wayfinder_paths/mcp/tools/execute.py
@@ -340,11 +340,11 @@ async def onchain_swap(
         status = "failed"
 
     bridge_tracking = best_quote.get("bridge_tracking")
-    if sent_ok and wait_for_receipt and isinstance(bridge_tracking, dict):
+    if sent_ok and wait_for_receipt and bridge_tracking:
         try:
             bridge_result = await BRAP_CLIENT.wait_for_bridge_execution(
                 bridge_tracking=bridge_tracking,
-                tx_hash=sent.get("txn_hash") if isinstance(sent, dict) else None,
+                tx_hash=sent["txn_hash"],
             )
             response["effects"]["bridge"] = bridge_result
             if not bridge_result.get("is_success"):
@@ -354,6 +354,7 @@ async def onchain_swap(
                 "state": "pending",
                 "error": sanitize_for_json(str(exc)),
             }
+            status = "submitted"
 
     response["status"] = status
     response["raw"] = _compact_quote(quote_data, best_quote)

--- a/wayfinder_paths/mcp/tools/execute.py
+++ b/wayfinder_paths/mcp/tools/execute.py
@@ -191,9 +191,10 @@ async def onchain_swap(
     """Broadcast a cross-chain / cross-DEX swap via BRAP.
 
     **Always quote first** — call `onchain_quote_swap` and confirm route + output with the
-    user before running this. Waits for the receipt by default and returns
-    `status="confirmed"`; pass `wait_for_receipt=False` for fire-and-forget broadcast
-    on slow chains where the MCP client may time out.
+    user before running this. Same-chain swaps wait for the source receipt; cross-chain
+    swaps additionally wait for the destination bridge leg to settle (via the
+    BRAP wait-bridge-execution endpoint). Pass `wait_for_receipt=False` for
+    fire-and-forget broadcast (skips both waits).
 
     Args:
         wallet_label: Wallet label.
@@ -337,6 +338,23 @@ async def onchain_swap(
     status = "confirmed" if sent_ok and wait_for_receipt else "submitted"
     if not sent_ok:
         status = "failed"
+
+    bridge_tracking = best_quote.get("bridge_tracking")
+    if sent_ok and wait_for_receipt and isinstance(bridge_tracking, dict):
+        try:
+            bridge_result = await BRAP_CLIENT.wait_for_bridge_execution(
+                bridge_tracking=bridge_tracking,
+                tx_hash=sent.get("txn_hash") if isinstance(sent, dict) else None,
+            )
+            response["effects"]["bridge"] = bridge_result
+            if not bridge_result.get("is_success"):
+                status = "failed"
+        except Exception as exc:  # noqa: BLE001
+            response["effects"]["bridge"] = {
+                "state": "pending",
+                "error": sanitize_for_json(str(exc)),
+            }
+
     response["status"] = status
     response["raw"] = _compact_quote(quote_data, best_quote)
 

--- a/wayfinder_paths/tests/test_mcp_execute.py
+++ b/wayfinder_paths/tests/test_mcp_execute.py
@@ -208,3 +208,184 @@ async def test_execute_swap(tmp_path: Path, monkeypatch):
         send_transaction_mock.assert_awaited_once()
         assert send_transaction_mock.await_args.kwargs["wait_for_receipt"] is False
         assert send_transaction_mock.await_args.kwargs["confirmations"] == 0
+        fake_brap.wait_for_bridge_execution.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_execute_cross_chain_swap_waits_for_bridge(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("WAYFINDER_MCP_STATE_PATH", str(tmp_path / "mcp.sqlite3"))
+    monkeypatch.setenv("WAYFINDER_RUNS_DIR", str(tmp_path / "runs"))
+
+    wallet = {
+        "address": "0x000000000000000000000000000000000000dEaD",
+        "private_key_hex": "0x" + "11" * 32,
+    }
+    from_meta = {
+        "symbol": "USDC",
+        "decimals": 6,
+        "chain_id": 1,
+        "address": "0x1111111111111111111111111111111111111111",
+    }
+    to_meta = {
+        "symbol": "USDC",
+        "decimals": 6,
+        "chain_id": 8453,
+        "address": "0x2222222222222222222222222222222222222222",
+    }
+    bridge_tracking = {
+        "provider": "lifi",
+        "requires_source_tx_hash": True,
+        "from_chain": 1,
+        "to_chain": 8453,
+        "bridge": "across",
+    }
+
+    async def fake_resolve(query: str, *, chain_id: int | None = None):
+        _ = chain_id
+        return from_meta if query == "from" else to_meta
+
+    fake_brap = AsyncMock()
+    fake_brap.get_quote = AsyncMock(
+        return_value={
+            "quotes": [{"provider": "lifi"}],
+            "best_quote": {
+                "provider": "lifi",
+                "input_amount": "1000000",
+                "calldata": {
+                    "to": "0x" + "33" * 20,
+                    "data": "0xdeadbeef",
+                    "value": "0",
+                },
+                "bridge_tracking": bridge_tracking,
+            },
+        }
+    )
+    fake_brap.wait_for_bridge_execution = AsyncMock(
+        return_value={"is_success": True, "state": "completed"}
+    )
+
+    async def fake_ensure_allowance(**_kwargs):  # noqa: ANN003
+        return True, "0xapprove"
+
+    with (
+        patch(
+            "wayfinder_paths.core.utils.wallets.find_wallet_by_label",
+            return_value=wallet,
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.TokenResolver.resolve_token_meta",
+            new_callable=AsyncMock,
+            side_effect=fake_resolve,
+        ),
+        patch("wayfinder_paths.mcp.tools.execute.BRAP_CLIENT", fake_brap),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.ensure_allowance",
+            new=AsyncMock(side_effect=fake_ensure_allowance),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.send_transaction",
+            new_callable=AsyncMock,
+            return_value="0xsrctx",
+        ),
+    ):
+        out = await onchain_swap(
+            wallet_label="main",
+            from_token="from",
+            to_token="to",
+            amount="1.0",
+        )
+
+    assert out["ok"] is True
+    assert out["result"]["status"] == "confirmed"
+    assert out["result"]["effects"]["bridge"]["is_success"] is True
+    fake_brap.wait_for_bridge_execution.assert_awaited_once()
+    call_kwargs = fake_brap.wait_for_bridge_execution.await_args.kwargs
+    assert call_kwargs["bridge_tracking"] == bridge_tracking
+    assert call_kwargs["tx_hash"] == "0xsrctx"
+
+
+@pytest.mark.asyncio
+async def test_execute_cross_chain_swap_failed_bridge_marks_failed(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.setenv("WAYFINDER_MCP_STATE_PATH", str(tmp_path / "mcp.sqlite3"))
+    monkeypatch.setenv("WAYFINDER_RUNS_DIR", str(tmp_path / "runs"))
+
+    wallet = {
+        "address": "0x000000000000000000000000000000000000dEaD",
+        "private_key_hex": "0x" + "11" * 32,
+    }
+    from_meta = {
+        "decimals": 6,
+        "chain_id": 1,
+        "address": "0x1111111111111111111111111111111111111111",
+    }
+    to_meta = {
+        "decimals": 6,
+        "chain_id": 8453,
+        "address": "0x2222222222222222222222222222222222222222",
+    }
+
+    fake_brap = AsyncMock()
+    fake_brap.get_quote = AsyncMock(
+        return_value={
+            "quotes": [{"provider": "lifi"}],
+            "best_quote": {
+                "provider": "lifi",
+                "input_amount": "1000000",
+                "calldata": {
+                    "to": "0x" + "33" * 20,
+                    "data": "0xdeadbeef",
+                    "value": "0",
+                },
+                "bridge_tracking": {
+                    "provider": "lifi",
+                    "requires_source_tx_hash": True,
+                    "from_chain": 1,
+                    "to_chain": 8453,
+                },
+            },
+        }
+    )
+    fake_brap.wait_for_bridge_execution = AsyncMock(
+        return_value={"is_success": False, "state": "failed", "error": "reverted"}
+    )
+
+    async def fake_resolve(query: str, *, chain_id: int | None = None):
+        _ = chain_id
+        return from_meta if query == "from" else to_meta
+
+    async def fake_ensure_allowance(**_kwargs):  # noqa: ANN003
+        return True, "0xapprove"
+
+    with (
+        patch(
+            "wayfinder_paths.core.utils.wallets.find_wallet_by_label",
+            return_value=wallet,
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.TokenResolver.resolve_token_meta",
+            new_callable=AsyncMock,
+            side_effect=fake_resolve,
+        ),
+        patch("wayfinder_paths.mcp.tools.execute.BRAP_CLIENT", fake_brap),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.ensure_allowance",
+            new=AsyncMock(side_effect=fake_ensure_allowance),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.send_transaction",
+            new_callable=AsyncMock,
+            return_value="0xsrctx",
+        ),
+    ):
+        out = await onchain_swap(
+            wallet_label="main",
+            from_token="from",
+            to_token="to",
+            amount="1.0",
+        )
+
+    assert out["ok"] is True
+    assert out["result"]["status"] == "failed"
+    assert out["result"]["effects"]["bridge"]["is_success"] is False


### PR DESCRIPTION
### Summary
- `onchain_swap` now waits for the destination bridge leg on cross-chain swaps by calling `BRAPClient.wait_for_bridge_execution` (POST `/api/v1/blockchain/braps/wait-bridge-execution/`) after the source receipt confirms. Same-chain swaps unchanged — they only wait for the source block. Cross-chain detection uses `best_quote.bridge_tracking` (null on same-chain). Triggered automatically when `wait_for_receipt=True` (the default); no new flag added.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>