### PR TITLE
Config - Revert ensure_config api_key guard

### DIFF
--- a/scripts/remote_setup_utils.py
+++ b/scripts/remote_setup_utils.py
@@ -80,7 +80,7 @@ def ensure_config(
     system = config.get("system")
     if not isinstance(system, dict):
         system = {}
-    if api_key and not system.get("api_key"):
+    if api_key:
         system["api_key"] = api_key
     system.setdefault("api_base_url", "https://wayfinder.ai/api/v1")
     config["system"] = system


### PR DESCRIPTION
### Summary

Reverts #437's change to `ensure_config`: it no longer skips writing the env api_key when config.json already has one — it always writes it, as before #437. The guard was only needed for a strategy where the on-machine key could change at runtime (mint-at-claim), which was dropped in favor of re-parenting. Reverting also removes the template-placeholder edge case the guard introduced (first boot left `wk_your_key_here` in config.json). Exact one-line reverse of #437's hunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)