### PR TITLE
BRAP Swap + Send - Pre-flight Balance Guards

### DIFF
--- a/wayfinder_paths/mcp/tools/execute.py
+++ b/wayfinder_paths/mcp/tools/execute.py
@@ -11,8 +11,10 @@ from wayfinder_paths.core.utils.token_resolver import TokenResolver
 from wayfinder_paths.core.utils.tokens import (
     build_send_transaction,
     ensure_allowance,
+    get_token_balance,
 )
 from wayfinder_paths.core.utils.transaction import send_transaction
+from wayfinder_paths.core.utils.units import from_erc20_raw
 from wayfinder_paths.core.utils.wallets import get_wallet_signing_callback
 from wayfinder_paths.mcp.state.profile_store import WalletProfileStore
 from wayfinder_paths.mcp.utils import (
@@ -254,6 +256,22 @@ async def onchain_swap(
     except ValueError as exc:
         return err("invalid_amount", str(exc))
 
+    balance = await get_token_balance(from_token_addr, int(from_chain_id), sender)
+    if balance < amount_raw:
+        symbol = from_meta["symbol"] or "tokens"
+        return err(
+            "insufficient_balance",
+            f"Wallet has {from_erc20_raw(balance, decimals):.6f} {symbol}, "
+            f"need {from_erc20_raw(amount_raw, decimals):.6f}.",
+            {
+                "sender": sender,
+                "chain_id": int(from_chain_id),
+                "token_address": from_token_addr,
+                "have_raw": balance,
+                "need_raw": amount_raw,
+            },
+        )
+
     slippage = max(0.0, float(int(slippage_bps)) / 10_000.0)
     try:
         quote_data = await BRAP_CLIENT.get_quote(
@@ -445,6 +463,22 @@ async def onchain_send(
         amount_raw = parse_amount_to_raw(amount, decimals)
     except ValueError as exc:
         return err("invalid_amount", str(exc))
+
+    balance = await get_token_balance(token_address, int(resolved_chain_id), sender)
+    if balance < amount_raw:
+        symbol = token_meta["symbol"] or "tokens"
+        return err(
+            "insufficient_balance",
+            f"Wallet has {from_erc20_raw(balance, decimals):.6f} {symbol}, "
+            f"need {from_erc20_raw(amount_raw, decimals):.6f}.",
+            {
+                "sender": sender,
+                "chain_id": int(resolved_chain_id),
+                "token_address": token_address,
+                "have_raw": balance,
+                "need_raw": amount_raw,
+            },
+        )
 
     transaction = await build_send_transaction(
         from_address=sender,

--- a/wayfinder_paths/tests/test_mcp_execute.py
+++ b/wayfinder_paths/tests/test_mcp_execute.py
@@ -177,6 +177,10 @@ async def test_execute_swap(tmp_path: Path, monkeypatch):
             new_callable=AsyncMock,
             return_value="0xtx",
         ) as send_transaction_mock,
+        patch(
+            "wayfinder_paths.mcp.tools.execute.get_token_balance",
+            new=AsyncMock(return_value=10**18),
+        ),
     ):
         out1 = await onchain_swap(
             wallet_label="main",
@@ -287,6 +291,10 @@ async def test_execute_cross_chain_swap_waits_for_bridge(tmp_path: Path, monkeyp
             new_callable=AsyncMock,
             return_value="0xsrctx",
         ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.get_token_balance",
+            new=AsyncMock(return_value=10**18),
+        ),
     ):
         out = await onchain_swap(
             wallet_label="main",
@@ -377,6 +385,10 @@ async def test_execute_cross_chain_swap_failed_bridge_marks_failed(
             "wayfinder_paths.mcp.tools.execute.send_transaction",
             new_callable=AsyncMock,
             return_value="0xsrctx",
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.get_token_balance",
+            new=AsyncMock(return_value=10**18),
         ),
     ):
         out = await onchain_swap(


### PR DESCRIPTION
### Summary
`onchain_swap` and `onchain_send` used to skip a basic balance check on the sender:

- `onchain_swap` would burn a BRAP `get_quote` credit and only fail later when the on-chain swap reverted (or sometimes silently emitted a tx that the node refused).
- `onchain_send` would build + sign + broadcast a transfer that reverted on chain when the wallet was short.

Adds a shared `_reject_if_insufficient_balance` helper that calls `get_token_balance` (handles native + ERC20 uniformly) and returns `err("insufficient_balance", "have X, need Y", details)` early.

Wired into:
- `onchain_swap` — pre-BRAP-quote
- `onchain_send` — pre-broadcast