### PR TITLE
HIP-4 Outcomes - Migrate collateral from USDH to USDC

### DIFF
--- a/.claude/skills/using-hyperliquid-adapter/rules/outcomes.md
+++ b/.claude/skills/using-hyperliquid-adapter/rules/outcomes.md
@@ -2,7 +2,7 @@
 
 HIP-4 is a hypercore-native prediction-contract surface. Phase 1 ships **binary daily markets** (e.g. "BTC > $78,213 by 06:00 UTC"); the protocol generalizes to multi-outcome later. Outcomes settle daily at **06:00 UTC**, after which the `outcome_id` rolls and old ids stop trading.
 
-**Collateral / quote: USDH** (Hyperliquid's stablecoin, token id 360). All currently-live HIP-4 outcomes settle in USDH — `outcomeMeta` doesn't expose a per-market quote field, so treat the whole surface as USDH-only until HL deploys outcomes against another token. You need a USDH balance to place orders; a USDC balance won't be debited.
+**Collateral / quote: USDC.** HIP-4 outcomes settle in USDC (migrated from USDH as of May 2026). You need a USDC balance to place orders.
 
 ## Asset id encoding
 
@@ -90,7 +90,7 @@ hyperliquid_cancel_order(
 
 ## Gotchas
 
-- **Collateral is USDH, not USDC.** Outcome buys debit USDH (token 360). If you only hold USDC, orders fail even with plenty of buying power — swap USDC → USDH on the `USDH/USDC` spot pair first.
+- **Collateral is USDC.** Outcome buys debit USDC from your spot account.
 - **Daily settlement rolls outcome ids.** A live `outcome_id=20` at 05:55 UTC may be expired by 06:05 UTC and a new id replaces it. Re-fetch `get_outcome_markets()` rather than caching ids across days.
 - **Sizes are integer contracts.** The adapter rejects non-integer `size` loudly; don't pass floats.
 - **Price decimals follow the spot rule** (`MAX_DECIMALS=8`, 5-sig-figs); for typical 0..1 outcome prices this means up to ~5 decimals.

--- a/.claude/skills/using-hyperliquid-adapter/rules/outcomes.md
+++ b/.claude/skills/using-hyperliquid-adapter/rules/outcomes.md
@@ -2,7 +2,7 @@
 
 HIP-4 is a hypercore-native prediction-contract surface. Phase 1 ships **binary daily markets** (e.g. "BTC > $78,213 by 06:00 UTC"); the protocol generalizes to multi-outcome later. Outcomes settle daily at **06:00 UTC**, after which the `outcome_id` rolls and old ids stop trading.
 
-**Collateral / quote: USDC.** HIP-4 outcomes settle in USDC (migrated from USDH as of May 2026). You need a USDC balance to place orders.
+**Collateral / quote: USDC.** HIP-4 outcomes settle in USDC.
 
 ## Asset id encoding
 

--- a/.opencode/agents/wayfinder.md
+++ b/.opencode/agents/wayfinder.md
@@ -152,7 +152,7 @@ Before any order is placed, the Hyperliquid Adapter enforces [Unified Account mo
 | HIP-3 `cash`  | USDT                                                                      |
 | HIP-3 `hyna`  | USDE                                                                      |
 | Spot          | For market {A} - {B}, {B} is the quote asset, typically: USDC, USDH, USDT |
-| HIP-4 Outcome | USDH in spot account                                                      |
+| HIP-4 Outcome | USDC in spot account                                                      |
 
 If a user is on a legacy split account, migration may require closing positions, moving balances to spot, then enabling UnifiedAccountMode. `ensure_unified_account` runs before order placement, but can fail mid-state if open positions or stuck spot balances block the switch.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,7 @@ When a user wants **immediate, one-off execution**:
 - **Gas check first:** Before any on-chain execution, verify the wallet has native gas on the target chain (see "Gas requirements" under Supported chains). If bridging to a new chain, bridge once and swap locally — don't do two separate bridges.
 - **On-chain:** use `mcp__wayfinder__onchain_swap` (cross-chain / cross-DEX swaps via BRAP) or `mcp__wayfinder__onchain_send` (ERC-20 / native transfers). The `amount` parameter is **human-readable** (e.g. `"5"` for 5 USDC), not wei.
 - **Outcome / prediction markets — search both venues, let the user pick.** When a user mentions "outcome market" or "prediction market" without naming the platform, **search both venues in parallel** and present the candidates side-by-side so the user can choose where to trade. Two venues:
-  - **Hyperliquid HIP-4** — daily binary price contracts, settled in USDH on the HL L1. Lineup rotates daily. Search via `mcp__wayfinder__hyperliquid_search_market(query=...)` and read the `outcomes` bucket.
+  - **Hyperliquid HIP-4** — daily binary price contracts, settled in USDC on the HL L1. Lineup rotates daily. Search via `mcp__wayfinder__hyperliquid_search_market(query=...)` and read the `outcomes` bucket.
   - **Polymarket** — long-form prediction markets (politics, sports, events, crypto milestones), settled in pUSD on Polygon (V2 collateral; the adapter wraps from USDC/USDC.e as needed). Search via `mcp__wayfinder__polymarket_read(action="search", query=..., limit=...)`.
 
   Present results as a table grouped by venue, then ask the user which market to act on. Don't assume — the same theme (e.g. "BTC above X by date Y") can list on both venues with different sizes, expiries, and collateral.
@@ -220,7 +220,7 @@ Hyperliquid minimums:
 - **Minimum deposit: $5 USD** (deposits below this are **lost**)
 - **Minimum order: $10 USD notional** (applies to both perp and spot)
 
-HIP-3 dex abstraction (xyz/flx/vntl/hyna/km perps), HIP-4 outcome markets (binary daily prediction contracts, **collateralized in USDH**, not USDC), and Hyperliquid deposits/withdrawals: all handled in the Hyperliquid adapter/tooling — load `/using-hyperliquid-adapter` when scripting.
+HIP-3 dex abstraction (xyz/flx/vntl/hyna/km perps), HIP-4 outcome markets (binary daily prediction contracts, **collateralized in USDC**), and Hyperliquid deposits/withdrawals: all handled in the Hyperliquid adapter/tooling — load `/using-hyperliquid-adapter` when scripting.
 
 Polymarket quick flows:
 

--- a/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
+++ b/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
@@ -53,9 +53,7 @@ MAINNET = "Mainnet"
 # ships sideSpecs=[Yes, No] for the binary daily, so 0=YES and 1=NO —
 # but multi-outcome contracts may reorder, so always read sideSpecs[side].name
 # instead of hardcoding a YES/NO convention.
-# Collateral: outcomes settle in USDH (spot token 360), not USDC. The spot
-# wallet must hold USDH before placing orders; outcomeMeta has no per-market
-# quote field, so the whole surface is treated as USDH-only.
+# Collateral: outcomes settle in USDC (migrated from USDH as of May 2026).
 
 
 def outcome_encoding(outcome_id: int, side: int) -> int:

--- a/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
+++ b/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
@@ -53,7 +53,7 @@ MAINNET = "Mainnet"
 # ships sideSpecs=[Yes, No] for the binary daily, so 0=YES and 1=NO —
 # but multi-outcome contracts may reorder, so always read sideSpecs[side].name
 # instead of hardcoding a YES/NO convention.
-# Collateral: outcomes settle in USDC (migrated from USDH as of May 2026).
+# Collateral: outcomes settle in USDC.
 
 
 def outcome_encoding(outcome_id: int, side: int) -> int:

--- a/wayfinder_paths/mcp/tools/hyperliquid.py
+++ b/wayfinder_paths/mcp/tools/hyperliquid.py
@@ -939,8 +939,8 @@ async def _place_outcome_order(
 ) -> dict[str, Any]:
     """HIP-4 outcome leg of hyperliquid_place_{market,limit}_order.
 
-    Outcomes settle in USDH (token 360), trade as integer contracts, and have
-    a $10 USDH minimum order value. The standard Wayfinder builder code is
+    Outcomes settle in USDC, trade as integer contracts, and have
+    a $10 USDC minimum order value. The standard Wayfinder builder code is
     attached on every outcome order (HL accrues the fee on the sell side per
     the HIP-4 spec). `usd_amount` sizing is market-only — limit outcome
     orders require explicit integer `size`.
@@ -999,17 +999,12 @@ async def _place_outcome_order(
         cloid=cloid,
         address=sender,
     )
-    # Outcome orders settle in USDH. When the wallet lacks USDH, HL just says
-    # "Insufficient spot balance asset=N" — append a funding hint so agents
-    # know how to recover. Only the inner-status-error shape carries this
-    # message; outer-status errors (res["status"]=="err") use a different
-    # response schema and are skipped here.
     if not ok_order and res["status"] == "ok":
         for s in res["response"]["data"]["statuses"]:
             if "error" in s and "Insufficient spot balance" in s["error"]:
                 s["error"] += (
-                    " — Outcome markets are purchased using USDH, please "
-                    "swap into sufficient USDH using the USDH/USDC spot pair."
+                    " — Outcome markets are purchased using USDC, "
+                    "ensure you have sufficient USDC balance."
                 )
     effects.append(
         {"type": "hl", "label": "place_outcome_order", "ok": ok_order, "result": res}
@@ -1499,7 +1494,7 @@ async def hyperliquid_place_market_order(
     """Place an IOC market order on a Hyperliquid perp / spot / HIP-4 market.
 
     HIP-4 outcome markets (`#N` asset names) trade as integer contracts and
-    require a $10 USDH minimum order value — `usd_amount` is converted to
+    require a $10 USDC minimum order value — `usd_amount` is converted to
     contracts at mid.
 
     `usd_amount` is converted to asset units at the mid price, then **rounded
@@ -1658,7 +1653,7 @@ async def hyperliquid_place_limit_order(
     """Place a GTC limit order on a Hyperliquid perp / spot / HIP-4 market.
 
     HIP-4 outcome markets (`#N` asset names) trade as integer contracts and
-    require a $10 USDH minimum order value. `usd_amount` sizing is not
+    require a $10 USDC minimum order value. `usd_amount` sizing is not
     supported for limit outcomes — pass an integer `size`.
 
     For leverage / margin mode, call `hyperliquid_update_leverage` first.

--- a/wayfinder_paths/mcp/tools/hyperliquid.py
+++ b/wayfinder_paths/mcp/tools/hyperliquid.py
@@ -999,13 +999,6 @@ async def _place_outcome_order(
         cloid=cloid,
         address=sender,
     )
-    if not ok_order and res["status"] == "ok":
-        for s in res["response"]["data"]["statuses"]:
-            if "error" in s and "Insufficient spot balance" in s["error"]:
-                s["error"] += (
-                    " — Outcome markets are purchased using USDC, "
-                    "ensure you have sufficient USDC balance."
-                )
     effects.append(
         {"type": "hl", "label": "place_outcome_order", "ok": ok_order, "result": res}
     )


### PR DESCRIPTION
### Summary
- HIP-4 outcome markets now settle in USDC (confirmed on app.hyperliquid.xyz, May 25 2026) after the platform-wide USDH sunset
- Updated docstrings, adapter comment, CLAUDE.md, agent instructions, and skill rules to reflect USDC collateral
- Removed the now-redundant USDH insufficient-balance error guard on outcome orders