### PR TITLE
Wayfinder agent - allow clearing the live chart

### DIFF
--- a/.opencode/agents/wayfinder.md
+++ b/.opencode/agents/wayfinder.md
@@ -39,7 +39,7 @@ permission:
   wayfinder_polymarket_deposit_pusd: ask
   wayfinder_polymarket_withdraw_pusd: ask
   wayfinder_polymarket_redeem_positions: ask
-  # visual_* — primary can inspect/switch/search and annotate the live chart;
+  # visual_* — primary can inspect/switch/search, annotate, and clear the live chart;
   # workspace chart creation/series mutations delegate
   wayfinder_visual_*: deny
   wayfinder_visual_get_frontend_context: allow
@@ -47,6 +47,7 @@ permission:
   wayfinder_visual_search_chart_series: allow
   wayfinder_visual_add_workspace_chart_annotation: allow
   wayfinder_visual_add_workspace_chart_overlay: allow
+  wayfinder_visual_clear_chart_workspace: allow
   # notification_send — main agent owns user-facing notifications
   wayfinder_notification_send: allow
   # research_* — delegated to wayfinder-research subagent
@@ -359,6 +360,7 @@ Use direct visual tools for cheap chart orchestration before involving subagents
 - `visual_set_active_market` can return an `active_market_request` before the browser has applied it. Do not say the chart switched unless the returned/current `frontend_context.chart.market_id` matches the requested market. Otherwise say the switch was requested and may apply on the next frontend poll.
 - Use `visual_search_chart_series` only to look up backend-supported series/source references for a chart request. A search result is not a rendered chart.
 - Use `visual_add_workspace_chart_annotation` or `visual_add_workspace_chart_overlay` directly for simple live/current chart annotations after reading `visual_get_frontend_context`; pass the exact `frontend_context.chart.id`, use ISO timestamps, use `event_markers.data` for bulk events, and verify `chart_workspace.defaultAnnotations[chart_id]` contains the expected annotations before claiming completion.
+- Use `visual_clear_chart_workspace` when the user asks to clear the chart, remove the markers/lines/annotations, or reset the chart. It is the only tool that removes annotations — it deletes every agent-drawn annotation and any agent-created workspace charts in one call. `visual_set_active_market` only switches markets and never removes annotations, so do not use it to clear. After clearing, confirm `chart_workspace.defaultAnnotations` is empty before claiming completion.
 - Delegate workspace chart creation/mutation to `wayfinder-visual`: comparisons, relative performance, APY/funding/lending/basis charts, and derived/multi-series panes.
 - Do not call `wayfinder-quant` for simple iteration, single-token chart routing, or source-backed chart comparisons the visual tools can render.
 

--- a/wayfinder_paths/tests/test_mcp_profiles.py
+++ b/wayfinder_paths/tests/test_mcp_profiles.py
@@ -104,6 +104,7 @@ def test_opencode_agents_scope_single_mcp_tool_names() -> None:
     assert primary["wayfinder_visual_search_chart_series"] == "allow"
     assert primary["wayfinder_visual_add_workspace_chart_annotation"] == "allow"
     assert primary["wayfinder_visual_add_workspace_chart_overlay"] == "allow"
+    assert primary["wayfinder_visual_clear_chart_workspace"] == "allow"
     assert "wayfinder_visual_create_chart" not in primary
     assert "wayfinder_visual_import_chart_spec" not in primary
     assert primary["wayfinder_notification_send"] == "allow"
@@ -173,6 +174,7 @@ def test_opencode_agent_frontmatter_scopes_visible_wayfinder_tools() -> None:
         "wayfinder_visual_search_chart_series": "allow",
         "wayfinder_visual_add_workspace_chart_annotation": "allow",
         "wayfinder_visual_add_workspace_chart_overlay": "allow",
+        "wayfinder_visual_clear_chart_workspace": "allow",
         "wayfinder_notification_send": "allow",
         "wayfinder_research_*": "deny",
         "wayfinder_core_run_script": "ask",


### PR DESCRIPTION
### Summary

The primary `wayfinder` agent denies `wayfinder_visual_*` and allow-lists tools individually, but the clear tool was never on the list — so the agent could not remove chart annotations. Asked to "clear my chart", it fell back to `visual_set_active_market` (which only switches markets and never clears) and reported a false failure. This allows `wayfinder_visual_clear_chart_workspace` and adds a Chart Fast Path note that it is the only tool that removes annotations, and that `set_active_market` must not be used to clear.