### PR TITLE
Polymarket - Accept market_slug + outcome on limit orders

### DIFF
--- a/wayfinder_paths/adapters/polymarket_adapter/adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/adapter.py
@@ -665,6 +665,30 @@ class PolymarketAdapter(BaseAdapter):
             max_slippage_pct=max_slippage_pct,
         )
 
+    async def place_limit_prediction(
+        self,
+        *,
+        market_slug: str,
+        outcome: str | int = "YES",
+        side: Literal["BUY", "SELL"],
+        price: float,
+        size: float,
+        post_only: bool = False,
+    ) -> tuple[bool, dict[str, Any] | str]:
+        ok, token_id = await self.resolve_token_id_from_slug(
+            market_slug=market_slug, outcome=outcome
+        )
+        if not ok:
+            return False, token_id
+
+        return await self.place_limit_order(
+            token_id=token_id,
+            side=side,
+            price=price,
+            size=size,
+            post_only=post_only,
+        )
+
     async def get_market_prices_history(
         self,
         *,

--- a/wayfinder_paths/mcp/tools/polymarket.py
+++ b/wayfinder_paths/mcp/tools/polymarket.py
@@ -771,38 +771,62 @@ async def polymarket_place_market_order(
 async def polymarket_place_limit_order(
     *,
     wallet_label: str,
-    token_id: str,
     side: Literal["BUY", "SELL"],
     price: float,
     size: float,
+    market_slug: str | None = None,
+    outcome: str | int = "YES",
+    token_id: str | None = None,
     post_only: bool = False,
 ) -> dict[str, Any]:
-    """Place a Polymarket limit order on a specific CLOB token id.
+    """Place a Polymarket limit order.
 
+    Provide `market_slug`+`outcome` OR `token_id` (mirrors `polymarket_place_market_order`).
     `post_only=True` enforces maker-only — the order is rejected if it would cross.
 
     Args:
         wallet_label: Owner EOA wallet (deposit wallet must already be funded).
-        token_id: CLOB token id (from market.yesTokenId / .noTokenId).
         side: `"BUY"` or `"SELL"`.
         price: Limit price in [0, 1] (probability).
         size: Shares.
+        market_slug: Polymarket market slug; used with `outcome` to resolve token_id.
+        outcome: `"YES"`/`"NO"` or numeric index (default `"YES"`).
+        token_id: Direct CLOB token id; alternative to market_slug + outcome.
         post_only: Reject if order would cross the book.
     """
     wallet_label = throw_if_empty_str("wallet_label is required", wallet_label)
-    tid = throw_if_empty_str("token_id is required", token_id)
+    side = normalize_pm_side(side)
     throw_if_none("price is required", price)
     throw_if_none("size is required", size)
 
     adapter, sender = await _make_polymarket_adapter(wallet_label)
+    resolved_outcome: str | None = None
     try:
-        ok_lo, res = await adapter.place_limit_order(
-            token_id=tid,
-            side=side,
-            price=float(price),
-            size=float(size),
-            post_only=bool(post_only),
-        )
+        if market_slug:
+            ok_lo, res = await adapter.place_limit_prediction(
+                market_slug=str(market_slug),
+                outcome=outcome,
+                side=side,
+                price=float(price),
+                size=float(size),
+                post_only=bool(post_only),
+            )
+            resolved_outcome = str(outcome)
+            tid: str | None = None
+        else:
+            tid = throw_if_empty_str("token_id or market_slug is required", token_id)
+            ok_tm, market = await adapter.get_market_by_token_id(token_id=tid)
+            if ok_tm:
+                resolved_outcome = adapter.resolve_outcome_from_token_id(
+                    market=market, token_id=tid
+                )
+            ok_lo, res = await adapter.place_limit_order(
+                token_id=tid,
+                side=side,
+                price=float(price),
+                size=float(size),
+                post_only=bool(post_only),
+            )
         effects = [
             {
                 "type": "polymarket",
@@ -819,7 +843,9 @@ async def polymarket_place_limit_order(
             status=status,
             chain_id=POLYGON_CHAIN_ID,
             details={
+                "market_slug": str(market_slug) if market_slug else None,
                 "token_id": tid,
+                "outcome": resolved_outcome,
                 "side": side,
                 "price": float(price),
                 "size": float(size),
@@ -831,7 +857,9 @@ async def polymarket_place_limit_order(
                 "status": status,
                 "wallet_label": wallet_label,
                 "address": sender,
+                "market_slug": str(market_slug) if market_slug else None,
                 "token_id": tid,
+                "outcome": resolved_outcome,
                 "side": side,
                 "price": float(price),
                 "size": float(size),


### PR DESCRIPTION
### Summary

- Adds `adapter.place_limit_prediction` — the limit-order analog of `place_prediction` / `cash_out_prediction`. Uses the same `resolve_token_id_from_slug` helper as the market-order pair, so slug→token_id resolution lives in exactly one place
- `polymarket_place_limit_order` MCP tool now accepts `market_slug` + `outcome` (matching `polymarket_place_market_order`); `token_id` remains an optional escape hatch for callers that already have it
- Stacked on #422 (the helper extraction) — merge that first