### PR TITLE
Config - Default api_base_url to wayfinder.ai

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -1,6 +1,6 @@
 {
   "system": {
-    "api_base_url": "https://strategies.wayfinder.ai/api/v1",
+    "api_base_url": "https://wayfinder.ai/api/v1",
     "api_key": "wk_your_key_here",
     "etherscan_api_key": "",
     "allow_local_wallets": true

--- a/scripts/remote_setup_utils.py
+++ b/scripts/remote_setup_utils.py
@@ -82,7 +82,7 @@ def ensure_config(
         system = {}
     if api_key:
         system["api_key"] = api_key
-    system.setdefault("api_base_url", "https://strategies.wayfinder.ai/api/v1")
+    system.setdefault("api_base_url", "https://wayfinder.ai/api/v1")
     config["system"] = system
 
     if "strategy" not in config:

--- a/wayfinder_paths/core/config.py
+++ b/wayfinder_paths/core/config.py
@@ -5,7 +5,7 @@ from typing import Any
 
 _CONFIG_ENV_KEYS = ("WAYFINDER_CONFIG_PATH", "WAYFINDER_CONFIG")
 _DEFAULT_CONFIG_FILENAME = "config.json"
-_DEFAULT_API_BASE_URL = "https://strategies.wayfinder.ai/api/v1"
+_DEFAULT_API_BASE_URL = "https://wayfinder.ai/api/v1"
 _WALLET_MNEMONIC_KEY = "wallet_mnemonic"
 
 

--- a/wayfinder_paths/tests/test_config_resolution.py
+++ b/wayfinder_paths/tests/test_config_resolution.py
@@ -60,10 +60,10 @@ def test_missing_explicit_config_does_not_clear_loaded_config(
     assert config.get_api_base_url() == "https://strategies-dev.wayfinder.ai/api/v1"
 
 
-def test_api_base_url_defaults_to_strategies_api(restore_global_config: None) -> None:
+def test_api_base_url_defaults_to_wayfinder_api(restore_global_config: None) -> None:
     config.set_config({})
 
-    assert config.get_api_base_url() == "https://strategies.wayfinder.ai/api/v1"
+    assert config.get_api_base_url() == "https://wayfinder.ai/api/v1"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary
Flips the SDK default `api_base_url` from `https://strategies.wayfinder.ai/api/v1` to `https://wayfinder.ai/api/v1` in `core/config.py`, `config.example.json`, and `scripts/remote_setup_utils.py`. Existing instances with `config.json` already written are unaffected; new instances and SDK consumers that don't override will use the canonical name. `strategies.wayfinder.ai` continues to work for backwards compat.