### PR TITLE
Agents - Split shells_* into visual_* + notification_send

### DIFF
--- a/.claude/skills/using-notification-email/SKILL.md
+++ b/.claude/skills/using-notification-email/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: using-shells-notify
+name: using-notification-email
 description: How to email or text the Wayfinder Shells instance owner from agents/scripts via the notify MCP tool or NotifyClient (Markdown body rendered to themed HTML for email, throttled).
 metadata:
   tags: wayfinder, shells, notify, email, opencode
@@ -12,7 +12,7 @@ Notify the user who owns this Wayfinder Shells instance. Email renders Markdown 
 **MCP tool (preferred from agents):**
 
 ```
-shells_notify(
+notification_email(
   title="Rebalance complete",
   message="Moved **50 USDC** from Aave → Morpho.\n\n- tx: 0x…\n- new APY: 7.4%",
 )

--- a/.claude/skills/using-notification-send/SKILL.md
+++ b/.claude/skills/using-notification-send/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: using-notification-email
+name: using-notification-send
 description: How to email or text the Wayfinder Shells instance owner from agents/scripts via the notify MCP tool or NotifyClient (Markdown body rendered to themed HTML for email, throttled).
 metadata:
   tags: wayfinder, shells, notify, email, opencode
@@ -12,7 +12,7 @@ Notify the user who owns this Wayfinder Shells instance. Email renders Markdown 
 **MCP tool (preferred from agents):**
 
 ```
-notification_email(
+notification_send(
   title="Rebalance complete",
   message="Moved **50 USDC** from Aave → Morpho.\n\n- tx: 0x…\n- new APY: 7.4%",
 )

--- a/.claude/skills/using-visual-chart-annotations/SKILL.md
+++ b/.claude/skills/using-visual-chart-annotations/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: using-shells-chart-annotations
+name: using-visual-chart-annotations
 description: How to read Wayfinder Shells frontend state, create chart panes, and add TradingView annotations or overlays to the default live chart or agent-created workspace charts.
 metadata:
   tags: wayfinder, shells, opencode, frontend, charts, annotations, overlays
@@ -12,10 +12,10 @@ Read the current Shells chart id, then write chart changes through the chart wor
 **Typical flow (switch default market):**
 
 ```
-1. shells_set_active_market(query="PENGU perp")
+1. visual_set_active_market(query="PENGU perp")
    -> switches the live chart, order book, trades, and trade ticket together
 2. chart_id = data["frontend_context"]["active_market_request"]["market_id"]
-3. shells_add_workspace_chart_annotation(
+3. visual_add_workspace_chart_annotation(
      chart_id=chart_id,
      type="marker",
      config={"time": 1760000000, "price": 0.035, "shape": "flag", "color": "#22c55e"}
@@ -25,10 +25,10 @@ Read the current Shells chart id, then write chart changes through the chart wor
 **Typical flow (default chart):**
 
 ```
-1. shells_get_frontend_context()
+1. visual_get_frontend_context()
    -> {"ok": true, "data": {"frontend_context": {"chart": {"id": "hl-perp-BTC", "market_id": "hl-perp-BTC", "market_type": "hl-perp"}}}}
 2. chart_id = data["frontend_context"]["chart"]["id"]
-3. shells_add_workspace_chart_annotation(
+3. visual_add_workspace_chart_annotation(
      chart_id=chart_id,
      type="horizontal_line",
      config={"price": 73500, "color": "#ef4444", "label": "Support"}
@@ -39,9 +39,9 @@ Read the current Shells chart id, then write chart changes through the chart wor
 **Typical flow (agent-created visual pane):**
 
 ```
-1. shells_search_chart_series(query="BTC ETH relative performance")
+1. visual_search_chart_series(query="BTC ETH relative performance")
    -> copy compatible `source` objects and each result's `shape.default_y`
-2. shells_create_chart(
+2. visual_create_chart(
      chart_id="btc-eth-relative",
      title="BTC vs ETH",
      kind="line",
@@ -52,8 +52,8 @@ Read the current Shells chart id, then write chart changes through the chart wor
      ],
      transforms=[{"type": "rebase", "base": 100}]
    )
-3. shells_set_active_chart(chart_id="btc-eth-relative")
-4. shells_add_workspace_chart_annotation(
+3. visual_set_active_chart(chart_id="btc-eth-relative")
+4. visual_add_workspace_chart_annotation(
      chart_id="btc-eth-relative",
      type="text_label",
      config={"time": 1760000000, "price": 120, "text": "Relative breakout"}
@@ -64,25 +64,25 @@ Read the current Shells chart id, then write chart changes through the chart wor
 
 | Tool | Args | Use |
 |------|------|-----|
-| `shells_get_frontend_context` | none | Read current default chart context and workspace |
-| `shells_search_chart_series` | `query`, `kind?`, `venue?`, `market_type?`, `limit?` | Discover supported chart datasets and their column shapes |
-| `shells_set_active_market` | `query?`, `market_id?`, `market_type?`, `chain_id?`, `clear_workspace?` | Switch the default chart/trading context to one tradable market |
-| `shells_create_chart` | `chart_id`, `title`, `kind`, `series`, `transforms?`, `overlays?`, `lookback_days?`, `limit?`, `layout?`, `context_market_id?` | Validate, create, or replace a visual pane |
-| `shells_set_active_chart` | `chart_id` | Focus an existing workspace chart |
-| `shells_add_workspace_chart_annotation` | `chart_id`, `type`, `config`, `annotation_id?` | Add one TradingView annotation to a default or workspace chart |
-| `shells_add_workspace_chart_overlay` | `chart_id`, `overlay` | Add a raw overlay, usually bulk `event_markers` |
-| `shells_add_workspace_chart_series` | `chart_id`, `series` | Add or replace a data series on an existing workspace chart |
-| `shells_clear_chart_workspace` | none | Clear agent-created charts and default-chart annotations |
+| `visual_get_frontend_context` | none | Read current default chart context and workspace |
+| `visual_search_chart_series` | `query`, `kind?`, `venue?`, `market_type?`, `limit?` | Discover supported chart datasets and their column shapes |
+| `visual_set_active_market` | `query?`, `market_id?`, `market_type?`, `chain_id?`, `clear_workspace?` | Switch the default chart/trading context to one tradable market |
+| `visual_create_chart` | `chart_id`, `title`, `kind`, `series`, `transforms?`, `overlays?`, `lookback_days?`, `limit?`, `layout?`, `context_market_id?` | Validate, create, or replace a visual pane |
+| `visual_set_active_chart` | `chart_id` | Focus an existing workspace chart |
+| `visual_add_workspace_chart_annotation` | `chart_id`, `type`, `config`, `annotation_id?` | Add one TradingView annotation to a default or workspace chart |
+| `visual_add_workspace_chart_overlay` | `chart_id`, `overlay` | Add a raw overlay, usually bulk `event_markers` |
+| `visual_add_workspace_chart_series` | `chart_id`, `series` | Add or replace a data series on an existing workspace chart |
+| `visual_clear_chart_workspace` | none | Clear agent-created charts and default-chart annotations |
 
 All gate on `is_opencode_instance()` and return `{"ok": false, "error": {"code": "not_opencode_instance"}}` when run outside Shells.
 
 ## Chart panes
 
-Use `shells_set_active_market` when the user asks to show, switch to, or open one tradable market such as "show AAVE", "switch to PENGU perp", "open POL spot", or "show this Polymarket market". It is the one-call path that updates the default chart and the rest of the trading context.
+Use `visual_set_active_market` when the user asks to show, switch to, or open one tradable market such as "show AAVE", "switch to PENGU perp", "open POL spot", or "show this Polymarket market". It is the one-call path that updates the default chart and the rest of the trading context.
 
-Use `shells_create_chart` when the user asks for a new visual pane, comparison, APY/funding chart, table, or custom derived visualization, not when they only want to switch or annotate the live chart.
+Use `visual_create_chart` when the user asks for a new visual pane, comparison, APY/funding chart, table, or custom derived visualization, not when they only want to switch or annotate the live chart.
 
-If `shells_create_chart` returns `ok: false`, do not tell the user the chart is ready. Read the error, pick a compatible source/kind, and retry.
+If `visual_create_chart` returns `ok: false`, do not tell the user the chart is ready. Read the error, pick a compatible source/kind, and retry.
 
 | Chart kind | Use |
 |------------|-----|
@@ -94,7 +94,7 @@ If `shells_create_chart` returns `ok: false`, do not tell the user the chart is 
 Supported source types:
 
 - `market_price`: `{"type": "market_price", "market_id": "hl-perp-btc"}`
-- `dataset_series`: returned by `shells_search_chart_series`; preferred for known backend datasets, including the current Delta Lab registry-backed series
+- `dataset_series`: returned by `visual_search_chart_series`; preferred for known backend datasets, including the current Delta Lab registry-backed series
 - `delta_lab_asset`: `{"type": "delta_lab_asset", "symbol": "USDC", "series": "lending", "venue"?: "...", "basis"?: true}`. Legacy fallback only; use a returned `dataset_series` source when available.
 - `inline`: `{"type": "inline", "points": [{...}]}`
 
@@ -156,14 +156,14 @@ Series can set `color` and `axis` (`left` or `right`). Keep related units on the
 
 Always search known datasets before inventing or fetching your own data.
 
-0. If the user asks for a single tradable token/perp/spot/prediction market, use `shells_set_active_market` first. Do not search chart datasets or create a workspace chart for simple market switches.
-1. Use `shells_search_chart_series` with the user intent/assets first. Do not pass `kind` by default; inspect returned `kind`, `shape.default_y`, `shape.columns`, and `shape.supported_chart_kinds` to decide whether to use the candidate.
+0. If the user asks for a single tradable token/perp/spot/prediction market, use `visual_set_active_market` first. Do not search chart datasets or create a workspace chart for simple market switches.
+1. Use `visual_search_chart_series` with the user intent/assets first. Do not pass `kind` by default; inspect returned `kind`, `shape.default_y`, `shape.columns`, and `shape.supported_chart_kinds` to decide whether to use the candidate.
 2. Prefer a common source family across compared series. For example, use Hyperliquid perp prices for BTC and ETH together; do not mix Hyperliquid BTC with CoinGecko ETH unless there is no common source.
 3. For asset price/performance requests, prefer Hyperliquid perp price series over spot/fallback price series unless the user explicitly asks for spot. Prefer registry-returned Delta Lab `dataset_series` sources for lending/yield/Boros/Pendle/funding research series, CoinGecko only as broad spot price fallback, and DeFiLlama for current ranked yield tables/bars.
 4. Pass `kind` only to narrow a known data family (`funding`, `yield`, `price`) or a large result set. Do not pass chart kinds such as `line` as the first search because that hides useful candidate metadata.
 5. Use Polymarket-specific tools/API for prediction markets. Do not route Polymarket discovery through chart-series search.
 6. Use `inline` only when the registry does not expose the needed data. If using inline data, keep it small and describe the columns in the chart label or nearby message.
-7. Set `lookback_days` on `shells_create_chart` when the user gives a time window. Use 90 for "3 months".
+7. Set `lookback_days` on `visual_create_chart` when the user gives a time window. Use 90 for "3 months".
 8. When a chart represents a tradable Hyperliquid perp, set
    `context_market_id` to `hl-perp-<symbol-lowercase>` unless the tool result
    already provides a more specific market id.
@@ -190,6 +190,6 @@ Registry results include:
 - `marker` does not accept `label`. Use `text_label` for annotated points.
 - All `time` values are unix seconds.
 - For default chart annotations, use the exact `frontend_context.chart.id`.
-- For workspace charts, use the `chart_id` passed to `shells_create_chart`.
+- For workspace charts, use the `chart_id` passed to `visual_create_chart`.
 - Default chart annotations are stored in `chart_workspace.defaultAnnotations`; workspace chart annotations are stored in the chart's `overlays`.
 - Chart workspace state is scoped to the current Shells instance, not the user vault.

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ abis/
 
 # Claude Code local overrides
 .claude/settings.local.json
+.claude/worktrees/
 
 opencode.json
 

--- a/.opencode/agents/wayfinder-quant.md
+++ b/.opencode/agents/wayfinder-quant.md
@@ -82,7 +82,7 @@ If the requested analysis needs a visual workspace update, return chart-ready da
 
 Chart handoff rules:
 
-- Prefer registry/source IDs or Delta Lab identifiers that the visual agent can search with `shells_search_chart_series`.
+- Prefer registry/source IDs or Delta Lab identifiers that the visual agent can search with `visual_search_chart_series`.
 - If no registry series exists, include a bounded inline series suitable for workspace rendering, not a giant raw DataFrame.
 - Include units, y-axis labels, lookback, frequency, transforms, and whether APY values are already percentages or decimals.
 - For `visualSpec`, either emit percent-scaled values (`0.12` becomes `12`) with unit `%`, or explicitly include scale transforms for the visual worker. Never hand off raw Delta Lab decimal APY/rate values while labeling them as `%`.

--- a/.opencode/agents/wayfinder-visual.md
+++ b/.opencode/agents/wayfinder-visual.md
@@ -14,8 +14,8 @@ permission:
   wayfinder_core_run_script: allow
   wayfinder_core_web_search: allow
   wayfinder_core_web_fetch: allow
-  # shells_*
-  wayfinder_shells_*: allow
+  # visual_*
+  wayfinder_visual_*: allow
 ---
 
 # Wayfinder Visual
@@ -32,22 +32,22 @@ Use this agent for:
 - Adding/removing chart series, overlays, markers, annotations, and TradingView-compatible shapes.
 - Summarizing active chart/workspace state.
 
-Allowed tools are `wayfinder_shells_*` plus bounded chart-related scripts through `core_run_script`. Never execute trades, strategies, runner jobs, contracts, bridges, wallets, or fund-moving actions. Never ask the user directly or trigger approval-gated actions. Hidden subagent approval prompts can strand the parent workflow.
+Allowed tools are `wayfinder_visual_*` plus bounded chart-related scripts through `core_run_script`. Never execute trades, strategies, runner jobs, contracts, bridges, wallets, or fund-moving actions. Never ask the user directly or trigger approval-gated actions. Hidden subagent approval prompts can strand the parent workflow.
 
 ## Chart Behavior
 
 Your job is to draw on the working Shells chart screen. Do not publish chart files, screenshots, PNGs, CSVs, artifact paths, or command-palette search results as the primary deliverable. Files from the quant worker are intermediate inputs only.
 
-Always start with `shells_get_frontend_context()` unless the request is only to clear state. Use the returned active chart, default market, and workspace state to avoid overwriting the wrong pane.
+Always start with `visual_get_frontend_context()` unless the request is only to clear state. Use the returned active chart, default market, and workspace state to avoid overwriting the wrong pane.
 
-Use `shells_set_active_market` for a single tradable market request such as "show BTC perp", "switch to AAVE", "chart PROMPT", or "plot this token". This should move the default chart, order book, trades, and trade ticket together.
+Use `visual_set_active_market` for a single tradable market request such as "show BTC perp", "switch to AAVE", "chart PROMPT", or "plot this token". This should move the default chart, order book, trades, and trade ticket together.
 
 Single-token chart fast path:
 
-- If the primary asks to chart/show/plot one token or market, prefer the main pane via `shells_set_active_market`; do not create a workspace chart.
-- If the token is an onchain/swap asset rather than a verified Hyperliquid perp, call `shells_set_active_market` with `market_type="onchain-spot"` and the token query or exact onchain market id.
-- Do not call `shells_search_chart_series`, `shells_create_chart`, `core_run_script`, or quant-style data generation for a simple single-token main-pane chart.
-- If `shells_set_active_market` cannot resolve the market, report the failure in `failedSeries`/`needsClarification` with the query used; do not substitute a speculative perp or funding series.
+- If the primary asks to chart/show/plot one token or market, prefer the main pane via `visual_set_active_market`; do not create a workspace chart.
+- If the token is an onchain/swap asset rather than a verified Hyperliquid perp, call `visual_set_active_market` with `market_type="onchain-spot"` and the token query or exact onchain market id.
+- Do not call `visual_search_chart_series`, `visual_create_chart`, `core_run_script`, or quant-style data generation for a simple single-token main-pane chart.
+- If `visual_set_active_market` cannot resolve the market, report the failure in `failedSeries`/`needsClarification` with the query used; do not substitute a speculative perp or funding series.
 
 Use workspace charts for comparisons and derived visualizations such as:
 
@@ -58,7 +58,7 @@ Use workspace charts for comparisons and derived visualizations such as:
 
 For Delta Lab, APY, funding, lending, Pendle, borrow-route, basis, and time-series charts:
 
-- Call `shells_search_chart_series` before creating the chart, but use it only for discovery. A successful search is not a rendered chart. If the task asks to plot, chart, show, draw, or update the workspace, complete the render by creating/updating a workspace chart in the main chart pane.
+- Call `visual_search_chart_series` before creating the chart, but use it only for discovery. A successful search is not a rendered chart. If the task asks to plot, chart, show, draw, or update the workspace, complete the render by creating/updating a workspace chart in the main chart pane.
 - Run chart-series searches sequentially with explicit non-empty `query` values. Do not launch parallel chart-series searches, and never call search with `{}` or an empty query.
 - Prefer returned `dataset_series` sources because they let the frontend own data loading.
 - Copy the returned source object exactly when creating or adding a series.
@@ -73,13 +73,13 @@ For Delta Lab, APY, funding, lending, Pendle, borrow-route, basis, and time-seri
 
 Use TradingView annotations when applying markers or labels to a live/default chart. Use workspace charts when the requested visualization is derived, multi-series, or not a single tradable instrument.
 
-Use `shells_create_chart` for a new visual pane, `shells_set_active_chart` before modifying a specific existing pane, `shells_add_workspace_chart_series` for additional series, and annotation/overlay tools only after the target chart is known.
+Use `visual_create_chart` for a new visual pane, `visual_set_active_chart` before modifying a specific existing pane, `visual_add_workspace_chart_series` for additional series, and annotation/overlay tools only after the target chart is known.
 
-If data is missing, a tool call stalls/fails, or a series fails to render, report the failed series/source in `viewSummary` or `needsClarification` rather than claiming success. If you did not call `shells_create_chart` or update an existing workspace chart, the chart is not done. Do not return a chart-series availability report as the final result for a charting task.
+If data is missing, a tool call stalls/fails, or a series fails to render, report the failed series/source in `viewSummary` or `needsClarification` rather than claiming success. If you did not call `visual_create_chart` or update an existing workspace chart, the chart is not done. Do not return a chart-series availability report as the final result for a charting task.
 
 Use skills only as fallback references when blocked by chart syntax details:
 
-- `/using-shells-chart-annotations`
+- `/using-visual-chart-annotations`
 - `/writing-wayfinder-scripts`
 
 ## Output Contract

--- a/.opencode/agents/wayfinder.md
+++ b/.opencode/agents/wayfinder.md
@@ -39,8 +39,8 @@ permission:
   wayfinder_polymarket_redeem_positions: ask
   # visual_* — delegated to wayfinder-visual subagent
   wayfinder_visual_*: deny
-  # notification_email — main agent owns user-facing notifications
-  wayfinder_notification_email: allow
+  # notification_send — main agent owns user-facing notifications
+  wayfinder_notification_send: allow
   # research_* — delegated to wayfinder-research subagent
   wayfinder_research_*: deny
 ---
@@ -226,7 +226,7 @@ core_runner(action="daemon_stop")
 
 #### Noise
 
-- For recurring alert scripts, store local state and call `notification_email`/`NotifyClient` only on edge transitions with cooldown/hysteresis; never call notify on every poll.
+- For recurring alert scripts, store local state and call `notification_send`/`NotifyClient` only on edge transitions with cooldown/hysteresis; never call notify on every poll.
 - If a successful job needs to hand control back to chat without notifying externally, print a single-line runner marker: `WAYFINDER_JOB_RESULT {"summary":"Funding crossover detected","instructions":"Research whether to unroll the position, then propose the unwind script.","severity":"warning"}`.
 - When a `job_result` does post into the conversation, treat it as an event you must respond to — read the result, decide whether action is needed, and reply (act, escalate via `notify`, or acknowledge). Never skip past it silently or fold it into an unrelated turn.
 - Position-bound monitors must verify the live position still exists and matches expected side, size/notional, leverage, and margin mode before alerting.

--- a/.opencode/agents/wayfinder.md
+++ b/.opencode/agents/wayfinder.md
@@ -37,6 +37,10 @@ permission:
   wayfinder_polymarket_deposit_pusd: ask
   wayfinder_polymarket_withdraw_pusd: ask
   wayfinder_polymarket_redeem_positions: ask
+  # shells_*
+  wayfinder_shells_*: allow
+  # research_* — delegated to wayfinder-research subagent
+  wayfinder_research_*: deny
 ---
 
 # Wayfinder

--- a/.opencode/agents/wayfinder.md
+++ b/.opencode/agents/wayfinder.md
@@ -37,8 +37,10 @@ permission:
   wayfinder_polymarket_deposit_pusd: ask
   wayfinder_polymarket_withdraw_pusd: ask
   wayfinder_polymarket_redeem_positions: ask
-  # shells_*
-  wayfinder_shells_*: allow
+  # visual_* — delegated to wayfinder-visual subagent
+  wayfinder_visual_*: deny
+  # notification_email — main agent owns user-facing notifications
+  wayfinder_notification_email: allow
   # research_* — delegated to wayfinder-research subagent
   wayfinder_research_*: deny
 ---
@@ -224,7 +226,7 @@ core_runner(action="daemon_stop")
 
 #### Noise
 
-- For recurring alert scripts, store local state and call `shells_notify`/`NotifyClient` only on edge transitions with cooldown/hysteresis; never call notify on every poll.
+- For recurring alert scripts, store local state and call `notification_email`/`NotifyClient` only on edge transitions with cooldown/hysteresis; never call notify on every poll.
 - If a successful job needs to hand control back to chat without notifying externally, print a single-line runner marker: `WAYFINDER_JOB_RESULT {"summary":"Funding crossover detected","instructions":"Research whether to unroll the position, then propose the unwind script.","severity":"warning"}`.
 - When a `job_result` does post into the conversation, treat it as an event you must respond to — read the result, decide whether action is needed, and reply (act, escalate via `notify`, or acknowledge). Never skip past it silently or fold it into an unrelated turn.
 - Position-bound monitors must verify the live position still exists and matches expected side, size/notional, leverage, and margin mode before alerting.

--- a/wayfinder_paths/mcp/server.py
+++ b/wayfinder_paths/mcp/server.py
@@ -94,7 +94,7 @@ from wayfinder_paths.mcp.tools.instance_state import (
     visual_set_active_chart,
     visual_set_active_market,
 )
-from wayfinder_paths.mcp.tools.notify import notification_email
+from wayfinder_paths.mcp.tools.notify import notification_send
 from wayfinder_paths.mcp.tools.polymarket import (
     polymarket_cancel_order,
     polymarket_deposit_pusd,
@@ -213,7 +213,7 @@ def build_mcp(
     mcp.tool()(research_search_perp)
     mcp.tool()(research_search_borrow_routes)
 
-    # ─── visual_* + notification_email (opencode-only) ─────────────────
+    # ─── visual_* + notification_send (opencode-only) ─────────────────
     if is_opencode_instance():
         mcp.tool()(visual_get_frontend_context)
         mcp.tool()(visual_search_chart_series)
@@ -224,7 +224,7 @@ def build_mcp(
         mcp.tool()(visual_add_workspace_chart_annotation)
         mcp.tool()(visual_add_workspace_chart_overlay)
         mcp.tool()(visual_clear_chart_workspace)
-        mcp.tool()(notification_email)
+        mcp.tool()(notification_send)
 
     return mcp
 

--- a/wayfinder_paths/mcp/server.py
+++ b/wayfinder_paths/mcp/server.py
@@ -84,17 +84,17 @@ from wayfinder_paths.mcp.tools.hyperliquid import (
     hyperliquid_withdraw_usdc,
 )
 from wayfinder_paths.mcp.tools.instance_state import (
-    shells_add_workspace_chart_annotation,
-    shells_add_workspace_chart_overlay,
-    shells_add_workspace_chart_series,
-    shells_clear_chart_workspace,
-    shells_create_chart,
-    shells_get_frontend_context,
-    shells_search_chart_series,
-    shells_set_active_chart,
-    shells_set_active_market,
+    visual_add_workspace_chart_annotation,
+    visual_add_workspace_chart_overlay,
+    visual_add_workspace_chart_series,
+    visual_clear_chart_workspace,
+    visual_create_chart,
+    visual_get_frontend_context,
+    visual_search_chart_series,
+    visual_set_active_chart,
+    visual_set_active_market,
 )
-from wayfinder_paths.mcp.tools.notify import shells_notify
+from wayfinder_paths.mcp.tools.notify import notification_email
 from wayfinder_paths.mcp.tools.polymarket import (
     polymarket_cancel_order,
     polymarket_deposit_pusd,
@@ -213,18 +213,18 @@ def build_mcp(
     mcp.tool()(research_search_perp)
     mcp.tool()(research_search_borrow_routes)
 
-    # ─── shells_* (opencode-only) ──────────────────────────────────────
+    # ─── visual_* + notification_email (opencode-only) ─────────────────
     if is_opencode_instance():
-        mcp.tool()(shells_get_frontend_context)
-        mcp.tool()(shells_search_chart_series)
-        mcp.tool()(shells_set_active_market)
-        mcp.tool()(shells_create_chart)
-        mcp.tool()(shells_set_active_chart)
-        mcp.tool()(shells_add_workspace_chart_series)
-        mcp.tool()(shells_add_workspace_chart_annotation)
-        mcp.tool()(shells_add_workspace_chart_overlay)
-        mcp.tool()(shells_clear_chart_workspace)
-        mcp.tool()(shells_notify)
+        mcp.tool()(visual_get_frontend_context)
+        mcp.tool()(visual_search_chart_series)
+        mcp.tool()(visual_set_active_market)
+        mcp.tool()(visual_create_chart)
+        mcp.tool()(visual_set_active_chart)
+        mcp.tool()(visual_add_workspace_chart_series)
+        mcp.tool()(visual_add_workspace_chart_annotation)
+        mcp.tool()(visual_add_workspace_chart_overlay)
+        mcp.tool()(visual_clear_chart_workspace)
+        mcp.tool()(notification_email)
 
     return mcp
 

--- a/wayfinder_paths/mcp/tools/instance_state.py
+++ b/wayfinder_paths/mcp/tools/instance_state.py
@@ -95,7 +95,7 @@ def _normalize_chart_series_for_display(
 
 
 @catch_errors
-async def shells_get_frontend_context() -> dict[str, Any]:
+async def visual_get_frontend_context() -> dict[str, Any]:
     """Read the current frontend UI state.
 
     Returns what the user is currently viewing plus any chart workspace
@@ -110,7 +110,7 @@ async def shells_get_frontend_context() -> dict[str, Any]:
 
 
 @catch_errors
-async def shells_search_chart_series(
+async def visual_search_chart_series(
     query: str,
     kind: str | None = None,
     venue: str | None = None,
@@ -148,7 +148,7 @@ async def shells_search_chart_series(
 
 
 @catch_errors
-async def shells_set_active_market(
+async def visual_set_active_market(
     query: str | None = None,
     market_id: str | None = None,
     market_type: str | None = None,
@@ -160,7 +160,7 @@ async def shells_set_active_market(
     Use this for requests like "show AAVE", "switch to PENGU perp", "chart
     PROMPT", or "open this Polymarket market". This updates the live chart,
     order book, trades, and trade ticket together. Prefer this over
-    `shells_create_chart` when the user wants a single tradable token, perp,
+    `visual_create_chart` when the user wants a single tradable token, perp,
     spot, or prediction market rather than a custom visual pane. For onchain
     swap-token charts, pass market_type="onchain-spot" instead of searching
     chart-series candidates.
@@ -194,7 +194,7 @@ async def shells_set_active_market(
 
 
 @catch_errors
-async def shells_create_chart(
+async def visual_create_chart(
     chart_id: str,
     title: str,
     kind: str,
@@ -217,14 +217,14 @@ async def shells_create_chart(
     Supported chart kinds:
       - price_candle: primary market price chart. Use source type
         {"type": "market_price", "market_id": "..."} or a dataset_series
-        returned by `shells_search_chart_series` for Hyperliquid perp prices.
+        returned by `visual_search_chart_series` for Hyperliquid perp prices.
       - line: one or more time series.
       - bar: ranked/latest categorical values.
       - table: tabular data.
 
     Supported source types:
       - market_price: {"type": "market_price", "market_id": "hl-perp-btc"}
-      - dataset_series: use `shells_search_chart_series` and copy the returned
+      - dataset_series: use `visual_search_chart_series` and copy the returned
         source object. Preferred for assets, funding, APYs, Delta Lab registry
         series, DeFiLlama snapshots, and CoinGecko fallback prices.
       - delta_lab_asset: {"type": "delta_lab_asset", "symbol": "USDC",
@@ -284,7 +284,7 @@ async def shells_create_chart(
 
 
 @catch_errors
-async def shells_set_active_chart(chart_id: str) -> dict[str, Any]:
+async def visual_set_active_chart(chart_id: str) -> dict[str, Any]:
     """Focus an existing chart in the shell chart workspace."""
     if not is_opencode_instance():
         return err(*_NOT_OPENCODE_ERR)
@@ -301,7 +301,7 @@ async def shells_set_active_chart(chart_id: str) -> dict[str, Any]:
 
 
 @catch_errors
-async def shells_add_workspace_chart_series(
+async def visual_add_workspace_chart_series(
     chart_id: str,
     series: dict[str, Any],
 ) -> dict[str, Any]:
@@ -324,7 +324,7 @@ async def shells_add_workspace_chart_series(
 
 
 @catch_errors
-async def shells_add_workspace_chart_annotation(
+async def visual_add_workspace_chart_annotation(
     chart_id: str,
     type: str,
     config: dict[str, Any],
@@ -332,7 +332,7 @@ async def shells_add_workspace_chart_annotation(
 ) -> dict[str, Any]:
     """Add a TradingView annotation to a workspace or default Shells chart.
 
-    Use `shells_get_frontend_context()` to read the current default chart id,
+    Use `visual_get_frontend_context()` to read the current default chart id,
     then pass that chart_id here. If chart_id matches an agent-created
     workspace chart, the annotation attaches there. Otherwise it attaches to
     the default live chart for that id.
@@ -365,7 +365,7 @@ async def shells_add_workspace_chart_annotation(
 
 
 @catch_errors
-async def shells_add_workspace_chart_overlay(
+async def visual_add_workspace_chart_overlay(
     chart_id: str,
     overlay: dict[str, Any],
 ) -> dict[str, Any]:
@@ -383,7 +383,7 @@ async def shells_add_workspace_chart_overlay(
 
 
 @catch_errors
-async def shells_clear_chart_workspace() -> dict[str, Any]:
+async def visual_clear_chart_workspace() -> dict[str, Any]:
     """Remove all agent-created workspace charts."""
     if not is_opencode_instance():
         return err(*_NOT_OPENCODE_ERR)

--- a/wayfinder_paths/mcp/tools/notify.py
+++ b/wayfinder_paths/mcp/tools/notify.py
@@ -13,7 +13,7 @@ MESSAGE_MAX = 20_000
 
 
 @catch_errors
-async def notification_email(title: str, message: str, delivery: str = "email") -> dict:
+async def notification_send(title: str, message: str, delivery: str = "email") -> dict:
     """Notify the OpenCode instance owner by email or SMS.
 
     Email requires a verified email address and renders Markdown into a themed

--- a/wayfinder_paths/mcp/tools/notify.py
+++ b/wayfinder_paths/mcp/tools/notify.py
@@ -13,7 +13,7 @@ MESSAGE_MAX = 20_000
 
 
 @catch_errors
-async def shells_notify(title: str, message: str, delivery: str = "email") -> dict:
+async def notification_email(title: str, message: str, delivery: str = "email") -> dict:
     """Notify the OpenCode instance owner by email or SMS.
 
     Email requires a verified email address and renders Markdown into a themed

--- a/wayfinder_paths/mcp/tools/runner.py
+++ b/wayfinder_paths/mcp/tools/runner.py
@@ -136,7 +136,7 @@ async def core_runner(
     Args:
         sock_path: Override the daemon socket (default: standard runner location).
         notify_session_on_success: Post successful runs into chat. Defaults false to keep
-            routine scheduled checks quiet; use script-level `notification_email`/`NotifyClient`
+            routine scheduled checks quiet; use script-level `notification_send`/`NotifyClient`
             for owner alerts or print `WAYFINDER_JOB_RESULT {"summary": "...",
             "instructions": "..."}` for conditional chat callbacks.
         debug: Verbose response payload for troubleshooting.

--- a/wayfinder_paths/mcp/tools/runner.py
+++ b/wayfinder_paths/mcp/tools/runner.py
@@ -136,7 +136,7 @@ async def core_runner(
     Args:
         sock_path: Override the daemon socket (default: standard runner location).
         notify_session_on_success: Post successful runs into chat. Defaults false to keep
-            routine scheduled checks quiet; use script-level `shells_notify`/`NotifyClient`
+            routine scheduled checks quiet; use script-level `notification_email`/`NotifyClient`
             for owner alerts or print `WAYFINDER_JOB_RESULT {"summary": "...",
             "instructions": "..."}` for conditional chat callbacks.
         debug: Verbose response payload for troubleshooting.

--- a/wayfinder_paths/tests/test_instance_state_tools.py
+++ b/wayfinder_paths/tests/test_instance_state_tools.py
@@ -6,7 +6,7 @@ from wayfinder_paths.mcp.tools import instance_state
 
 
 @pytest.mark.asyncio
-async def test_shells_create_chart_normalizes_delta_lab_rate_fields(
+async def test_visual_create_chart_normalizes_delta_lab_rate_fields(
     monkeypatch,
 ) -> None:
     monkeypatch.setattr(instance_state, "is_opencode_instance", lambda: True)
@@ -23,7 +23,7 @@ async def test_shells_create_chart_normalizes_delta_lab_rate_fields(
         fake_upsert,
     )
 
-    result = await instance_state.shells_create_chart(
+    result = await instance_state.visual_create_chart(
         chart_id="ena-yield",
         title="ENA yield",
         kind="line",
@@ -56,7 +56,7 @@ async def test_shells_create_chart_normalizes_delta_lab_rate_fields(
 
 
 @pytest.mark.asyncio
-async def test_shells_create_chart_annualizes_funding_to_percent(monkeypatch) -> None:
+async def test_visual_create_chart_annualizes_funding_to_percent(monkeypatch) -> None:
     monkeypatch.setattr(instance_state, "is_opencode_instance", lambda: True)
 
     captured: dict[str, object] = {}
@@ -71,7 +71,7 @@ async def test_shells_create_chart_annualizes_funding_to_percent(monkeypatch) ->
         fake_upsert,
     )
 
-    await instance_state.shells_create_chart(
+    await instance_state.visual_create_chart(
         chart_id="ena-funding",
         title="ENA funding",
         kind="line",

--- a/wayfinder_paths/tests/test_mcp_profiles.py
+++ b/wayfinder_paths/tests/test_mcp_profiles.py
@@ -82,7 +82,7 @@ def test_mcp_catalog_exposes_shells_tools_in_opencode(monkeypatch) -> None:
     assert "visual_get_frontend_context" in names
     assert "visual_set_active_market" in names
     assert "visual_create_chart" in names
-    assert "notification_email" in names
+    assert "notification_send" in names
 
 
 def test_opencode_agents_scope_single_mcp_tool_names() -> None:
@@ -98,7 +98,7 @@ def test_opencode_agents_scope_single_mcp_tool_names() -> None:
     assert primary["wayfinder_polymarket_*"] == "allow"
     assert primary["wayfinder_contracts_*"] == "allow"
     assert primary["wayfinder_visual_*"] == "deny"
-    assert primary["wayfinder_notification_email"] == "allow"
+    assert primary["wayfinder_notification_send"] == "allow"
     assert primary["wayfinder_research_*"] == "deny"
     assert primary["wayfinder_core_run_script"] == "ask"
     assert primary["wayfinder_onchain_swap"] == "ask"
@@ -152,7 +152,7 @@ def test_opencode_agent_frontmatter_scopes_visible_wayfinder_tools() -> None:
         "wayfinder_polymarket_*": "allow",
         "wayfinder_contracts_*": "allow",
         "wayfinder_visual_*": "deny",
-        "wayfinder_notification_email": "allow",
+        "wayfinder_notification_send": "allow",
         "wayfinder_research_*": "deny",
         "wayfinder_core_run_script": "ask",
         "wayfinder_core_run_strategy": "ask",

--- a/wayfinder_paths/tests/test_mcp_profiles.py
+++ b/wayfinder_paths/tests/test_mcp_profiles.py
@@ -71,7 +71,7 @@ def test_mcp_catalog_exposes_expected_non_shell_tools() -> None:
     assert "polymarket_place_market_order" in names
     assert "polymarket_deposit_pusd" in names
     assert "contracts_deploy" in names
-    assert "shells_create_chart" not in names
+    assert "visual_create_chart" not in names
 
 
 def test_mcp_catalog_exposes_shells_tools_in_opencode(monkeypatch) -> None:
@@ -79,10 +79,10 @@ def test_mcp_catalog_exposes_shells_tools_in_opencode(monkeypatch) -> None:
 
     names = _tool_names(mcp_server.build_mcp())
 
-    assert "shells_get_frontend_context" in names
-    assert "shells_set_active_market" in names
-    assert "shells_create_chart" in names
-    assert "shells_notify" in names
+    assert "visual_get_frontend_context" in names
+    assert "visual_set_active_market" in names
+    assert "visual_create_chart" in names
+    assert "notification_email" in names
 
 
 def test_opencode_agents_scope_single_mcp_tool_names() -> None:
@@ -97,7 +97,9 @@ def test_opencode_agents_scope_single_mcp_tool_names() -> None:
     assert primary["wayfinder_hyperliquid_*"] == "allow"
     assert primary["wayfinder_polymarket_*"] == "allow"
     assert primary["wayfinder_contracts_*"] == "allow"
-    assert "wayfinder_research_*" not in primary
+    assert primary["wayfinder_visual_*"] == "deny"
+    assert primary["wayfinder_notification_email"] == "allow"
+    assert primary["wayfinder_research_*"] == "deny"
     assert primary["wayfinder_core_run_script"] == "ask"
     assert primary["wayfinder_onchain_swap"] == "ask"
     assert primary["wayfinder_onchain_send"] == "ask"
@@ -131,11 +133,11 @@ def test_opencode_agents_scope_single_mcp_tool_names() -> None:
     _assert_rule_order(quant, "wayfinder_*", "wayfinder_research_*")
 
     assert visual["wayfinder_*"] == "deny"
-    assert visual["wayfinder_shells_*"] == "allow"
+    assert visual["wayfinder_visual_*"] == "allow"
     assert visual["wayfinder_core_run_script"] == "allow"
     assert visual["wayfinder_core_web_search"] == "allow"
     assert visual["wayfinder_core_web_fetch"] == "allow"
-    _assert_rule_order(visual, "wayfinder_*", "wayfinder_shells_*")
+    _assert_rule_order(visual, "wayfinder_*", "wayfinder_visual_*")
 
 
 def test_opencode_agent_frontmatter_scopes_visible_wayfinder_tools() -> None:
@@ -149,6 +151,9 @@ def test_opencode_agent_frontmatter_scopes_visible_wayfinder_tools() -> None:
         "wayfinder_hyperliquid_*": "allow",
         "wayfinder_polymarket_*": "allow",
         "wayfinder_contracts_*": "allow",
+        "wayfinder_visual_*": "deny",
+        "wayfinder_notification_email": "allow",
+        "wayfinder_research_*": "deny",
         "wayfinder_core_run_script": "ask",
         "wayfinder_core_run_strategy": "ask",
         "wayfinder_core_runner": "ask",
@@ -210,12 +215,12 @@ def test_opencode_agent_frontmatter_scopes_visible_wayfinder_tools() -> None:
         key: value for key, value in visual.items() if key.startswith("wayfinder_")
     } == {
         "wayfinder_*": "deny",
-        "wayfinder_shells_*": "allow",
+        "wayfinder_visual_*": "allow",
         "wayfinder_core_run_script": "allow",
         "wayfinder_core_web_search": "allow",
         "wayfinder_core_web_fetch": "allow",
     }
-    _assert_rule_order(visual, "wayfinder_*", "wayfinder_shells_*")
+    _assert_rule_order(visual, "wayfinder_*", "wayfinder_visual_*")
 
 
 def test_opencode_agents_route_simple_onchain_token_charts_without_quant() -> None:
@@ -227,7 +232,7 @@ def test_opencode_agents_route_simple_onchain_token_charts_without_quant() -> No
 
     assert "Single-token chart fast path" in visual
     assert 'market_type="onchain-spot"' in visual
-    assert "Do not call `shells_search_chart_series`" in visual
+    assert "Do not call `visual_search_chart_series`" in visual
     assert "do not substitute a speculative perp or funding series" in visual
 
 

--- a/wayfinder_paths/tests/test_notify_client.py
+++ b/wayfinder_paths/tests/test_notify_client.py
@@ -73,14 +73,14 @@ def test_normalize_notify_delivery_rejects_unknown_delivery() -> None:
 
 
 @pytest.mark.asyncio
-async def test_notification_email_passes_sms_delivery(
+async def test_notification_send_passes_sms_delivery(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     fake_client = AsyncMock()
     fake_client.notify.return_value = {"sent": True, "delivery": "sms"}
     monkeypatch.setattr(notify_tool_module, "NOTIFY_CLIENT", fake_client)
 
-    out = await notify_tool_module.notification_email("Alert", "Body", delivery="text")
+    out = await notify_tool_module.notification_send("Alert", "Body", delivery="text")
 
     assert out == {"ok": True, "result": {"sent": True, "delivery": "sms"}}
     fake_client.notify.assert_awaited_once_with(
@@ -91,8 +91,8 @@ async def test_notification_email_passes_sms_delivery(
 
 
 @pytest.mark.asyncio
-async def test_notification_email_rejects_invalid_delivery() -> None:
-    out = await notify_tool_module.notification_email("Alert", "Body", delivery="fax")
+async def test_notification_send_rejects_invalid_delivery() -> None:
+    out = await notify_tool_module.notification_send("Alert", "Body", delivery="fax")
 
     assert out["ok"] is False
     assert out["error"]["code"] == "invalid_request"

--- a/wayfinder_paths/tests/test_notify_client.py
+++ b/wayfinder_paths/tests/test_notify_client.py
@@ -73,14 +73,14 @@ def test_normalize_notify_delivery_rejects_unknown_delivery() -> None:
 
 
 @pytest.mark.asyncio
-async def test_shells_notify_passes_sms_delivery(
+async def test_notification_email_passes_sms_delivery(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     fake_client = AsyncMock()
     fake_client.notify.return_value = {"sent": True, "delivery": "sms"}
     monkeypatch.setattr(notify_tool_module, "NOTIFY_CLIENT", fake_client)
 
-    out = await notify_tool_module.shells_notify("Alert", "Body", delivery="text")
+    out = await notify_tool_module.notification_email("Alert", "Body", delivery="text")
 
     assert out == {"ok": True, "result": {"sent": True, "delivery": "sms"}}
     fake_client.notify.assert_awaited_once_with(
@@ -91,8 +91,8 @@ async def test_shells_notify_passes_sms_delivery(
 
 
 @pytest.mark.asyncio
-async def test_shells_notify_rejects_invalid_delivery() -> None:
-    out = await notify_tool_module.shells_notify("Alert", "Body", delivery="fax")
+async def test_notification_email_rejects_invalid_delivery() -> None:
+    out = await notify_tool_module.notification_email("Alert", "Body", delivery="fax")
 
     assert out["ok"] is False
     assert out["error"]["code"] == "invalid_request"


### PR DESCRIPTION
### Summary

`shells_*` was conflating two distinct concerns: 9 chart/UI tools owned by the visual subagent, and 1 notification tool owned by the main agent. Split the namespace:

- 9 chart tools renamed `shells_*` → `visual_*` (e.g., `shells_search_chart_series` → `visual_search_chart_series`).
- `shells_notify` → `notification_send` (keeps the existing `delivery: "email" | "sms"` arg — the tool drives both transports).

### Permission updates

- **wayfinder (main)**: `wayfinder_notification_send: allow` + `wayfinder_visual_*: deny` (delegated to wayfinder-visual subagent) + `wayfinder_research_*: deny` (delegated to wayfinder-research).
- **wayfinder-visual (subagent)**: allowlist flipped from `wayfinder_shells_*` to `wayfinder_visual_*`.

### Skills

- `.claude/skills/using-shells-chart-annotations/` → `using-visual-chart-annotations/`
- `.claude/skills/using-shells-notify/` → `using-notification-send/`

### Tests

`test_mcp_profiles.py` updated to match the new permission shape — main agent now asserts `wayfinder_visual_*: deny`, `wayfinder_notification_send: allow`, and `wayfinder_research_*: deny`. Visual subagent asserts `wayfinder_visual_*: allow`. All 15 profile tests pass.