### PR TITLE
Docs - Default to wayfinder.ai over strategies subdomain

### DIFF
--- a/.claude/skills/developing-wayfinder-paths/rules/applet.md
+++ b/.claude/skills/developing-wayfinder-paths/rules/applet.md
@@ -101,7 +101,7 @@ when the applet is served from the path page.
    "data unavailable" / "waiting for host API" state, don't crash.
 
 Host environments:
-- prod: `https://strategies.wayfinder.ai`
+- prod: `https://wayfinder.ai`
 - dev: `https://strategies-dev.wayfinder.ai`
 
 Authenticated Delta Lab routes (`/api/v1/delta-lab/assets/...`) are for

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -24,7 +24,7 @@ python3 scripts/setup.py
 This will:
 1. Ensure Python 3.12 and Poetry are installed
 2. Install all dependencies
-3. Prompt for your Wayfinder API key (get one at https://strategies.wayfinder.ai)
+3. Prompt for your Wayfinder API key (get one at https://wayfinder.ai)
 4. Create `config.json` from the template
 5. Generate local development wallets
 6. Configure the MCP server
@@ -44,7 +44,7 @@ If you see "api_key not set":
 - Edit `config.json` and add your key under `system.api_key`
 - Or re-run setup: `python3 scripts/setup.py`
 
-Get your API key at: **https://strategies.wayfinder.ai**
+Get your API key at: **https://wayfinder.ai**
 
 ## Rules
 

--- a/.claude/skills/setup/rules/api-key.md
+++ b/.claude/skills/setup/rules/api-key.md
@@ -2,7 +2,7 @@
 
 ## Getting an API Key
 
-1. Go to https://strategies.wayfinder.ai
+1. Go to https://wayfinder.ai
 2. Create an account or sign in
 3. Navigate to Settings > API Keys
 4. Generate a new key (starts with `wk_`)
@@ -45,6 +45,6 @@ poetry run python -c "from wayfinder_paths.core.clients.WayfinderClient import W
 - Re-run setup: `python3 scripts/setup.py`
 
 ### Key not working
-- Verify the key is active at https://strategies.wayfinder.ai
+- Verify the key is active at https://wayfinder.ai
 - Check for typos (copy-paste the key directly)
 - Ensure no extra whitespace around the key value

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,13 +13,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
    - The script may skip the API key prompt in non-interactive terminals - that's OK
    - After setup completes, ask the user: "Do you have a Wayfinder API key?"
      - If yes: Use the Edit tool to add it to `config.json` under `system.api_key`
-     - If no: Direct them to **https://strategies.wayfinder.ai** to create an account and get one
+     - If no: Direct them to **https://wayfinder.ai** to create an account and get one
    - After config is complete, tell the user: **"Please restart Claude Code to load the MCP server, then we can continue."**
 
 3. If `config.json` exists but `system.api_key` is empty/missing:
    - Ask: "I see you haven't set up your API key yet. Do you have a Wayfinder API key?"
    - If yes: Help them add it to `config.json` under `system.api_key`
-   - If no: Direct them to **https://strategies.wayfinder.ai** to get one
+   - If no: Direct them to **https://wayfinder.ai** to get one
 
 4. If everything is configured, proceed normally
 

--- a/CONFIG_GUIDE.md
+++ b/CONFIG_GUIDE.md
@@ -60,7 +60,7 @@ The `config.json` file has three main sections:
 | Field | Required | Description |
 |-------|----------|-------------|
 | `api_key` | Yes | Wayfinder API key (sent as `X-API-KEY` header) |
-| `api_base_url` | No | API endpoint (default: `https://strategies.wayfinder.ai/api/v1`) |
+| `api_base_url` | No | API endpoint (default: `https://wayfinder.ai/api/v1`) |
 | `etherscan_api_key` | No | Etherscan V2 API key (used for Solidity contract verification) |
 | `polymarket_builder_code` | No | Optional Polymarket v2 builder code for order attribution / builder rewards when builder support is enabled |
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Use `config.example.json` as a template. The SDK reads `config.json` by default.
 Key fields:
 
 - `system.api_key`: Wayfinder API key (or set `WAYFINDER_API_KEY` env var)
-- `system.api_base_url`: API base URL (defaults to `https://strategies.wayfinder.ai/api/v1` if omitted)
+- `system.api_base_url`: API base URL (defaults to `https://wayfinder.ai/api/v1` if omitted)
 - `strategy.rpc_urls`: *(optional)* chain ID -> RPC URL(s) (string or list). If omitted for a chain, reads default to the Wayfinder proxy RPC at `${system.api_base_url}/blockchain/rpc/<chain_id>/`.
 - `wallets`: local wallets with `label`, `address`, and `private_key_hex`. Remote wallets (Privy server wallets) are auto-fetched when `system.api_key` is configured.
 
@@ -85,7 +85,7 @@ Example:
 ```json
 {
   "system": {
-    "api_base_url": "https://strategies.wayfinder.ai/api/v1",
+    "api_base_url": "https://wayfinder.ai/api/v1",
     "api_key": "wk_your_api_key_here"
   },
   "strategy": {
@@ -320,9 +320,9 @@ If you are automating path publication:
 
 Use two different Delta Lab access patterns depending on what is running:
 
-- SDK scripts, MCP tools, and agent-side Python should use `DELTA_LAB_CLIENT` with `system.api_base_url`, for example `https://strategies.wayfinder.ai/api/v1/delta-lab/...`
+- SDK scripts, MCP tools, and agent-side Python should use `DELTA_LAB_CLIENT` with `system.api_base_url`, for example `https://wayfinder.ai/api/v1/delta-lab/...`
 - presentation applets shown on the public path page should use the public browser-safe timeseries endpoint:
-  - prod: `https://strategies.wayfinder.ai/api/v1/delta-lab/public/assets/<symbol>/timeseries/`
+  - prod: `https://wayfinder.ai/api/v1/delta-lab/public/assets/<symbol>/timeseries/`
   - dev: `https://strategies-dev.wayfinder.ai/api/v1/delta-lab/public/assets/<symbol>/timeseries/`
 
 For applet authors and agents:


### PR DESCRIPTION
### Summary
Flips user-facing docs (README, CONFIG_GUIDE, CLAUDE.md, setup + applet skill rules) from `strategies.wayfinder.ai` to `wayfinder.ai`. Terms.md keeps both hostnames intentionally. Strategies still works for backwards compat.