### PR TITLE
Gas Sponsorship - Fallback to Local Broadcast

### DIFF
--- a/wayfinder_paths/core/utils/test_transaction.py
+++ b/wayfinder_paths/core/utils/test_transaction.py
@@ -11,6 +11,7 @@ from wayfinder_paths.core.constants.base import (
 )
 from wayfinder_paths.core.utils.transaction import (
     PRE_EIP_1559_CHAIN_IDS,
+    SponsorshipUnavailableError,
     TransactionRevertedError,
     _get_transaction_from_address,
     gas_limit_transaction,
@@ -488,3 +489,49 @@ class TestSendTransaction:
             wait_for_receipt=True,
         )
         assert txn_hash == "0xabc"
+
+    @patch("wayfinder_paths.core.utils.transaction.wait_for_transaction_receipt")
+    @patch("wayfinder_paths.core.utils.transaction.broadcast_transaction")
+    @patch("wayfinder_paths.core.utils.transaction.gas_price_transaction")
+    @patch("wayfinder_paths.core.utils.transaction.nonce_transaction")
+    @patch("wayfinder_paths.core.utils.transaction.gas_limit_transaction")
+    @patch("wayfinder_paths.core.utils.transaction.send_sponsored_transaction")
+    @patch("wayfinder_paths.core.utils.transaction.sponsorship_enabled")
+    async def test_falls_back_to_local_broadcast_when_sponsorship_unavailable(
+        self,
+        mock_sponsorship_enabled,
+        mock_send_sponsored,
+        mock_gas_limit,
+        mock_nonce,
+        mock_gas_price,
+        mock_broadcast,
+        mock_wait_receipt,
+    ):
+        mock_sponsorship_enabled.return_value = True
+        mock_send_sponsored.side_effect = SponsorshipUnavailableError(
+            "Sponsored send rejected with 402"
+        )
+        tx = {"from": RANDOM_USER_0, "chainId": 1, "gas": 50_000}
+        mock_gas_limit.return_value = tx
+        mock_nonce.return_value = {**tx, "nonce": 1}
+        mock_gas_price.return_value = {
+            **tx,
+            "nonce": 1,
+            "maxFeePerGas": 1,
+            "maxPriorityFeePerGas": 1,
+        }
+        mock_broadcast.return_value = "0xabc"
+        mock_wait_receipt.return_value = {"status": 1, "gasUsed": 40_000}
+
+        async def sign_callback(_tx: dict) -> bytes:
+            return b"\x00"
+
+        sign_callback.wallet_address = RANDOM_USER_0
+        txn_hash = await send_transaction(
+            {"from": RANDOM_USER_0, "chainId": 1},
+            sign_callback,
+            wait_for_receipt=True,
+        )
+        assert txn_hash == "0xabc"
+        mock_send_sponsored.assert_awaited_once()
+        mock_broadcast.assert_awaited_once()

--- a/wayfinder_paths/core/utils/test_transaction.py
+++ b/wayfinder_paths/core/utils/test_transaction.py
@@ -1,6 +1,7 @@
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from web3 import AsyncWeb3
 
@@ -17,6 +18,7 @@ from wayfinder_paths.core.utils.transaction import (
     gas_limit_transaction,
     gas_price_transaction,
     nonce_transaction,
+    send_sponsored_transaction,
     send_transaction,
 )
 from wayfinder_paths.core.utils.web3 import get_transaction_chain_id
@@ -535,3 +537,34 @@ class TestSendTransaction:
         assert txn_hash == "0xabc"
         mock_send_sponsored.assert_awaited_once()
         mock_broadcast.assert_awaited_once()
+
+
+def _http_status_error(status: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://backend/send-transaction-sponsored/")
+    return httpx.HTTPStatusError(
+        "rejected", request=request, response=httpx.Response(status, request=request)
+    )
+
+
+@pytest.mark.asyncio
+class TestSendSponsoredTransaction:
+    @pytest.mark.parametrize("status", [400, 402, 403, 429])
+    @patch("wayfinder_paths.core.utils.transaction.WALLET_CLIENT")
+    async def test_rejection_maps_to_fallback(self, mock_client, status):
+        mock_client.send_privy_transaction_sponsored = AsyncMock(
+            side_effect=_http_status_error(status)
+        )
+        with pytest.raises(SponsorshipUnavailableError):
+            await send_sponsored_transaction(
+                RANDOM_USER_0, {"chainId": 1, "to": RANDOM_USER_0}
+            )
+
+    @patch("wayfinder_paths.core.utils.transaction.WALLET_CLIENT")
+    async def test_server_error_stays_fatal(self, mock_client):
+        mock_client.send_privy_transaction_sponsored = AsyncMock(
+            side_effect=_http_status_error(502)
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            await send_sponsored_transaction(
+                RANDOM_USER_0, {"chainId": 1, "to": RANDOM_USER_0}
+            )

--- a/wayfinder_paths/core/utils/transaction.py
+++ b/wayfinder_paths/core/utils/transaction.py
@@ -4,6 +4,7 @@ import time
 from collections.abc import Callable
 from typing import Any, cast
 
+import httpx
 from eth_account import Account
 from loguru import logger
 from web3 import AsyncWeb3
@@ -38,6 +39,10 @@ def _is_gorlami_fork_chain(chain_id: int) -> bool:
     if isinstance(rpcs, str):
         rpcs = [rpcs]
     return any(_is_gorlami_fork_rpc(rpc) for rpc in rpcs if isinstance(rpc, str))
+
+
+class SponsorshipUnavailableError(RuntimeError):
+    """Sponsored submission was rejected before anything reached the chain."""
 
 
 class TransactionRevertedError(RuntimeError):
@@ -268,9 +273,21 @@ async def send_sponsored_transaction(wallet_address: str, transaction: dict) -> 
     """
     tx = dict(transaction)
     tx["from"] = wallet_address
-    result = await WALLET_CLIENT.send_privy_transaction_sponsored(
-        wallet_address, _prepare_tx_for_privy(tx)
-    )
+    try:
+        result = await WALLET_CLIENT.send_privy_transaction_sponsored(
+            wallet_address, _prepare_tx_for_privy(tx)
+        )
+    except httpx.HTTPStatusError as exc:
+        # A 4xx means the broadcaster refused the submission (sponsorship
+        # disabled, credits depleted, chain not covered) and nothing reached
+        # the chain — safe to retry unsponsored. 5xx/timeouts are ambiguous:
+        # the transaction may have been accepted, so retrying risks a
+        # double-send and they stay fatal.
+        if exc.response.status_code in (400, 402, 403):
+            raise SponsorshipUnavailableError(
+                f"Sponsored send rejected with {exc.response.status_code}"
+            ) from exc
+        raise
     txn_hash = result["hash"]
     deadline = time.monotonic() + 120
     while not txn_hash:
@@ -286,7 +303,7 @@ async def send_sponsored_transaction(wallet_address: str, transaction: dict) -> 
         # "failed" is pre-broadcast (no hash will ever land); an on-chain
         # revert still yields a hash and is caught by the receipt wait.
         if status["status"] == "failed":
-            raise RuntimeError(
+            raise SponsorshipUnavailableError(
                 f"Sponsored transaction {result['transaction_id']} failed before broadcast"
             )
         txn_hash = status["hash"]
@@ -353,16 +370,22 @@ async def send_transaction(
     # job, not ours. Fork chains keep the local path so simulations never
     # leave the fork. Every sign callback carries `wallet_address` (None for
     # local keys) — see the factories in core/utils/wallets.py.
+    txn_hash = None
     if (
         sign_callback.wallet_address
         and chain_id in GAS_SPONSORED_CHAIN_IDS
         and not _is_gorlami_fork_chain(chain_id)
         and await sponsorship_enabled()
     ):
-        txn_hash = await send_sponsored_transaction(
-            sign_callback.wallet_address, transaction
-        )
-    else:
+        try:
+            txn_hash = await send_sponsored_transaction(
+                sign_callback.wallet_address, transaction
+            )
+        except SponsorshipUnavailableError as exc:
+            logger.warning(
+                f"Sponsored send unavailable, falling back to local broadcast: {exc}"
+            )
+    if txn_hash is None:
         transaction = await gas_limit_transaction(transaction)
         transaction = await nonce_transaction(transaction)
         transaction = await gas_price_transaction(transaction)

--- a/wayfinder_paths/core/utils/transaction.py
+++ b/wayfinder_paths/core/utils/transaction.py
@@ -279,11 +279,11 @@ async def send_sponsored_transaction(wallet_address: str, transaction: dict) -> 
         )
     except httpx.HTTPStatusError as exc:
         # A 4xx means the broadcaster refused the submission (sponsorship
-        # disabled, credits depleted, chain not covered) and nothing reached
-        # the chain — safe to retry unsponsored. 5xx/timeouts are ambiguous:
-        # the transaction may have been accepted, so retrying risks a
-        # double-send and they stay fatal.
-        if exc.response.status_code in (400, 402, 403):
+        # disabled, credits depleted, chain not covered, or the daily quota is
+        # spent — 429) and nothing reached the chain, so it's safe to retry
+        # unsponsored. 5xx/timeouts are ambiguous: the transaction may have
+        # been accepted, so retrying risks a double-send and they stay fatal.
+        if exc.response.status_code in (400, 402, 403, 429):
             raise SponsorshipUnavailableError(
                 f"Sponsored send rejected with {exc.response.status_code}"
             ) from exc


### PR DESCRIPTION
### Summary
When a sponsored submission is rejected before broadcast — backend `400/402/403/429` (sponsorship disabled, gas credits depleted, chain not covered, or the daily quota is spent), or a pre-broadcast `failed` status — `send_transaction` falls back to the local sign-and-broadcast path instead of raising. `5xx`/timeouts stay fatal since the transaction may have been accepted and retrying would risk a double-send.