### PR TITLE
Gas Sponsorship - Feature-switch gate for sponsored broadcast

### DIFF
--- a/wayfinder_paths/core/clients/WalletClient.py
+++ b/wayfinder_paths/core/clients/WalletClient.py
@@ -9,6 +9,11 @@ from wayfinder_paths.core.config import get_api_base_url
 
 
 class WalletClient(WayfinderClient):
+    async def get_features(self) -> dict[str, Any]:
+        url = f"{get_api_base_url()}/features/"
+        resp = await self._authed_request("GET", url)
+        return resp.json()
+
     async def list_wallets(
         self, instance_id: str | None = None
     ) -> list[dict[str, Any]]:

--- a/wayfinder_paths/core/utils/transaction.py
+++ b/wayfinder_paths/core/utils/transaction.py
@@ -251,6 +251,15 @@ async def broadcast_transaction(chain_id, signed_transaction: bytes) -> str:
         return tx_hash.hex()
 
 
+async def sponsorship_enabled() -> bool:
+    # Fetch failure falls back to the local sign-and-broadcast path.
+    try:
+        features = await WALLET_CLIENT.get_features()
+        return "privy_gas_sponsorship_enabled" in features["enabledSwitches"]
+    except Exception:
+        return False
+
+
 async def send_sponsored_transaction(wallet_address: str, transaction: dict) -> str:
     """Submit via the backend's sponsored broadcast and return the tx hash.
 
@@ -348,6 +357,7 @@ async def send_transaction(
         sign_callback.wallet_address
         and chain_id in GAS_SPONSORED_CHAIN_IDS
         and not _is_gorlami_fork_chain(chain_id)
+        and await sponsorship_enabled()
     ):
         txn_hash = await send_sponsored_transaction(
             sign_callback.wallet_address, transaction


### PR DESCRIPTION
### Summary
- `send_transaction`'s sponsored branch now also requires the backend feature switch `privy_gas_sponsorship_enabled`, read from `GET /features/` fresh on every transaction so a toggle applies immediately. Switch off — or any fetch failure — falls back to the existing local sign-and-broadcast path.
- `WalletClient.get_features` added (transport only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)