### PR TITLE
Shells visual tools - drop set_active_market clear_workspace flag

### DIFF
--- a/wayfinder_paths/core/clients/InstanceStateClient.py
+++ b/wayfinder_paths/core/clients/InstanceStateClient.py
@@ -72,14 +72,12 @@ class InstanceStateClient(WayfinderClient):
         market_id: str | None = None,
         market_type: str | None = None,
         chain_id: int | None = None,
-        clear_workspace: bool = True,
     ) -> dict[str, Any]:
         payload = {
             "query": query,
             "market_id": market_id,
             "market_type": market_type,
             "chain_id": chain_id,
-            "clear_workspace": clear_workspace,
         }
         resp = await self._authed_request(
             "POST",

--- a/wayfinder_paths/mcp/tools/instance_state.py
+++ b/wayfinder_paths/mcp/tools/instance_state.py
@@ -220,7 +220,6 @@ async def visual_set_active_market(
     market_id: str | None = None,
     market_type: str | None = None,
     chain_id: int | None = None,
-    clear_workspace: bool = True,
 ) -> dict[str, Any]:
     """Switch the default Shells chart and trading context to one market.
 
@@ -238,8 +237,6 @@ async def visual_set_active_market(
       market_type: Optional narrowing: hl-perp, hl-spot, onchain-spot,
         polymarket.
       chain_id: Optional EVM chain id for onchain spot resolution.
-      clear_workspace: Set false only if an existing custom pane should stay
-        active while the trading context changes.
     """
     if not is_opencode_instance():
         return err(*_NOT_OPENCODE_ERR)
@@ -250,7 +247,6 @@ async def visual_set_active_market(
                 market_id=market_id,
                 market_type=market_type,
                 chain_id=chain_id,
-                clear_workspace=clear_workspace,
             )
         )
     except httpx.HTTPStatusError as exc:


### PR DESCRIPTION
### Summary

Removes the redundant `clear_workspace` parameter from the `set_active_market` MCP tool and its client. Chart-pane lifecycle on market switch is already handled by the consuming UI, and both downstream consumers default the behavior on, so the parameter changed nothing while inviting misuse as a chart "clear".