### PR TITLE
Shells - Rename notify_session_on_success to always_notify_session_on_job_completion

### DIFF
--- a/.claude/skills/using-notification-send/SKILL.md
+++ b/.claude/skills/using-notification-send/SKILL.md
@@ -40,7 +40,7 @@ Both POST to `{api_base}/opencode/notify/` with the configured `WAYFINDER_API_KE
 - **Throttle:** Backend caps at **12 notifications / user / day** across email/SMS. Budget sends; don't spam progress updates.
 - **Shells-only:** No-op (or HTTP error) outside a Wayfinder Shells instance. The MCP tool gates on `is_opencode_instance()` indirectly via the API; the client just hits the URL. Detection: `OPENCODE_INSTANCE_ID` env var is set, or the health probe at `http://localhost:3096/global/health` returns `healthy: true`.
 - Client returns the parsed JSON dict directly (no `(ok, data)` tuple — it's a `WayfinderClient`, not an adapter).
-- **Scheduled jobs:** Routine successful runs already sync to backend job history. Only opt into all success chat `job_result` messages with `notify_session_on_success=True` when the user explicitly wants live run output. For conditional chat callbacks, print one line from the script: `WAYFINDER_JOB_RESULT {"summary":"Funding crossover detected","instructions":"Research whether to unroll the position.","severity":"warning"}`.
+- **Scheduled jobs:** Routine successful runs already sync to backend job history. Only opt into all success chat `job_result` messages with `always_notify_session_on_job_completion=True` when the user explicitly wants live run output. For conditional chat callbacks, print one line from the script: `WAYFINDER_JOB_RESULT {"summary":"Funding crossover detected","instructions":"Research whether to unroll the position.","severity":"warning"}`.
 
 ## When to use
 

--- a/.opencode/agents/wayfinder.md
+++ b/.opencode/agents/wayfinder.md
@@ -240,14 +240,23 @@ core_runner(action="daemon_stop")
 - If `add_job`, `delete_job`, `update_job`, or `run_once` times out or returns an ambiguous transport error, treat mutation state as unknown. Call `runner(action="status")`, `runner(action="job_runs", name=...)`, or `runner(action="run_report", run_id=...)` before retrying, restarting, or telling the user what happened.
 - Generated monitor scripts must store durable state with `wayfinder_paths.runner.monitor_state`; it writes under `$WAYFINDER_RUNNER_DIR/job_state/$WAYFINDER_KV_NAMESPACE/`. Do not store monitor state in `/tmp`; restart-pruned state can duplicate alerts.
 
-#### Noise
+#### Conversation Noise
 
-- For recurring alert scripts, store local state and call `notification_send`/`NotifyClient` only on edge transitions with cooldown/hysteresis; never call notify on every poll.
-- If a successful job needs to hand control back to chat without notifying externally, print a single-line runner marker: `WAYFINDER_JOB_RESULT {"summary":"Funding crossover detected","instructions":"Research whether to unroll the position, then propose the unwind script.","severity":"warning"}`.
+By default failing jobs, timed out jobs, and stdout with WAYFINDER_JOB_RESULT will emit a chat message under the user back to the chat - this EXCLUDES successful job run results by default. If you wish to have successful job run logs entering the main conversation please set always_notify_session_on_job_completion=True.
+
+WAYFINDER_JOB_RESULT should be used for exceptions, bad arguments OR significant events:
+
+- e.g. `WAYFINDER_JOB_RESULT {"summary":"Funding crossover detected","instructions":"Research whether to unroll the position, then propose the unwind script.","severity":"warning"}`.
+- e.g. `WAYFINDER_JOB_RESULT {"summary":"Exception" ,"instructions":"Please remediate","severity":"warning"}`.
+
+Note:
+This conversation noise is different than sms/email noise. Please reserve sms/email for important events that you must notify the user of. Please dump async messages into the conversation, the user will see them when they come back.
+
+Handling:
+
 - When a `job_result` does post into the conversation, treat it as an event you must respond to — read the result, decide whether action is needed, and reply (act, escalate via `notify`, or acknowledge). Never skip past it silently or fold it into an unrelated turn.
+- For recurring alert scripts, store local state and call `notification_send`/`NotifyClient` only on edge transitions with cooldown/hysteresis; never call notify on every poll.
 - Position-bound monitors must verify the live position still exists and matches expected side, size/notional, leverage, and margin mode before alerting.
-- Data-fetch or notification failures must exit nonzero or emit a `WAYFINDER_JOB_RESULT` handoff with the failure. Do not let broken monitoring look like a healthy successful run.
-- Reserve SMS/email for actionable alerts. Normal, net-positive, or informational state transitions should stay in runner logs or use a conditional `WAYFINDER_JOB_RESULT` chat handoff when investigation is needed.
 
 ### Wayfinder Paths
 

--- a/.opencode/agents/wayfinder.md
+++ b/.opencode/agents/wayfinder.md
@@ -242,7 +242,7 @@ core_runner(action="daemon_stop")
 
 #### Conversation Noise
 
-By default failing jobs, timed out jobs, and stdout with WAYFINDER_JOB_RESULT will emit a chat message under the user back to the chat - this EXCLUDES successful job run results by default. If you wish to have successful job run logs entering the main conversation please set always_notify_session_on_job_completion=True.
+By default: failing jobs, timed out jobs, and stdout messages with the string WAYFINDER_JOB_RESULT will emit a chat message under the user back to the chat - NOTE THIS EXCLUDES successful job run results by default. If you wish to have successful job run logs entering the main conversation please set `always_notify_session_on_job_completion`=True.
 
 WAYFINDER_JOB_RESULT should be used for exceptions, bad arguments OR significant events:
 

--- a/wayfinder_paths/mcp/tools/runner.py
+++ b/wayfinder_paths/mcp/tools/runner.py
@@ -89,14 +89,13 @@ async def core_runner(
     always_notify_session_on_job_completion: bool = False,
     debug: bool = False,
 ) -> dict[str, Any]:
-    """Control the local runner daemon — the only sanctioned scheduler for recurring jobs.
-
-    All scheduled/recurring tasks MUST go through this tool. Don't use cron, systemd timers,
+    """Control the local runner daemon — the only sanctioned scheduler for recurring jobs. All scheduled/recurring tasks MUST go through this tool. Don't use cron, systemd timers,
     or background loops. The daemon owns persistence, failure tracking, timeouts, and (on
-    Wayfinder Shells) backend job/run sync. Routine successful scheduled runs sync to the
-    backend but do not post chat `job_result` messages unless
-    `always_notify_session_on_job_completion` is explicitly true or the script emits a
-    `WAYFINDER_JOB_RESULT {...}` marker; failures still post to the session.
+    Wayfinder Shells) backend job/run sync.
+
+    To minimize conversation noise, use always_notify_session_on_job_completion=False. By default, failures always post to the chat session. Successes are silent unless
+    `always_notify_session_on_job_completion` is true or the script emits a
+    `WAYFINDER_JOB_RESULT {...}` line.
 
     Lifecycle actions:
       - `daemon_status`: lightweight probe — has the socket, is anyone listening.
@@ -135,11 +134,7 @@ async def core_runner(
 
     Args:
         sock_path: Override the daemon socket (default: standard runner location).
-        always_notify_session_on_job_completion: Post all completed runs into chat. Defaults
-            false to keep routine scheduled checks quiet; use script-level
-            `notification_send`/`NotifyClient` for owner alerts or print
-            `WAYFINDER_JOB_RESULT {"summary": "...", "instructions": "..."}` for conditional
-            chat callbacks.
+        always_notify_session_on_job_completion: Additionally, all successful runs are sent into chat. Defaults false to keep routine scheduled checks quiet.
         debug: Verbose response payload for troubleshooting.
     """
 

--- a/wayfinder_paths/mcp/tools/runner.py
+++ b/wayfinder_paths/mcp/tools/runner.py
@@ -86,7 +86,7 @@ async def core_runner(
     script_path: str | None = None,
     args: list[str] | None = None,
     env: dict[str, str] | None = None,
-    notify_session_on_success: bool = False,
+    always_notify_session_on_job_completion: bool = False,
     debug: bool = False,
 ) -> dict[str, Any]:
     """Control the local runner daemon — the only sanctioned scheduler for recurring jobs.
@@ -94,9 +94,9 @@ async def core_runner(
     All scheduled/recurring tasks MUST go through this tool. Don't use cron, systemd timers,
     or background loops. The daemon owns persistence, failure tracking, timeouts, and (on
     Wayfinder Shells) backend job/run sync. Routine successful scheduled runs sync to the
-    backend but do not post chat `job_result` messages unless `notify_session_on_success`
-    is explicitly true or the script emits a `WAYFINDER_JOB_RESULT {...}` marker; failures
-    still post to the session.
+    backend but do not post chat `job_result` messages unless
+    `always_notify_session_on_job_completion` is explicitly true or the script emits a
+    `WAYFINDER_JOB_RESULT {...}` marker; failures still post to the session.
 
     Lifecycle actions:
       - `daemon_status`: lightweight probe — has the socket, is anyone listening.
@@ -135,10 +135,11 @@ async def core_runner(
 
     Args:
         sock_path: Override the daemon socket (default: standard runner location).
-        notify_session_on_success: Post successful runs into chat. Defaults false to keep
-            routine scheduled checks quiet; use script-level `notification_send`/`NotifyClient`
-            for owner alerts or print `WAYFINDER_JOB_RESULT {"summary": "...",
-            "instructions": "..."}` for conditional chat callbacks.
+        always_notify_session_on_job_completion: Post all completed runs into chat. Defaults
+            false to keep routine scheduled checks quiet; use script-level
+            `notification_send`/`NotifyClient` for owner alerts or print
+            `WAYFINDER_JOB_RESULT {"summary": "...", "instructions": "..."}` for conditional
+            chat callbacks.
         debug: Verbose response payload for troubleshooting.
     """
 
@@ -367,8 +368,8 @@ async def core_runner(
                     if not isinstance(env, dict):
                         return err("invalid_request", "env must be an object")
                     job_payload["env"] = {str(k): str(v) for k, v in env.items()}
-                if notify_session_on_success:
-                    job_payload["notify_session_on_success"] = True
+                if always_notify_session_on_job_completion:
+                    job_payload["always_notify_session_on_job_completion"] = True
 
                 if job_type == JOB_TYPE_STRATEGY:
                     strat = (strategy or "").strip()

--- a/wayfinder_paths/runner/cli.py
+++ b/wayfinder_paths/runner/cli.py
@@ -139,10 +139,10 @@ def status_cmd() -> None:
     "--env-json", default=None, help="JSON object of env vars for the worker."
 )
 @click.option(
-    "--notify-session-on-success",
+    "--always-notify-session-on-job-completion",
     is_flag=True,
     default=False,
-    help="Post successful runs into the bound OpenCode session.",
+    help="Post all completed runs into the bound OpenCode session.",
 )
 @click.option("--debug/--no-debug", default=False, show_default=True)
 def add_job_cmd(
@@ -157,7 +157,7 @@ def add_job_cmd(
     wallet_label: str | None,
     timeout_seconds: int | None,
     env_json: str | None,
-    notify_session_on_success: bool,
+    always_notify_session_on_job_completion: bool,
     debug: bool,
 ) -> None:
     paths = get_runner_paths()
@@ -186,8 +186,8 @@ def add_job_cmd(
             payload["timeout_seconds"] = int(timeout_seconds)
         if env_payload is not None:
             payload["env"] = env_payload
-        if notify_session_on_success:
-            payload["notify_session_on_success"] = True
+        if always_notify_session_on_job_completion:
+            payload["always_notify_session_on_job_completion"] = True
     elif jt == JOB_TYPE_SCRIPT:
         if not script_path:
             raise click.UsageError("--script-path is required for type=script")
@@ -203,8 +203,8 @@ def add_job_cmd(
             payload["timeout_seconds"] = int(timeout_seconds)
         if env_payload is not None:
             payload["env"] = env_payload
-        if notify_session_on_success:
-            payload["notify_session_on_success"] = True
+        if always_notify_session_on_job_completion:
+            payload["always_notify_session_on_job_completion"] = True
     else:
         raise click.UsageError(f"Unsupported type: {job_type}")
 

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -404,9 +404,9 @@ class RunnerDaemon:
         if not session_id or not OPENCODE_CLIENT.healthy():
             return
         event = _extract_job_result_event(running_process.log_path)
-        should_post_success = job.payload.get("notify_session_on_success") is True or (
-            event is not None
-        )
+        should_post_success = job.payload.get(
+            "always_notify_session_on_job_completion"
+        ) is True or (event is not None)
         if status == RunStatus.OK and not should_post_success:
             return
         message = _tail_text(running_process.log_path, max_bytes=4000) or "(no output)"


### PR DESCRIPTION
### Summary
- Rename `notify_session_on_success` → `always_notify_session_on_job_completion` across MCP tool, CLI flag, daemon, and skill docs for clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)