### PR TITLE
Add paladin_trust adapter — pre-trade token trust gate

### DIFF
--- a/examples/paladin_trust_demo.py
+++ b/examples/paladin_trust_demo.py
@@ -1,0 +1,71 @@
+"""Demo: screen real Base tokens an agent would route a swap into.
+
+Run it as-is to exercise the free OFAC screen:
+
+    python examples/paladin_trust_demo.py
+
+Set PALADIN_DEMO_PRIVATE_KEY (a funded Base wallet) to also exercise the
+x402-paid full trust composition (~$0.001 USDC per token):
+
+    PALADIN_DEMO_PRIVATE_KEY=0x... python examples/paladin_trust_demo.py
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+
+from wayfinder_paths.adapters.paladin_trust_adapter.adapter import PaladinTrustAdapter
+
+# Real Base (chainId 8453) tokens. AERO/WELL/cbBTC are legit tokens the SDK's
+# own adapters route into; NORMIE is a real token GoPlus flags as a honeypot.
+TOKENS = {
+    "AERO (Aerodrome)": "0x940181a94A35A4569E4529A3CDfB74e38FD98631",
+    "WELL (Moonwell)": "0xA88594D404727625A9437C3f886C7643872296AE",
+    "cbBTC": "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf",
+    "NORMIE (honeypot)": "0x7F12d13B34F5F4f0a9449c16Bcd42f0da47AF200",
+}
+# A live OFAC SDN-listed address (real entry on the U.S. Treasury list).
+SANCTIONED_ADDRESS = "0x0330070fd38ec3bb94f58fa55d40368271e9e54a"
+CLEAN_WALLET = "0xeA8C33d018760D034384e92D1B2a7cf0338834b4"
+
+
+def _line(label: str, ok: bool, result: object) -> str:
+    if not ok:
+        return f"  {label:<22} ERROR: {result}"
+    trust = result["trust"] if isinstance(result, dict) else {}
+    rec = trust.get("recommendation", "?")
+    signals = ", ".join(
+        f"{f.get('source')}:{f.get('signal')}" for f in trust.get("factors", [])
+    )
+    return f"  {label:<22} {rec.upper():<6} [{signals}]"
+
+
+async def main() -> None:
+    config = {}
+    private_key = os.environ.get("PALADIN_DEMO_PRIVATE_KEY")
+    if private_key:
+        config["private_key"] = private_key
+    adapter = PaladinTrustAdapter(config)
+
+    print("Free OFAC wallet screen (no payment):")
+    ok, res = await adapter.screen_wallet_ofac(CLEAN_WALLET)
+    print(_line("clean wallet", ok, res))
+    ok, res = await adapter.screen_wallet_ofac(SANCTIONED_ADDRESS)
+    print(_line("OFAC SDN address", ok, res))
+
+    if not adapter.can_pay:
+        print(
+            "\nFull trust composition (check_token) skipped — set "
+            "PALADIN_DEMO_PRIVATE_KEY to a funded Base wallet to run the "
+            "x402-paid screen on the tokens below."
+        )
+        return
+
+    print("\nFull trust composition via x402-paid check_token ($0.001/token):")
+    for label, address in TOKENS.items():
+        ok, res = await adapter.check_token(address, chain_id=8453)
+        print(_line(label, ok, res))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/wayfinder_paths/adapters/paladin_trust_adapter/README.md
+++ b/wayfinder_paths/adapters/paladin_trust_adapter/README.md
@@ -1,0 +1,113 @@
+# Paladin Trust Adapter
+
+Pre-trade token trust gate — a **"trust-check before swap"** companion to the
+SDK's *quote-before-swap* pattern. Screens a token contract for honeypot, rug,
+scam, unverified-source and sanction risk before an agent routes a swap into it.
+
+- **Type**: `TRUST`
+- **Module**: `wayfinder_paths.adapters.paladin_trust_adapter.adapter.PaladinTrustAdapter`
+
+## Overview
+
+The adapter calls [PaladinFi](https://paladinfi.com)'s trust API on Base
+(chainId 8453) and returns a single `allow` / `warn` / `block` recommendation
+plus the contributing factors. The verdict composes four signal sources:
+
+- **GoPlus** token security (honeypot, hidden owner, reversible renounce, DEX liquidity, trust list)
+- **Etherscan** source verification (verified vs unverified contracts, proxy detection)
+- **PaladinFi anomaly** heuristics (contract age, no-outbound-history flags)
+- **OFAC SDN** screening (refreshed daily from the U.S. Treasury XML feed)
+
+PaladinFi is non-custodial — it never holds funds or signs swaps. The adapter
+only reads a risk verdict; the agent keeps full control of execution.
+
+## Two tiers
+
+| Method | Endpoint | Cost | Signer |
+|---|---|---|---|
+| `check_token` | `POST /v1/trust-check` | x402-paid, $0.001 USDC/call on Base | required |
+| `screen_wallet_ofac` | `POST /v1/trust-check/ofac` | free | none |
+
+`check_token` runs the full composition and is the pre-swap gate.
+`screen_wallet_ofac` is a free OFAC-only screen, useful for vetting a
+recipient/taker wallet without a payment.
+
+### Verdicts
+
+`result["trust"]["recommendation"]` is one of:
+
+- `block` — do not proceed (OFAC SDN hit, or a high-severity GoPlus flag).
+- `warn` — proceed only with explicit handling (e.g. a GoPlus honeypot flag, an
+  unverified contract, or — for the free OFAC screen — a transiently unreachable
+  SDN source, per the API's fail-closed contract).
+- `allow` — no risk factor fired.
+
+`result["trust"]["factors"]` lists the contributing `{source, signal, details}`
+so the agent can log or branch on the specific reason.
+
+## Usage
+
+```python
+from wayfinder_paths.adapters.paladin_trust_adapter.adapter import PaladinTrustAdapter
+
+# Paid full check needs a signer (eth-account LocalAccount or a hex key).
+adapter = PaladinTrustAdapter({"private_key": "0x..."})
+
+success, result = await adapter.check_token(
+    "0x940181a94A35A4569E4529A3CDfB74e38FD98631",  # AERO on Base
+    chain_id=8453,
+)
+if success and result["trust"]["recommendation"] == "block":
+    raise RuntimeError(f"trust gate blocked token: {result['trust']['factors']}")
+```
+
+## Methods
+
+### check_token
+
+Full trust composition for a token contract (x402-paid). Requires a signer in
+config to authorize the $0.001 USDC micropayment.
+
+```python
+success, result = await adapter.check_token(token_address, chain_id=8453)
+# result["trust"]["recommendation"] in {"allow", "warn", "block"}
+# result["trust"]["factors"] -> list of {source, signal, details}
+```
+
+If no signer is configured, returns `(False, "<reason>")` and you should fall
+back to `screen_wallet_ofac` or configure a signer.
+
+### screen_wallet_ofac
+
+Free OFAC SDN screen for any wallet or contract address. No payment, no signer.
+
+```python
+success, result = await adapter.screen_wallet_ofac(address, chain_id=8453)
+# result["trust"]["recommendation"] in {"allow", "block"}
+```
+
+## Payment (x402)
+
+`check_token` pays per call over [x402](https://x402.org): on the `402` response
+it signs an EIP-3009 `transferWithAuthorization` for USDC on Base with the
+configured signer and retries. The signing is assembled with `eth-account`
+(already an SDK dependency) — **no additional package is required**.
+
+## Configuration
+
+| Key | Default | Notes |
+|---|---|---|
+| `signer` | `None` | eth-account `LocalAccount` for the x402 micropayment |
+| `private_key` | `None` | hex key used to build a signer if `signer` is absent |
+| `base_url` | `https://swap.paladinfi.com` | API host |
+| `timeout` | `30` | per-request timeout (seconds) |
+
+## Dependencies
+
+- `httpx`, `eth-account` — both already in `wayfinder-paths`. No new dependency.
+
+## Testing
+
+```bash
+poetry run pytest wayfinder_paths/adapters/paladin_trust_adapter/ -v
+```

--- a/wayfinder_paths/adapters/paladin_trust_adapter/__init__.py
+++ b/wayfinder_paths/adapters/paladin_trust_adapter/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import PaladinTrustAdapter
+
+__all__ = ["PaladinTrustAdapter"]

--- a/wayfinder_paths/adapters/paladin_trust_adapter/adapter.py
+++ b/wayfinder_paths/adapters/paladin_trust_adapter/adapter.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import base64
+import json
+import os
+import time
+from typing import Any
+
+import httpx
+from eth_account import Account
+from eth_account.signers.local import LocalAccount
+
+from wayfinder_paths.core.adapters.BaseAdapter import BaseAdapter
+
+DEFAULT_BASE_URL = "https://swap.paladinfi.com"
+BASE_CHAIN_ID = 8453  # Base mainnet — the only chain PaladinFi screens today
+DEFAULT_TIMEOUT_SECONDS = 30.0
+HTTP_PAYMENT_REQUIRED = 402
+
+# x402 "exact" EVM scheme wire format, verified against a live 402 from
+# swap.paladinfi.com. The server returns a base64 `payment-required` header
+# whose `accepts[]` carries payTo / amount / asset / extra{name,version}; the
+# client replies with a base64 `payment-signature` header carrying a signed
+# EIP-3009 TransferWithAuthorization. We assemble and sign it directly with
+# eth-account (already a wayfinder-paths dependency) so this adapter needs no
+# additional package.
+PAYMENT_REQUIRED_HEADER = "payment-required"
+PAYMENT_SIGNATURE_HEADER = "payment-signature"
+TRANSFER_WITH_AUTHORIZATION_TYPES: dict[str, list[dict[str, str]]] = {
+    "TransferWithAuthorization": [
+        {"name": "from", "type": "address"},
+        {"name": "to", "type": "address"},
+        {"name": "value", "type": "uint256"},
+        {"name": "validAfter", "type": "uint256"},
+        {"name": "validBefore", "type": "uint256"},
+        {"name": "nonce", "type": "bytes32"},
+    ]
+}
+# valid_after is backdated to tolerate client/server clock skew (x402 default).
+VALIDITY_BACKDATE_SECONDS = 600
+# Refuse to sign a payment authorization larger than this (USDC atomic units,
+# 6 decimals). The trust-check fee is ~1000 (=$0.001); this caps the blast
+# radius if a server/MITM advertises an inflated `amount`. Override via config.
+DEFAULT_MAX_FEE_ATOMIC = 100_000  # $0.10
+
+
+class PaladinTrustAdapter(BaseAdapter):
+    """Pre-trade token trust gate — a "trust-check before swap" companion.
+
+    Screens a token contract for honeypot / rug / scam / unverified-source and
+    sanction risk before an agent routes a swap into it, mirroring PaladinFi's
+    production trust composition (GoPlus token security + Etherscan source
+    verification + anomaly heuristics + OFAC SDN) as a single allow/warn/block
+    recommendation with the contributing factors.
+
+    Two tiers:
+      * ``check_token`` — full composition via the x402-paid /v1/trust-check
+        endpoint ($0.001 USDC/call, EIP-3009 on Base). Needs a signer.
+      * ``screen_wallet_ofac`` — free OFAC SDN screen via /v1/trust-check/ofac.
+        No payment, no signer.
+
+    Config keys (all optional):
+      * ``signer`` — an eth-account ``LocalAccount`` used to authorize the
+        x402 micropayment, or ``private_key`` (hex) to build one.
+      * ``base_url`` — defaults to https://swap.paladinfi.com.
+      * ``timeout`` — per-request timeout in seconds (default 30).
+    """
+
+    adapter_type: str = "TRUST"
+
+    def __init__(self, config: dict[str, Any] | None = None):
+        super().__init__("paladin_trust_adapter", config)
+        self.base_url = str(self.config.get("base_url", DEFAULT_BASE_URL)).rstrip("/")
+        self.timeout = float(self.config.get("timeout", DEFAULT_TIMEOUT_SECONDS))
+        self.max_fee_atomic = int(self.config.get("max_fee_atomic", DEFAULT_MAX_FEE_ATOMIC))
+        self._signer = self._resolve_signer(self.config)
+
+    @property
+    def can_pay(self) -> bool:
+        """Whether a signer is configured for the x402-paid check_token call."""
+        return self._signer is not None
+
+    @staticmethod
+    def _resolve_signer(config: dict[str, Any]) -> LocalAccount | None:
+        signer = config.get("signer")
+        if signer is not None:
+            return signer
+        private_key = config.get("private_key")
+        if private_key:
+            return Account.from_key(private_key)
+        return None
+
+    async def check_token(
+        self, token_address: str, *, chain_id: int = BASE_CHAIN_ID
+    ) -> tuple[bool, dict[str, Any] | str]:
+        """Full trust composition for a token contract via x402-paid trust-check.
+
+        On success returns ``(True, response)`` where
+        ``response["trust"]["recommendation"]`` is one of ``allow`` / ``warn`` /
+        ``block`` — the gate an agent checks before routing a swap into
+        ``token_address``.
+        """
+        if self._signer is None:
+            return False, (
+                "check_token requires a signer (config['signer'] or "
+                "config['private_key']) to pay the x402 trust-check fee; "
+                "use screen_wallet_ofac for the free OFAC-only screen"
+            )
+        return await self._post_x402(
+            "/v1/trust-check", {"address": token_address, "chainId": int(chain_id)}
+        )
+
+    async def screen_wallet_ofac(
+        self, address: str, *, chain_id: int = BASE_CHAIN_ID
+    ) -> tuple[bool, dict[str, Any] | str]:
+        """Free OFAC SDN screen for a wallet or contract address (no payment).
+
+        ``result["trust"]["recommendation"]`` is ``allow`` or ``block``; treat a
+        ``warn`` (returned if the SDN source is transiently unreachable, per the
+        API's fail-closed contract) as not-cleared.
+        """
+        body = {"address": address, "chainId": int(chain_id)}
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                resp = await client.post(
+                    f"{self.base_url}/v1/trust-check/ofac", json=body
+                )
+                resp.raise_for_status()
+                return True, resp.json()
+        except Exception as exc:  # noqa: BLE001
+            self.logger.error(f"OFAC screen failed for {address}: {exc}")
+            return False, str(exc)
+
+    async def _post_x402(
+        self, path: str, body: dict[str, Any]
+    ) -> tuple[bool, dict[str, Any] | str]:
+        url = f"{self.base_url}{path}"
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                resp = await client.post(url, json=body)
+                if resp.status_code == HTTP_PAYMENT_REQUIRED:
+                    payment_header = self._build_payment_header(resp.headers)
+                    resp = await client.post(
+                        url, json=body, headers={PAYMENT_SIGNATURE_HEADER: payment_header}
+                    )
+                resp.raise_for_status()
+                return True, resp.json()
+        except Exception as exc:  # noqa: BLE001
+            self.logger.error(f"paid trust-check failed for {body}: {exc}")
+            return False, str(exc)
+
+    def _build_payment_header(self, response_headers: Any) -> str:
+        """Construct the base64 x402 `payment-signature` header from a 402."""
+        required_b64 = response_headers.get(PAYMENT_REQUIRED_HEADER)
+        if not required_b64:
+            raise ValueError("402 response is missing the payment-required header")
+        required = json.loads(base64.b64decode(required_b64))
+        option = self._select_payment_option(required["accepts"])
+        authorization = self._build_authorization(option)
+        signature = self._sign_authorization(authorization, option)
+        payload: dict[str, Any] = {
+            "x402Version": required.get("x402Version", 2),
+            "payload": {"authorization": authorization, "signature": signature},
+            "accepted": option,
+            "resource": required.get("resource"),
+        }
+        # Echo server-advertised extensions (e.g. bazaar discovery metadata)
+        # unchanged, matching the x402 reference client. They are not part of
+        # the signed EIP-3009 authorization.
+        extensions = required.get("extensions")
+        if extensions is not None:
+            payload["extensions"] = extensions
+        encoded = json.dumps(payload, separators=(",", ":")).encode()
+        return base64.b64encode(encoded).decode()
+
+    @staticmethod
+    def _select_payment_option(accepts: list[dict[str, Any]]) -> dict[str, Any]:
+        target_network = f"eip155:{BASE_CHAIN_ID}"
+        for option in accepts:
+            if option.get("scheme") == "exact" and option.get("network") == target_network:
+                return option
+        raise ValueError(f"no exact {target_network} payment option offered: {accepts}")
+
+    def _build_authorization(self, option: dict[str, Any]) -> dict[str, str]:
+        signer = self._require_signer()
+        amount = int(option["amount"])
+        if amount > self.max_fee_atomic:
+            raise ValueError(
+                f"refusing to authorize {amount} (> max_fee_atomic "
+                f"{self.max_fee_atomic}); the trust-check fee should be ~1000"
+            )
+        now = int(time.time())
+        return {
+            "from": signer.address,
+            "to": option["payTo"],
+            "value": str(amount),
+            "validAfter": str(now - VALIDITY_BACKDATE_SECONDS),
+            "validBefore": str(now + int(option.get("maxTimeoutSeconds", 300))),
+            "nonce": "0x" + os.urandom(32).hex(),
+        }
+
+    def _sign_authorization(
+        self, authorization: dict[str, str], option: dict[str, Any]
+    ) -> str:
+        signer = self._require_signer()
+        extra = option.get("extra") or {}
+        domain = {
+            "name": extra.get("name", "USD Coin"),
+            "version": extra.get("version", "2"),
+            "chainId": int(str(option["network"]).split(":")[1]),
+            "verifyingContract": option["asset"],
+        }
+        message = {
+            "from": authorization["from"],
+            "to": authorization["to"],
+            "value": int(authorization["value"]),
+            "validAfter": int(authorization["validAfter"]),
+            "validBefore": int(authorization["validBefore"]),
+            "nonce": bytes.fromhex(authorization["nonce"].removeprefix("0x")),
+        }
+        signed = Account.sign_typed_data(
+            signer.key, domain, TRANSFER_WITH_AUTHORIZATION_TYPES, message
+        )
+        return "0x" + signed.signature.hex().removeprefix("0x")
+
+    def _require_signer(self) -> LocalAccount:
+        if self._signer is None:
+            raise ValueError("signer is not configured")
+        return self._signer

--- a/wayfinder_paths/adapters/paladin_trust_adapter/examples.json
+++ b/wayfinder_paths/adapters/paladin_trust_adapter/examples.json
@@ -1,0 +1,14 @@
+{
+  "trust_check_before_swap": {
+    "description": "Gate a swap on a full token trust check (paid x402 call). recommendation is allow/warn/block.",
+    "code": "from wayfinder_paths.adapters.paladin_trust_adapter.adapter import PaladinTrustAdapter\n\n# A signer is required for the paid full-composition check. Pass an eth-account\n# LocalAccount via config['signer'], or a hex key via config['private_key'].\nadapter = PaladinTrustAdapter({\"private_key\": \"0x...\"})\n\n# Before routing a swap into `to_token`, check it.\nsuccess, result = await adapter.check_token(\n    \"0x940181a94A35A4569E4529A3CDfB74e38FD98631\",  # AERO\n    chain_id=8453,\n)\nif success:\n    trust = result[\"trust\"]\n    if trust[\"recommendation\"] == \"block\":\n        raise RuntimeError(f\"trust gate blocked token: {trust['factors']}\")\n    if trust[\"recommendation\"] == \"warn\":\n        print(f\"proceed with caution: {trust['factors']}\")\nelse:\n    print(f\"trust check failed: {result}\")"
+  },
+  "free_ofac_screen": {
+    "description": "Free OFAC SDN screen for a wallet or contract address. No signer, no payment.",
+    "code": "from wayfinder_paths.adapters.paladin_trust_adapter.adapter import PaladinTrustAdapter\n\n# No config needed for the free OFAC-only screen.\nadapter = PaladinTrustAdapter()\n\nsuccess, result = await adapter.screen_wallet_ofac(\n    \"0xeA8C33d018760D034384e92D1B2a7cf0338834b4\",\n    chain_id=8453,\n)\nif success:\n    print(f\"OFAC recommendation: {result['trust']['recommendation']}\")\nelse:\n    print(f\"OFAC screen failed: {result}\")"
+  },
+  "screen_swap_recipient": {
+    "description": "Screen the recipient/taker wallet for sanctions before executing a swap (free).",
+    "code": "from wayfinder_paths.adapters.paladin_trust_adapter.adapter import PaladinTrustAdapter\n\nadapter = PaladinTrustAdapter()\n\nsuccess, result = await adapter.screen_wallet_ofac(recipient_address, chain_id=8453)\nif success and result[\"trust\"][\"recommendation\"] == \"block\":\n    raise RuntimeError(\"recipient is OFAC-sanctioned; aborting swap\")"
+  }
+}

--- a/wayfinder_paths/adapters/paladin_trust_adapter/manifest.yaml
+++ b/wayfinder_paths/adapters/paladin_trust_adapter/manifest.yaml
@@ -1,0 +1,6 @@
+schema_version: "0.1"
+entrypoint: "wayfinder_paths.adapters.paladin_trust_adapter.adapter.PaladinTrustAdapter"
+capabilities:
+  - "trust.check"
+  - "trust.screen"
+dependencies: []

--- a/wayfinder_paths/adapters/paladin_trust_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/paladin_trust_adapter/test_adapter.py
@@ -1,0 +1,231 @@
+import base64
+import json
+from unittest.mock import patch
+
+import pytest
+from eth_account import Account
+from eth_account.messages import encode_typed_data
+
+from wayfinder_paths.adapters.paladin_trust_adapter.adapter import (
+    PaladinTrustAdapter,
+    TRANSFER_WITH_AUTHORIZATION_TYPES,
+)
+
+# Deterministic throwaway key — used only to exercise signing in tests.
+TEST_PRIVATE_KEY = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+TEST_ADDRESS = Account.from_key(TEST_PRIVATE_KEY).address
+USDC_BASE = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+TREASURY = "0xeA8C33d018760D034384e92D1B2a7cf0338834b4"
+
+PAYMENT_REQUIRED = {
+    "x402Version": 2,
+    "error": "Payment required",
+    "resource": {
+        "url": "https://swap.paladinfi.com/v1/trust-check",
+        "description": "PaladinFi Trust Check",
+        "mimeType": "application/json",
+    },
+    "accepts": [
+        {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "asset": USDC_BASE,
+            "amount": "1000",
+            "payTo": TREASURY,
+            "maxTimeoutSeconds": 300,
+            "extra": {"name": "USD Coin", "version": "2"},
+        }
+    ],
+}
+PAYMENT_REQUIRED_HEADER_B64 = base64.b64encode(
+    json.dumps(PAYMENT_REQUIRED).encode()
+).decode()
+
+TRUST_OK = {
+    "address": USDC_BASE,
+    "chainId": 8453,
+    "trust": {
+        "risk_score": 0,
+        "recommendation": "allow",
+        "factors": [{"source": "ofac", "signal": "not_listed", "details": ""}],
+        "version": "1.1",
+    },
+}
+OFAC_OK = {
+    "address": TREASURY,
+    "chainId": 8453,
+    "trust": {
+        "recommendation": "allow",
+        "factors": [{"source": "ofac", "signal": "not_listed", "details": ""}],
+        "version": "1.1",
+        "_real": True,
+    },
+}
+
+
+class _FakeResponse:
+    def __init__(self, status_code, json_body=None, headers=None):
+        self.status_code = status_code
+        self._json = json_body or {}
+        self.headers = headers or {}
+
+    def raise_for_status(self):
+        if self.status_code >= 400 and self.status_code != 402:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._json
+
+
+class _FakeAsyncClient:
+    """Stands in for httpx.AsyncClient; returns queued responses per post()."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls: list[dict] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def post(self, url, json=None, headers=None):
+        self.calls.append({"url": url, "json": json, "headers": headers})
+        return self._responses.pop(0)
+
+
+def _patch_client(responses):
+    return patch(
+        "wayfinder_paths.adapters.paladin_trust_adapter.adapter.httpx.AsyncClient",
+        return_value=_FakeAsyncClient(responses),
+    )
+
+
+class TestPaladinTrustAdapter:
+    @pytest.fixture
+    def adapter(self):
+        return PaladinTrustAdapter({"private_key": TEST_PRIVATE_KEY})
+
+    def test_init(self):
+        adapter = PaladinTrustAdapter()
+        assert adapter.adapter_type == "TRUST"
+        assert adapter.name == "paladin_trust_adapter"
+        assert adapter._signer is None
+
+    def test_init_builds_signer_from_private_key(self, adapter):
+        assert adapter._signer is not None
+        assert adapter._signer.address == TEST_ADDRESS
+
+    @pytest.mark.asyncio
+    async def test_check_token_requires_signer(self):
+        adapter = PaladinTrustAdapter()
+        success, result = await adapter.check_token(USDC_BASE, chain_id=8453)
+        assert success is False
+        assert "signer" in result
+
+    @pytest.mark.asyncio
+    async def test_screen_wallet_ofac_success(self):
+        adapter = PaladinTrustAdapter()
+        with _patch_client([_FakeResponse(200, OFAC_OK)]):
+            success, result = await adapter.screen_wallet_ofac(TREASURY, chain_id=8453)
+        assert success
+        assert result["trust"]["recommendation"] == "allow"
+
+    @pytest.mark.asyncio
+    async def test_screen_wallet_ofac_error(self):
+        adapter = PaladinTrustAdapter()
+        with _patch_client([_FakeResponse(500)]):
+            success, result = await adapter.screen_wallet_ofac(TREASURY)
+        assert success is False
+        assert "500" in result
+
+    @pytest.mark.asyncio
+    async def test_check_token_pays_402_then_succeeds(self, adapter):
+        responses = [
+            _FakeResponse(402, headers={"payment-required": PAYMENT_REQUIRED_HEADER_B64}),
+            _FakeResponse(200, TRUST_OK),
+        ]
+        fake = _FakeAsyncClient(responses)
+        with patch(
+            "wayfinder_paths.adapters.paladin_trust_adapter.adapter.httpx.AsyncClient",
+            return_value=fake,
+        ):
+            success, result = await adapter.check_token(USDC_BASE, chain_id=8453)
+        assert success
+        assert result["trust"]["recommendation"] == "allow"
+        # second call must carry the payment-signature header
+        assert fake.calls[1]["headers"] is not None
+        assert "payment-signature" in fake.calls[1]["headers"]
+
+    def test_payment_header_signature_recovers_to_signer(self, adapter):
+        header_b64 = adapter._build_payment_header(
+            {"payment-required": PAYMENT_REQUIRED_HEADER_B64}
+        )
+        decoded = json.loads(base64.b64decode(header_b64))
+        auth = decoded["payload"]["authorization"]
+        signature = decoded["payload"]["signature"]
+
+        domain = {
+            "name": "USD Coin",
+            "version": "2",
+            "chainId": 8453,
+            "verifyingContract": USDC_BASE,
+        }
+        message = {
+            "from": auth["from"],
+            "to": auth["to"],
+            "value": int(auth["value"]),
+            "validAfter": int(auth["validAfter"]),
+            "validBefore": int(auth["validBefore"]),
+            "nonce": bytes.fromhex(auth["nonce"].removeprefix("0x")),
+        }
+        signable = encode_typed_data(
+            domain_data=domain,
+            message_types=TRANSFER_WITH_AUTHORIZATION_TYPES,
+            message_data=message,
+        )
+        recovered = Account.recover_message(signable, signature=bytes.fromhex(signature.removeprefix("0x")))
+        assert recovered == TEST_ADDRESS
+
+    def test_payment_header_structure(self, adapter):
+        header_b64 = adapter._build_payment_header(
+            {"payment-required": PAYMENT_REQUIRED_HEADER_B64}
+        )
+        decoded = json.loads(base64.b64decode(header_b64))
+        assert decoded["x402Version"] == 2
+        assert decoded["accepted"]["payTo"] == TREASURY
+        assert decoded["accepted"]["amount"] == "1000"
+        auth = decoded["payload"]["authorization"]
+        assert auth["from"] == TEST_ADDRESS
+        assert auth["to"] == TREASURY
+        assert auth["value"] == "1000"
+        assert auth["nonce"].startswith("0x") and len(auth["nonce"]) == 66
+        assert int(auth["validBefore"]) > int(auth["validAfter"])
+
+    def test_build_payment_header_missing_header_raises(self, adapter):
+        with pytest.raises(ValueError, match="payment-required"):
+            adapter._build_payment_header({})
+
+    def test_can_pay(self):
+        assert PaladinTrustAdapter().can_pay is False
+        assert PaladinTrustAdapter({"private_key": TEST_PRIVATE_KEY}).can_pay is True
+
+    def test_select_payment_option_no_match_raises(self, adapter):
+        with pytest.raises(ValueError, match="no exact"):
+            adapter._select_payment_option([{"scheme": "exact", "network": "eip155:1"}])
+
+    def test_validity_window_bounds(self, adapter):
+        header = adapter._build_payment_header(
+            {"payment-required": PAYMENT_REQUIRED_HEADER_B64}
+        )
+        auth = json.loads(base64.b64decode(header))["payload"]["authorization"]
+        # backdate 600s + maxTimeoutSeconds (300 in the fixture) => 900s window
+        assert int(auth["validBefore"]) - int(auth["validAfter"]) == 900
+
+    def test_refuses_oversized_payment(self, adapter):
+        required = dict(PAYMENT_REQUIRED)
+        required["accepts"] = [dict(PAYMENT_REQUIRED["accepts"][0], amount="999999999")]
+        header_b64 = base64.b64encode(json.dumps(required).encode()).decode()
+        with pytest.raises(ValueError, match="max_fee_atomic"):
+            adapter._build_payment_header({"payment-required": header_b64})


### PR DESCRIPTION
## Add `paladin_trust` adapter — pre-trade token trust gate

This adds a `TRUST`-type adapter that screens a token for honeypot / rug /
hidden-owner / unverified-source risk **before** an agent routes a swap into it,
returning a single `allow` / `warn` / `block` recommendation plus the
contributing factors.

### Why

The SDK's safety model around swaps is execution-side — quote-before-swap, tx
simulation, human-confirm. There's no signal on *whether the token itself is
safe to acquire*. An agent executing arbitrary ERC-20 swaps can route into a
honeypot or a freshly-deployed rug and the simulation still "succeeds." This
adapter is the **trust-check-before-swap** companion to the existing
quote-before-swap step: `check_token(to_token, chain_id=8453)` before routing in.

### It catches what simulation doesn't

`check_token` on real Base tokens (live, reproducible — see `DEMO_RUN.md`):

| token (Base) | verdict | factors |
|---|---|---|
| **NORMIE** | **`warn`** | ofac:not_listed · anomaly:contract · **goplus:is_honeypot** · etherscan:verified |
| AERO | `allow` | ofac:not_listed · anomaly:contract · etherscan:verified |
| WELL | `allow` | ofac:not_listed · anomaly:contract · etherscan:verified+proxy |
| cbBTC | `allow` | ofac:not_listed · anomaly:contract · goplus:trust_list · etherscan:verified+proxy |

NORMIE is a verified, un-sanctioned contract — OFAC and source-verification
checks wave it through — but GoPlus flags it as a honeypot, so `check_token`
returns `warn`. That's the gap this closes. *(Verdicts above are read via the
free `/v1/quote` trust embed, which composes the same sources `check_token`
returns over the paid endpoint, so they reproduce without a payment.)*

### What it does

Calls [PaladinFi](https://paladinfi.com)'s trust API on Base (chainId 8453),
composing four signal sources into one verdict:

- **GoPlus** token security — honeypot, hidden owner, reversible renounce, DEX liquidity, trust list
- **Etherscan** source verification — verified vs unverified, proxy detection
- **PaladinFi anomaly** heuristics — contract age, no-outbound-history
- **OFAC SDN** screening — refreshed daily from the U.S. Treasury feed

`recommendation` is `block` on an OFAC hit or a high-severity GoPlus flag, `warn`
on a softer risk (honeypot flag, unverified source), else `allow`. The output is
a risk *recommendation* with its factors — not a guarantee.

Two tiers:

| method | endpoint | cost | signer |
|---|---|---|---|
| `check_token` | `/v1/trust-check` | x402-paid, ~$0.001 USDC/call on Base | required |
| `screen_wallet_ofac` | `/v1/trust-check/ofac` | free | none |

### For SDK maintainers

- The adapter is fully functional in **free mode** (`screen_wallet_ofac`) with no
  signer and no payment. The default install costs nobody anything.
- The paid `check_token` path is **opt-in per user**: the caller supplies their
  own signer/key and pays ~$0.001/call from their own wallet. The SDK / the
  Foundation takes on no cost, no custody, and no API-key management.
- Health/liveness is at `swap.paladinfi.com/health`. Operated by Malcontent
  Games LLC dba PaladinFi (no SLA implied).

### Drop-in

- Adds only files under `wayfinder_paths/adapters/paladin_trust_adapter/` plus one example.
- **No new dependency** — the x402 payment is signed with `eth-account` (already in the SDK). In our cross-check the signed payload matched the reference `x402` SDK client byte-for-byte for the same `402` and key.
- Matches the adapter contract: `BaseAdapter`, async `(success, data | error)` returns, `manifest.yaml`, `examples.json`, README, and `test_adapter.py` (mocked HTTP; `pytest` green, `mypy` clean).

### Non-custodial

PaladinFi never holds funds or signs swaps on your behalf. The only signature the
adapter produces is an EIP-3009 USDC payment authorization for the ~$0.001
paid-tier fee (the free OFAC screen signs nothing); the agent keeps full control
of swap execution.

### Notes

Happy to adjust scope, naming, the `capabilities` taxonomy, or split the
free/paid methods differently if that fits the SDK's conventions better.