### PR TITLE
Gas Sponsorship - Backend broadcast for sponsored chains

### DIFF
--- a/wayfinder_paths/core/clients/WalletClient.py
+++ b/wayfinder_paths/core/clients/WalletClient.py
@@ -56,17 +56,21 @@ class WalletClient(WayfinderClient):
             logger.error(f"sign_transaction failed for {wallet_address}: {exc}")
             raise
 
-    async def send_transaction(
+    async def send_transaction_sponsored(
         self, wallet_address: str, transaction: dict
     ) -> dict[str, Any]:
-        url = f"{get_api_base_url()}/wallets/{wallet_address}/send-evm-transaction/"
+        url = (
+            f"{get_api_base_url()}/wallets/{wallet_address}/send-transaction-sponsored/"
+        )
         try:
             resp = await self._authed_request(
                 "POST", url, json={"transaction": transaction}
             )
             return resp.json()
         except Exception as exc:
-            logger.error(f"send_transaction failed for {wallet_address}: {exc}")
+            logger.error(
+                f"send_transaction_sponsored failed for {wallet_address}: {exc}"
+            )
             raise
 
     async def get_transaction_status(

--- a/wayfinder_paths/core/clients/WalletClient.py
+++ b/wayfinder_paths/core/clients/WalletClient.py
@@ -56,6 +56,33 @@ class WalletClient(WayfinderClient):
             logger.error(f"sign_transaction failed for {wallet_address}: {exc}")
             raise
 
+    async def send_transaction(
+        self, wallet_address: str, transaction: dict
+    ) -> dict[str, Any]:
+        url = f"{get_api_base_url()}/wallets/{wallet_address}/send-evm-transaction/"
+        try:
+            resp = await self._authed_request(
+                "POST", url, json={"transaction": transaction}
+            )
+            return resp.json()
+        except Exception as exc:
+            logger.error(f"send_transaction failed for {wallet_address}: {exc}")
+            raise
+
+    async def get_transaction_status(
+        self, wallet_address: str, transaction_id: str
+    ) -> dict[str, Any]:
+        url = (
+            f"{get_api_base_url()}/wallets/{wallet_address}"
+            f"/transactions/{transaction_id}/"
+        )
+        try:
+            resp = await self._authed_request("GET", url)
+            return resp.json()
+        except Exception as exc:
+            logger.error(f"get_transaction_status failed for {wallet_address}: {exc}")
+            raise
+
     async def sign_typed_data(self, wallet_address: str, typed_data: dict) -> str:
         url = f"{get_api_base_url()}/wallets/{wallet_address}/sign-typed-data/"
         try:

--- a/wayfinder_paths/core/clients/WalletClient.py
+++ b/wayfinder_paths/core/clients/WalletClient.py
@@ -56,7 +56,7 @@ class WalletClient(WayfinderClient):
             logger.error(f"sign_transaction failed for {wallet_address}: {exc}")
             raise
 
-    async def send_transaction_sponsored(
+    async def send_privy_transaction_sponsored(
         self, wallet_address: str, transaction: dict
     ) -> dict[str, Any]:
         url = (
@@ -69,11 +69,11 @@ class WalletClient(WayfinderClient):
             return resp.json()
         except Exception as exc:
             logger.error(
-                f"send_transaction_sponsored failed for {wallet_address}: {exc}"
+                f"send_privy_transaction_sponsored failed for {wallet_address}: {exc}"
             )
             raise
 
-    async def get_transaction_status(
+    async def get_privy_transaction_status(
         self, wallet_address: str, transaction_id: str
     ) -> dict[str, Any]:
         url = (
@@ -84,7 +84,9 @@ class WalletClient(WayfinderClient):
             resp = await self._authed_request("GET", url)
             return resp.json()
         except Exception as exc:
-            logger.error(f"get_transaction_status failed for {wallet_address}: {exc}")
+            logger.error(
+                f"get_privy_transaction_status failed for {wallet_address}: {exc}"
+            )
             raise
 
     async def sign_typed_data(self, wallet_address: str, typed_data: dict) -> str:

--- a/wayfinder_paths/core/constants/chains.py
+++ b/wayfinder_paths/core/constants/chains.py
@@ -49,6 +49,20 @@ SUPPORTED_CHAINS = [
     CHAIN_ID_ROBINHOOD,
 ]
 
+# Chains where remote-wallet transactions are gas-sponsored: the backend
+# broadcasts them and gas is covered, so local nonce/gas handling and the
+# raw broadcast are skipped (see send_transaction).
+GAS_SPONSORED_CHAIN_IDS: set[int] = {
+    CHAIN_ID_ETHEREUM,
+    CHAIN_ID_BASE,
+    CHAIN_ID_ARBITRUM,
+    CHAIN_ID_BSC,
+    CHAIN_ID_POLYGON,
+    CHAIN_ID_MONAD,
+    CHAIN_ID_MEGAETH,
+    CHAIN_ID_PLASMA,
+}
+
 POA_MIDDLEWARE_CHAIN_IDS: set[int] = {
     CHAIN_ID_BSC,
     CHAIN_ID_POLYGON,

--- a/wayfinder_paths/core/utils/test_transaction.py
+++ b/wayfinder_paths/core/utils/test_transaction.py
@@ -435,6 +435,7 @@ class TestSendTransaction:
         async def sign_callback(_tx: dict) -> bytes:
             return b"\x00"
 
+        sign_callback.wallet_address = None
         with pytest.raises(TransactionRevertedError, match="Transaction reverted"):
             await send_transaction(
                 {"from": RANDOM_USER_0, "chainId": 1},
@@ -480,6 +481,7 @@ class TestSendTransaction:
         async def sign_callback(_tx: dict) -> bytes:
             return b"\x00"
 
+        sign_callback.wallet_address = None
         txn_hash = await send_transaction(
             {"from": RANDOM_USER_0, "chainId": 1},
             sign_callback,

--- a/wayfinder_paths/core/utils/transaction.py
+++ b/wayfinder_paths/core/utils/transaction.py
@@ -15,9 +15,11 @@ from wayfinder_paths.core.constants.base import (
     SUGGESTED_PRIORITY_FEE_MULTIPLIER,
 )
 from wayfinder_paths.core.constants.chains import (
+    GAS_SPONSORED_CHAIN_IDS,
     MIN_PRIORITY_FEE_BY_CHAIN_ID,
     PRE_EIP_1559_CHAIN_IDS,
 )
+from wayfinder_paths.core.utils.wallets import send_sponsored_transaction
 from wayfinder_paths.core.utils.web3 import (
     _is_gorlami_fork_rpc,
     get_transaction_chain_id,
@@ -302,11 +304,23 @@ async def send_transaction(
         confirmations = (
             0 if _is_gorlami_fork_chain(chain_id) else _DEFAULT_CONFIRMATIONS
         )
-    transaction = await gas_limit_transaction(transaction)
-    transaction = await nonce_transaction(transaction)
-    transaction = await gas_price_transaction(transaction)
-    signed_transaction = await sign_callback(transaction)
-    txn_hash = await broadcast_transaction(chain_id, signed_transaction)
+    # Remote wallets on gas-sponsored chains: the backend signs, broadcasts,
+    # and covers gas — nonce/gas/fee resolution and the raw broadcast are its
+    # job, not ours. Fork chains keep the local path so simulations never
+    # leave the fork.
+    sponsored_wallet = getattr(sign_callback, "wallet_address", None)
+    if (
+        sponsored_wallet
+        and chain_id in GAS_SPONSORED_CHAIN_IDS
+        and not _is_gorlami_fork_chain(chain_id)
+    ):
+        txn_hash = await send_sponsored_transaction(sponsored_wallet, transaction)
+    else:
+        transaction = await gas_limit_transaction(transaction)
+        transaction = await nonce_transaction(transaction)
+        transaction = await gas_price_transaction(transaction)
+        signed_transaction = await sign_callback(transaction)
+        txn_hash = await broadcast_transaction(chain_id, signed_transaction)
     if isinstance(txn_hash, str) and not txn_hash.startswith("0x"):
         txn_hash = f"0x{txn_hash}"
     logger.info(f"Transaction broadcasted: {txn_hash}")

--- a/wayfinder_paths/core/utils/transaction.py
+++ b/wayfinder_paths/core/utils/transaction.py
@@ -251,10 +251,6 @@ async def broadcast_transaction(chain_id, signed_transaction: bytes) -> str:
         return tx_hash.hex()
 
 
-_SPONSORED_HASH_TIMEOUT_SECONDS = 120
-_SPONSORED_HASH_POLL_SECONDS = 2
-
-
 async def send_sponsored_transaction(wallet_address: str, transaction: dict) -> str:
     """Submit via the backend's sponsored broadcast and return the tx hash.
 
@@ -263,19 +259,19 @@ async def send_sponsored_transaction(wallet_address: str, transaction: dict) -> 
     """
     tx = dict(transaction)
     tx["from"] = wallet_address
-    result = await WALLET_CLIENT.send_transaction_sponsored(
+    result = await WALLET_CLIENT.send_privy_transaction_sponsored(
         wallet_address, _prepare_tx_for_privy(tx)
     )
     txn_hash = result["hash"]
-    deadline = time.monotonic() + _SPONSORED_HASH_TIMEOUT_SECONDS
+    deadline = time.monotonic() + 120
     while not txn_hash:
         if time.monotonic() > deadline:
             raise TimeoutError(
                 f"Sponsored transaction {result['transaction_id']} has no hash "
-                f"after {_SPONSORED_HASH_TIMEOUT_SECONDS}s"
+                f"after 120s"
             )
-        await asyncio.sleep(_SPONSORED_HASH_POLL_SECONDS)
-        status = await WALLET_CLIENT.get_transaction_status(
+        await asyncio.sleep(2)
+        status = await WALLET_CLIENT.get_privy_transaction_status(
             wallet_address, result["transaction_id"]
         )
         # "failed" is pre-broadcast (no hash will ever land); an on-chain

--- a/wayfinder_paths/core/utils/transaction.py
+++ b/wayfinder_paths/core/utils/transaction.py
@@ -1,5 +1,6 @@
 import asyncio
 import math
+import time
 from collections.abc import Callable
 from typing import Any, cast
 
@@ -7,6 +8,7 @@ from eth_account import Account
 from loguru import logger
 from web3 import AsyncWeb3
 
+from wayfinder_paths.core.clients.WalletClient import WALLET_CLIENT
 from wayfinder_paths.core.config import get_rpc_urls
 from wayfinder_paths.core.constants.base import (
     GAS_BUFFER_MULTIPLIER,
@@ -19,7 +21,7 @@ from wayfinder_paths.core.constants.chains import (
     MIN_PRIORITY_FEE_BY_CHAIN_ID,
     PRE_EIP_1559_CHAIN_IDS,
 )
-from wayfinder_paths.core.utils.wallets import send_sponsored_transaction
+from wayfinder_paths.core.utils.wallets import _prepare_tx_for_privy
 from wayfinder_paths.core.utils.web3 import (
     _is_gorlami_fork_rpc,
     get_transaction_chain_id,
@@ -249,6 +251,43 @@ async def broadcast_transaction(chain_id, signed_transaction: bytes) -> str:
         return tx_hash.hex()
 
 
+_SPONSORED_HASH_TIMEOUT_SECONDS = 120
+_SPONSORED_HASH_POLL_SECONDS = 2
+
+
+async def send_sponsored_transaction(wallet_address: str, transaction: dict) -> str:
+    """Submit via the backend's sponsored broadcast and return the tx hash.
+
+    Nonce, gas, and fees are resolved by the broadcaster, and the hash can lag
+    the submit (sponsored sends confirm asynchronously) — poll until it lands.
+    """
+    tx = dict(transaction)
+    tx["from"] = wallet_address
+    result = await WALLET_CLIENT.send_transaction_sponsored(
+        wallet_address, _prepare_tx_for_privy(tx)
+    )
+    txn_hash = result["hash"]
+    deadline = time.monotonic() + _SPONSORED_HASH_TIMEOUT_SECONDS
+    while not txn_hash:
+        if time.monotonic() > deadline:
+            raise TimeoutError(
+                f"Sponsored transaction {result['transaction_id']} has no hash "
+                f"after {_SPONSORED_HASH_TIMEOUT_SECONDS}s"
+            )
+        await asyncio.sleep(_SPONSORED_HASH_POLL_SECONDS)
+        status = await WALLET_CLIENT.get_transaction_status(
+            wallet_address, result["transaction_id"]
+        )
+        # "failed" is pre-broadcast (no hash will ever land); an on-chain
+        # revert still yields a hash and is caught by the receipt wait.
+        if status["status"] == "failed":
+            raise RuntimeError(
+                f"Sponsored transaction {result['transaction_id']} failed before broadcast"
+            )
+        txn_hash = status["hash"]
+    return txn_hash
+
+
 async def wait_for_transaction_receipt(
     chain_id: int,
     txn_hash: str,
@@ -307,14 +346,16 @@ async def send_transaction(
     # Remote wallets on gas-sponsored chains: the backend signs, broadcasts,
     # and covers gas — nonce/gas/fee resolution and the raw broadcast are its
     # job, not ours. Fork chains keep the local path so simulations never
-    # leave the fork.
-    sponsored_wallet = getattr(sign_callback, "wallet_address", None)
+    # leave the fork. Every sign callback carries `wallet_address` (None for
+    # local keys) — see the factories in core/utils/wallets.py.
     if (
-        sponsored_wallet
+        sign_callback.wallet_address
         and chain_id in GAS_SPONSORED_CHAIN_IDS
         and not _is_gorlami_fork_chain(chain_id)
     ):
-        txn_hash = await send_sponsored_transaction(sponsored_wallet, transaction)
+        txn_hash = await send_sponsored_transaction(
+            sign_callback.wallet_address, transaction
+        )
     else:
         transaction = await gas_limit_transaction(transaction)
         transaction = await nonce_transaction(transaction)
@@ -350,6 +391,7 @@ async def sign_and_send_transaction(
         signed = account.sign_transaction(tx)
         return signed.raw_transaction
 
+    sign_callback.wallet_address = None
     return await send_transaction(
         transaction,
         sign_callback,

--- a/wayfinder_paths/core/utils/wallets.py
+++ b/wayfinder_paths/core/utils/wallets.py
@@ -214,6 +214,12 @@ async def send_sponsored_transaction(wallet_address: str, transaction: dict) -> 
         status = await WALLET_CLIENT.get_transaction_status(
             wallet_address, result["transaction_id"]
         )
+        # "failed" is pre-broadcast (no hash will ever land); an on-chain
+        # revert still yields a hash and is caught by the receipt wait.
+        if status["status"] == "failed":
+            raise RuntimeError(
+                f"Sponsored transaction {result['transaction_id']} failed before broadcast"
+            )
         txn_hash = status["hash"]
     return txn_hash
 

--- a/wayfinder_paths/core/utils/wallets.py
+++ b/wayfinder_paths/core/utils/wallets.py
@@ -1,6 +1,4 @@
-import asyncio
 import json
-import time
 from pathlib import Path
 from typing import Any
 
@@ -112,6 +110,10 @@ def get_local_sign_callback(private_key: str):
         signed = account.sign_transaction(transaction)
         return signed.raw_transaction
 
+    # Sign-callback contract: `wallet_address` is set on every callback.
+    # None means local key — send_transaction() never routes it through the
+    # sponsored backend broadcast.
+    sign_callback.wallet_address = None
     return sign_callback
 
 
@@ -181,47 +183,10 @@ def get_remote_sign_callback(wallet_address: str):
         )
         return bytes.fromhex(hex_str.removeprefix("0x"))
 
-    # send_transaction() reads this to route gas-sponsored chains through the
-    # backend broadcast; local-key callbacks never carry it.
+    # Sign-callback contract: send_transaction() reads this to route
+    # gas-sponsored chains through the backend broadcast.
     sign_callback.wallet_address = wallet_address
     return sign_callback
-
-
-_SPONSORED_HASH_TIMEOUT_SECONDS = 120
-_SPONSORED_HASH_POLL_SECONDS = 2
-
-
-async def send_sponsored_transaction(wallet_address: str, transaction: dict) -> str:
-    """Submit via the backend's sponsored broadcast and return the tx hash.
-
-    Nonce, gas, and fees are resolved by the broadcaster, and the hash can lag
-    the submit (sponsored sends confirm asynchronously) — poll until it lands.
-    """
-    tx = dict(transaction)
-    tx["from"] = wallet_address
-    result = await WALLET_CLIENT.send_transaction(
-        wallet_address, _prepare_tx_for_privy(tx)
-    )
-    txn_hash = result["hash"]
-    deadline = time.monotonic() + _SPONSORED_HASH_TIMEOUT_SECONDS
-    while not txn_hash:
-        if time.monotonic() > deadline:
-            raise TimeoutError(
-                f"Sponsored transaction {result['transaction_id']} has no hash "
-                f"after {_SPONSORED_HASH_TIMEOUT_SECONDS}s"
-            )
-        await asyncio.sleep(_SPONSORED_HASH_POLL_SECONDS)
-        status = await WALLET_CLIENT.get_transaction_status(
-            wallet_address, result["transaction_id"]
-        )
-        # "failed" is pre-broadcast (no hash will ever land); an on-chain
-        # revert still yields a hash and is caught by the receipt wait.
-        if status["status"] == "failed":
-            raise RuntimeError(
-                f"Sponsored transaction {result['transaction_id']} failed before broadcast"
-            )
-        txn_hash = status["hash"]
-    return txn_hash
 
 
 def _sanitize_typed_data(obj: Any) -> Any:

--- a/wayfinder_paths/core/utils/wallets.py
+++ b/wayfinder_paths/core/utils/wallets.py
@@ -1,4 +1,6 @@
+import asyncio
 import json
+import time
 from pathlib import Path
 from typing import Any
 
@@ -179,7 +181,41 @@ def get_remote_sign_callback(wallet_address: str):
         )
         return bytes.fromhex(hex_str.removeprefix("0x"))
 
+    # send_transaction() reads this to route gas-sponsored chains through the
+    # backend broadcast; local-key callbacks never carry it.
+    sign_callback.wallet_address = wallet_address
     return sign_callback
+
+
+_SPONSORED_HASH_TIMEOUT_SECONDS = 120
+_SPONSORED_HASH_POLL_SECONDS = 2
+
+
+async def send_sponsored_transaction(wallet_address: str, transaction: dict) -> str:
+    """Submit via the backend's sponsored broadcast and return the tx hash.
+
+    Nonce, gas, and fees are resolved by the broadcaster, and the hash can lag
+    the submit (sponsored sends confirm asynchronously) — poll until it lands.
+    """
+    tx = dict(transaction)
+    tx["from"] = wallet_address
+    result = await WALLET_CLIENT.send_transaction(
+        wallet_address, _prepare_tx_for_privy(tx)
+    )
+    txn_hash = result["hash"]
+    deadline = time.monotonic() + _SPONSORED_HASH_TIMEOUT_SECONDS
+    while not txn_hash:
+        if time.monotonic() > deadline:
+            raise TimeoutError(
+                f"Sponsored transaction {result['transaction_id']} has no hash "
+                f"after {_SPONSORED_HASH_TIMEOUT_SECONDS}s"
+            )
+        await asyncio.sleep(_SPONSORED_HASH_POLL_SECONDS)
+        status = await WALLET_CLIENT.get_transaction_status(
+            wallet_address, result["transaction_id"]
+        )
+        txn_hash = status["hash"]
+    return txn_hash
 
 
 def _sanitize_typed_data(obj: Any) -> Any:


### PR DESCRIPTION
### Summary
- `send_transaction` gains a single branch: remote wallets on gas-sponsored chains submit the unsigned transaction to the backend, which broadcasts it with gas covered — local gas/nonce/fee resolution and the raw broadcast are skipped. All other chains (and fork chains, so simulations never leave the fork) keep the existing sign→broadcast path unchanged.
- Sign-callback contract: every callback factory sets `wallet_address` (remote address, or `None` for local keys) so the routing check is a direct attribute read.
- `GAS_SPONSORED_CHAIN_IDS` in `core/constants/chains.py` (ETH, Base, Arbitrum, BSC, Polygon, Monad, MegaETH, Plasma).
- `send_sponsored_transaction` lives beside `broadcast_transaction` in `core/utils/transaction.py`: submits via `WalletClient.send_transaction_sponsored`, polls status until the hash lands, and fails fast if the transaction dies pre-broadcast; the usual receipt wait then applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)