### PR TITLE
Polymarket Market Orders - Resolve outcome label from token_id

### DIFF
--- a/wayfinder_paths/adapters/polymarket_adapter/adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/adapter.py
@@ -386,7 +386,7 @@ class PolymarketAdapter(BaseAdapter):
             )
             res.raise_for_status()
             data = res.json()
-            if not isinstance(data, list) or not data or not isinstance(data[0], dict):
+            if not data:
                 return False, "Market not found"
             return True, self._normalize_market(data[0])
         except Exception as exc:  # noqa: BLE001

--- a/wayfinder_paths/adapters/polymarket_adapter/adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/adapter.py
@@ -376,6 +376,34 @@ class PolymarketAdapter(BaseAdapter):
         except Exception as exc:  # noqa: BLE001
             return False, self._gamma_error(exc, endpoint=endpoint)
 
+    async def get_market_by_token_id(
+        self, *, token_id: str
+    ) -> tuple[bool, dict[str, Any] | str]:
+        endpoint = "/markets"
+        try:
+            res = await self._gamma_http.get(
+                endpoint, params={"clob_token_ids": token_id}
+            )
+            res.raise_for_status()
+            data = res.json()
+            if not isinstance(data, list) or not data or not isinstance(data[0], dict):
+                return False, "Market not found"
+            return True, self._normalize_market(data[0])
+        except Exception as exc:  # noqa: BLE001
+            return False, self._gamma_error(exc, endpoint=endpoint)
+
+    def resolve_outcome_from_token_id(
+        self, *, market: dict[str, Any], token_id: str
+    ) -> str | None:
+        outcomes: list[Any] = market.get("outcomes") or []
+        token_ids: list[Any] = market.get("clobTokenIds") or []
+        for i, tok in enumerate(token_ids):
+            if str(tok) == str(token_id):
+                if i < len(outcomes):
+                    return str(outcomes[i])
+                return None
+        return None
+
     def resolve_clob_token_id(
         self,
         *,

--- a/wayfinder_paths/mcp/tools/polymarket.py
+++ b/wayfinder_paths/mcp/tools/polymarket.py
@@ -676,7 +676,7 @@ async def polymarket_place_market_order(
     )
 
     adapter, sender = await _make_polymarket_adapter(wallet_label)
-    resolved_outcome: str | None = None
+    resolved_outcome = str(outcome) if market_slug else None
     try:
         if market_slug:
             if side == "BUY":
@@ -693,11 +693,10 @@ async def polymarket_place_market_order(
                     shares=sizing["adapter_amount"],
                     max_slippage_pct=max_slippage_pct,
                 )
-            resolved_outcome = str(outcome)
         else:
             tid = throw_if_empty_str("token_id or market_slug is required", token_id)
             ok_tm, market = await adapter.get_market_by_token_id(token_id=tid)
-            if ok_tm and isinstance(market, dict):
+            if ok_tm:
                 resolved_outcome = adapter.resolve_outcome_from_token_id(
                     market=market, token_id=tid
                 )

--- a/wayfinder_paths/mcp/tools/polymarket.py
+++ b/wayfinder_paths/mcp/tools/polymarket.py
@@ -676,6 +676,7 @@ async def polymarket_place_market_order(
     )
 
     adapter, sender = await _make_polymarket_adapter(wallet_label)
+    resolved_outcome: str | None = None
     try:
         if market_slug:
             if side == "BUY":
@@ -692,8 +693,14 @@ async def polymarket_place_market_order(
                     shares=sizing["adapter_amount"],
                     max_slippage_pct=max_slippage_pct,
                 )
+            resolved_outcome = str(outcome)
         else:
             tid = throw_if_empty_str("token_id or market_slug is required", token_id)
+            ok_tm, market = await adapter.get_market_by_token_id(token_id=tid)
+            if ok_tm and isinstance(market, dict):
+                resolved_outcome = adapter.resolve_outcome_from_token_id(
+                    market=market, token_id=tid
+                )
             ok_trade, res = await adapter.place_market_order(
                 token_id=tid,
                 side=side,
@@ -727,7 +734,7 @@ async def polymarket_place_market_order(
             details={
                 "market_slug": str(market_slug) if market_slug else None,
                 "token_id": str(token_id) if token_id else None,
-                "outcome": str(outcome),
+                "outcome": resolved_outcome,
                 "side": side,
                 "sizing_kind": sizing["sizing_kind"],
                 "buy_amount_pusd": sizing["buy_amount_pusd"],
@@ -744,7 +751,7 @@ async def polymarket_place_market_order(
                 "address": sender,
                 "market_slug": str(market_slug) if market_slug else None,
                 "token_id": str(token_id) if token_id else None,
-                "outcome": str(outcome),
+                "outcome": resolved_outcome,
                 "side": side,
                 "sizing_kind": sizing["sizing_kind"],
                 "buy_amount_pusd": sizing["buy_amount_pusd"],


### PR DESCRIPTION
### Summary

- When the agent placed a market order via `token_id` (no `market_slug`), the response always echoed `outcome="YES"` (the function default) regardless of which token was actually traded — misleading the agent about whether it just bought YES or NO shares
- Added `get_market_by_token_id` adapter method (mirrors `get_market_by_condition_id`, queries Gamma `/markets?clob_token_ids=`) and `resolve_outcome_from_token_id` to map a token_id back to its outcome label
- `polymarket_place_market_order` now resolves the outcome label from the token_id when the token_id path is used, and uses the actual outcome in both the response and the wallet profile annotation