### PR TITLE
Polymarket Relayer - Surface response body in deposit-wallet setup errors

### DIFF
--- a/wayfinder_paths/adapters/polymarket_adapter/adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/adapter.py
@@ -1628,10 +1628,9 @@ class PolymarketAdapter(BaseAdapter):
                 }
                 body = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
                 headers = await self._builder_headers("POST", "/submit", body)
-                # The relayer's owner→deposit-wallet registry can lag a few
-                # seconds after a fresh EOA's first WALLET-CREATE, returning 400
-                # until propagation completes. Re-check on-chain code each iter
-                # so we exit as soon as the wallet exists either way.
+                # WALLET-CREATE has been observed to transient-400 with no
+                # retry in place. Re-check on-chain code each iter so we exit
+                # as soon as the wallet exists if a concurrent post succeeded.
                 retry_deadline = time.monotonic() + 15.0
                 last_error_text: str | None = None
                 while True:

--- a/wayfinder_paths/adapters/polymarket_adapter/adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/adapter.py
@@ -1628,30 +1628,16 @@ class PolymarketAdapter(BaseAdapter):
                 }
                 body = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
                 headers = await self._builder_headers("POST", "/submit", body)
-                # WALLET-CREATE has been observed to transient-400 with no
-                # retry in place. Re-check on-chain code each iter so we exit
-                # as soon as the wallet exists if a concurrent post succeeded.
-                retry_deadline = time.monotonic() + 15.0
-                last_error_text: str | None = None
-                while True:
-                    res = await self._relayer_http.post(
-                        "/submit", content=body, headers=headers
+                res = await self._relayer_http.post(
+                    "/submit", content=body, headers=headers
+                )
+                if not res.is_success:
+                    raise ValueError(
+                        f"Polymarket relayer rejected WALLET-CREATE "
+                        f"(HTTP {res.status_code}): {res.text}"
                     )
-                    if res.is_success:
-                        deploy_tx = await self._poll_relayer_tx(
-                            res.json()["transactionID"]
-                        )
-                        deploy_tx_hash = deploy_tx["transactionHash"]
-                        break
-                    last_error_text = res.text
-                    if await web3.eth.get_code(deposit_wallet):
-                        break
-                    if time.monotonic() >= retry_deadline:
-                        raise ValueError(
-                            f"Polymarket relayer rejected WALLET-CREATE "
-                            f"(HTTP {res.status_code}): {last_error_text}"
-                        )
-                    await asyncio.sleep(0.25)
+                deploy_tx = await self._poll_relayer_tx(res.json()["transactionID"])
+                deploy_tx_hash = deploy_tx["transactionHash"]
 
             calls: list[dict[str, Any]] = []
             for spender, allowance in zip(

--- a/wayfinder_paths/adapters/polymarket_adapter/adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/adapter.py
@@ -1498,7 +1498,10 @@ class PolymarketAdapter(BaseAdapter):
                 or "is not registered" in text
             )
             if not transient:
-                submit_res.raise_for_status()
+                raise ValueError(
+                    f"Polymarket relayer rejected WALLET batch "
+                    f"(HTTP {submit_res.status_code}): {text}"
+                )
             last_error_text = text
             if time.monotonic() >= retry_deadline:
                 break
@@ -1625,12 +1628,31 @@ class PolymarketAdapter(BaseAdapter):
                 }
                 body = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
                 headers = await self._builder_headers("POST", "/submit", body)
-                res = await self._relayer_http.post(
-                    "/submit", content=body, headers=headers
-                )
-                res.raise_for_status()
-                deploy_tx = await self._poll_relayer_tx(res.json()["transactionID"])
-                deploy_tx_hash = deploy_tx["transactionHash"]
+                # The relayer's owner→deposit-wallet registry can lag a few
+                # seconds after a fresh EOA's first WALLET-CREATE, returning 400
+                # until propagation completes. Re-check on-chain code each iter
+                # so we exit as soon as the wallet exists either way.
+                retry_deadline = time.monotonic() + 15.0
+                last_error_text: str | None = None
+                while True:
+                    res = await self._relayer_http.post(
+                        "/submit", content=body, headers=headers
+                    )
+                    if res.is_success:
+                        deploy_tx = await self._poll_relayer_tx(
+                            res.json()["transactionID"]
+                        )
+                        deploy_tx_hash = deploy_tx["transactionHash"]
+                        break
+                    last_error_text = res.text
+                    if await web3.eth.get_code(deposit_wallet):
+                        break
+                    if time.monotonic() >= retry_deadline:
+                        raise ValueError(
+                            f"Polymarket relayer rejected WALLET-CREATE "
+                            f"(HTTP {res.status_code}): {last_error_text}"
+                        )
+                    await asyncio.sleep(0.25)
 
             calls: list[dict[str, Any]] = []
             for spender, allowance in zip(


### PR DESCRIPTION
### Summary

- WALLET-CREATE and the non-transient branch of `_submit_wallet_batch` were calling `raise_for_status()` directly, which produces httpx's default message (`Client error '400 Bad Request' for url 'https://relayer-v2.polymarket.com/submit'`) and drops the response body. That's the message the agent saw when slug-based polymarket orders failed on a fresh EOA, and it gave us no way to diagnose the actual cause.
- Both paths now capture HTTP status + response body in the raised error so future failures surface the relayer's actual message.

Stacks on top of #419.