### PR TITLE
Config - Read API key fresh from config.json

### DIFF
--- a/scripts/remote_setup_utils.py
+++ b/scripts/remote_setup_utils.py
@@ -80,7 +80,7 @@ def ensure_config(
     system = config.get("system")
     if not isinstance(system, dict):
         system = {}
-    if api_key:
+    if api_key and not system.get("api_key"):
         system["api_key"] = api_key
     system.setdefault("api_base_url", "https://wayfinder.ai/api/v1")
     config["system"] = system

--- a/wayfinder_paths/core/config.py
+++ b/wayfinder_paths/core/config.py
@@ -126,8 +126,7 @@ def allow_local_wallets() -> bool:
 
 
 def get_api_key() -> str | None:
-    system = CONFIG.get("system", {})
-    api_key = system.get("api_key")
+    api_key = load_config_json().get("system", {}).get("api_key")
     if api_key:
         return str(api_key).strip()
     return os.environ.get("WAYFINDER_API_KEY")

--- a/wayfinder_paths/tests/test_config_resolution.py
+++ b/wayfinder_paths/tests/test_config_resolution.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import json
 from pathlib import Path
 
 import pytest
@@ -13,6 +14,14 @@ def restore_global_config() -> None:
     original = copy.deepcopy(config.CONFIG)
     yield
     config.set_config(original)
+
+
+def _write_api_key_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # get_api_key() reads fresh from config.json on every call, so the key
+    # must exist on disk — set_config() alone is not enough.
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps({"system": {"api_key": "wk_test"}}))
+    monkeypatch.setenv("WAYFINDER_CONFIG_PATH", str(cfg_path))
 
 
 def test_resolve_config_path_defaults_to_repo_root(
@@ -70,7 +79,9 @@ def test_api_base_url_defaults_to_wayfinder_api(restore_global_config: None) -> 
 async def test_web3s_fallback_to_rpc_proxy(
     restore_global_config: None,
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
+    _write_api_key_config(tmp_path, monkeypatch)
     config.set_config(
         {
             "system": {
@@ -103,7 +114,9 @@ async def test_web3s_fallback_to_rpc_proxy(
 async def test_user_rpcs_override_proxy(
     restore_global_config: None,
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
+    _write_api_key_config(tmp_path, monkeypatch)
     config.set_config(
         {
             "system": {
@@ -134,7 +147,9 @@ async def test_user_rpcs_override_proxy(
 async def test_web3s_uses_indexed_rpc_proxy_pool(
     restore_global_config: None,
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
+    _write_api_key_config(tmp_path, monkeypatch)
     config.set_config(
         {
             "system": {


### PR DESCRIPTION
### Summary

`get_api_key()` reads `config.json` on each call instead of serving the import-time `CONFIG` snapshot, so a key rotated on disk is picked up by long-running processes without a restart — one line, no new state, the global `CONFIG` untouched. Fallback to the `WAYFINDER_API_KEY` env var is unchanged; callers are low-QPS so the per-call read is negligible. `ensure_config()` now only sets `api_key` when the config doesn't already have one, instead of unconditionally overwriting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)