### PR TITLE
Hyperliquid triggers - allow non-reduce-only via optional flag

### DIFF
--- a/.claude/skills/using-hyperliquid-adapter/rules/execution-opportunities.md
+++ b/.claude/skills/using-hyperliquid-adapter/rules/execution-opportunities.md
@@ -18,11 +18,11 @@ Orders below this threshold will be rejected by Hyperliquid.
 Orders:
 - `place_market_order(asset_id, is_buy, slippage, size, address, reduce_only=False, cloid=None, builder=None)`
 - `place_limit_order(asset_id, is_buy, price, size, address, reduce_only=False, builder=None)`
-- `place_trigger_order(asset_id, is_buy, trigger_price, size, address, tpsl, is_market=True, limit_price=None)`
+- `place_trigger_order(asset_id, is_buy, trigger_price, size, address, tpsl, is_market=True, limit_price=None, reduce_only=True)`
   - `tpsl="sl"` → stop-loss; `tpsl="tp"` → take-profit
   - `is_market=True` (default): fires a market order when the trigger price is hit
   - `is_market=False`: fires a limit order at `limit_price` when triggered (requires `limit_price`)
-  - Always `reduce_only=True` — closes an existing position, never opens a new one
+  - `reduce_only=True` (default): closes an existing position, never opens one. Set `False` for opening/scaling triggers (e.g. a stop-entry that adds exposure on touch)
 - `place_stop_loss(asset_id, is_buy, trigger_price, size, address)` — convenience wrapper for `place_trigger_order(..., tpsl="sl", is_market=True)`
 - `cancel_order(asset_id, order_id, address)`
 - `cancel_order_by_cloid(asset_id, cloid, address)`

--- a/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
+++ b/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
@@ -1279,6 +1279,7 @@ class HyperliquidAdapter(BaseAdapter):
         is_market: bool = True,
         limit_price: float | None = None,
         builder: dict[str, Any] | None = None,
+        reduce_only: bool = True,
     ) -> tuple[bool, dict[str, Any]]:
         builder_fee = self._mandatory_builder_fee(builder)
         await self.ensure_unified_account(address)
@@ -1296,7 +1297,7 @@ class HyperliquidAdapter(BaseAdapter):
                 asset_id, limit_price if limit_price is not None else trigger_price
             )
         order_actions = self._create_hypecore_order_actions(
-            asset_id, is_buy, price, size, True, order_type, builder_info
+            asset_id, is_buy, price, size, reduce_only, order_type, builder_info
         )
         result = await self._sign_and_broadcast_hypecore(order_actions, address)
 

--- a/wayfinder_paths/mcp/tools/hyperliquid.py
+++ b/wayfinder_paths/mcp/tools/hyperliquid.py
@@ -1359,12 +1359,12 @@ async def hyperliquid_place_trigger_order(
     size: float,
     is_market_trigger: bool = True,
     price: float | None = None,
+    reduce_only: bool = True,
 ) -> dict[str, Any]:
     """Place a perp take-profit / stop-loss trigger order.
 
     Perp-only: spot and HIP-4 outcome markets are rejected up-front because
-    triggers close an existing perp position (always `reduce_only`), which
-    those markets don't have.
+    triggers act on an existing perp position, which those markets don't have.
 
     Set `is_buy` to the side that **closes** your position (long → False, short → True).
     A market trigger fills at market on touch; a limit trigger needs `price`.
@@ -1380,6 +1380,11 @@ async def hyperliquid_place_trigger_order(
             rounds to zero.
         is_market_trigger: Default True (market on touch). False = limit-on-touch.
         price: Limit price; required only when `is_market_trigger=False`.
+        reduce_only: Default True — the trigger can only close, never open/flip a
+            position (HL cancels it at trigger time if there's nothing to reduce).
+            Set False for opening/scaling triggers (e.g. a stop-entry that adds
+            exposure on touch); the order then rests as a normal non-reduce-only
+            trigger.
     """
     wallet_label = throw_if_empty_str("wallet_label is required", wallet_label)
     asset_name = throw_if_empty_str("asset_name is required", asset_name)
@@ -1408,9 +1413,9 @@ async def hyperliquid_place_trigger_order(
     except ValueError as exc:
         return err("invalid_coin", str(exc))
 
-    # Trigger orders close existing positions (always reduce_only). Spot has no
-    # positions to reduce, and HIP-4 outcomes are binary integer contracts with
-    # no TP/SL semantics — HL rejects both downstream, so guard up-front.
+    # Trigger orders act on a perp position. Spot has no positions, and HIP-4
+    # outcomes are binary integer contracts with no TP/SL semantics — HL rejects
+    # both downstream, so guard up-front.
     if market_type in (MARKET_TYPE_SPOT, MARKET_TYPE_HIP4):
         return err(
             "invalid_market",
@@ -1445,6 +1450,7 @@ async def hyperliquid_place_trigger_order(
         is_market=bool(is_market_trigger),
         limit_price=limit_px,
         builder=DEFAULT_HYPERLIQUID_BUILDER_FEE,
+        reduce_only=bool(reduce_only),
     )
     effects.append(
         {
@@ -1484,6 +1490,7 @@ async def hyperliquid_place_trigger_order(
                 "limit_price": limit_px,
                 "size_requested": float(sz),
                 "size_valid": float(sz_valid),
+                "reduce_only": bool(reduce_only),
                 "builder": DEFAULT_HYPERLIQUID_BUILDER_FEE,
             },
             "effects": effects,


### PR DESCRIPTION
## What

`place_trigger_order` hardcoded `reduce_only=True`, so the MCP tool and adapter path could only ever **close** a position — there was no way to place an opening/scaling trigger (e.g. a stop-entry).

This exposes `reduce_only` on both `HyperliquidAdapter.place_trigger_order` and the `hyperliquid_place_trigger_order` MCP tool, **defaulting to `True`** so existing close-only behavior is unchanged. Callers can now pass `reduce_only=False` when they explicitly want a trigger that opens/increases/flips on touch.

## Why it's safe / correct

HL's API readily accepts and rests non-reduce-only triggers — this isn't a protocol constraint, just a repo-side default. Verified live before writing the change:

- Submitted a `reduce_only=False` stop-market on BTC → HL responded `resting` (not rejected).
- Read back from HL's own `frontendOpenOrders`: `reduceOnly=False`, `orderType=Stop Market`.

The default stays `True`, so an agent gets safe close-only TP/SL unless it deliberately opts out (documented in the tool docstring).

## Changes

- `adapter.py` — `place_trigger_order(..., reduce_only: bool = True)`, threaded into the order wire instead of a hardcoded `True`.
- `mcp/tools/hyperliquid.py` — new `reduce_only: bool = True` param, docstring note, passed through, and echoed in the response payload.
- `using-hyperliquid-adapter/rules/execution-opportunities.md` — doc updated to reflect the optional flag.

## Testing

- `pytest wayfinder_paths/adapters/hyperliquid_adapter/` → 34 passed, 2 skipped.
- `mypy` on both changed files introduces **no new errors** (only pre-existing legacy ones remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)