### PR TITLE
Agents - Set per-agent temperatures

### DIFF
--- a/.opencode/agents/wayfinder-quant.md
+++ b/.opencode/agents/wayfinder-quant.md
@@ -3,6 +3,7 @@ description: Hidden quant worker for backtests, Delta Lab time series, CCXT anal
 mode: subagent
 hidden: true
 steps: 10
+temperature: 0.8
 permission:
   task:
     "*": deny

--- a/.opencode/agents/wayfinder-research.md
+++ b/.opencode/agents/wayfinder-research.md
@@ -3,6 +3,7 @@ description: Hidden research worker for crypto, web, social, DeFiLlama, Goldsky,
 mode: subagent
 hidden: true
 steps: 8
+temperature: 0.8
 permission:
   task:
     "*": deny

--- a/.opencode/agents/wayfinder-visual.md
+++ b/.opencode/agents/wayfinder-visual.md
@@ -2,6 +2,7 @@
 description: Hidden visual worker for Shells chart context, workspace charts, overlays, and annotations.
 mode: subagent
 hidden: true
+temperature: 0.2
 permission:
   task:
     "*": deny

--- a/.opencode/agents/wayfinder-visual.md
+++ b/.opencode/agents/wayfinder-visual.md
@@ -2,7 +2,7 @@
 description: Hidden visual worker for Shells chart context, workspace charts, overlays, and annotations.
 mode: subagent
 hidden: true
-temperature: 0.2
+temperature: 0.1
 permission:
   task:
     "*": deny

--- a/.opencode/agents/wayfinder.md
+++ b/.opencode/agents/wayfinder.md
@@ -1,6 +1,7 @@
 ---
 description: User-facing Wayfinder orchestrator, executor, coder, and strategy lifecycle owner.
 mode: primary
+temperature: 0.2
 permission:
   task:
     "*": deny

--- a/.opencode/agents/wayfinder.md
+++ b/.opencode/agents/wayfinder.md
@@ -1,7 +1,7 @@
 ---
 description: User-facing Wayfinder orchestrator, executor, coder, and strategy lifecycle owner.
 mode: primary
-temperature: 0.2
+temperature: 0.1
 permission:
   task:
     "*": deny


### PR DESCRIPTION
### Summary

Per-agent temperature defaults via the OpenCode `temperature` frontmatter field:

- `wayfinder` (primary / main) → **0.1**
- `wayfinder-quant` → **0.8**
- `wayfinder-research` → **0.8**
- `wayfinder-visual` → **0.1**