### PR TITLE
Uncap the primary wayfinder agent's step limit

### DIFF
--- a/.opencode/agents/wayfinder.md
+++ b/.opencode/agents/wayfinder.md
@@ -2,7 +2,6 @@
 description: User-facing Wayfinder orchestrator, executor, coder, and strategy lifecycle owner.
 mode: primary
 temperature: 0.1
-steps: 38
 permission:
   task:
     explore: allow


### PR DESCRIPTION
## Problem

A dev Shells session hit **"Maximum Steps Reached"** mid-task in the **main** agent while debugging the Robinhood RPC issue — opencode forced a text-only wrap-up ("Statement that maximum steps for this agent have been reached" is opencode's injected template).

Root cause: `.opencode/agents/wayfinder.md` sets `steps: 38` in the primary agent's frontmatter. It landed in #442 alongside the deliberate subagent workpack budgets (planner 8, research 14, quant 22, sports 28, job workers 30/40) — but for the user-facing primary agent a hard iteration cap means any long interactive session (multi-tool debugging, multi-leg execution flows) dies mid-task.

## Fix

Remove `steps` from the primary agent only. Per opencode docs, with `steps` unset the agent "will continue to iterate until the model chooses to stop or the user interrupts the session" — the right behavior for an interactive primary. All subagent/job-worker budgets are unchanged (those are autonomous and should stay bounded).

## Deployment

Rides the next shell-image SDK pin bump (same train as #455).