### PR TITLE
Wallet Activity - Accept address and pagination

### DIFF
--- a/wayfinder_paths/mcp/tools/wallets.py
+++ b/wayfinder_paths/mcp/tools/wallets.py
@@ -505,25 +505,38 @@ async def core_get_wallets(
 
 
 @catch_errors
-async def onchain_get_wallet_activity(label: str) -> dict[str, Any]:
-    """Return the last 20 on-chain transactions for a wallet across supported chains.
+async def onchain_get_wallet_activity(
+    label: str | None = None,
+    wallet_address: str | None = None,
+    limit: int = 20,
+    offset: str | None = None,
+) -> dict[str, Any]:
+    """Return on-chain transactions for a wallet across supported chains.
+
+    Pass either a configured wallet label or a raw wallet address. To crawl
+    further back, pass the previous response's next_offset as offset.
 
     Args:
         label: Wallet label as configured in config.json, e.g. main.
+        wallet_address: Raw wallet address; takes precedence over label.
+        limit: Number of transactions to return (default 20).
+        offset: Pagination cursor from a prior response's next_offset.
     """
-    w = await find_wallet_by_label(label)
-    if not w:
-        return err("not_found", f"Wallet not found: {label}")
-
-    address = normalize_address(w.get("address"))
+    address, lbl = await resolve_wallet_address(
+        wallet_label=label, wallet_address=wallet_address
+    )
     if not address:
-        return err("invalid_wallet", f"Invalid address for wallet: {label}")
+        if lbl:
+            return err("not_found", f"Wallet not found: {lbl}")
+        return err("invalid_request", "label or wallet_address is required")
 
-    data = await BALANCE_CLIENT.get_wallet_activity(wallet_address=address, limit=20)
+    data = await BALANCE_CLIENT.get_wallet_activity(
+        wallet_address=address, limit=limit, offset=offset
+    )
 
     return ok(
         {
-            "label": label,
+            "label": lbl,
             "address": address,
             "activity": data.get("activity", []),
             "next_offset": data.get("next_offset"),

--- a/wayfinder_paths/tests/test_mcp_wallets.py
+++ b/wayfinder_paths/tests/test_mcp_wallets.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from wayfinder_paths.mcp.tools.wallets import core_wallets
+from wayfinder_paths.mcp.tools.wallets import (
+    core_wallets,
+    onchain_get_wallet_activity,
+)
 from wayfinder_paths.mcp.utils import resolve_wallet_address
 
 
@@ -33,6 +36,57 @@ async def test_resolve_wallet_address_missing_label_returns_double_none():
     addr, lbl = await resolve_wallet_address()
     assert addr is None
     assert lbl is None
+
+
+@pytest.mark.asyncio
+async def test_wallet_activity_accepts_raw_address_with_pagination():
+    mock = AsyncMock(return_value={"activity": [{"id": 1}], "next_offset": "cursor"})
+    with patch(
+        "wayfinder_paths.mcp.tools.wallets.BALANCE_CLIENT.get_wallet_activity", mock
+    ):
+        out = await onchain_get_wallet_activity(
+            wallet_address="0x000000000000000000000000000000000000dEaD",
+            limit=50,
+            offset="prev-cursor",
+        )
+
+    mock.assert_awaited_once_with(
+        wallet_address="0x000000000000000000000000000000000000dEaD",
+        limit=50,
+        offset="prev-cursor",
+    )
+    assert out["ok"] is True
+    assert out["result"]["label"] is None
+    assert out["result"]["next_offset"] == "cursor"
+
+
+@pytest.mark.asyncio
+async def test_wallet_activity_resolves_label():
+    mock = AsyncMock(return_value={"activity": [], "next_offset": None})
+    with (
+        patch(
+            "wayfinder_paths.mcp.utils.find_wallet_by_label",
+            return_value={"address": "0x000000000000000000000000000000000000bEEF"},
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.wallets.BALANCE_CLIENT.get_wallet_activity", mock
+        ),
+    ):
+        out = await onchain_get_wallet_activity(label="main")
+
+    mock.assert_awaited_once_with(
+        wallet_address="0x000000000000000000000000000000000000bEEF",
+        limit=20,
+        offset=None,
+    )
+    assert out["result"]["label"] == "main"
+
+
+@pytest.mark.asyncio
+async def test_wallet_activity_requires_label_or_address():
+    out = await onchain_get_wallet_activity()
+    assert out["ok"] is False
+    assert out["error"]["code"] == "invalid_request"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

`onchain_get_wallet_activity` now accepts a raw `wallet_address` (in addition to a configured `label`) and `limit`/`offset` parameters so the agent can crawl through a wallet's transaction history. Address resolution goes through the shared `resolve_wallet_address` helper; pass a prior response's `next_offset` as `offset` to page back further.