### PR TITLE
Fix visual chart spec import on Shells and surface workspace API errors

### DIFF
--- a/.claude/skills/using-delta-lab/rules/v2-surface.md
+++ b/.claude/skills/using-delta-lab/rules/v2-surface.md
@@ -22,6 +22,13 @@ legacy `get_basis_apy_sources`, `get_top_apy`, `get_asset_timeseries`,
 **Never** default to `limit=500` on opportunity endpoints in agent
 contexts. Default `limit=25` lands under 10 KB for every search surface.
 
+Point time-series methods (`get_asset_price_ts`, `get_asset_yield_ts`,
+`get_market_lending_ts`, `get_market_pendle_ts`, `get_market_boros_ts`,
+`get_instrument_funding_ts`) auto-size `limit` to the `lookback_days`
+window at hourly cadence (`days × 24`, capped at 10,000) when you don't
+pass one — so `lookback_days=90` returns the full 90 days. Still verify
+the returned row count matches the window you asked for before charting.
+
 ## Composition recipes (chain calls for hard asks)
 
 Most single methods are narrow primitives. When one method doesn't give

--- a/.claude/skills/using-visual-chart-annotations/SKILL.md
+++ b/.claude/skills/using-visual-chart-annotations/SKILL.md
@@ -125,7 +125,9 @@ order book, trades, and trade ticket while keeping the workspace chart active:
 
 Supported transforms: `filter`, `latest_by`, `top_n`, `rebase`, `pct_change`, `scale`, `multiply`, `ratio`, `spread`, `moving_average`. Prefer `rebase(base=100)` for relative performance across different units.
 
-Transforms can live on the chart or on a single series. Copy any `default_transforms` from a search result into the series `transforms`, then add metric conversions. Use series-level transforms when only one dataset needs conversion.
+Transforms can live on the chart or on a single series. Copy any `default_transforms` from a search result into the series `transforms`, then add metric conversions. Use series-level transforms when only one dataset needs conversion. Chart-level transforms hit **every** series unless you scope them with `"series_ids": ["..."]`.
+
+**Scaling a ratio**: put `scale` on the ratio transform itself — `{"type": "ratio", "left": "a", "right": "b", "scale": 1e6, "label_suffix": "(×10⁶)", "unit": "ratio"}` — which scales only the derived series. Never use a chart-level `scale` for this: it multiplies the sources *before* division, so it corrupts them and mathematically cancels out of the ratio.
 
 Delta Lab APY/rate fields are decimal fractions. `0.12` means `12%`, not `0.12%`.
 

--- a/.opencode/agents/wayfinder-visual.md
+++ b/.opencode/agents/wayfinder-visual.md
@@ -93,6 +93,7 @@ For Delta Lab, APY, funding, lending, Pendle, borrow-route, basis, and time-seri
   - Pendle/lending/Boros/yield APY or APR fields such as `implied_apy`, `underlying_apy`, `supply_apr`, `borrow_apr`, `fixed_rate_mark`, and `floating_rate_oracle`: `{"type": "scale", "factor": 100, "unit": "%", "label_suffix": "(%)"}`.
   - Hyperliquid/Delta Lab hourly `funding_rate` shown annualized: `{"type": "scale", "factor": 876000, "unit": "%", "label_suffix": "(annualized %)"}`.
   - Do not label raw `0.12` as `0.12%`; it is `12%` after scaling.
+- Chart-level transforms apply to **every** series unless scoped with `"series_ids": ["..."]`. Prefer series-level transforms or scoped chart-level ones; an unscoped chart-level `scale` on a mixed chart corrupts the series you didn't mean to touch.
 
 ### Common Chart Patterns
 
@@ -103,6 +104,13 @@ Relative performance:
 - Apply `{"type":"rebase","base":100}` to each price series.
 - Use visibly distinct colors. Do not put two comparison assets in near-identical brand colors (for example ZEC orange and BTC orange); keep the first natural color if useful, then choose contrasting green/blue/yellow/red/purple for the rest.
 - State the shared lookback and base timestamp in `viewSummary`.
+
+Ratio / spread of two assets (e.g. AERO/ETH):
+
+- Add both source series, then a chart-level `{"type": "ratio", "left": "<series-id>", "right": "<series-id>"}` transform — it appends a derived series.
+- To make a tiny ratio readable, put `scale` **on the ratio transform itself**: `{"type": "ratio", "left": "a", "right": "b", "scale": 1e6, "label_suffix": "(×10⁶)", "unit": "ratio"}`. Never use a chart-level `scale` for this — it multiplies the sources *before* division, so it corrupts them and mathematically cancels out of the ratio.
+- Mixed units on one pane (raw ratio next to rebased prices) render badly on a shared axis. Either set `"axis": "right"` on the differently-scaled series, or split into two charts (ratio pane + rebased-performance pane). Decide the layout before creating; do not rebuild the same chart repeatedly to discover it.
+- Statistical overlays (mean/±σ bands) must be computed from the same window and scaling as the plotted derived series.
 
 VIRTUAL APY/funding/net:
 
@@ -134,6 +142,10 @@ After creating or importing a workspace chart, verify the returned workspace sta
 Describe workspace navigation accurately: workspace charts render as chart cards in the main chart area, not inside the command/search palette. When at least one workspace chart exists, the chart header shows a small chart-mode icon toggle; from the live market it opens the saved workspace charts, and from workspace mode it returns to the live market. If no workspace charts exist, there is no toggle.
 
 If data is missing, a tool call stalls/fails, or a series fails to render, report the failed series/source in `viewSummary` or `needsClarification` rather than claiming success. If you did not call `visual_create_chart` or update an existing workspace chart, the chart is not done. Do not return a chart-series availability report as the final result for a charting task.
+
+When a chart tool returns `ok: false`, read `error.message` and `error.details` — workspace 400s carry the exact backend validation failure (for example `chart resolved empty series: <labels>`). Fix that specific problem (usually via `visual_add_workspace_chart_series` on the offending series) instead of rebuilding the whole chart blind. If the same call fails twice with the same error, change approach or report the failure; do not retry a third time unchanged.
+
+When fetching Delta Lab time series for a lookback window, sanity-check the returned row count against the expected cadence (hourly data ⇒ `lookback_days × 24` rows). A short result means truncation or gaps — widen `limit` or report the actual covered window; never present a truncated window as the requested one.
 
 Empty task results are forbidden. If the chart cannot be rendered, return the attempted source/path, the exact failure, and the next concrete action in `failedSeries` or `needsClarification`.
 

--- a/.opencode/agents/wayfinder.md
+++ b/.opencode/agents/wayfinder.md
@@ -423,7 +423,7 @@ Use direct visual tools for cheap chart orchestration before involving subagents
 - Delegate workspace chart creation and multi-series mutations to `wayfinder-visual`: comparisons, relative performance, APY/funding/lending/basis charts, and derived/multi-series panes.
 - Do not call `wayfinder-quant` for simple iteration, single-token chart routing, or source-backed chart comparisons the visual tools can render.
 
-When delegating chart work, pass the exact user request, current chart context if relevant, exact series/source IDs you already found, desired lookback/window, and units/formulas. Do not ask the visual agent to rediscover data you already resolved.
+When delegating chart work, pass the exact user request, current chart context if relevant, exact series/source IDs you already found, desired lookback/window, and units/formulas. Do not ask the visual agent to rediscover data you already resolved. For derived charts (ratios, spreads, net series), also state the expected value range and the desired layout up front — for example "ratio is ~2e-4: scale it ×1e6 on the ratio transform itself, and put rebased prices on a separate axis or pane" — so the visual agent picks the right structure on the first attempt instead of rebuilding.
 
 Examples:
 

--- a/wayfinder_paths/core/clients/DeltaLabClient.py
+++ b/wayfinder_paths/core/clients/DeltaLabClient.py
@@ -1947,9 +1947,7 @@ def _ts_params(
     truncated lookback_days=90 to ~21 days of data.
     """
     if limit is None:
-        limit = (
-            min(10_000, max(500, lookback_days * 24 + 24)) if lookback_days else 500
-        )
+        limit = min(10_000, max(500, lookback_days * 24 + 24)) if lookback_days else 500
     params: dict[str, Any] = {
         "lookback_days": lookback_days,
         "limit": limit,

--- a/wayfinder_paths/core/clients/DeltaLabClient.py
+++ b/wayfinder_paths/core/clients/DeltaLabClient.py
@@ -1196,7 +1196,7 @@ class DeltaLabClient(WayfinderClient):
         *,
         asset_id: int,
         lookback_days: int | None = 30,
-        limit: int | None = 500,
+        limit: int | None = None,
         start: datetime | str | None = None,
         end: datetime | str | None = None,
     ) -> pd.DataFrame:
@@ -1222,7 +1222,7 @@ class DeltaLabClient(WayfinderClient):
         *,
         asset_id: int,
         lookback_days: int | None = 30,
-        limit: int | None = 500,
+        limit: int | None = None,
         start: datetime | str | None = None,
         end: datetime | str | None = None,
     ) -> pd.DataFrame:
@@ -1249,7 +1249,7 @@ class DeltaLabClient(WayfinderClient):
         market_id: int,
         asset_id: int,
         lookback_days: int | None = 30,
-        limit: int | None = 500,
+        limit: int | None = None,
         start: datetime | str | None = None,
         end: datetime | str | None = None,
     ) -> pd.DataFrame:
@@ -1287,7 +1287,7 @@ class DeltaLabClient(WayfinderClient):
         *,
         market_id: int,
         lookback_days: int | None = 30,
-        limit: int | None = 500,
+        limit: int | None = None,
         start: datetime | str | None = None,
         end: datetime | str | None = None,
     ) -> pd.DataFrame:
@@ -1313,7 +1313,7 @@ class DeltaLabClient(WayfinderClient):
         *,
         market_id: int,
         lookback_days: int | None = 30,
-        limit: int | None = 500,
+        limit: int | None = None,
         start: datetime | str | None = None,
         end: datetime | str | None = None,
     ) -> pd.DataFrame:
@@ -1339,7 +1339,7 @@ class DeltaLabClient(WayfinderClient):
         *,
         instrument_id: int,
         lookback_days: int | None = 30,
-        limit: int | None = 500,
+        limit: int | None = None,
         start: datetime | str | None = None,
         end: datetime | str | None = None,
     ) -> pd.DataFrame:
@@ -1940,7 +1940,16 @@ def _ts_params(
     end: datetime | str | None,
     extra: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Common query params for all ID-keyed point-TS endpoints."""
+    """Common query params for all ID-keyed point-TS endpoints.
+
+    When the caller sets a lookback but no explicit limit, size the limit to
+    cover the window at hourly cadence — a fixed 500 default silently
+    truncated lookback_days=90 to ~21 days of data.
+    """
+    if limit is None:
+        limit = (
+            min(10_000, max(500, lookback_days * 24 + 24)) if lookback_days else 500
+        )
     params: dict[str, Any] = {
         "lookback_days": lookback_days,
         "limit": limit,

--- a/wayfinder_paths/mcp/tools/instance_state.py
+++ b/wayfinder_paths/mcp/tools/instance_state.py
@@ -109,7 +109,6 @@ def _resolve_visual_spec_path(path_raw: str) -> tuple[Path, str] | dict[str, Any
     resolved = path.resolve(strict=False)
 
     try:
-        display_path = str(resolved.relative_to(root))
         resolved.relative_to(allowed_dir)
     except ValueError:
         return err(
@@ -117,6 +116,14 @@ def _resolve_visual_spec_path(path_raw: str) -> tuple[Path, str] | dict[str, Any
             "path must be under .wayfinder_runs/visual_specs",
             {"path": str(resolved), "allowed_dir": str(allowed_dir)},
         )
+
+    # Display path only. On Shells, .wayfinder_runs is a symlink out of the
+    # repo (/wf/user_vault/scripts), so the resolved path legitimately escapes
+    # the repo root — that must not fail validation.
+    try:
+        display_path = str(resolved.relative_to(root))
+    except ValueError:
+        display_path = str(resolved)
 
     if resolved.suffix.lower() != ".json":
         return err(
@@ -414,7 +421,8 @@ async def visual_set_active_chart(chart_id: str) -> dict[str, Any]:
         workspace["version"] = int(workspace.get("version") or 1) + 1
         return ok(await INSTANCE_STATE_CLIENT.patch_chart_workspace(workspace))
     except httpx.HTTPStatusError as exc:
-        return err("chart_workspace_http_error", f"HTTP {exc.response.status_code}")
+        message, details = _http_error_message(exc)
+        return err("chart_workspace_http_error", message, details)
     except Exception as exc:  # noqa: BLE001
         return err("chart_workspace_error", str(exc))
 
@@ -437,7 +445,8 @@ async def visual_add_workspace_chart_series(
             await INSTANCE_STATE_CLIENT.add_workspace_chart_series(chart_id, series)
         )
     except httpx.HTTPStatusError as exc:
-        return err("chart_workspace_http_error", f"HTTP {exc.response.status_code}")
+        message, details = _http_error_message(exc)
+        return err("chart_workspace_http_error", message, details)
     except Exception as exc:  # noqa: BLE001
         return err("chart_workspace_error", str(exc))
 

--- a/wayfinder_paths/mcp/tools/instance_state.py
+++ b/wayfinder_paths/mcp/tools/instance_state.py
@@ -314,8 +314,12 @@ async def visual_create_chart(
       {"type": "scale", "factor": 100, "unit": "%", "label_suffix": "(%)"}.
       Annualize hourly funding directly to percent with {"type": "scale",
       "factor": 876000, "unit": "%", "label_suffix": "(annualized %)"}.
-      Use chart-level transforms only when all series should be transformed
-      together.
+      Chart-level transforms apply to every series unless scoped with
+      `series_ids: ["..."]`. To display a tiny ratio readably, put `scale`
+      on the ratio transform itself — {"type": "ratio", "left": "a",
+      "right": "b", "scale": 1000000, "label_suffix": "(×10⁶)"} — which
+      scales only the derived series; a chart-level scale would corrupt the
+      source series and cancel out of the ratio.
 
     Series can include optional `axis` ("left" or "right") and `color`.
     Keep comparable units on the same axis; use a right axis for unrelated

--- a/wayfinder_paths/tests/test_delta_lab_ts_latest.py
+++ b/wayfinder_paths/tests/test_delta_lab_ts_latest.py
@@ -102,6 +102,25 @@ async def test_price_ts_returns_indexed_dataframe(
 
 
 @pytest.mark.asyncio
+async def test_price_ts_sizes_limit_to_lookback_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without an explicit limit, size it to hourly cadence — a fixed 500
+    default silently truncated lookback_days=90 to ~21 days of data."""
+    c, mock = _make_client(monkeypatch, [{"items": _PRICE_ROWS, "count": 2}])
+    await c.get_asset_price_ts(asset_id=2, lookback_days=90)
+    assert mock.await_args.kwargs["params"]["limit"] == 90 * 24 + 24
+
+    c, mock = _make_client(monkeypatch, [{"items": _PRICE_ROWS, "count": 2}])
+    await c.get_asset_price_ts(asset_id=2, lookback_days=3)
+    assert mock.await_args.kwargs["params"]["limit"] == 500
+
+    c, mock = _make_client(monkeypatch, [{"items": _PRICE_ROWS, "count": 2}])
+    await c.get_asset_price_ts(asset_id=2, lookback_days=90, limit=100)
+    assert mock.await_args.kwargs["params"]["limit"] == 100
+
+
+@pytest.mark.asyncio
 async def test_price_latest_returns_typed(monkeypatch: pytest.MonkeyPatch) -> None:
     c, _ = _make_client(
         monkeypatch,

--- a/wayfinder_paths/tests/test_instance_state_tools.py
+++ b/wayfinder_paths/tests/test_instance_state_tools.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 
+import httpx
 import pytest
 
 from wayfinder_paths.mcp.tools import instance_state
@@ -206,6 +207,79 @@ async def test_visual_import_chart_spec_imports_safe_spec(
         "chart_workspace": {"activeChartId": "virtual-yield", "version": 4},
         "chart_validation": {"series": [{"id": "moonwell-virtual"}]},
     }
+
+
+@pytest.mark.asyncio
+async def test_visual_import_chart_spec_accepts_symlinked_wayfinder_runs(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Shells mounts .wayfinder_runs as a symlink out of the repo root
+    (/wf/user_vault/scripts). The resolved spec path escapes the root but is
+    still under the resolved visual_specs dir — validation must accept it."""
+    repo = tmp_path / "sdk"
+    repo.mkdir()
+    real_runs = tmp_path / "user_vault" / "scripts"
+    (real_runs / "visual_specs").mkdir(parents=True)
+    (repo / ".wayfinder_runs").symlink_to(real_runs, target_is_directory=True)
+
+    monkeypatch.setattr(instance_state, "is_opencode_instance", lambda: True)
+    monkeypatch.setattr(instance_state, "repo_root", lambda: repo)
+
+    spec_path = real_runs / "visual_specs" / "chart.json"
+    spec_path.write_text(
+        json.dumps({"id": "c1", "title": "C1", "kind": "line", "series": []})
+    )
+
+    async def fake_upsert(chart: dict[str, object]) -> dict[str, object]:
+        return {"chart_workspace": {"activeChartId": chart["id"], "version": 1}}
+
+    monkeypatch.setattr(
+        instance_state.INSTANCE_STATE_CLIENT,
+        "upsert_workspace_chart",
+        fake_upsert,
+    )
+
+    result = await instance_state.visual_import_chart_spec(
+        ".wayfinder_runs/visual_specs/chart.json"
+    )
+
+    assert result["ok"] is True, result
+    assert result["result"]["chart"]["id"] == "c1"
+
+
+@pytest.mark.asyncio
+async def test_visual_add_workspace_chart_series_surfaces_error_body(
+    monkeypatch,
+) -> None:
+    """Backend 400s must carry their body through — 'HTTP 400' with no details
+    left the visual agent guessing at validation failures."""
+    monkeypatch.setattr(instance_state, "is_opencode_instance", lambda: True)
+
+    request = httpx.Request("POST", "http://backend/chart-series")
+    response = httpx.Response(
+        400,
+        json={"error": "series id already exists on chart"},
+        request=request,
+    )
+
+    async def fake_add(chart_id: str, series: dict[str, object]):
+        raise httpx.HTTPStatusError("400", request=request, response=response)
+
+    monkeypatch.setattr(
+        instance_state.INSTANCE_STATE_CLIENT,
+        "add_workspace_chart_series",
+        fake_add,
+    )
+
+    result = await instance_state.visual_add_workspace_chart_series(
+        "chart-1", {"id": "s1"}
+    )
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "chart_workspace_http_error"
+    assert "series id already exists on chart" in result["error"]["message"]
+    assert result["error"]["details"] == {"error": "series id already exists on chart"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Context

Forensics on a prod visual-agent session ("Chart AERO/ETH ratio", instance `cmltpwx1w002l0cl2vwl-bd79d8c4f`): the agent needed 5 failed imports, 4 chart rebuilds, and 3 workarounds to ship two charts. Two of the four root causes are SDK tool defects fixed here (the other two are backend — companion PR in vault-backend).

## Fixes

1. **`visual_import_chart_spec` could never succeed on a Shells box.** The tool exists precisely so visual-agent scripts can generate specs with inline data without pushing large JSON through model context — and it was structurally broken: the cosmetic display-path computation (`resolved.relative_to(repo_root)`) shared a `try` with the allowed-dir containment check and raised first, because `.wayfinder_runs` is a symlink out of the repo root (`/wf/user_vault/scripts`) on every Shells instance. The containment check itself passed; the agent got a self-contradictory error showing the path *inside* the allowed dir. Split the checks; display path falls back to the absolute path. Regression test builds a real symlinked `.wayfinder_runs`.

2. **Opaque workspace API errors.** `visual_add_workspace_chart_series` and `visual_set_active_chart` returned `HTTP 400` with `details: null`, discarding the backend's `{"error": "..."}` body that names the exact validation failure — the sibling create/import tools already used the `_http_error_message` helper. The prod agent hit this, couldn't tell why, and abandoned the repair path for a full rebuild. Both tools now surface message + details.

3. Docs: tool docstring + `using-visual-chart-annotations` skill document the new backend semantics (ratio self-`scale`, chart-level transform `series_ids` scoping) so agents stop reaching for chart-level scale on ratios — it multiplies sources before division, corrupting them while cancelling out of the ratio.

## Testing

`pytest wayfinder_paths/tests/test_instance_state_tools.py` — 9 passed (2 new: symlinked-runs import succeeds; 400 body surfaces). ruff clean; zero new mypy errors vs baseline.