### PR TITLE
MCP Tools - Fire-and-forget Tool Execution Metrics

### DIFF
--- a/wayfinder_paths/core/clients/MetricsClient.py
+++ b/wayfinder_paths/core/clients/MetricsClient.py
@@ -6,7 +6,7 @@ from wayfinder_paths.core.config import get_api_base_url
 
 class MetricsClient(WayfinderClient):
     async def report_tool(self, *, tool: str, success: bool, code: str) -> None:
-        url = f"{get_api_base_url()}/sdk/tool-metric/"
+        url = f"{get_api_base_url()}/metric-reporting/"
         await self._authed_request(
             "POST",
             url,

--- a/wayfinder_paths/core/clients/MetricsClient.py
+++ b/wayfinder_paths/core/clients/MetricsClient.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from wayfinder_paths.core.clients.WayfinderClient import WayfinderClient
+from wayfinder_paths.core.config import get_api_base_url
+
+
+class MetricsClient(WayfinderClient):
+    async def report_tool(self, *, tool: str, success: bool, code: str) -> None:
+        url = f"{get_api_base_url()}/sdk/tool-metric/"
+        await self._authed_request(
+            "POST",
+            url,
+            json={"tool": tool, "success": success, "code": code},
+        )
+
+
+METRICS_CLIENT = MetricsClient()

--- a/wayfinder_paths/mcp/tools/instance_state.py
+++ b/wayfinder_paths/mcp/tools/instance_state.py
@@ -109,6 +109,7 @@ async def shells_get_frontend_context() -> dict[str, Any]:
         return err("state_http_error", f"HTTP {exc.response.status_code}")
 
 
+@catch_errors
 async def shells_search_chart_series(
     query: str,
     kind: str | None = None,
@@ -146,6 +147,7 @@ async def shells_search_chart_series(
         return err("chart_series_error", str(exc))
 
 
+@catch_errors
 async def shells_set_active_market(
     query: str | None = None,
     market_id: str | None = None,
@@ -191,6 +193,7 @@ async def shells_set_active_market(
         return err("active_market_error", str(exc))
 
 
+@catch_errors
 async def shells_create_chart(
     chart_id: str,
     title: str,
@@ -280,6 +283,7 @@ async def shells_create_chart(
         return err("chart_workspace_error", str(exc))
 
 
+@catch_errors
 async def shells_set_active_chart(chart_id: str) -> dict[str, Any]:
     """Focus an existing chart in the shell chart workspace."""
     if not is_opencode_instance():
@@ -296,6 +300,7 @@ async def shells_set_active_chart(chart_id: str) -> dict[str, Any]:
         return err("chart_workspace_error", str(exc))
 
 
+@catch_errors
 async def shells_add_workspace_chart_series(
     chart_id: str,
     series: dict[str, Any],
@@ -318,6 +323,7 @@ async def shells_add_workspace_chart_series(
         return err("chart_workspace_error", str(exc))
 
 
+@catch_errors
 async def shells_add_workspace_chart_annotation(
     chart_id: str,
     type: str,
@@ -358,6 +364,7 @@ async def shells_add_workspace_chart_annotation(
         return err("chart_workspace_error", str(exc))
 
 
+@catch_errors
 async def shells_add_workspace_chart_overlay(
     chart_id: str,
     overlay: dict[str, Any],
@@ -375,6 +382,7 @@ async def shells_add_workspace_chart_overlay(
         return err("chart_workspace_error", str(exc))
 
 
+@catch_errors
 async def shells_clear_chart_workspace() -> dict[str, Any]:
     """Remove all agent-created workspace charts."""
     if not is_opencode_instance():

--- a/wayfinder_paths/mcp/utils.py
+++ b/wayfinder_paths/mcp/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import functools
 import hashlib
 import inspect
@@ -11,6 +12,7 @@ from typing import Any
 
 import yaml
 
+from wayfinder_paths.core.clients.MetricsClient import METRICS_CLIENT
 from wayfinder_paths.core.utils.wallets import (  # noqa: F401
     find_wallet_by_label,
     get_local_sign_typed_data_callback,
@@ -88,32 +90,47 @@ def _wrap(fn: Callable, prefix: str) -> Callable:
         @functools.wraps(fn)
         async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
             try:
-                return await fn(*args, **kwargs)
+                result = await fn(*args, **kwargs)
             except MCPArgumentError as exc:
-                return err(
+                result = err(
                     "invalid_argument",
                     f"{prefix} {exc}".strip(),
                     details=exc.details,
                 )
             except Exception as exc:
-                return err("error", f"{prefix} {exc}".strip())
+                result = err("error", f"{prefix} {exc}".strip())
+            _report_tool_metric(fn.__name__, result)
+            return result
 
         return async_wrapper
 
     @functools.wraps(fn)
     def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
         try:
-            return fn(*args, **kwargs)
+            result = fn(*args, **kwargs)
         except MCPArgumentError as exc:
-            return err(
+            result = err(
                 "invalid_argument",
                 f"{prefix} {exc}".strip(),
                 details=exc.details,
             )
         except Exception as exc:
-            return err("error", f"{prefix} {exc}".strip())
+            result = err("error", f"{prefix} {exc}".strip())
+        _report_tool_metric(fn.__name__, result)
+        return result
 
     return sync_wrapper
+
+
+def _report_tool_metric(tool: str, result: dict[str, Any]) -> None:
+    """Fire-and-forget POST of the tool's ok/err outcome. Metrics never block the tool."""
+    success = result["ok"]
+    code = "ok" if success else result["error"]["code"]
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    loop.create_task(METRICS_CLIENT.report_tool(tool=tool, success=success, code=code))
 
 
 def repo_root() -> Path:


### PR DESCRIPTION
### Summary
Every `catch_errors`-wrapped MCP tool now reports its outcome to vault-backend's new `POST /api/v1/sdk/tool-metric/` endpoint after returning. Backend bumps `sdk_tool_executions_total{tool, success, code}` which lands in GMP.

- `MetricsClient`: thin `WayfinderClient` subclass for the new endpoint. Auth via standard `X-API-KEY`.
- `catch_errors._wrap`: capture the `ok()`/`err()` result, schedule the report on the running event loop (fire-and-forget — no waiting). Tool latency unchanged; sync paths outside an asyncio context silently drop the report.

Every tool is already wrapped by `catch_errors`, so no per-tool changes are needed for blanket coverage.

Pairs with vault-backend endpoint PR and terallel-wayfinder dashboard PR.