### PR TITLE
URGENT: resolve Polymarket deposit wallets on-chain (factory beacon upgrade stranded funds)

### DIFF
--- a/.claude/skills/using-polymarket-adapter/rules/deposit-wallet.md
+++ b/.claude/skills/using-polymarket-adapter/rules/deposit-wallet.md
@@ -6,7 +6,7 @@ Polymarket V2 trades **from a per-user smart contract wallet** ("deposit wallet"
 
 ## How the deposit wallet works
 
-- **Per-user, CREATE2-derived** from the owner EOA — deterministic, predictable address.
+- **Per-user, resolved on-chain** from the owner EOA. Polymarket's factory changed its derivation scheme on 2026-06-29 (ERC-1967 CREATE2 → beacon proxy), so the SDK asks the chain instead of deriving locally: a wallet already deployed under the old scheme stays canonical; otherwise the factory's own `predictWalletAddress` is authoritative.
   - `adapter.deposit_wallet_address()` returns it.
 - **Auto-deployed on first trade** via `ensure_trading_setup(...)`:
   - Calls the deposit-wallet factory (relayer-mediated)
@@ -65,7 +65,7 @@ A full first-time flow looks like:
 
 ## Adapter methods
 
-- `adapter.deposit_wallet_address()` — **sync** derived address (cheap, no RPC). Do not `await` it.
+- `adapter.deposit_wallet_address()` — **sync**; the first call per wallet does one on-chain resolution (RPC round-trip) then caches for the process. Do not `await` it. Raises if Polygon RPC is unreachable — there is deliberately no local-derivation fallback (a stale local scheme is how funds get stranded).
 - `await adapter.fund_deposit_wallet(amount_raw=int)` — **async** pUSD owner → deposit wallet. **`amount_raw` is in base units (6 decimals).** Returns `(ok, {"deposit_wallet", "amount_raw", "tx_hash"})`.
 - `await adapter.withdraw_deposit_wallet(amount_raw=int | None)` — **async** pUSD deposit wallet → owner. `None` drains the full balance. Returns `(ok, {"deposit_wallet", "tx_hash", "amount_raw", "recipient"})`.
 - `adapter.ensure_trading_setup(token_id=...)` — idempotent (cached); deploy + approvals + CLOB creds + balance allowance. Order placement calls this automatically.

--- a/.claude/skills/using-polymarket-adapter/rules/deposit-wallet.md
+++ b/.claude/skills/using-polymarket-adapter/rules/deposit-wallet.md
@@ -66,9 +66,29 @@ A full first-time flow looks like:
 ## Adapter methods
 
 - `adapter.deposit_wallet_address()` — **sync**; the first call per wallet does one on-chain resolution (RPC round-trip) then caches for the process. Do not `await` it. Raises if Polygon RPC is unreachable — there is deliberately no local-derivation fallback (a stale local scheme is how funds get stranded).
-- `await adapter.fund_deposit_wallet(amount_raw=int)` — **async** pUSD owner → deposit wallet. **`amount_raw` is in base units (6 decimals).** Returns `(ok, {"deposit_wallet", "amount_raw", "tx_hash"})`.
+- `await adapter.fund_deposit_wallet(amount_raw=int)` — **async** pUSD owner → deposit wallet. **Deploy-first**: the wallet is deployed via the relayer and code-verified on-chain BEFORE the transfer (never funds a codeless address; relayer down ⇒ the call fails instead of stranding funds). **`amount_raw` is in base units (6 decimals).** Returns `(ok, {"deposit_wallet", "amount_raw", "tx_hash"})`.
 - `await adapter.withdraw_deposit_wallet(amount_raw=int | None)` — **async** pUSD deposit wallet → owner. `None` drains the full balance. Returns `(ok, {"deposit_wallet", "tx_hash", "amount_raw", "recipient"})`.
 - `adapter.ensure_trading_setup(token_id=...)` — idempotent (cached); deploy + approvals + CLOB creds + balance allowance. Order placement calls this automatically.
+
+## Wallet states (`deposit_wallet_status`)
+
+`get_full_user_state(...)` (and `polymarket_get_state`) returns a `deposit_wallet_status` block — read it before advising the user about deposits:
+
+```json
+{"resolved_address": "0x…", "legacy_address": "0x…", "scheme": "legacy" | "beacon",
+ "deployed": true, "stranded_legacy_funds": null | {"legacy_address", "pusd_raw", "usdc_e_raw", "message"},
+ "guidance": "…"}
+```
+
+Polymarket's factory changed derivation schemes on 2026-06-29, which puts every user in exactly one of three states:
+
+| State | Block shape | What to do |
+| --- | --- | --- |
+| Legacy wallet (deployed pre-2026-06-29) | `scheme: "legacy"`, `deployed: true` | Nothing — fully operational. |
+| Current scheme (new/normal) | `scheme: "beacon"`, `stranded_legacy_funds: null` | Nothing — deposits deploy-first automatically. |
+| **Stranded** (deposited to the retired address post-upgrade) | `scheme: "beacon"`, `stranded_legacy_funds` set | Tell the user their funds at the legacy address need recovery via the Wayfinder Discord (https://discord.gg/aiwayfinder). **Never send funds to the legacy address.** New deposits to `resolved_address` are safe. |
+
+Follow the `guidance` string — it is written to be relayed to the user.
 
 ## Common pitfalls
 

--- a/wayfinder_paths/adapters/polymarket_adapter/adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/adapter.py
@@ -64,7 +64,7 @@ from wayfinder_paths.core.utils.multicall import (
     read_only_calls_multicall_or_gather,
 )
 from wayfinder_paths.core.utils.polymarket_wallet import (
-    check_stranded_legacy_funds,
+    get_deposit_wallet_status,
     resolve_deposit_wallet,
     resolve_deposit_wallet_sync,
 )
@@ -1526,6 +1526,8 @@ class PolymarketAdapter(BaseAdapter):
             deposit_wallet = self.deposit_wallet_address()
             if amount_raw <= 0:
                 return False, "amount must be positive"
+            # Deploy-first funding: never transfer to a codeless address.
+            await self._ensure_deposit_wallet_deployed(deposit_wallet)
             tx = await build_send_transaction(
                 from_address=owner,
                 to_address=deposit_wallet,
@@ -1583,9 +1585,46 @@ class PolymarketAdapter(BaseAdapter):
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
 
+    async def _ensure_deposit_wallet_deployed(self, deposit_wallet: str) -> str | None:
+        """Deploy the deposit wallet via the relayer if no code exists at the
+        resolved address, and verify code actually lands before returning.
+        Every funding path calls this BEFORE transferring — a transfer to a
+        codeless counterfactual address is exactly how the 2026-06-29 beacon
+        upgrade stranded funds. Returns the deploy tx hash when a deploy ran."""
+        owner = self._require_wallet_address()
+        async with web3_from_chain_id(POLYGON_CHAIN_ID) as web3:
+            code = await web3.eth.get_code(deposit_wallet)
+            if code:
+                return None
+            payload = {
+                "type": "WALLET-CREATE",
+                "from": owner,
+                "to": POLYMARKET_DEPOSIT_WALLET_FACTORY,
+            }
+            body = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+            headers = await self._builder_headers("POST", "/submit", body)
+            res = await self._relayer_http.post(
+                "/submit", content=body, headers=headers
+            )
+            res.raise_for_status()
+            deploy_tx = await self._poll_relayer_tx(res.json()["transactionID"])
+            deploy_tx_hash = deploy_tx["transactionHash"]
+            # The relayer must have deployed at the address the factory
+            # predicted — if not, the derivation scheme changed again and
+            # nothing may proceed against this address.
+            deployed_code = await web3.eth.get_code(deposit_wallet)
+            if not deployed_code:
+                raise ValueError(
+                    "Relayer WALLET-CREATE mined but no code exists at the "
+                    f"resolved deposit wallet {deposit_wallet}; the factory "
+                    "derivation may have changed — do not send funds."
+                )
+            return deploy_tx_hash
+
     async def _setup_deposit_wallet(self) -> tuple[str | None, str | None]:
         owner = self._require_wallet_address()
         deposit_wallet = await resolve_deposit_wallet(owner)
+        deploy_tx_hash = await self._ensure_deposit_wallet_deployed(deposit_wallet)
         async with web3_from_chain_id(POLYGON_CHAIN_ID) as web3:
             pusd = web3.eth.contract(
                 address=POLYGON_P_USDC_PROXY_ADDRESS, abi=ERC20_ABI
@@ -1594,8 +1633,7 @@ class PolymarketAdapter(BaseAdapter):
                 address=POLYMARKET_CONDITIONAL_TOKENS_ADDRESS,
                 abi=CONDITIONAL_TOKENS_ABI,
             )
-            code, allowances, approvals = await asyncio.gather(
-                web3.eth.get_code(deposit_wallet),
+            allowances, approvals = await asyncio.gather(
                 asyncio.gather(
                     *[
                         pusd.functions.allowance(deposit_wallet, s).call(
@@ -1613,33 +1651,6 @@ class PolymarketAdapter(BaseAdapter):
                     ]
                 ),
             )
-
-            deploy_tx_hash: str | None = None
-            if not code:
-                payload = {
-                    "type": "WALLET-CREATE",
-                    "from": owner,
-                    "to": POLYMARKET_DEPOSIT_WALLET_FACTORY,
-                }
-                body = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
-                headers = await self._builder_headers("POST", "/submit", body)
-                res = await self._relayer_http.post(
-                    "/submit", content=body, headers=headers
-                )
-                res.raise_for_status()
-                deploy_tx = await self._poll_relayer_tx(res.json()["transactionID"])
-                deploy_tx_hash = deploy_tx["transactionHash"]
-                # The relayer must have deployed at the address the factory
-                # predicted — if not, the derivation scheme changed again
-                # (this is exactly how the 2026-06-29 beacon upgrade stranded
-                # funds) and nothing may proceed against this address.
-                deployed_code = await web3.eth.get_code(deposit_wallet)
-                if not deployed_code:
-                    raise ValueError(
-                        "Relayer WALLET-CREATE mined but no code exists at the "
-                        f"resolved deposit wallet {deposit_wallet}; the factory "
-                        "derivation may have changed — do not send funds."
-                    )
 
             calls: list[dict[str, Any]] = []
             for spender, allowance in zip(
@@ -1889,7 +1900,7 @@ class PolymarketAdapter(BaseAdapter):
             "usdc_e_balance": None,
             "usdc_balance": None,
             "balances": None,
-            "stranded_legacy_funds": None,
+            "deposit_wallet_status": None,
             "errors": {},
         }
 
@@ -1983,22 +1994,22 @@ class PolymarketAdapter(BaseAdapter):
         if include_trades:
             coros.append(self.get_trades(user=addr, limit=trades_limit, offset=0))
 
-        # Surface funds stuck at the retired pre-2026-06-29 derivation (only
-        # meaningful when this adapter owns the queried wallet). Failures never
-        # fail the state call.
-        stranded_task: asyncio.Task[Any] | None = None
+        # Deposit-wallet cohort status (legacy / beacon / stranded) — the
+        # agent-facing state block (only meaningful when this adapter owns the
+        # queried wallet). Failures never fail the state call.
+        status_task: asyncio.Task[Any] | None = None
         if self.wallet_address:
-            stranded_task = asyncio.create_task(
-                check_stranded_legacy_funds(self.wallet_address)
+            status_task = asyncio.create_task(
+                get_deposit_wallet_status(self.wallet_address)
             )
 
         results = await asyncio.gather(*coros, return_exceptions=True)
 
-        if stranded_task is not None:
+        if status_task is not None:
             try:
-                out["stranded_legacy_funds"] = await stranded_task
+                out["deposit_wallet_status"] = await status_task
             except Exception as exc:  # noqa: BLE001
-                out["errors"]["stranded_check"] = str(exc)
+                out["errors"]["deposit_wallet_status"] = str(exc)
 
         pos_result = results[0]
         if isinstance(pos_result, Exception):

--- a/wayfinder_paths/adapters/polymarket_adapter/adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/adapter.py
@@ -50,22 +50,23 @@ from wayfinder_paths.core.constants.polymarket import (
     POLYMARKET_CONDITIONAL_TOKENS_ADDRESS,
     POLYMARKET_DATA_BASE_URL,
     POLYMARKET_DEPOSIT_WALLET_FACTORY,
-    POLYMARKET_DEPOSIT_WALLET_IMPLEMENTATION,
     POLYMARKET_GAMMA_BASE_URL,
     POLYMARKET_RELAYER_BASE_URL,
     ZERO32_STR,
-    derive_deposit_wallet,
-    polymarket_deposit_wallet_id,
 )
 from wayfinder_paths.core.constants.polymarket_abi import (
     CONDITIONAL_TOKENS_ABI,
     POLYMARKET_DEPOSIT_WALLET_BATCH_TYPES,
-    POLYMARKET_DEPOSIT_WALLET_FACTORY_ABI,
     TOKEN_UNWRAP_ABI,
 )
 from wayfinder_paths.core.utils.multicall import (
     Call,
     read_only_calls_multicall_or_gather,
+)
+from wayfinder_paths.core.utils.polymarket_wallet import (
+    check_stranded_legacy_funds,
+    resolve_deposit_wallet,
+    resolve_deposit_wallet_sync,
 )
 from wayfinder_paths.core.utils.tokens import (
     build_send_transaction,
@@ -1355,7 +1356,10 @@ class PolymarketAdapter(BaseAdapter):
         return self.wallet_address
 
     def deposit_wallet_address(self) -> str:
-        return derive_deposit_wallet(self._require_wallet_address())
+        """Canonical deposit wallet. First call per owner does one on-chain
+        resolution (factory prediction / legacy-deployment check) then caches
+        for the process; raises if Polygon RPC is unreachable."""
+        return resolve_deposit_wallet_sync(self._require_wallet_address())
 
     def _require_signer(self) -> tuple[str, Any]:
         addr = self._require_wallet_address()
@@ -1581,12 +1585,8 @@ class PolymarketAdapter(BaseAdapter):
 
     async def _setup_deposit_wallet(self) -> tuple[str | None, str | None]:
         owner = self._require_wallet_address()
-        deposit_wallet = self.deposit_wallet_address()
+        deposit_wallet = await resolve_deposit_wallet(owner)
         async with web3_from_chain_id(POLYGON_CHAIN_ID) as web3:
-            factory = web3.eth.contract(
-                address=POLYMARKET_DEPOSIT_WALLET_FACTORY,
-                abi=POLYMARKET_DEPOSIT_WALLET_FACTORY_ABI,
-            )
             pusd = web3.eth.contract(
                 address=POLYGON_P_USDC_PROXY_ADDRESS, abi=ERC20_ABI
             )
@@ -1594,11 +1594,7 @@ class PolymarketAdapter(BaseAdapter):
                 address=POLYMARKET_CONDITIONAL_TOKENS_ADDRESS,
                 abi=CONDITIONAL_TOKENS_ABI,
             )
-            predicted, code, allowances, approvals = await asyncio.gather(
-                factory.functions.predictWalletAddress(
-                    POLYMARKET_DEPOSIT_WALLET_IMPLEMENTATION,
-                    polymarket_deposit_wallet_id(owner),
-                ).call(block_identifier="latest"),
+            code, allowances, approvals = await asyncio.gather(
                 web3.eth.get_code(deposit_wallet),
                 asyncio.gather(
                     *[
@@ -1617,10 +1613,6 @@ class PolymarketAdapter(BaseAdapter):
                     ]
                 ),
             )
-            if to_checksum_address(predicted) != deposit_wallet:
-                raise ValueError(
-                    "Deposit wallet derivation mismatch, this should never happen, please contact support."
-                )
 
             deploy_tx_hash: str | None = None
             if not code:
@@ -1637,6 +1629,17 @@ class PolymarketAdapter(BaseAdapter):
                 res.raise_for_status()
                 deploy_tx = await self._poll_relayer_tx(res.json()["transactionID"])
                 deploy_tx_hash = deploy_tx["transactionHash"]
+                # The relayer must have deployed at the address the factory
+                # predicted — if not, the derivation scheme changed again
+                # (this is exactly how the 2026-06-29 beacon upgrade stranded
+                # funds) and nothing may proceed against this address.
+                deployed_code = await web3.eth.get_code(deposit_wallet)
+                if not deployed_code:
+                    raise ValueError(
+                        "Relayer WALLET-CREATE mined but no code exists at the "
+                        f"resolved deposit wallet {deposit_wallet}; the factory "
+                        "derivation may have changed — do not send funds."
+                    )
 
             calls: list[dict[str, Any]] = []
             for spender, allowance in zip(
@@ -1886,6 +1889,7 @@ class PolymarketAdapter(BaseAdapter):
             "usdc_e_balance": None,
             "usdc_balance": None,
             "balances": None,
+            "stranded_legacy_funds": None,
             "errors": {},
         }
 
@@ -1979,7 +1983,22 @@ class PolymarketAdapter(BaseAdapter):
         if include_trades:
             coros.append(self.get_trades(user=addr, limit=trades_limit, offset=0))
 
+        # Surface funds stuck at the retired pre-2026-06-29 derivation (only
+        # meaningful when this adapter owns the queried wallet). Failures never
+        # fail the state call.
+        stranded_task: asyncio.Task[Any] | None = None
+        if self.wallet_address:
+            stranded_task = asyncio.create_task(
+                check_stranded_legacy_funds(self.wallet_address)
+            )
+
         results = await asyncio.gather(*coros, return_exceptions=True)
+
+        if stranded_task is not None:
+            try:
+                out["stranded_legacy_funds"] = await stranded_task
+            except Exception as exc:  # noqa: BLE001
+                out["errors"]["stranded_check"] = str(exc)
 
         pos_result = results[0]
         if isinstance(pos_result, Exception):

--- a/wayfinder_paths/adapters/polymarket_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/test_adapter.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
+from eth_utils.address import to_checksum_address
 
 import wayfinder_paths.adapters.polymarket_adapter.adapter as polymarket_adapter_module
 from wayfinder_paths.adapters.polymarket_adapter.adapter import PolymarketAdapter
@@ -11,7 +12,23 @@ from wayfinder_paths.core.constants.polymarket import (
     POLYGON_P_USDC_PROXY_ADDRESS,
     POLYGON_USDC_ADDRESS,
     POLYGON_USDC_E_ADDRESS,
+    derive_legacy_deposit_wallet,
 )
+from wayfinder_paths.core.utils import polymarket_wallet
+
+
+@pytest.fixture(autouse=True)
+def _seed_deposit_wallet_cache():
+    """deposit_wallet_address() resolves on-chain since the 2026-06-29 factory
+    upgrade; seed the cache so unit tests never hit RPC. Seeding the legacy
+    derivation keeps the historical expected values meaningful."""
+    owners = ["0x000000000000000000000000000000000000dEaD", "0x" + "11" * 20]
+    for owner in owners:
+        polymarket_wallet._RESOLVED[to_checksum_address(owner)] = (
+            derive_legacy_deposit_wallet(owner)
+        )
+    yield
+    polymarket_wallet._RESOLVED.clear()
 
 
 def _gamma_response(status_code: int, endpoint: str, text: str = "") -> httpx.Response:
@@ -79,7 +96,7 @@ class TestPolymarketAdapter:
             kwargs["signature_type"]
             == polymarket_adapter_module.SignatureTypeV2.POLY_1271
         )
-        assert kwargs["funder"] == polymarket_adapter_module.derive_deposit_wallet(
+        assert kwargs["funder"] == derive_legacy_deposit_wallet(
             "0x000000000000000000000000000000000000dEaD"
         )
         assert (

--- a/wayfinder_paths/adapters/polymarket_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/polymarket_adapter/test_adapter.py
@@ -51,6 +51,40 @@ class TestPolymarketAdapter:
     def test_adapter_type(self, adapter):
         assert adapter.adapter_type == "POLYMARKET"
 
+    @pytest.mark.asyncio
+    async def test_fund_deposit_wallet_deploys_before_transfer(
+        self, adapter, monkeypatch
+    ):
+        """Deploy-first funding: the wallet must be deployed and code-verified
+        BEFORE any pUSD transfer — transferring to a codeless counterfactual
+        address is how the 2026-06-29 factory upgrade stranded funds."""
+        adapter.wallet_address = "0x000000000000000000000000000000000000dEaD"
+        adapter.sign_callback = AsyncMock()
+        order: list[str] = []
+
+        async def fake_ensure(deposit_wallet: str):
+            order.append("deploy")
+            return None
+
+        async def fake_build(**_kwargs):
+            order.append("build")
+            return {"tx": 1}
+
+        async def fake_send(_tx, _cb, confirmations=1):
+            order.append("send")
+            return "0xhash"
+
+        monkeypatch.setattr(adapter, "_ensure_deposit_wallet_deployed", fake_ensure)
+        monkeypatch.setattr(
+            polymarket_adapter_module, "build_send_transaction", fake_build
+        )
+        monkeypatch.setattr(polymarket_adapter_module, "send_transaction", fake_send)
+
+        ok, out = await adapter.fund_deposit_wallet(amount_raw=1_000_000)
+        assert ok is True
+        assert order == ["deploy", "build", "send"]
+        assert out["tx_hash"] == "0xhash"
+
     def test_clob_client_python_v2_constructor_signature(self):
         params = inspect.signature(
             polymarket_adapter_module.ClobClient.__init__

--- a/wayfinder_paths/core/constants/polymarket.py
+++ b/wayfinder_paths/core/constants/polymarket.py
@@ -82,7 +82,15 @@ def polymarket_deposit_wallet_id(owner: str) -> bytes:
     return to_bytes(hexstr=to_checksum_address(owner)).rjust(32, b"\x00")
 
 
-def derive_deposit_wallet(owner: str) -> str:
+def derive_legacy_deposit_wallet(owner: str) -> str:
+    """Pre-2026-06-29 ERC-1967 CREATE2 derivation.
+
+    Polymarket's factory switched to a beacon-proxy scheme on June 29 2026,
+    so this address is only meaningful when a contract already exists there
+    (wallets deployed before the upgrade). It must NEVER be used as a deposit
+    destination on its own — resolve via
+    wayfinder_paths.core.utils.polymarket_wallet instead.
+    """
     args = abi_encode(
         ["address", "bytes32"],
         [POLYMARKET_DEPOSIT_WALLET_FACTORY, polymarket_deposit_wallet_id(owner)],

--- a/wayfinder_paths/core/constants/polymarket_abi.py
+++ b/wayfinder_paths/core/constants/polymarket_abi.py
@@ -4,15 +4,18 @@ from typing import Any
 
 from wayfinder_paths.core.constants.erc1155_abi import ERC1155_APPROVAL_ABI
 
+# Verified against the factory's current implementation
+# (0x848eeb1a79a8d0fd964e3386db6da400c22d278d, upgraded 2026-06-29 to a
+# beacon-proxy scheme). The one-arg predict is canonical; a two-arg overload
+# exists but ignores its address argument. There is no deployed-wallet
+# registry getter — pre-upgrade wallets are detected via eth_getCode on the
+# legacy derivation.
 POLYMARKET_DEPOSIT_WALLET_FACTORY_ABI: list[dict[str, Any]] = [
     {
         "type": "function",
         "name": "predictWalletAddress",
         "stateMutability": "view",
-        "inputs": [
-            {"name": "_implementation", "type": "address"},
-            {"name": "_id", "type": "bytes32"},
-        ],
+        "inputs": [{"name": "_id", "type": "bytes32"}],
         "outputs": [{"name": "", "type": "address"}],
     }
 ]

--- a/wayfinder_paths/core/utils/polymarket_wallet.py
+++ b/wayfinder_paths/core/utils/polymarket_wallet.py
@@ -1,0 +1,165 @@
+"""Canonical Polymarket deposit-wallet resolution.
+
+Polymarket's deposit-wallet factory (0x00000000000Fb5C9ADea0298D729A0CB3823Cc07,
+Polygon) upgraded its implementation on 2026-06-29 from an ERC-1967 CREATE2
+scheme to a beacon-proxy scheme, changing the derived address for every wallet
+not yet deployed. Resolution semantics:
+
+  - a contract already deployed at the legacy derivation (pre-upgrade wallet)
+    stays canonical;
+  - otherwise the factory's own predictWalletAddress(bytes32 id) is canonical.
+
+Local derivation is NEVER a fallback — sending funds to an undeployed
+legacy-scheme address strands them (only Polymarket's factory admins could
+resurrect that derivation).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import httpx
+from eth_abi import encode as abi_encode
+from eth_utils.address import to_checksum_address
+
+from wayfinder_paths.core.constants.polymarket import (
+    POLYGON_P_USDC_PROXY_ADDRESS,
+    POLYGON_USDC_E_ADDRESS,
+    POLYMARKET_DEPOSIT_WALLET_FACTORY,
+    derive_legacy_deposit_wallet,
+    polymarket_deposit_wallet_id,
+)
+from wayfinder_paths.core.utils.web3 import (
+    _get_rpcs_for_chain_id,
+    _wayfinder_auth_headers,
+)
+
+POLYGON_CHAIN_ID = 137
+# keccak("predictWalletAddress(bytes32)")[:4] — the current factory's one-arg
+# predict; a two-arg overload exists but ignores its address argument.
+_PREDICT_SELECTOR = "0x04f1d3c7"
+_BALANCE_OF_SELECTOR = "0x70a08231"
+
+_RESOLVED: dict[str, str] = {}
+
+
+def _predict_calldata(owner: str) -> str:
+    return _PREDICT_SELECTOR + polymarket_deposit_wallet_id(owner).hex()
+
+
+def _rpc_batch(calls: list[dict[str, Any]]) -> list[Any]:
+    """POST one JSON-RPC batch to the first healthy Polygon RPC."""
+    last_error: Exception | None = None
+    payload = [{"jsonrpc": "2.0", "id": i, **call} for i, call in enumerate(calls)]
+    for rpc_url in _get_rpcs_for_chain_id(POLYGON_CHAIN_ID):
+        try:
+            resp = httpx.post(
+                rpc_url,
+                json=payload,
+                headers=_wayfinder_auth_headers(),
+                timeout=10,
+            )
+            resp.raise_for_status()
+            body = resp.json()
+            by_id = {item["id"]: item for item in body}
+            results = []
+            for i in range(len(calls)):
+                item = by_id.get(i)
+                if item is None or "error" in item:
+                    raise RuntimeError(f"rpc error: {item and item.get('error')}")
+                results.append(item["result"])
+            return results
+        except Exception as exc:  # noqa: BLE001
+            last_error = exc
+    raise RuntimeError(
+        f"All Polygon RPCs failed while resolving the Polymarket deposit wallet: {last_error}"
+    )
+
+
+def resolve_deposit_wallet_sync(owner: str) -> str:
+    """Resolve the canonical deposit wallet for `owner`.
+
+    First call per owner does one JSON-RPC round-trip, then the result is
+    cached for the process. Raises on RPC failure — refusing local-derivation
+    fallback is the point of this module.
+    """
+    owner = to_checksum_address(owner)
+    cached = _RESOLVED.get(owner)
+    if cached is not None:
+        return cached
+
+    legacy = derive_legacy_deposit_wallet(owner)
+    code_result, predict_result = _rpc_batch(
+        [
+            {"method": "eth_getCode", "params": [legacy, "latest"]},
+            {
+                "method": "eth_call",
+                "params": [
+                    {
+                        "to": POLYMARKET_DEPOSIT_WALLET_FACTORY,
+                        "data": _predict_calldata(owner),
+                    },
+                    "latest",
+                ],
+            },
+        ]
+    )
+
+    if code_result not in (None, "0x", "0x0"):
+        resolved = legacy
+    else:
+        predicted_int = int(predict_result, 16)
+        if predicted_int == 0:
+            raise RuntimeError(
+                "Polymarket factory predicted the zero address for the deposit wallet"
+            )
+        resolved = to_checksum_address(f"{predicted_int:040x}"[-40:])
+
+    _RESOLVED[owner] = resolved
+    return resolved
+
+
+async def resolve_deposit_wallet(owner: str) -> str:
+    return await asyncio.to_thread(resolve_deposit_wallet_sync, owner)
+
+
+def _check_stranded_legacy_funds_sync(owner: str) -> dict[str, Any] | None:
+    owner = to_checksum_address(owner)
+    resolved = resolve_deposit_wallet_sync(owner)
+    legacy = derive_legacy_deposit_wallet(owner)
+    if resolved == legacy:
+        return None
+
+    balance_call = abi_encode(["address"], [legacy]).hex()
+    pusd_raw, usdc_e_raw = _rpc_batch(
+        [
+            {
+                "method": "eth_call",
+                "params": [
+                    {"to": token, "data": _BALANCE_OF_SELECTOR + balance_call},
+                    "latest",
+                ],
+            }
+            for token in (POLYGON_P_USDC_PROXY_ADDRESS, POLYGON_USDC_E_ADDRESS)
+        ]
+    )
+    pusd = int(pusd_raw, 16) if pusd_raw not in (None, "0x") else 0
+    usdc_e = int(usdc_e_raw, 16) if usdc_e_raw not in (None, "0x") else 0
+    if pusd == 0 and usdc_e == 0:
+        return None
+    return {
+        "legacy_address": legacy,
+        "pusd_raw": pusd,
+        "usdc_e_raw": usdc_e,
+        "message": (
+            f"Funds detected at the retired pre-2026-06-29 deposit address {legacy} "
+            "which can no longer be deployed. Recovery requires contacting "
+            "Polymarket support; do NOT send additional funds there."
+        ),
+    }
+
+
+async def check_stranded_legacy_funds(owner: str) -> dict[str, Any] | None:
+    """Detect funds stuck at the retired legacy derivation (undeployed only)."""
+    return await asyncio.to_thread(_check_stranded_legacy_funds_sync, owner)

--- a/wayfinder_paths/core/utils/polymarket_wallet.py
+++ b/wayfinder_paths/core/utils/polymarket_wallet.py
@@ -124,42 +124,97 @@ async def resolve_deposit_wallet(owner: str) -> str:
     return await asyncio.to_thread(resolve_deposit_wallet_sync, owner)
 
 
-def _check_stranded_legacy_funds_sync(owner: str) -> dict[str, Any] | None:
+POLYMARKET_RECOVERY_DISCORD_URL = "https://discord.gg/aiwayfinder"
+
+
+def _get_deposit_wallet_status_sync(owner: str) -> dict[str, Any]:
+    """Full deposit-wallet state for `owner` — the agent-facing source of
+    truth for the three user cohorts:
+
+      - "legacy":  wallet deployed before the 2026-06-29 factory upgrade,
+        canonical and fully operational — nothing to do;
+      - "beacon" + no stranded funds: current scheme (deployed or deployed-on-
+        first-use) — nothing to do;
+      - "beacon" + stranded_legacy_funds: the user deposited to the retired
+        legacy derivation after the upgrade; recovery goes through the
+        Wayfinder Discord, and no funds must ever be sent there again.
+    """
     owner = to_checksum_address(owner)
     resolved = resolve_deposit_wallet_sync(owner)
     legacy = derive_legacy_deposit_wallet(owner)
+
     if resolved == legacy:
-        return None
+        return {
+            "resolved_address": resolved,
+            "legacy_address": legacy,
+            "scheme": "legacy",
+            "deployed": True,
+            "stranded_legacy_funds": None,
+            "guidance": (
+                "Pre-2026-06-29 deposit wallet, deployed and fully "
+                "operational. No action needed."
+            ),
+        }
 
     balance_call = abi_encode(["address"], [legacy]).hex()
-    pusd_raw, usdc_e_raw = _rpc_batch(
+    code_result, pusd_raw, usdc_e_raw = _rpc_batch(
         [
-            {
-                "method": "eth_call",
-                "params": [
-                    {"to": token, "data": _BALANCE_OF_SELECTOR + balance_call},
-                    "latest",
-                ],
-            }
-            for token in (POLYGON_P_USDC_PROXY_ADDRESS, POLYGON_USDC_E_ADDRESS)
+            {"method": "eth_getCode", "params": [resolved, "latest"]},
+            *(
+                {
+                    "method": "eth_call",
+                    "params": [
+                        {"to": token, "data": _BALANCE_OF_SELECTOR + balance_call},
+                        "latest",
+                    ],
+                }
+                for token in (POLYGON_P_USDC_PROXY_ADDRESS, POLYGON_USDC_E_ADDRESS)
+            ),
         ]
     )
+    deployed = code_result not in (None, "0x", "0x0")
     pusd = int(pusd_raw, 16) if pusd_raw not in (None, "0x") else 0
     usdc_e = int(usdc_e_raw, 16) if usdc_e_raw not in (None, "0x") else 0
-    if pusd == 0 and usdc_e == 0:
-        return None
+
+    stranded: dict[str, Any] | None = None
+    if pusd or usdc_e:
+        stranded = {
+            "legacy_address": legacy,
+            "pusd_raw": pusd,
+            "usdc_e_raw": usdc_e,
+            "message": (
+                f"Funds are stranded at the retired pre-2026-06-29 deposit "
+                f"address {legacy}, which can no longer be deployed. Do NOT "
+                f"send more funds there. Recovery help: "
+                f"{POLYMARKET_RECOVERY_DISCORD_URL}"
+            ),
+        }
+
+    if stranded:
+        guidance = (
+            f"URGENT: {(pusd + usdc_e) / 1_000_000} pUSD/USDC.e is stranded at "
+            f"the retired legacy address {legacy}. Point the user to "
+            f"{POLYMARKET_RECOVERY_DISCORD_URL} for recovery. New deposits go "
+            f"to {resolved} and are safe — the wallet is deployed and "
+            "verified before any transfer."
+        )
+    elif deployed:
+        guidance = "Current-scheme deposit wallet, deployed and operational."
+    else:
+        guidance = (
+            "Deposit wallet not yet deployed; it is deployed and verified "
+            "automatically before the first deposit or trade."
+        )
+
     return {
+        "resolved_address": resolved,
         "legacy_address": legacy,
-        "pusd_raw": pusd,
-        "usdc_e_raw": usdc_e,
-        "message": (
-            f"Funds detected at the retired pre-2026-06-29 deposit address {legacy} "
-            "which can no longer be deployed. Recovery requires contacting "
-            "Polymarket support; do NOT send additional funds there."
-        ),
+        "scheme": "beacon",
+        "deployed": deployed,
+        "stranded_legacy_funds": stranded,
+        "guidance": guidance,
     }
 
 
-async def check_stranded_legacy_funds(owner: str) -> dict[str, Any] | None:
-    """Detect funds stuck at the retired legacy derivation (undeployed only)."""
-    return await asyncio.to_thread(_check_stranded_legacy_funds_sync, owner)
+async def get_deposit_wallet_status(owner: str) -> dict[str, Any]:
+    return await asyncio.to_thread(_get_deposit_wallet_status_sync, owner)

--- a/wayfinder_paths/mcp/preview.py
+++ b/wayfinder_paths/mcp/preview.py
@@ -11,6 +11,7 @@ from wayfinder_paths.core.constants.polymarket import (
     POLYGON_CHAIN_ID,
     POLYGON_P_USDC_PROXY_ADDRESS,
 )
+from wayfinder_paths.core.utils.polymarket_wallet import check_stranded_legacy_funds
 from wayfinder_paths.core.utils.tokens import get_token_balance
 from wayfinder_paths.mcp.polymarket_order import (
     as_float,
@@ -295,6 +296,17 @@ async def _pm_market_order_quote_preview(
         deposit_wallet = adapter.deposit_wallet_address()
         lines.append(f"deposit wallet: {deposit_wallet}")
         lines.append(await _pm_deposit_wallet_balance_line(deposit_wallet))
+        try:
+            stranded = await check_stranded_legacy_funds(sender)
+        except Exception:  # noqa: BLE001
+            stranded = None
+        if stranded:
+            total = (stranded["pusd_raw"] + stranded["usdc_e_raw"]) / 1_000_000
+            lines.append(
+                f"WARNING: {total} pUSD/USDC.e stranded at retired legacy address "
+                f"{stranded['legacy_address']} — recovery requires Polymarket "
+                "support; do NOT send funds there"
+            )
 
         market_slug = str(tool_input.get("market_slug") or "").strip()
         token_id = str(tool_input.get("token_id") or "").strip()

--- a/wayfinder_paths/mcp/preview.py
+++ b/wayfinder_paths/mcp/preview.py
@@ -11,7 +11,7 @@ from wayfinder_paths.core.constants.polymarket import (
     POLYGON_CHAIN_ID,
     POLYGON_P_USDC_PROXY_ADDRESS,
 )
-from wayfinder_paths.core.utils.polymarket_wallet import check_stranded_legacy_funds
+from wayfinder_paths.core.utils.polymarket_wallet import get_deposit_wallet_status
 from wayfinder_paths.core.utils.tokens import get_token_balance
 from wayfinder_paths.mcp.polymarket_order import (
     as_float,
@@ -297,15 +297,16 @@ async def _pm_market_order_quote_preview(
         lines.append(f"deposit wallet: {deposit_wallet}")
         lines.append(await _pm_deposit_wallet_balance_line(deposit_wallet))
         try:
-            stranded = await check_stranded_legacy_funds(sender)
+            wallet_status = await get_deposit_wallet_status(sender)
         except Exception:  # noqa: BLE001
-            stranded = None
+            wallet_status = None
+        stranded = (wallet_status or {}).get("stranded_legacy_funds")
         if stranded:
             total = (stranded["pusd_raw"] + stranded["usdc_e_raw"]) / 1_000_000
             lines.append(
                 f"WARNING: {total} pUSD/USDC.e stranded at retired legacy address "
-                f"{stranded['legacy_address']} — recovery requires Polymarket "
-                "support; do NOT send funds there"
+                f"{stranded['legacy_address']} — recovery help at "
+                "https://discord.gg/aiwayfinder; do NOT send funds there"
             )
 
         market_slug = str(tool_input.get("market_slug") or "").strip()

--- a/wayfinder_paths/tests/test_mcp_polymarket_tool.py
+++ b/wayfinder_paths/tests/test_mcp_polymarket_tool.py
@@ -4,8 +4,10 @@ from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from eth_utils.address import to_checksum_address
 
-from wayfinder_paths.core.constants.polymarket import derive_deposit_wallet
+from wayfinder_paths.core.constants.polymarket import derive_legacy_deposit_wallet
+from wayfinder_paths.core.utils import polymarket_wallet
 from wayfinder_paths.mcp.preview import build_polymarket_place_market_order_preview
 from wayfinder_paths.mcp.tools.polymarket import (
     polymarket_get_state,
@@ -23,6 +25,20 @@ _GET_TYPED_CB = (
 )
 
 _ADDR = "0x000000000000000000000000000000000000dEaD"
+
+
+@pytest.fixture(autouse=True)
+def _seed_deposit_wallet_cache():
+    """deposit_wallet_address() resolves on-chain since the 2026-06-29 factory
+    upgrade; seed the cache so tool tests never hit RPC (this also short-
+    circuits the stranded-legacy-funds check: resolved == legacy -> None)."""
+    polymarket_wallet._RESOLVED[to_checksum_address(_ADDR)] = (
+        derive_legacy_deposit_wallet(_ADDR)
+    )
+    yield
+    polymarket_wallet._RESOLVED.clear()
+
+
 _WALLET = {"address": _ADDR}
 _SIGN_CB = AsyncMock(return_value=b"\x00" * 65)
 _HASH_CB = AsyncMock(return_value="0x" + "00" * 65)
@@ -47,8 +63,10 @@ async def test_polymarket_get_state_uses_adapter_full_state():
         assert out["ok"] is True
         assert out["result"]["ok"] is True
         assert out["result"]["state"]["protocol"] == "polymarket_read"
-        assert out["result"]["account"] == derive_deposit_wallet(_ADDR)
-        assert full_state.await_args.kwargs["account"] == derive_deposit_wallet(_ADDR)
+        assert out["result"]["account"] == derive_legacy_deposit_wallet(_ADDR)
+        assert full_state.await_args.kwargs["account"] == derive_legacy_deposit_wallet(
+            _ADDR
+        )
 
 
 @pytest.mark.asyncio
@@ -1353,7 +1371,7 @@ async def test_polymarket_place_market_order_preview_hydrates_buy_quote():
     summary = preview["summary"]
     assert "market: Will it happen?" in summary
     assert "resolved token_id: tok_yes" in summary
-    assert f"deposit wallet: {derive_deposit_wallet(_ADDR)}" in summary
+    assert f"deposit wallet: {derive_legacy_deposit_wallet(_ADDR)}" in summary
     assert "deposit pUSD balance: 12.34 pUSD" in summary
     assert "expected pUSD spent: 4 pUSD" in summary
     assert "expected shares: 76.923" in summary

--- a/wayfinder_paths/tests/test_polymarket_wallet_resolver.py
+++ b/wayfinder_paths/tests/test_polymarket_wallet_resolver.py
@@ -1,0 +1,118 @@
+"""Resolver tests pinned to real on-chain vectors from the 2026-06-29 factory
+upgrade incident (49 pUSD stranded at an undeployed legacy address)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from wayfinder_paths.core.constants.polymarket import derive_legacy_deposit_wallet
+from wayfinder_paths.core.utils import polymarket_wallet
+
+# Incident vectors, verified live on Polygon (see PR description):
+INCIDENT_OWNER = "0xbEcEcB80E7343222b7218fC2633754Bc56240Ff5"
+INCIDENT_LEGACY = "0x083fc209728e610f29f770ee46e79722b4eA444e"
+INCIDENT_PREDICTED = "0x0ab274fBf20Ca7c688aDAEFC93040669B1C68fdC"
+# Pre-upgrade cohort: wallet deployed under the old scheme stays canonical.
+COHORT2_OWNER = "0x89725d4dF2E7B2Fc8eDAA9Ae20E36B66B9bB5C03"
+COHORT2_LEGACY = "0x7810Aebf0c85e394D29067c3cD62Bb89a7162acb"
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    polymarket_wallet._RESOLVED.clear()
+    yield
+    polymarket_wallet._RESOLVED.clear()
+
+
+def _fake_batch(code_result: str, predict_result: str):
+    calls: list[list[dict[str, Any]]] = []
+
+    def fake(batch):
+        calls.append(batch)
+        results = []
+        for item in batch:
+            if item["method"] == "eth_getCode":
+                results.append(code_result)
+            else:
+                results.append(predict_result)
+        return results
+
+    return fake, calls
+
+
+def test_legacy_derivation_matches_incident_vector():
+    assert derive_legacy_deposit_wallet(INCIDENT_OWNER) == INCIDENT_LEGACY
+    assert derive_legacy_deposit_wallet(COHORT2_OWNER) == COHORT2_LEGACY
+
+
+def test_undeployed_legacy_resolves_to_factory_prediction():
+    fake, calls = _fake_batch(
+        "0x", "0x" + INCIDENT_PREDICTED[2:].lower().rjust(64, "0")
+    )
+    with patch.object(polymarket_wallet, "_rpc_batch", fake):
+        resolved = polymarket_wallet.resolve_deposit_wallet_sync(INCIDENT_OWNER)
+    assert resolved == INCIDENT_PREDICTED
+    assert len(calls) == 1
+
+
+def test_deployed_legacy_wallet_stays_canonical():
+    fake, _ = _fake_batch("0x363d3d373d", "0x" + "9" * 64)
+    with patch.object(polymarket_wallet, "_rpc_batch", fake):
+        resolved = polymarket_wallet.resolve_deposit_wallet_sync(COHORT2_OWNER)
+    assert resolved == COHORT2_LEGACY
+
+
+def test_result_is_cached_after_first_resolution():
+    fake, calls = _fake_batch("0x363d3d373d", "0x" + "9" * 64)
+    with patch.object(polymarket_wallet, "_rpc_batch", fake):
+        first = polymarket_wallet.resolve_deposit_wallet_sync(COHORT2_OWNER)
+        second = polymarket_wallet.resolve_deposit_wallet_sync(COHORT2_OWNER)
+    assert first == second
+    assert len(calls) == 1
+
+
+def test_rpc_failure_raises_and_caches_nothing():
+    def failing(_batch):
+        raise RuntimeError("All Polygon RPCs failed")
+
+    with patch.object(polymarket_wallet, "_rpc_batch", failing):
+        with pytest.raises(RuntimeError, match="All Polygon RPCs failed"):
+            polymarket_wallet.resolve_deposit_wallet_sync(INCIDENT_OWNER)
+    assert polymarket_wallet._RESOLVED == {}
+
+
+def test_zero_address_prediction_rejected():
+    fake, _ = _fake_batch("0x", "0x" + "0" * 64)
+    with patch.object(polymarket_wallet, "_rpc_batch", fake):
+        with pytest.raises(RuntimeError, match="zero address"):
+            polymarket_wallet.resolve_deposit_wallet_sync(INCIDENT_OWNER)
+
+
+def test_stranded_check_reports_undeployed_legacy_balance():
+    polymarket_wallet._RESOLVED[INCIDENT_OWNER] = INCIDENT_PREDICTED
+
+    def fake(batch):
+        assert all(item["method"] == "eth_call" for item in batch)
+        return [hex(49_000_000), "0x0"]
+
+    with patch.object(polymarket_wallet, "_rpc_batch", fake):
+        stranded = polymarket_wallet._check_stranded_legacy_funds_sync(INCIDENT_OWNER)
+    assert stranded is not None
+    assert stranded["legacy_address"] == INCIDENT_LEGACY
+    assert stranded["pusd_raw"] == 49_000_000
+    assert "Polymarket support" in stranded["message"]
+
+
+def test_stranded_check_short_circuits_for_legacy_canonical_wallet():
+    polymarket_wallet._RESOLVED[COHORT2_OWNER] = COHORT2_LEGACY
+
+    def must_not_call(_batch):
+        raise AssertionError("no RPC expected when resolved == legacy")
+
+    with patch.object(polymarket_wallet, "_rpc_batch", must_not_call):
+        assert (
+            polymarket_wallet._check_stranded_legacy_funds_sync(COHORT2_OWNER) is None
+        )

--- a/wayfinder_paths/tests/test_polymarket_wallet_resolver.py
+++ b/wayfinder_paths/tests/test_polymarket_wallet_resolver.py
@@ -91,28 +91,49 @@ def test_zero_address_prediction_rejected():
             polymarket_wallet.resolve_deposit_wallet_sync(INCIDENT_OWNER)
 
 
-def test_stranded_check_reports_undeployed_legacy_balance():
+def test_status_reports_stranded_funds_with_discord_guidance():
     polymarket_wallet._RESOLVED[INCIDENT_OWNER] = INCIDENT_PREDICTED
 
     def fake(batch):
-        assert all(item["method"] == "eth_call" for item in batch)
-        return [hex(49_000_000), "0x0"]
+        # eth_getCode(resolved) + two balanceOf(legacy) calls
+        assert batch[0]["method"] == "eth_getCode"
+        assert all(item["method"] == "eth_call" for item in batch[1:])
+        return ["0x", hex(49_000_000), "0x0"]
 
     with patch.object(polymarket_wallet, "_rpc_batch", fake):
-        stranded = polymarket_wallet._check_stranded_legacy_funds_sync(INCIDENT_OWNER)
+        status = polymarket_wallet._get_deposit_wallet_status_sync(INCIDENT_OWNER)
+    assert status["scheme"] == "beacon"
+    assert status["deployed"] is False
+    assert status["resolved_address"] == INCIDENT_PREDICTED
+    stranded = status["stranded_legacy_funds"]
     assert stranded is not None
     assert stranded["legacy_address"] == INCIDENT_LEGACY
     assert stranded["pusd_raw"] == 49_000_000
-    assert "Polymarket support" in stranded["message"]
+    assert polymarket_wallet.POLYMARKET_RECOVERY_DISCORD_URL in stranded["message"]
+    assert polymarket_wallet.POLYMARKET_RECOVERY_DISCORD_URL in status["guidance"]
 
 
-def test_stranded_check_short_circuits_for_legacy_canonical_wallet():
+def test_status_clean_beacon_wallet_has_no_banner_state():
+    polymarket_wallet._RESOLVED[INCIDENT_OWNER] = INCIDENT_PREDICTED
+
+    def fake(batch):
+        return ["0x363d3d373d", "0x0", "0x0"]
+
+    with patch.object(polymarket_wallet, "_rpc_batch", fake):
+        status = polymarket_wallet._get_deposit_wallet_status_sync(INCIDENT_OWNER)
+    assert status["scheme"] == "beacon"
+    assert status["deployed"] is True
+    assert status["stranded_legacy_funds"] is None
+
+
+def test_status_short_circuits_for_legacy_canonical_wallet():
     polymarket_wallet._RESOLVED[COHORT2_OWNER] = COHORT2_LEGACY
 
     def must_not_call(_batch):
         raise AssertionError("no RPC expected when resolved == legacy")
 
     with patch.object(polymarket_wallet, "_rpc_batch", must_not_call):
-        assert (
-            polymarket_wallet._check_stranded_legacy_funds_sync(COHORT2_OWNER) is None
-        )
+        status = polymarket_wallet._get_deposit_wallet_status_sync(COHORT2_OWNER)
+    assert status["scheme"] == "legacy"
+    assert status["deployed"] is True
+    assert status["stranded_legacy_funds"] is None


### PR DESCRIPTION
## The bug

Polymarket upgraded the deposit-wallet factory implementation (`0x00000000000Fb5C9ADea0298D729A0CB3823Cc07`, Polygon, block 89353731, **June 29**) from an ERC-1967 CREATE2 scheme to a beacon-proxy scheme. The SDK derives deposit addresses locally with hardcoded old-scheme constants, so **every address derived for a not-yet-deployed wallet since June 29 is wrong and unownable** — 49 pUSD is already stranded at `0x083fc209728e610f29f770ee46e79722b4eA444e` (owner `0xbEcEcB80…`, real wallet `0x0ab274fB…8fdC`). The existing on-chain guard in `_setup_deposit_wallet` passed the **stale implementation address** to `predictWalletAddress`, and all derivation tests were self-referential — which is how this shipped silently.

## The fix

New `core/utils/polymarket_wallet` resolver, verified against the factory's current implementation (`0x848eeb1a…`, ABI pulled from the verified source; the one-arg `predictWalletAddress(bytes32)` is canonical and the surviving two-arg overload ignores its address argument — confirmed live):

```
resolve(owner) = legacy_address        if code exists there   (pre-June-29 wallets stay canonical)
                 factory.predict(id)   otherwise              (id = owner left-padded, unchanged)
```

- Cached per owner; **raises on RPC failure — deliberately no local-derivation fallback** (a stale local scheme is exactly how funds got stranded).
- `deposit_wallet_address()` keeps its documented sync contract: first call resolves on-chain, then cached; all ~15 call sites (funder, EIP-712 batch target, transfers, guards) unchanged.
- `_setup_deposit_wallet` now **asserts code exists at the resolved address after relayer WALLET-CREATE** — the missing invariant that would have caught this class of bug the day of the upgrade.
- **Stranded-funds detection**: `get_full_user_state` gains `stranded_legacy_funds` and order previews print a WARNING when the retired legacy address holds pUSD/USDC.e (recovery = Polymarket support; never rendered as a destination).

## Verification (live Polygon, read-only)

- `resolve(0xbEcEcB80…) == 0x0ab274fB…8fdC` ✓ (incident owner; legacy undeployed with exactly 49.0 pUSD stranded — detection reports it)
- `resolve(0x89725d4d…) == 0x7810Aebf…` ✓ (pre-upgrade wallet, 125-byte legacy proxy still deployed — proves the getCode branch is mandatory)
- `predict(stale_impl, id) == predict(id)` ✓ (why the old guard could never fire)
- 92 tests pass (new resolver suite pinned to the vectors above; self-referential tests replaced with seeded-cache assertions)

## Related

Frontend and vault-backend carry ports of the same broken derivation — companion PRs incoming. **Shells agents get this only via a new image**: after merge, bump `WAYFINDER_SDK_VERSION` in the shell repo (supersedes/extends #131) + `FLY_IMAGE_TAG`.