### PR TITLE
Core Get Wallets - Limit Profile Transactions to 5 by Default

### DIFF
--- a/wayfinder_paths/mcp/state/profile_store.py
+++ b/wayfinder_paths/mcp/state/profile_store.py
@@ -58,7 +58,7 @@ class WalletProfileStore:
             return None
         out = {"address": norm, **profile}
         if transactions_limit is not None:
-            out["transactions"] = (out.get("transactions") or [])[:transactions_limit]
+            out["transactions"] = out["transactions"][:transactions_limit]
         return out
 
     def list_profiles(self) -> list[dict[str, Any]]:

--- a/wayfinder_paths/mcp/state/profile_store.py
+++ b/wayfinder_paths/mcp/state/profile_store.py
@@ -48,13 +48,18 @@ class WalletProfileStore:
     def _normalize_address(self, address: str) -> str:
         return str(address).strip().lower()
 
-    def get_profile(self, address: str) -> dict[str, Any] | None:
+    def get_profile(
+        self, address: str, *, transactions_limit: int | None = None
+    ) -> dict[str, Any] | None:
         data = self._load()
         norm = self._normalize_address(address)
         profile = data["profiles"].get(norm)
-        if profile:
-            return {"address": norm, **profile}
-        return None
+        if not profile:
+            return None
+        out = {"address": norm, **profile}
+        if transactions_limit is not None:
+            out["transactions"] = (out.get("transactions") or [])[:transactions_limit]
+        return out
 
     def list_profiles(self) -> list[dict[str, Any]]:
         data = self._load()

--- a/wayfinder_paths/mcp/tools/wallets.py
+++ b/wayfinder_paths/mcp/tools/wallets.py
@@ -457,11 +457,19 @@ async def _fetch_balances(address: str) -> dict[str, Any] | None:
 
 
 @catch_errors
-async def core_get_wallets(label: str | None = None) -> dict[str, Any]:
+async def core_get_wallets(
+    label: str | None = None, transactions_limit: int = 5
+) -> dict[str, Any]:
     """List configured wallets with profile + protocols + current balances.
 
     No args → every wallet. Pass `label` to filter to a single wallet (returns the same
     shape, list with one entry, or an `err(...)` response if not found).
+
+    Args:
+        label: Optional wallet label filter.
+        transactions_limit: Most-recent N entries to include in `profile.transactions`.
+            Defaults to 5 to keep the response compact (the store caps history at 100).
+            Bump higher for deeper audit; the agent should rarely need >20.
     """
     store = WalletProfileStore.default()
     if label is not None:
@@ -479,7 +487,9 @@ async def core_get_wallets(label: str | None = None) -> dict[str, Any]:
         addr = normalize_address(w.get("address"))
         if addr:
             view["protocols"] = store.get_protocols_for_wallet(addr.lower())
-            view["profile"] = store.get_profile(addr)
+            view["profile"] = store.get_profile(
+                addr, transactions_limit=transactions_limit
+            )
         else:
             view["protocols"] = []
         views.append(view)


### PR DESCRIPTION
### Summary
`WalletProfileStore` stores up to 100 transaction annotations per wallet (every `place_order` / `deposit` / `withdraw` call pushes one with arbitrary `details`), and `core_get_wallets` was packing the **entire** 100-deep log into its response. Cap the slice agents see by default.

- `WalletProfileStore.get_profile` gains an optional `transactions_limit` kwarg; `None` keeps the existing all-history behaviour.
- `core_get_wallets` exposes `transactions_limit=5` as the default. Agents can bump it for deeper audit; the store's own `MAX_TRANSACTIONS=100` caps the upper bound.

Sanity-tested locally:

```
default 5:          5 tx (expected 5)   newest first
unlimited (None):  30 tx (expected 30)
zero:               0 tx (expected 0)
```