### PR TITLE
Transaction - Polygon priority fee floor at 25 gwei

### DIFF
--- a/wayfinder_paths/core/constants/chains.py
+++ b/wayfinder_paths/core/constants/chains.py
@@ -57,6 +57,12 @@ PRE_EIP_1559_CHAIN_IDS: set[int] = {
     CHAIN_ID_ARBITRUM,
 }
 
+# Polygon's bor node enforces a 25 gwei min priority fee at pool admission;
+# txs below this are rejected with "transaction gas price below minimum".
+MIN_PRIORITY_FEE_BY_CHAIN_ID: dict[int, int] = {
+    CHAIN_ID_POLYGON: 25 * 10**9,
+}
+
 CHAIN_EXPLORER_URLS: dict[int, str] = {
     CHAIN_ID_ETHEREUM: "https://etherscan.io/",
     CHAIN_ID_ARBITRUM: "https://arbiscan.io/",

--- a/wayfinder_paths/core/utils/test_transaction.py
+++ b/wayfinder_paths/core/utils/test_transaction.py
@@ -297,6 +297,24 @@ class TestGasPriceTransaction:
         assert "gasPrice" not in result
 
     @patch("wayfinder_paths.core.utils.transaction.web3s_from_chain_id")
+    async def test_polygon_priority_fee_floor(self, mock_web3s_context):
+        # Polygon's bor node rejects tips < 25 gwei. Suggested = 1 gwei * 1.5 = 1.5 gwei,
+        # below the floor — must be clamped up to 25 gwei.
+        mock_block = {"baseFeePerGas": 30_000_000_000}
+        mock_fee_history = {"reward": [[1_000_000_000] for _ in range(10)]}
+        mock_web3 = MagicMock()
+        mock_web3.eth = MagicMock()
+        mock_web3.eth.get_block = AsyncMock(return_value=mock_block)
+        mock_web3.eth.fee_history = AsyncMock(return_value=mock_fee_history)
+        mock_web3.provider.disconnect = AsyncMock()
+        mock_web3s_context.return_value.__aenter__.return_value = [mock_web3]
+
+        result = await gas_price_transaction({"chainId": 137})
+
+        assert result["maxPriorityFeePerGas"] == 25_000_000_000
+        assert result["maxFeePerGas"] == 30_000_000_000 * 2 + 25_000_000_000
+
+    @patch("wayfinder_paths.core.utils.transaction.web3s_from_chain_id")
     async def test_non_eip1559_max_aggregation(self, mock_web3s_context):
         # Mock multiple web3 instances with different gas prices
         # gas_price is an awaitable property, so we need to make it a coroutine

--- a/wayfinder_paths/core/utils/transaction.py
+++ b/wayfinder_paths/core/utils/transaction.py
@@ -150,16 +150,19 @@ async def gas_price_transaction(transaction: dict):
             base_fee = max(base_fees)
             priority_fee = max(priority_fees)
 
-            suggested_priority_fee = int(
-                priority_fee * SUGGESTED_PRIORITY_FEE_MULTIPLIER
-            )
-            min_priority_fee = MIN_PRIORITY_FEE_BY_CHAIN_ID.get(chain_id, 0)
-            final_priority_fee = max(suggested_priority_fee, min_priority_fee)
-
             transaction["maxFeePerGas"] = int(
-                base_fee * MAX_BASE_FEE_GROWTH_MULTIPLIER + final_priority_fee
+                base_fee * MAX_BASE_FEE_GROWTH_MULTIPLIER
+                + max(
+                    priority_fee * SUGGESTED_PRIORITY_FEE_MULTIPLIER,
+                    MIN_PRIORITY_FEE_BY_CHAIN_ID.get(chain_id, 0),
+                )
             )
-            transaction["maxPriorityFeePerGas"] = final_priority_fee
+            transaction["maxPriorityFeePerGas"] = int(
+                max(
+                    priority_fee * SUGGESTED_PRIORITY_FEE_MULTIPLIER,
+                    MIN_PRIORITY_FEE_BY_CHAIN_ID.get(chain_id, 0),
+                )
+            )
 
     return transaction
 

--- a/wayfinder_paths/core/utils/transaction.py
+++ b/wayfinder_paths/core/utils/transaction.py
@@ -15,6 +15,7 @@ from wayfinder_paths.core.constants.base import (
     SUGGESTED_PRIORITY_FEE_MULTIPLIER,
 )
 from wayfinder_paths.core.constants.chains import (
+    MIN_PRIORITY_FEE_BY_CHAIN_ID,
     PRE_EIP_1559_CHAIN_IDS,
 )
 from wayfinder_paths.core.utils.web3 import (
@@ -149,13 +150,16 @@ async def gas_price_transaction(transaction: dict):
             base_fee = max(base_fees)
             priority_fee = max(priority_fees)
 
-            transaction["maxFeePerGas"] = int(
-                base_fee * MAX_BASE_FEE_GROWTH_MULTIPLIER
-                + priority_fee * SUGGESTED_PRIORITY_FEE_MULTIPLIER
-            )
-            transaction["maxPriorityFeePerGas"] = int(
+            suggested_priority_fee = int(
                 priority_fee * SUGGESTED_PRIORITY_FEE_MULTIPLIER
             )
+            min_priority_fee = MIN_PRIORITY_FEE_BY_CHAIN_ID.get(chain_id, 0)
+            final_priority_fee = max(suggested_priority_fee, min_priority_fee)
+
+            transaction["maxFeePerGas"] = int(
+                base_fee * MAX_BASE_FEE_GROWTH_MULTIPLIER + final_priority_fee
+            )
+            transaction["maxPriorityFeePerGas"] = final_priority_fee
 
     return transaction
 


### PR DESCRIPTION
### Summary

Polygon's bor node rejects EIP-1559 txs with `maxPriorityFeePerGas < 25 gwei` at pool admission (error: `transaction gas price below minimum: gas tip cap X, minimum needed 25000000000`). When the 80th-percentile historical tip is low, the `1.5x` multiplier in `gas_price_transaction` can still produce a value below the floor.

Add `MIN_PRIORITY_FEE_BY_CHAIN_ID` (Polygon = 25 gwei) and clamp the suggested priority fee upward. `maxFeePerGas` is rebuilt from the clamped value so it stays consistent.