### PR TITLE
Align SDK research responses with sanitized Exa payloads

### DIFF
--- a/wayfinder_paths/core/clients/research_types.py
+++ b/wayfinder_paths/core/clients/research_types.py
@@ -101,8 +101,6 @@ class ResearchWebSearchUsage(TypedDict):
 class ResearchWebSearchResponse(TypedDict):
     query: ResearchWebSearchQuery
     results: list[ResearchWebSearchResult]
-    provider: ResearchWebSearchProvider
-    usage: ResearchWebSearchUsage
 
 
 class ResearchWebFetchRequest(TypedDict):
@@ -133,8 +131,6 @@ class ResearchWebFetchResponse(TypedDict):
     query: ResearchWebFetchQuery
     results: list[ResearchWebSearchResult]
     statuses: list[dict[str, Any]]
-    provider: ResearchWebSearchProvider
-    usage: ResearchWebSearchUsage
 
 
 class ResearchCryptoSentimentRequest(TypedDict):

--- a/wayfinder_paths/tests/test_mcp_research_gateway.py
+++ b/wayfinder_paths/tests/test_mcp_research_gateway.py
@@ -19,8 +19,6 @@ async def test_core_web_search_converts_gateway_arguments(
                 return_value={
                     "query": {"query": "goldsky subgraph docs", "sessionID": "ses_abc"},
                     "results": [],
-                    "provider": {"name": "exa", "cached": False},
-                    "usage": {"provider": {"name": "exa", "cached": False}},
                 }
             ),
             "fetch": AsyncMock(return_value={"results": [], "statuses": []}),
@@ -43,6 +41,8 @@ async def test_core_web_search_converts_gateway_arguments(
     )
 
     assert result["ok"] is True
+    assert "provider" not in result["result"]
+    assert "usage" not in result["result"]
     fake_client.search.assert_awaited_once_with(
         query="goldsky subgraph docs",
         num_results=3,
@@ -73,8 +73,6 @@ async def test_core_web_search_allows_backend_context_default(
                 return_value={
                     "query": {"query": "defillama api", "sessionID": "mcp"},
                     "results": [],
-                    "provider": {"name": "exa", "cached": False},
-                    "usage": {"provider": {"name": "exa", "cached": False}},
                 }
             ),
             "fetch": AsyncMock(return_value={"results": [], "statuses": []}),
@@ -159,8 +157,6 @@ async def test_core_web_fetch_converts_gateway_arguments(
                     "query": {"urls": ["https://example.com"], "sessionID": "ses_abc"},
                     "results": [],
                     "statuses": [],
-                    "provider": {"name": "exa", "cached": False},
-                    "usage": {"provider": {"name": "exa", "cached": False}},
                 }
             ),
         },
@@ -180,6 +176,8 @@ async def test_core_web_fetch_converts_gateway_arguments(
     )
 
     assert result["ok"] is True
+    assert "provider" not in result["result"]
+    assert "usage" not in result["result"]
     fake_client.fetch.assert_awaited_once_with(
         urls=["https://example.com/a", "https://example.com/b"],
         query="main facts",

--- a/wayfinder_paths/tests/test_research_client.py
+++ b/wayfinder_paths/tests/test_research_client.py
@@ -48,11 +48,6 @@ async def test_search_posts_gateway_payload(monkeypatch: pytest.MonkeyPatch) -> 
                     "contextMaxCharacters": 1500,
                 },
                 "results": [],
-                "provider": {"name": "exa", "requestId": "req_1", "cached": False},
-                "usage": {
-                    "provider": {"name": "exa", "cached": False},
-                    "credits": None,
-                },
             }
         )
     )
@@ -67,6 +62,8 @@ async def test_search_posts_gateway_payload(monkeypatch: pytest.MonkeyPatch) -> 
     )
 
     assert result["query"]["sessionID"] == "ses_123"
+    assert "provider" not in result
+    assert "usage" not in result
     client._authed_request.assert_awaited_once()
     args, kwargs = client._authed_request.await_args
     assert args == ("POST", "https://example.com/api/v1/research/websearch/")
@@ -100,11 +97,6 @@ async def test_search_resolves_session_from_environment(
                     "contextMaxCharacters": None,
                 },
                 "results": [],
-                "provider": {"name": "exa", "requestId": None, "cached": False},
-                "usage": {
-                    "provider": {"name": "exa", "cached": False},
-                    "credits": None,
-                },
             }
         )
     )
@@ -163,11 +155,6 @@ async def test_fetch_posts_gateway_payload(monkeypatch: pytest.MonkeyPatch) -> N
                 },
                 "results": [],
                 "statuses": [],
-                "provider": {"name": "exa", "requestId": "req_1", "cached": False},
-                "usage": {
-                    "provider": {"name": "exa", "cached": False},
-                    "credits": None,
-                },
             }
         )
     )
@@ -185,6 +172,8 @@ async def test_fetch_posts_gateway_payload(monkeypatch: pytest.MonkeyPatch) -> N
     )
 
     assert result["query"]["sessionID"] == "ses_123"
+    assert "provider" not in result
+    assert "usage" not in result
     args, kwargs = client._authed_request.await_args
     assert args == ("POST", "https://example.com/api/v1/research/webfetch/")
     assert kwargs["json"] == {


### PR DESCRIPTION
## Summary
- update SDK research response types to match sanitized Exa websearch/webfetch payloads
- update MCP/client tests so provider, request, usage, and credit metadata are not expected

## Validation
- `.venv/bin/python -m ruff check wayfinder_paths/core/clients/research_types.py wayfinder_paths/tests/test_research_client.py wayfinder_paths/tests/test_mcp_research_gateway.py`
- `.venv/bin/python -m ruff format --check wayfinder_paths/core/clients/research_types.py wayfinder_paths/tests/test_research_client.py wayfinder_paths/tests/test_mcp_research_gateway.py`
- `.venv/bin/python -m pytest -o addopts= wayfinder_paths/tests/test_research_client.py wayfinder_paths/tests/test_mcp_research_gateway.py`
- `git diff --check`