### PR TITLE
Agent Context - Sync supported-chains tables with SUPPORTED_CHAINS

### DIFF
--- a/.opencode/agents/wayfinder-baseline.md
+++ b/.opencode/agents/wayfinder-baseline.md
@@ -135,8 +135,12 @@ Supported chain identifiers:
 | Polygon   |   137 | `polygon`   | POL    | `polygon-ecosystem-token-polygon` |                                                                                                |
 | BSC       |    56 | `bsc`       | BNB    | `binancecoin-bsc`                 |                                                                                                |
 | Avalanche | 43114 | `avalanche` | AVAX   | `avalanche-avalanche`             |                                                                                                |
-| Plasma    |  9745 | `plasma`    | PLASMA | `plasma-plasma`                   | EVM chain where Pendle deploys PT/YT markets.                                                  |
+| Plasma    |  9745 | `plasma`    | XPL    | `plasma-plasma`                   | EVM chain where Pendle deploys PT/YT markets.                                                  |
 | HyperEVM  |   999 | `hyperevm`  | HYPE   | `hyperliquid-hyperevm`            | Hyperliquid's EVM layer; on-chain tokens live here, perp/spot trading uses the Hyperliquid L1. |
+| Katana    | 747474 | `katana`   | ETH    | `ethereum-katana`                 | DeFi-focused EVM chain.                                                                         |
+| Monad     |   143 | `monad`     | MON    | `monad-monad`                     | High-performance parallel EVM L1.                                                              |
+| MegaEth   |  4326 | `megaeth`   | ETH    | `ethereum-megaeth`                | High-throughput real-time EVM L2.                                                             |
+| Robinhood |  4663 | `robinhood` | ETH    | `ethereum-robinhood`              | Robinhood's EVM chain.                                                                          |
 
 ### Hyperliquid
 

--- a/.opencode/agents/wayfinder.md
+++ b/.opencode/agents/wayfinder.md
@@ -144,8 +144,12 @@ Supported chain identifiers:
 | Polygon   |   137 | `polygon`   | POL    | `polygon-ecosystem-token-polygon` |                                                                                                |
 | BSC       |    56 | `bsc`       | BNB    | `binancecoin-bsc`                 |                                                                                                |
 | Avalanche | 43114 | `avalanche` | AVAX   | `avalanche-avalanche`             |                                                                                                |
-| Plasma    |  9745 | `plasma`    | PLASMA | `plasma-plasma`                   | EVM chain where Pendle deploys PT/YT markets.                                                  |
+| Plasma    |  9745 | `plasma`    | XPL    | `plasma-plasma`                   | EVM chain where Pendle deploys PT/YT markets.                                                  |
 | HyperEVM  |   999 | `hyperevm`  | HYPE   | `hyperliquid-hyperevm`            | Hyperliquid's EVM layer; on-chain tokens live here, perp/spot trading uses the Hyperliquid L1. |
+| Katana    | 747474 | `katana`   | ETH    | `ethereum-katana`                 | DeFi-focused EVM chain.                                                                         |
+| Monad     |   143 | `monad`     | MON    | `monad-monad`                     | High-performance parallel EVM L1.                                                              |
+| MegaEth   |  4326 | `megaeth`   | ETH    | `ethereum-megaeth`                | High-throughput real-time EVM L2.                                                             |
+| Robinhood |  4663 | `robinhood` | ETH    | `ethereum-robinhood`              | Robinhood's EVM chain.                                                                          |
 
 ### Hyperliquid
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,8 +283,12 @@ Supported chains:
 | Polygon   | 137   | `polygon`   | POL    | `polygon-ecosystem-token-polygon` |
 | BSC       | 56    | `bsc`       | BNB    | `binancecoin-bsc`                 |
 | Avalanche | 43114 | `avalanche` | AVAX   | `avalanche-avalanche`             |
-| Plasma    | 9745  | `plasma`    | PLASMA | `plasma-plasma`                   |
+| Plasma    | 9745  | `plasma`    | XPL    | `plasma-plasma`                   |
 | HyperEVM  | 999   | `hyperevm`  | HYPE   | `hyperliquid-hyperevm`            |
+| Katana    | 747474 | `katana`   | ETH    | `ethereum-katana`                 |
+| Monad     | 143   | `monad`     | MON    | `monad-monad`                     |
+| MegaEth   | 4326  | `megaeth`   | ETH    | `ethereum-megaeth`                |
+| Robinhood | 4663  | `robinhood` | ETH    | `ethereum-robinhood`              |
 
 - **Plasma**: EVM chain where Pendle deploys PT/YT markets. Not Pendle-specific — it's its own chain.
 - **HyperEVM**: Hyperliquid's EVM layer. On-chain tokens (HYPE, USDC) live here; perp/spot trading uses the Hyperliquid L1 (off-chain, not EVM).

--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ The SDK includes built-in support for these chain IDs:
 | Avalanche | 43114 | `avalanche` |
 | Plasma   | 9745  | `plasma`   |
 | HyperEVM | 999   | `hyperevm` |
+| Katana   | 747474 | `katana`  |
+| Monad    | 143   | `monad`    |
+| MegaEth  | 4326  | `megaeth`  |
 | Robinhood | 4663 | `robinhood` |
 
 ## Strategies


### PR DESCRIPTION
### Summary

The agent prompt's **Supported chain identifiers** table had drifted from the code's `SUPPORTED_CHAINS` (`core/constants/chains.py`). The prompt listed 8 chains; the SDK actually supports 12 — so the agent didn't know **Katana, Monad, MegaEth, Robinhood** existed and would tell users those aren't blockchains.

Synced every active agent-context surface to the 12 chains in `SUPPORTED_CHAINS`, with metadata verified against the live gas-token API (`/blockchain/tokens/gas`):

| Chain | ID | Code | Symbol | Native token ID |
|---|---|---|---|---|
| Katana | 747474 | `katana` | ETH | `ethereum-katana` |
| Monad | 143 | `monad` | MON | `monad-monad` |
| MegaEth | 4326 | `megaeth` | ETH | `ethereum-megaeth` |
| Robinhood | 4663 | `robinhood` | ETH | `ethereum-robinhood` |

Also fixed Plasma's gas symbol (`PLASMA` → `XPL`, its real native token).

Files: `.opencode/agents/wayfinder.md`, `.opencode/agents/wayfinder-baseline.md`, `CLAUDE.md`, `README.md`. Eval overlays left untouched (frozen fixtures). Sonic (146) stays out — it has a constant but is not in `SUPPORTED_CHAINS`.