### PR TITLE
Make Morpho adapter resilient to transient API failures

### DIFF
--- a/wayfinder_paths/adapters/morpho_adapter/adapter.py
+++ b/wayfinder_paths/adapters/morpho_adapter/adapter.py
@@ -669,9 +669,7 @@ class MorphoAdapter(BaseAdapter):
                     if require_state
                     else v2_raw
                 )
-                out.extend(
-                    [self._format_vault_v2(int(chain_id), v) for v in v2_kept]
-                )
+                out.extend([self._format_vault_v2(int(chain_id), v) for v in v2_kept])
                 dropped += len(v2_raw) - len(v2_kept)
 
             if require_state and dropped:

--- a/wayfinder_paths/adapters/morpho_adapter/adapter.py
+++ b/wayfinder_paths/adapters/morpho_adapter/adapter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from eth_utils import to_checksum_address
+from loguru import logger
 
 from wayfinder_paths.core.adapters.BaseAdapter import BaseAdapter
 from wayfinder_paths.core.clients.MerklClient import MERKL_CLIENT
@@ -342,6 +343,7 @@ class MorphoAdapter(BaseAdapter):
         chain_id: int,
         listed: bool | None = True,
         include_idle: bool = False,
+        require_state: bool = True,
     ) -> tuple[bool, list[dict[str, Any]] | str]:
         try:
             morpho = await self._morpho_address(chain_id=int(chain_id))
@@ -350,7 +352,18 @@ class MorphoAdapter(BaseAdapter):
                 listed=listed,
                 include_idle=include_idle,
             )
-            out = [self._format_market(int(chain_id), morpho, m) for m in markets]
+            raw = [m for m in markets if isinstance(m, dict)]
+            # Morpho occasionally returns items with a null `state` (transient API
+            # degradation). Those have no usable APY, so drop them by default rather
+            # than emit a misleading 0% downstream.
+            kept = [m for m in raw if m.get("state")] if require_state else raw
+            if require_state and len(kept) != len(raw):
+                logger.warning(
+                    "Morpho get_all_markets: dropped {} market(s) with no state (chain {})",
+                    len(raw) - len(kept),
+                    chain_id,
+                )
+            out = [self._format_market(int(chain_id), morpho, m) for m in kept]
             return True, out
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
@@ -553,7 +566,11 @@ class MorphoAdapter(BaseAdapter):
                 "avg_net_apy": state.get("avgNetApy"),
                 "avg_net_apy_excluding_rewards": state.get("avgNetApyExcludingRewards"),
                 "reward_supply_apr": reward_supply_apr,
-                "apy_with_rewards": apy_float + reward_supply_apr,
+                # Never fabricate a 0% from a missing base apy -- keep it None so
+                # callers can distinguish "no data" from a genuine 0% yield.
+                "apy_with_rewards": (
+                    apy_float + reward_supply_apr if apy is not None else None
+                ),
                 "total_assets": int(state.get("totalAssets") or 0),
                 "total_assets_usd": state.get("totalAssetsUsd"),
                 "total_supply": state.get("totalSupply"),
@@ -597,7 +614,9 @@ class MorphoAdapter(BaseAdapter):
                 "avg_net_apy": vault.get("avgNetApy"),
                 "avg_net_apy_excluding_rewards": vault.get("avgNetApyExcludingRewards"),
                 "reward_supply_apr": reward_supply_apr,
-                "apy_with_rewards": apy_float + reward_supply_apr,
+                "apy_with_rewards": (
+                    apy_float + reward_supply_apr if apy is not None else None
+                ),
                 "total_assets": int(vault.get("totalAssets") or 0),
                 "total_assets_usd": vault.get("totalAssetsUsd"),
                 "total_supply": vault.get("totalSupply"),
@@ -620,20 +639,47 @@ class MorphoAdapter(BaseAdapter):
         chain_id: int,
         listed: bool | None = True,
         include_v2: bool = True,
+        require_state: bool = True,
     ) -> tuple[bool, list[dict[str, Any]] | str]:
         try:
             v1 = await MORPHO_CLIENT.get_all_vaults(
                 chain_id=int(chain_id), listed=listed
             )
+            # Drop items Morpho returned without usable APY data (transient null
+            # state / apy) so they don't get ranked at a fabricated 0% downstream.
+            v1_raw = [v for v in v1 if isinstance(v, dict)]
+            v1_kept = [v for v in v1_raw if v.get("state")] if require_state else v1_raw
             out: list[dict[str, Any]] = [
-                self._format_vault_v1(int(chain_id), v) for v in v1
+                self._format_vault_v1(int(chain_id), v) for v in v1_kept
             ]
+            dropped = len(v1_raw) - len(v1_kept)
 
             if include_v2:
                 v2 = await MORPHO_CLIENT.get_all_vault_v2s(
                     chain_id=int(chain_id), listed=listed
                 )
-                out.extend([self._format_vault_v2(int(chain_id), v) for v in v2])
+                # v2 vaults carry apy/netApy at the top level (no `state` wrapper).
+                v2_raw = [v for v in v2 if isinstance(v, dict)]
+                v2_kept = (
+                    [
+                        v
+                        for v in v2_raw
+                        if v.get("apy") is not None or v.get("netApy") is not None
+                    ]
+                    if require_state
+                    else v2_raw
+                )
+                out.extend(
+                    [self._format_vault_v2(int(chain_id), v) for v in v2_kept]
+                )
+                dropped += len(v2_raw) - len(v2_kept)
+
+            if require_state and dropped:
+                logger.warning(
+                    "Morpho get_all_vaults: dropped {} vault(s) with no APY data (chain {})",
+                    dropped,
+                    chain_id,
+                )
 
             return True, out
         except Exception as exc:  # noqa: BLE001

--- a/wayfinder_paths/adapters/morpho_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/morpho_adapter/test_adapter.py
@@ -684,7 +684,12 @@ async def test_get_all_vaults_drops_incomplete(adapter):
         "symbol": "v1good",
         "listed": True,
         "asset": asset,
-        "state": {"apy": 0.03, "netApy": 0.04, "totalAssets": "1", "totalAssetsUsd": 1.0},
+        "state": {
+            "apy": 0.03,
+            "netApy": 0.04,
+            "totalAssets": "1",
+            "totalAssetsUsd": 1.0,
+        },
     }
     v1_bad = {
         "address": "0x1111111111111111111111111111111111111112",

--- a/wayfinder_paths/adapters/morpho_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/morpho_adapter/test_adapter.py
@@ -633,3 +633,103 @@ async def test_vault_deposit_approves_asset_and_calls_deposit(adapter):
     _args, encode_kwargs = mock_encode.await_args
     assert encode_kwargs["fn_name"] == "deposit"
     assert encode_kwargs["args"][0] == 123
+
+
+@pytest.mark.asyncio
+async def test_get_all_markets_drops_null_state(adapter):
+    """Markets Morpho returned with no state (transient degradation) are dropped."""
+    key = "0x" + "11" * 32
+    good = _mock_market(
+        key,
+        loan_addr="0x4200000000000000000000000000000000000006",
+        collateral_addr="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    )
+    bad = _mock_market(
+        "0x" + "22" * 32,
+        loan_addr="0x4200000000000000000000000000000000000006",
+        collateral_addr="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    )
+    bad["state"] = None  # Morpho returned an item with no state snapshot
+
+    with patch(
+        "wayfinder_paths.adapters.morpho_adapter.adapter.MORPHO_CLIENT.get_all_markets",
+        new=AsyncMock(return_value=[good, bad]),
+    ):
+        ok, kept = await adapter.get_all_markets(chain_id=CHAIN_ID_BASE)
+        ok2, all_ = await adapter.get_all_markets(
+            chain_id=CHAIN_ID_BASE, require_state=False
+        )
+
+    assert ok and ok2
+    assert [m["marketId"] for m in kept] == [key]  # null-state market dropped
+    assert len(all_) == 2  # opt-out keeps everything
+
+
+def _vault_asset() -> dict:
+    return {
+        "address": "0x2222222222222222222222222222222222222222",
+        "symbol": "USDC",
+        "name": "USD Coin",
+        "decimals": 6,
+        "price": {"usd": 1.0},
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_all_vaults_drops_incomplete(adapter):
+    """v1 vaults with null state and v2 vaults with no apy are dropped; no fake 0%."""
+    asset = _vault_asset()
+    v1_good = {
+        "address": "0x1111111111111111111111111111111111111111",
+        "symbol": "v1good",
+        "listed": True,
+        "asset": asset,
+        "state": {"apy": 0.03, "netApy": 0.04, "totalAssets": "1", "totalAssetsUsd": 1.0},
+    }
+    v1_bad = {
+        "address": "0x1111111111111111111111111111111111111112",
+        "symbol": "v1bad",
+        "listed": True,
+        "asset": asset,
+        "state": None,  # transient -> would otherwise rank at fabricated 0%
+    }
+    v2_good = {
+        "address": "0x4444444444444444444444444444444444444444",
+        "type": "MetaMorphoV2",
+        "symbol": "v2good",
+        "listed": True,
+        "asset": asset,
+        "apy": 0.05,
+        "netApy": 0.06,
+    }
+    v2_bad = {
+        "address": "0x4444444444444444444444444444444444444445",
+        "type": "MetaMorphoV2",
+        "symbol": "v2bad",
+        "listed": True,
+        "asset": asset,
+        "apy": None,
+        "netApy": None,
+    }
+
+    with (
+        patch(
+            "wayfinder_paths.adapters.morpho_adapter.adapter.MORPHO_CLIENT.get_all_vaults",
+            new=AsyncMock(return_value=[v1_good, v1_bad]),
+        ),
+        patch(
+            "wayfinder_paths.adapters.morpho_adapter.adapter.MORPHO_CLIENT.get_all_vault_v2s",
+            new=AsyncMock(return_value=[v2_good, v2_bad]),
+        ),
+    ):
+        ok, kept = await adapter.get_all_vaults(chain_id=CHAIN_ID_BASE)
+        ok2, all_ = await adapter.get_all_vaults(
+            chain_id=CHAIN_ID_BASE, require_state=False
+        )
+
+    assert ok and ok2
+    kept_symbols = {v["symbol"] for v in kept}
+    assert kept_symbols == {"v1good", "v2good"}  # incomplete vaults dropped
+    # every kept vault has a real (non-None) APY -- never a fabricated 0%
+    assert all(v["state"]["apy_with_rewards"] is not None for v in kept)
+    assert len(all_) == 4  # opt-out keeps everything

--- a/wayfinder_paths/core/clients/MorphoClient.py
+++ b/wayfinder_paths/core/clients/MorphoClient.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import random
 from typing import Any, Required, TypedDict
 
 import httpx
@@ -54,8 +55,8 @@ class MorphoClient:
     async def _post(
         self, *, query: str, variables: dict[str, Any] | None = None
     ) -> Any:
-        max_retries = 3
-        delay_s = 0.25
+        max_retries = 4
+        delay_s = 0.5
 
         for attempt in range(max_retries):
             try:
@@ -87,8 +88,13 @@ class MorphoClient:
             except httpx.HTTPStatusError as exc:
                 status = exc.response.status_code
                 retryable = status in (429, 500, 502, 503, 504)
+                # Morpho's API also returns 400 under rate/load (not just for bad
+                # queries), so retry a 400 unless its body shows a genuine query error
+                # (validation/parse) -- retrying those would never succeed.
+                if status == 400 and not self._is_nonretryable_400(exc.response):
+                    retryable = True
                 if retryable and attempt < (max_retries - 1):
-                    await asyncio.sleep(delay_s * (2**attempt))
+                    await asyncio.sleep(delay_s * (2**attempt) + random.uniform(0, delay_s))
                     continue
                 raise
             except (
@@ -109,6 +115,35 @@ class MorphoClient:
                 raise
 
         raise RuntimeError("Morpho API request failed")
+
+    @staticmethod
+    def _is_nonretryable_400(response: httpx.Response) -> bool:
+        """Whether a 400 is a genuine query error (validation/parse) -- retrying won't help.
+
+        Morpho returns HTTP 400 both for malformed queries AND for transient rate/load
+        conditions. Only the former is non-retryable; an unparseable body is treated as
+        transient (retry allowed).
+        """
+        try:
+            body = response.json()
+        except Exception:  # noqa: BLE001
+            return False
+        errors = body.get("errors") if isinstance(body, dict) else None
+        if not isinstance(errors, list):
+            return False
+        nonretryable = {
+            "GRAPHQL_VALIDATION_FAILED",
+            "GRAPHQL_PARSE_FAILED",
+            "BAD_USER_INPUT",
+        }
+        for error in errors:
+            if not isinstance(error, dict):
+                continue
+            status = str(error.get("status") or "").upper()
+            code = str((error.get("extensions") or {}).get("code") or "").upper()
+            if status in nonretryable or code in nonretryable:
+                return True
+        return False
 
     @staticmethod
     def _is_retryable_graphql_error(errors: Any) -> bool:

--- a/wayfinder_paths/core/clients/MorphoClient.py
+++ b/wayfinder_paths/core/clients/MorphoClient.py
@@ -94,7 +94,9 @@ class MorphoClient:
                 if status == 400 and not self._is_nonretryable_400(exc.response):
                     retryable = True
                 if retryable and attempt < (max_retries - 1):
-                    await asyncio.sleep(delay_s * (2**attempt) + random.uniform(0, delay_s))
+                    await asyncio.sleep(
+                        delay_s * (2**attempt) + random.uniform(0, delay_s)
+                    )
                     continue
                 raise
             except (

--- a/wayfinder_paths/tests/test_morpho_client.py
+++ b/wayfinder_paths/tests/test_morpho_client.py
@@ -1,8 +1,27 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from wayfinder_paths.core.clients.MorphoClient import MorphoClient
+
+
+def _http_400(body: dict) -> MagicMock:
+    """A mocked httpx response that raises HTTPStatusError(400) on raise_for_status."""
+    resp = MagicMock()
+    resp.status_code = 400
+    resp.json.return_value = body
+    resp.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError("400", request=MagicMock(), response=resp)
+    )
+    return resp
+
+
+def _ok(data: dict) -> MagicMock:
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = {"data": data}
+    return resp
 
 
 @pytest.mark.asyncio
@@ -48,3 +67,51 @@ async def test_post_retries_retryable_graphql_errors():
     assert payload == {"markets": {"items": []}}
     assert client.client.post.await_count == 2
     client._reset_client.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_post_retries_transient_400():
+    """Morpho returns 400 under rate/load; a non-validation 400 should be retried."""
+    client = MorphoClient(graphql_url="https://example.com/graphql")
+    client._ensure_client = AsyncMock()
+    client._reset_client = AsyncMock()
+
+    transient = _http_400({"errors": [{"message": "rate limited, try again"}]})
+    success = _ok({"markets": {"items": []}})
+    client.client = MagicMock(post=AsyncMock(side_effect=[transient, success]))
+
+    with patch(
+        "wayfinder_paths.core.clients.MorphoClient.asyncio.sleep", new=AsyncMock()
+    ):
+        payload = await client._post(query="query { markets { items { marketId } } }")
+
+    assert payload == {"markets": {"items": []}}
+    assert client.client.post.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_post_fails_fast_on_validation_400():
+    """A 400 caused by an invalid query must NOT be retried -- it would never succeed."""
+    client = MorphoClient(graphql_url="https://example.com/graphql")
+    client._ensure_client = AsyncMock()
+    client._reset_client = AsyncMock()
+
+    validation = _http_400(
+        {
+            "errors": [
+                {
+                    "message": 'Cannot query field "uniqueKey" on type "Market".',
+                    "status": "GRAPHQL_VALIDATION_FAILED",
+                }
+            ]
+        }
+    )
+    client.client = MagicMock(post=AsyncMock(side_effect=[validation]))
+
+    with patch(
+        "wayfinder_paths.core.clients.MorphoClient.asyncio.sleep", new=AsyncMock()
+    ):
+        with pytest.raises(httpx.HTTPStatusError):
+            await client._post(query="query { markets { items { uniqueKey } } }")
+
+    assert client.client.post.await_count == 1


### PR DESCRIPTION
Morpho's GraphQL API intermittently returns HTTP 400 under load and occasionally returns items with null state. Previously a single 400 aborted the whole markets scan (Morpho dropped from yield rankings), and null-state vaults were ranked at a fabricated 0% APY. Now MorphoClient._post retries transient 400s with backoff (failing fast only on genuine query/validation errors), and get_all_markets/get_all_vaults drop items with no usable APY data by default (require_state opt-out) instead of emitting a misleading 0%.