### PR TITLE
Transaction - Surface per-RPC errors when gas estimation fails on all

### DIFF
--- a/wayfinder_paths/core/utils/test_transaction.py
+++ b/wayfinder_paths/core/utils/test_transaction.py
@@ -370,6 +370,30 @@ class TestGasLimitTransaction:
             assert "gas" in result
             assert result["gas"] > 0
 
+    @patch("wayfinder_paths.core.utils.transaction.web3s_from_chain_id")
+    async def test_all_rpcs_failed_error_includes_rpc_errors(self, mock_web3s_context):
+        rpc_a = MagicMock()
+        rpc_a.eth = MagicMock()
+        rpc_a.eth.estimate_gas = AsyncMock(side_effect=Exception("insufficient funds"))
+        rpc_a.provider.endpoint_uri = "https://rpc-a/137/0"
+        rpc_a.provider.disconnect = AsyncMock()
+
+        rpc_b = MagicMock()
+        rpc_b.eth = MagicMock()
+        rpc_b.eth.estimate_gas = AsyncMock(side_effect=Exception("execution reverted"))
+        rpc_b.provider.endpoint_uri = "https://rpc-b/137/1"
+        rpc_b.provider.disconnect = AsyncMock()
+
+        mock_web3s_context.return_value.__aenter__.return_value = [rpc_a, rpc_b]
+
+        with pytest.raises(Exception) as excinfo:
+            await gas_limit_transaction({"chainId": 137})
+
+        msg = str(excinfo.value)
+        assert "Gas estimation failed on all RPCs" in msg
+        assert "https://rpc-a/137/0: insufficient funds" in msg
+        assert "https://rpc-b/137/1: execution reverted" in msg
+
 
 @pytest.mark.asyncio
 class TestSendTransaction:

--- a/wayfinder_paths/core/utils/transaction.py
+++ b/wayfinder_paths/core/utils/transaction.py
@@ -190,10 +190,13 @@ async def gas_limit_transaction(transaction: dict):
         # Fallback if block gasLimit isn't available.
         return 3_000_000
 
+    rpc_errors: list[str] = []
+
     async def _estimate_gas(web3: AsyncWeb3, transaction: dict) -> int:
         try:
             return await web3.eth.estimate_gas(transaction, block_identifier="latest")
         except Exception as e:
+            rpc_errors.append(f"{web3.provider.endpoint_uri}: {e}")
             logger.info(
                 f"Failed to estimate gas using {web3.provider.endpoint_uri}. Error: {e}"
             )
@@ -217,8 +220,9 @@ async def gas_limit_transaction(transaction: dict):
                 transaction["gas"] = fallback_gas
                 return transaction
 
-            logger.error("Gas estimation failed on all RPCs")
-            raise Exception("Gas estimation failed on all RPCs")
+            detail = "; ".join(rpc_errors) if rpc_errors else "no errors captured"
+            logger.error(f"Gas estimation failed on all RPCs: {detail}")
+            raise Exception(f"Gas estimation failed on all RPCs: {detail}")
 
         # Add a defensive buffer. Some transactions (especially swaps) can use more gas
         # at execution time than at estimation time due to state changes between


### PR DESCRIPTION
### Summary

The previous `"Gas estimation failed on all RPCs"` message hid the actual reason. When the failure is a node-level precheck — `insufficient funds for gas * price + value`, low balance for `msg.value` bridge fees, nonce conflicts — the per-RPC error string is what tells the agent (and the user) what to fix.

Capture each `_estimate_gas` exception, concat them into the raised `Exception` message and the error log. No new types — same `Exception`, richer body.

#### Before

```
Gas estimation failed on all RPCs
```

#### After

```
Gas estimation failed on all RPCs: https://…/137/0: insufficient funds for gas * price + value: address 0xD5d9… have 331659383722000 want 1000000000000000; https://…/137/1: insufficient funds for gas * price + value: address 0xD5d9… have 331659383722000 want 1000000000000000; …
```

This would have made the recent DeBridge USDT0 → pUSD failure self-explanatory (wallet had 0.000332 ETH on Arbitrum, DeBridge flat fee `msg.value` = 0.001 ETH).