### PR TITLE
Uniswap v4 exact-in swaps (Ethereum, Base, Arbitrum, Robinhood)

### DIFF
--- a/.claude/skills/using-uniswap-adapter/rules/execution-opportunities.md
+++ b/.claude/skills/using-uniswap-adapter/rules/execution-opportunities.md
@@ -153,12 +153,13 @@ asyncio.run(main())
 | `remove_liquidity(token_id, liquidity=None, slippage_bps=50, collect=True, burn=False)` | Decrease/close | liquidity=None for full |
 | `collect_fees(token_id)` | Collect accrued fees | — |
 
-## Uniswap v4 swaps (v4-only tokens, e.g. Robinhood chain)
+## Uniswap v4 swaps
 
-Some chains (Robinhood 4663) run Uniswap v4, and aggregators (BRAP/LiFi) may have no v4 coverage there — so v4-only tokens either don't quote or route through dust pools at a huge markup. Use the adapter's v4 methods directly for these.
+Uniswap v4 is supported on Ethereum (1), Base (8453), Arbitrum (42161), and Robinhood (4663). Use the v4 methods directly for v4-only tokens — on newer chains (Robinhood) aggregators (BRAP/LiFi) may have no v4 coverage, so those tokens either don't quote or route through dust pools at a huge markup.
 
 ```python
-adapter = await get_adapter(UniswapAdapter, chain_id=4663, wallet_label="main")
+# chain_id: 1 (Ethereum), 8453 (Base), 42161 (Arbitrum), or 4663 (Robinhood)
+adapter = await get_adapter(UniswapAdapter, chain_id=8453, wallet_label="main")
 
 # 1. Discover pools, ranked by live liquidity (deepest first).
 ok, pools = await adapter.v4_find_pools(token_in, token_out)
@@ -178,4 +179,5 @@ ok, result = await adapter.v4_swap_exact_in(
 - **`amount_in`**: base units (wei), an int — not a decimal string.
 - **Pool selection is by liquidity, never fee tier.** v4 lets anyone open a pool at any fee; the 10/20/50% pools are traps with dust in them. `v4_find_pools`/`v4_quote` already pick the deepest, but if you inspect pools yourself, rank by `liquidity`.
 - **Quote first, always.** A direct v4 quote is usually far better than the aggregator's dust route for v4-only tokens (INDEX/ETH: v4 direct returned ~24% more than BRAP's fallback).
-- Supported chains: `v4.v4_supported(chain_id)` (Robinhood 4663 today; structured to add Base/Ethereum later).
+- Supported chains: `v4.v4_supported(chain_id)` — Ethereum, Base, Arbitrum, Robinhood.
+- Pool discovery: mainstream pairs on the big chains are found by enumerating standard fee tiers (fast, scan-free); hooked/custom-tier pools (e.g. Robinhood memes) are found via an event scan on small chains. Either way, `v4_find_pools`/`v4_quote` rank by liquidity — trust the deepest pool.

--- a/.claude/skills/using-uniswap-adapter/rules/execution-opportunities.md
+++ b/.claude/skills/using-uniswap-adapter/rules/execution-opportunities.md
@@ -152,3 +152,30 @@ asyncio.run(main())
 | `increase_liquidity(token_id, amount0_desired, amount1_desired, slippage_bps=50)` | Add to existing | amounts in raw |
 | `remove_liquidity(token_id, liquidity=None, slippage_bps=50, collect=True, burn=False)` | Decrease/close | liquidity=None for full |
 | `collect_fees(token_id)` | Collect accrued fees | — |
+
+## Uniswap v4 swaps (v4-only tokens, e.g. Robinhood chain)
+
+Some chains (Robinhood 4663) run Uniswap v4, and aggregators (BRAP/LiFi) may have no v4 coverage there — so v4-only tokens either don't quote or route through dust pools at a huge markup. Use the adapter's v4 methods directly for these.
+
+```python
+adapter = await get_adapter(UniswapAdapter, chain_id=4663, wallet_label="main")
+
+# 1. Discover pools, ranked by live liquidity (deepest first).
+ok, pools = await adapter.v4_find_pools(token_in, token_out)
+
+# 2. Quote exact-in against the best (deepest) pool.
+ok, quote = await adapter.v4_quote(token_in, token_out, amount_in_wei)
+#   -> {"amount_out", "pool_id", "fee", "liquidity"}
+
+# 3. Execute (native input rides as msg.value; ERC-20 goes through Permit2).
+ok, result = await adapter.v4_swap_exact_in(
+    token_in=token_in, token_out=token_out,
+    amount_in=amount_in_wei, slippage_bps=50,
+)
+```
+
+- **`token_in`/`token_out`**: use `0x0000…0000` for native ETH (v4 pools are native, not WETH — GeckoTerminal may still label them "WETH").
+- **`amount_in`**: base units (wei), an int — not a decimal string.
+- **Pool selection is by liquidity, never fee tier.** v4 lets anyone open a pool at any fee; the 10/20/50% pools are traps with dust in them. `v4_find_pools`/`v4_quote` already pick the deepest, but if you inspect pools yourself, rank by `liquidity`.
+- **Quote first, always.** A direct v4 quote is usually far better than the aggregator's dust route for v4-only tokens (INDEX/ETH: v4 direct returned ~24% more than BRAP's fallback).
+- Supported chains: `v4.v4_supported(chain_id)` (Robinhood 4663 today; structured to add Base/Ethereum later).

--- a/wayfinder_paths/adapters/uniswap_adapter/adapter.py
+++ b/wayfinder_paths/adapters/uniswap_adapter/adapter.py
@@ -5,12 +5,13 @@ from typing import Any
 from eth_utils import to_checksum_address
 
 from wayfinder_paths.adapters.uniswap_adapter.base import UniswapV3BaseAdapter
+from wayfinder_paths.adapters.uniswap_adapter.v4 import UniswapV4SwapMixin
 from wayfinder_paths.core.constants.contracts import UNISWAP_V3_FACTORY, UNISWAP_V3_NPM
 
 SUPPORTED_CHAIN_IDS = set(UNISWAP_V3_NPM.keys())
 
 
-class UniswapAdapter(UniswapV3BaseAdapter):
+class UniswapAdapter(UniswapV4SwapMixin, UniswapV3BaseAdapter):
     adapter_type = "UNISWAP"
 
     def __init__(

--- a/wayfinder_paths/adapters/uniswap_adapter/test_v4.py
+++ b/wayfinder_paths/adapters/uniswap_adapter/test_v4.py
@@ -125,6 +125,67 @@ async def test_v4_quote_reports_missing_pool():
     assert "No v4 pool" in result
 
 
-def test_v4_supported_flags_robinhood_only_where_configured():
-    assert v4.v4_supported(4663) is True
+def test_v4_supported_covers_configured_chains():
+    for chain_id in (1, 8453, 42161, 4663):
+        assert v4.v4_supported(chain_id) is True
     assert v4.v4_supported(999999) is False
+
+
+def test_all_v4_address_maps_agree_on_chains():
+    # PoolManager / UniversalRouter / Quoter / StateView must all be pinned for
+    # the same chain set — a swap needs every one of them.
+    from wayfinder_paths.core.constants.contracts import (
+        UNISWAP_V4_POOL_MANAGER,
+        UNISWAP_V4_QUOTER,
+        UNISWAP_V4_STATE_VIEW,
+        UNISWAP_V4_UNIVERSAL_ROUTER,
+    )
+
+    chains = set(UNISWAP_V4_POOL_MANAGER)
+    assert chains == {1, 8453, 42161, 4663}
+    assert set(UNISWAP_V4_UNIVERSAL_ROUTER) == chains
+    assert set(UNISWAP_V4_QUOTER) == chains
+    assert set(UNISWAP_V4_STATE_VIEW) == chains
+
+
+@pytest.mark.asyncio
+async def test_find_pools_enumerates_standard_tiers_scan_free():
+    # Large chains (no full log scan) discover mainstream pools by poolId +
+    # StateView liquidity — no Initialize log scan, so it scales to mainnet.
+    USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+
+    class _FakeEth:
+        def __init__(self):
+            self.get_logs_called = False
+
+        async def get_logs(self, *a, **k):
+            self.get_logs_called = True
+            return []
+
+        async def call(self, tx):
+            # Return non-zero liquidity only for the fee=3000 tier's poolId.
+            currency0, currency1 = v4._sorted_currencies(v4.NATIVE_ADDRESS, USDC)
+            target = PoolKey(currency0, currency1, 3000, 60, v4.NATIVE_ADDRESS).pool_id
+            data = tx["data"]
+            liq = 999 if target[2:] in data else 0
+            return bytes.fromhex(f"{liq:064x}")
+
+    fake_eth = _FakeEth()
+
+    class _FakeWeb3:
+        eth = fake_eth
+
+    class _Ctx:
+        async def __aenter__(self):
+            return _FakeWeb3()
+
+        async def __aexit__(self, *a):
+            return False
+
+    with patch.object(v4, "web3_from_chain_id", lambda _c: _Ctx()):
+        pools = await v4.find_pools(1, v4.NATIVE_ADDRESS, USDC)
+
+    assert fake_eth.get_logs_called is False  # mainnet: no log scan
+    assert len(pools) == 1
+    assert pools[0].key.fee == 3000
+    assert pools[0].liquidity == 999

--- a/wayfinder_paths/adapters/uniswap_adapter/test_v4.py
+++ b/wayfinder_paths/adapters/uniswap_adapter/test_v4.py
@@ -1,0 +1,130 @@
+"""Uniswap v4 encoding + pool-selection tests.
+
+The high-risk surface is the PoolKey/poolId hashing and the Universal Router
+swap encoding — a wrong byte there silently routes to the wrong pool or
+reverts. The poolId is asserted against the live Robinhood INDEX/ETH 1% pool
+(`0x00dd2df2…46edf3`), reconstructed from its on-chain Initialize event.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from eth_abi import decode as abi_decode
+
+from wayfinder_paths.adapters.uniswap_adapter import v4
+from wayfinder_paths.adapters.uniswap_adapter.v4 import (
+    NATIVE_ADDRESS,
+    PoolKey,
+    UniswapV4SwapMixin,
+    V4Pool,
+    _encode_swap_inputs,
+    _sorted_currencies,
+    best_pool,
+)
+
+# Live Robinhood (4663) INDEX/ETH 1% pool, from its Initialize event.
+INDEX = "0x56910d4409f3a0c78c64dd8d0545ff0705389870"
+HOOK = "0x2cd91bd228ff4c537031d6b8204782090c84c0cc"
+KNOWN_POOL_ID = "0x00dd2df2f17d431cf3a0938f06c9cf9abc5e9643b6cc466ca3f71f3af246edf3"
+
+
+def test_pool_id_matches_live_index_pool():
+    currency0, currency1 = _sorted_currencies(NATIVE_ADDRESS, INDEX)
+    key = PoolKey(currency0, currency1, fee=10000, tick_spacing=200, hooks=HOOK)
+    assert key.pool_id == KNOWN_POOL_ID
+
+
+def test_native_sorts_to_currency0():
+    # Native (0x0) is numerically smallest, so it is always currency0.
+    currency0, currency1 = _sorted_currencies(INDEX, NATIVE_ADDRESS)
+    assert currency0 == NATIVE_ADDRESS
+    assert currency1.lower() == INDEX
+
+
+def test_currency_ordering_is_address_sorted():
+    low = "0x1111111111111111111111111111111111111111"
+    high = "0x9999999999999999999999999999999999999999"
+    assert _sorted_currencies(high, low) == (low, high)
+    assert _sorted_currencies(low, high) == (low, high)
+
+
+def test_swap_input_encodes_actions_and_params():
+    currency0, currency1 = _sorted_currencies(NATIVE_ADDRESS, INDEX)
+    key = PoolKey(currency0, currency1, fee=10000, tick_spacing=200, hooks=HOOK)
+    encoded = _encode_swap_inputs(
+        key,
+        zero_for_one=True,
+        amount_in=3 * 10**15,
+        min_amount_out=9_000 * 10**18,
+        input_currency=NATIVE_ADDRESS,
+        output_currency=INDEX,
+    )
+    actions, params = abi_decode(["bytes", "bytes[]"], encoded)
+    # SWAP_EXACT_IN_SINGLE (0x06), SETTLE_ALL (0x0c), TAKE_ALL (0x0f)
+    assert actions == bytes([0x06, 0x0C, 0x0F])
+    assert len(params) == 3
+    # SETTLE_ALL carries (input_currency, amount_in)
+    settle_token, settle_amount = abi_decode(["address", "uint256"], params[1])
+    assert settle_token == NATIVE_ADDRESS
+    assert settle_amount == 3 * 10**15
+    # TAKE_ALL carries (output_currency, min_out)
+    take_token, take_amount = abi_decode(["address", "uint256"], params[2])
+    assert take_token.lower() == INDEX
+    assert take_amount == 9_000 * 10**18
+
+
+@pytest.mark.asyncio
+async def test_best_pool_ranks_by_liquidity_not_fee():
+    # The deep 1% pool must win over higher-fee dust pools (the traps).
+    deep = V4Pool(
+        PoolKey(NATIVE_ADDRESS, INDEX, 10000, 200, HOOK), liquidity=44_721 * 10**18
+    )
+    dust_20pct = V4Pool(
+        PoolKey(NATIVE_ADDRESS, INDEX, 200000, 4000, NATIVE_ADDRESS),
+        liquidity=250 * 10**18,
+    )
+    with patch.object(v4, "find_pools", AsyncMock(return_value=[deep, dust_20pct])):
+        pool = await best_pool(4663, NATIVE_ADDRESS, INDEX)
+    assert pool.key.fee == 10000
+    assert pool.liquidity == 44_721 * 10**18
+
+
+@pytest.mark.asyncio
+async def test_v4_quote_uses_best_pool_and_returns_output():
+    class _Host(UniswapV4SwapMixin):
+        chain_id = 4663
+        owner = "0x0000000000000000000000000000000000000001"
+        sign_callback = None
+
+    deep = V4Pool(
+        PoolKey(NATIVE_ADDRESS, INDEX, 10000, 200, HOOK), liquidity=44_721 * 10**18
+    )
+    with (
+        patch.object(v4, "best_pool", AsyncMock(return_value=deep)),
+        patch.object(v4, "quote_exact_in", AsyncMock(return_value=9_549 * 10**18)),
+    ):
+        ok, result = await _Host().v4_quote(NATIVE_ADDRESS, INDEX, 3 * 10**15)
+    assert ok is True
+    assert result["amount_out"] == 9_549 * 10**18
+    assert result["pool_id"] == KNOWN_POOL_ID
+    assert result["fee"] == 10000
+
+
+@pytest.mark.asyncio
+async def test_v4_quote_reports_missing_pool():
+    class _Host(UniswapV4SwapMixin):
+        chain_id = 4663
+        owner = "0x0000000000000000000000000000000000000001"
+        sign_callback = None
+
+    with patch.object(v4, "best_pool", AsyncMock(return_value=None)):
+        ok, result = await _Host().v4_quote(NATIVE_ADDRESS, INDEX, 3 * 10**15)
+    assert ok is False
+    assert "No v4 pool" in result
+
+
+def test_v4_supported_flags_robinhood_only_where_configured():
+    assert v4.v4_supported(4663) is True
+    assert v4.v4_supported(999999) is False

--- a/wayfinder_paths/adapters/uniswap_adapter/v4.py
+++ b/wayfinder_paths/adapters/uniswap_adapter/v4.py
@@ -46,6 +46,23 @@ _INITIALIZE_TOPIC = (
 # StateView view selector.
 _GET_LIQUIDITY_SELECTOR = "0x" + keccak(b"getLiquidity(bytes32)")[:4].hex()
 
+# Standard hookless (fee, tickSpacing) tiers — the v3-inherited convention that
+# mainstream pairs (ETH/USDC etc.) use on every chain. Enumerating these by
+# poolId + StateView is scan-free, so pool discovery works on large chains
+# (mainnet/Base/Arbitrum) where a from-genesis Initialize log scan is infeasible.
+_STANDARD_TIERS: tuple[tuple[int, int], ...] = (
+    (100, 1),
+    (500, 10),
+    (2500, 50),
+    (3000, 60),
+    (10000, 200),
+)
+
+# Chains small enough for a full-history Initialize log scan, which also finds
+# hooked/custom-tier pools (e.g. Robinhood meme pools with bespoke hooks). Large
+# chains rely on standard-tier enumeration for their mainstream (hookless) pools.
+_FULL_LOG_SCAN_CHAINS: frozenset[int] = frozenset({4663})
+
 # V4Quoter.quoteExactInputSingle((PoolKey,bool,uint128,bytes))
 _QUOTE_EXACT_IN_SELECTOR = (
     "0x"
@@ -145,50 +162,72 @@ async def _rpc_call(web3, to: str, data: str) -> str:
     return (await web3.eth.call({"to": to_checksum_address(to), "data": data})).hex()
 
 
+async def _pool_liquidity(web3, state_view: str, pool_id: str) -> int:
+    liquidity_hex = await _rpc_call(
+        web3, state_view, _GET_LIQUIDITY_SELECTOR + pool_id[2:]
+    )
+    return int(liquidity_hex, 16) if liquidity_hex not in ("", "0x") else 0
+
+
 async def find_pools(chain_id: int, token_a: str, token_b: str) -> list[V4Pool]:
     """All v4 pools for the pair, ranked by live liquidity (deepest first).
 
-    Discovers pools from PoolManager Initialize logs (currencies are indexed,
-    so the scan is a cheap topic filter) and reads current liquidity from
-    StateView. Never infers a pool from fee tier alone.
+    Two discovery paths, merged and deduped:
+    - Standard hookless tiers by poolId + StateView liquidity — scan-free, works
+      on every chain, covers mainstream pairs (the only feasible path on large
+      chains like mainnet/Base/Arbitrum).
+    - A full PoolManager Initialize log scan — only on small chains, to also
+      catch hooked/custom-tier pools (e.g. Robinhood meme pools).
+
+    Never infers a pool from fee tier alone; every candidate's liquidity is read
+    on-chain and zero-liquidity pools are dropped.
     """
     if chain_id not in UNISWAP_V4_POOL_MANAGER:
         return []
     currency0, currency1 = _sorted_currencies(token_a, token_b)
-    pool_manager = UNISWAP_V4_POOL_MANAGER[chain_id]
     state_view = UNISWAP_V4_STATE_VIEW[chain_id]
 
+    pools: list[V4Pool] = []
+    seen: set[str] = set()
+
     async with web3_from_chain_id(chain_id) as web3:
-        logs = await web3.eth.get_logs(
-            {
-                "address": to_checksum_address(pool_manager),
-                "fromBlock": 0,
-                "toBlock": "latest",
-                "topics": [
-                    _INITIALIZE_TOPIC,
-                    None,
-                    "0x" + "0" * 24 + currency0[2:].lower(),
-                    "0x" + "0" * 24 + currency1[2:].lower(),
-                ],
-            }
-        )
-        pools: list[V4Pool] = []
-        seen: set[str] = set()
-        for log in logs:
-            data = bytes(log["data"])
-            fee, tick_spacing, hooks, _sqrt_price, _tick = abi_decode(
-                ["uint24", "int24", "address", "uint160", "int24"], data
-            )
-            key = PoolKey(currency0, currency1, int(fee), int(tick_spacing), hooks)
+        # Path 1: standard hookless tiers (all chains).
+        for fee, tick_spacing in _STANDARD_TIERS:
+            key = PoolKey(currency0, currency1, fee, tick_spacing, NATIVE_ADDRESS)
             if key.pool_id in seen:
                 continue
             seen.add(key.pool_id)
-            liquidity_hex = await _rpc_call(
-                web3, state_view, _GET_LIQUIDITY_SELECTOR + key.pool_id[2:]
-            )
-            liquidity = int(liquidity_hex, 16) if liquidity_hex not in ("", "0x") else 0
+            liquidity = await _pool_liquidity(web3, state_view, key.pool_id)
             if liquidity > 0:
                 pools.append(V4Pool(key=key, liquidity=liquidity))
+
+        # Path 2: full Initialize scan for hooked/custom pools (small chains).
+        if chain_id in _FULL_LOG_SCAN_CHAINS:
+            logs = await web3.eth.get_logs(
+                {
+                    "address": to_checksum_address(UNISWAP_V4_POOL_MANAGER[chain_id]),
+                    "fromBlock": 0,
+                    "toBlock": "latest",
+                    "topics": [
+                        _INITIALIZE_TOPIC,
+                        None,
+                        "0x" + "0" * 24 + currency0[2:].lower(),
+                        "0x" + "0" * 24 + currency1[2:].lower(),
+                    ],
+                }
+            )
+            for log in logs:
+                fee, tick_spacing, hooks, _sqrt, _tick = abi_decode(
+                    ["uint24", "int24", "address", "uint160", "int24"],
+                    bytes(log["data"]),
+                )
+                key = PoolKey(currency0, currency1, int(fee), int(tick_spacing), hooks)
+                if key.pool_id in seen:
+                    continue
+                seen.add(key.pool_id)
+                liquidity = await _pool_liquidity(web3, state_view, key.pool_id)
+                if liquidity > 0:
+                    pools.append(V4Pool(key=key, liquidity=liquidity))
 
     pools.sort(key=lambda p: p.liquidity, reverse=True)
     return pools

--- a/wayfinder_paths/adapters/uniswap_adapter/v4.py
+++ b/wayfinder_paths/adapters/uniswap_adapter/v4.py
@@ -27,6 +27,10 @@ from wayfinder_paths.core.constants.contracts import (
     UNISWAP_V4_STATE_VIEW,
     UNISWAP_V4_UNIVERSAL_ROUTER,
 )
+from wayfinder_paths.core.constants.uniswap_v4_abi import (
+    PERMIT2_ABI,
+    UNIVERSAL_ROUTER_ABI,
+)
 from wayfinder_paths.core.utils.tokens import ensure_allowance, is_native_token
 from wayfinder_paths.core.utils.transaction import send_transaction
 from wayfinder_paths.core.utils.web3 import web3_from_chain_id
@@ -76,35 +80,6 @@ _UR_V4_SWAP = 0x10
 _V4_SWAP_EXACT_IN_SINGLE = 0x06
 _V4_SETTLE_ALL = 0x0C
 _V4_TAKE_ALL = 0x0F
-
-_UNIVERSAL_ROUTER_ABI = [
-    {
-        "type": "function",
-        "name": "execute",
-        "stateMutability": "payable",
-        "inputs": [
-            {"name": "commands", "type": "bytes"},
-            {"name": "inputs", "type": "bytes[]"},
-            {"name": "deadline", "type": "uint256"},
-        ],
-        "outputs": [],
-    }
-]
-
-_PERMIT2_ABI = [
-    {
-        "type": "function",
-        "name": "approve",
-        "stateMutability": "nonpayable",
-        "inputs": [
-            {"name": "token", "type": "address"},
-            {"name": "spender", "type": "address"},
-            {"name": "amount", "type": "uint160"},
-            {"name": "expiration", "type": "uint48"},
-        ],
-        "outputs": [],
-    }
-]
 
 _UINT160_MAX = (1 << 160) - 1
 _UINT48_MAX = (1 << 48) - 1
@@ -396,7 +371,7 @@ class UniswapV4SwapMixin:
 
             async with web3_from_chain_id(chain_id) as web3:
                 contract = web3.eth.contract(
-                    address=to_checksum_address(router), abi=_UNIVERSAL_ROUTER_ABI
+                    address=to_checksum_address(router), abi=UNIVERSAL_ROUTER_ABI
                 )
                 data = contract.encode_abi(
                     "execute", [bytes([_UR_V4_SWAP]), [swap_input], deadline]
@@ -426,7 +401,7 @@ class UniswapV4SwapMixin:
     async def _permit2_approve(self, token: str, spender: str) -> None:
         async with web3_from_chain_id(self.chain_id) as web3:
             contract = web3.eth.contract(
-                address=to_checksum_address(UNISWAP_PERMIT2), abi=_PERMIT2_ABI
+                address=to_checksum_address(UNISWAP_PERMIT2), abi=PERMIT2_ABI
             )
             data = contract.encode_abi(
                 "approve",

--- a/wayfinder_paths/adapters/uniswap_adapter/v4.py
+++ b/wayfinder_paths/adapters/uniswap_adapter/v4.py
@@ -1,0 +1,418 @@
+"""Uniswap v4 exact-in swaps.
+
+Aggregators (LiFi/BRAP) have no v4 coverage on newer chains like Robinhood,
+so v4-only tokens either don't quote or route through dust pools at a huge
+markup — the INDEX/ETH 1% pool ($87.5k) quotes ~24% more direct than the
+aggregator's dust fallback. This module discovers a token pair's v4 pools
+from PoolManager Initialize events, ranks them by live liquidity (StateView),
+quotes via the V4Quoter, and executes through the Universal Router.
+
+Pool selection is by liquidity, never fee tier: v4 lets anyone open a pool at
+any fee, so the 10/20/50% "pools" are traps with dust in them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from eth_abi import decode as abi_decode
+from eth_abi import encode as abi_encode
+from eth_utils import keccak, to_checksum_address
+
+from wayfinder_paths.core.constants.contracts import (
+    UNISWAP_PERMIT2,
+    UNISWAP_V4_POOL_MANAGER,
+    UNISWAP_V4_QUOTER,
+    UNISWAP_V4_STATE_VIEW,
+    UNISWAP_V4_UNIVERSAL_ROUTER,
+)
+from wayfinder_paths.core.utils.tokens import ensure_allowance, is_native_token
+from wayfinder_paths.core.utils.transaction import send_transaction
+from wayfinder_paths.core.utils.web3 import web3_from_chain_id
+
+NATIVE_ADDRESS = "0x0000000000000000000000000000000000000000"
+
+# PoolManager.Initialize(bytes32 indexed id, address indexed currency0,
+#   address indexed currency1, uint24 fee, int24 tickSpacing, address hooks,
+#   uint160 sqrtPriceX96, int24 tick)
+_INITIALIZE_TOPIC = (
+    "0x"
+    + keccak(
+        b"Initialize(bytes32,address,address,uint24,int24,address,uint160,int24)"
+    ).hex()
+)
+
+# StateView view selector.
+_GET_LIQUIDITY_SELECTOR = "0x" + keccak(b"getLiquidity(bytes32)")[:4].hex()
+
+# V4Quoter.quoteExactInputSingle((PoolKey,bool,uint128,bytes))
+_QUOTE_EXACT_IN_SELECTOR = (
+    "0x"
+    + keccak(
+        b"quoteExactInputSingle(((address,address,uint24,int24,address),bool,uint128,bytes))"
+    )[:4].hex()
+)
+
+# Universal Router command byte + v4 Actions (see @uniswap/v4-periphery).
+_UR_V4_SWAP = 0x10
+_V4_SWAP_EXACT_IN_SINGLE = 0x06
+_V4_SETTLE_ALL = 0x0C
+_V4_TAKE_ALL = 0x0F
+
+_UNIVERSAL_ROUTER_ABI = [
+    {
+        "type": "function",
+        "name": "execute",
+        "stateMutability": "payable",
+        "inputs": [
+            {"name": "commands", "type": "bytes"},
+            {"name": "inputs", "type": "bytes[]"},
+            {"name": "deadline", "type": "uint256"},
+        ],
+        "outputs": [],
+    }
+]
+
+_PERMIT2_ABI = [
+    {
+        "type": "function",
+        "name": "approve",
+        "stateMutability": "nonpayable",
+        "inputs": [
+            {"name": "token", "type": "address"},
+            {"name": "spender", "type": "address"},
+            {"name": "amount", "type": "uint160"},
+            {"name": "expiration", "type": "uint48"},
+        ],
+        "outputs": [],
+    }
+]
+
+_UINT160_MAX = (1 << 160) - 1
+_UINT48_MAX = (1 << 48) - 1
+
+
+def v4_supported(chain_id: int) -> bool:
+    return chain_id in UNISWAP_V4_POOL_MANAGER
+
+
+@dataclass(frozen=True)
+class PoolKey:
+    currency0: str
+    currency1: str
+    fee: int
+    tick_spacing: int
+    hooks: str
+
+    def as_tuple(self) -> tuple[str, str, int, int, str]:
+        return (
+            to_checksum_address(self.currency0),
+            to_checksum_address(self.currency1),
+            self.fee,
+            self.tick_spacing,
+            to_checksum_address(self.hooks),
+        )
+
+    @property
+    def pool_id(self) -> str:
+        encoded = abi_encode(
+            ["address", "address", "uint24", "int24", "address"],
+            list(self.as_tuple()),
+        )
+        return "0x" + keccak(encoded).hex()
+
+
+@dataclass(frozen=True)
+class V4Pool:
+    key: PoolKey
+    liquidity: int
+
+
+def _normalize_currency(address: str | None) -> str:
+    if address is None or is_native_token(address):
+        return NATIVE_ADDRESS
+    return to_checksum_address(address)
+
+
+def _sorted_currencies(token_a: str, token_b: str) -> tuple[str, str]:
+    a = _normalize_currency(token_a)
+    b = _normalize_currency(token_b)
+    return (a, b) if int(a, 16) <= int(b, 16) else (b, a)
+
+
+async def _rpc_call(web3, to: str, data: str) -> str:
+    return (await web3.eth.call({"to": to_checksum_address(to), "data": data})).hex()
+
+
+async def find_pools(chain_id: int, token_a: str, token_b: str) -> list[V4Pool]:
+    """All v4 pools for the pair, ranked by live liquidity (deepest first).
+
+    Discovers pools from PoolManager Initialize logs (currencies are indexed,
+    so the scan is a cheap topic filter) and reads current liquidity from
+    StateView. Never infers a pool from fee tier alone.
+    """
+    if chain_id not in UNISWAP_V4_POOL_MANAGER:
+        return []
+    currency0, currency1 = _sorted_currencies(token_a, token_b)
+    pool_manager = UNISWAP_V4_POOL_MANAGER[chain_id]
+    state_view = UNISWAP_V4_STATE_VIEW[chain_id]
+
+    async with web3_from_chain_id(chain_id) as web3:
+        logs = await web3.eth.get_logs(
+            {
+                "address": to_checksum_address(pool_manager),
+                "fromBlock": 0,
+                "toBlock": "latest",
+                "topics": [
+                    _INITIALIZE_TOPIC,
+                    None,
+                    "0x" + "0" * 24 + currency0[2:].lower(),
+                    "0x" + "0" * 24 + currency1[2:].lower(),
+                ],
+            }
+        )
+        pools: list[V4Pool] = []
+        seen: set[str] = set()
+        for log in logs:
+            data = bytes(log["data"])
+            fee, tick_spacing, hooks, _sqrt_price, _tick = abi_decode(
+                ["uint24", "int24", "address", "uint160", "int24"], data
+            )
+            key = PoolKey(currency0, currency1, int(fee), int(tick_spacing), hooks)
+            if key.pool_id in seen:
+                continue
+            seen.add(key.pool_id)
+            liquidity_hex = await _rpc_call(
+                web3, state_view, _GET_LIQUIDITY_SELECTOR + key.pool_id[2:]
+            )
+            liquidity = int(liquidity_hex, 16) if liquidity_hex not in ("", "0x") else 0
+            if liquidity > 0:
+                pools.append(V4Pool(key=key, liquidity=liquidity))
+
+    pools.sort(key=lambda p: p.liquidity, reverse=True)
+    return pools
+
+
+async def best_pool(chain_id: int, token_a: str, token_b: str) -> V4Pool | None:
+    pools = await find_pools(chain_id, token_a, token_b)
+    return pools[0] if pools else None
+
+
+async def quote_exact_in(
+    chain_id: int, pool: PoolKey, token_in: str, amount_in: int
+) -> int:
+    """Exact-in output for a single-hop v4 swap via V4Quoter (eth_call, no state)."""
+    if chain_id not in UNISWAP_V4_QUOTER:
+        raise ValueError(f"No Uniswap v4 quoter configured for chain {chain_id}")
+    zero_for_one = _normalize_currency(token_in) == pool.currency0
+    encoded_args = abi_encode(
+        ["((address,address,uint24,int24,address),bool,uint128,bytes)"],
+        [(pool.as_tuple(), zero_for_one, int(amount_in), b"")],
+    )
+    async with web3_from_chain_id(chain_id) as web3:
+        result = await _rpc_call(
+            web3,
+            UNISWAP_V4_QUOTER[chain_id],
+            _QUOTE_EXACT_IN_SELECTOR + encoded_args.hex(),
+        )
+    amount_out, _gas = abi_decode(["uint256", "uint256"], bytes.fromhex(result))
+    return int(amount_out)
+
+
+def _encode_swap_inputs(
+    pool: PoolKey,
+    zero_for_one: bool,
+    amount_in: int,
+    min_amount_out: int,
+    input_currency: str,
+    output_currency: str,
+) -> bytes:
+    """v4 SWAP_EXACT_IN_SINGLE + SETTLE_ALL + TAKE_ALL, packed for V4_SWAP."""
+    actions = bytes([_V4_SWAP_EXACT_IN_SINGLE, _V4_SETTLE_ALL, _V4_TAKE_ALL])
+
+    swap_params = abi_encode(
+        ["((address,address,uint24,int24,address),bool,uint128,uint128,bytes)"],
+        [(pool.as_tuple(), zero_for_one, int(amount_in), int(min_amount_out), b"")],
+    )
+    settle_params = abi_encode(
+        ["address", "uint256"], [to_checksum_address(input_currency), int(amount_in)]
+    )
+    take_params = abi_encode(
+        ["address", "uint256"],
+        [to_checksum_address(output_currency), int(min_amount_out)],
+    )
+    return abi_encode(
+        ["bytes", "bytes[]"], [actions, [swap_params, settle_params, take_params]]
+    )
+
+
+class UniswapV4SwapMixin:
+    """Adds v4 exact-in swaps to the Uniswap adapter.
+
+    Expects the host to provide `self.chain_id`, `self.owner`, and
+    `self.sign_callback` (the base adapter does).
+    """
+
+    chain_id: int
+    owner: str
+    sign_callback: Any
+
+    async def v4_find_pools(self, token_a: str, token_b: str) -> tuple[bool, Any]:
+        try:
+            pools = await find_pools(self.chain_id, token_a, token_b)
+            return True, [
+                {
+                    "pool_id": p.key.pool_id,
+                    "currency0": p.key.currency0,
+                    "currency1": p.key.currency1,
+                    "fee": p.key.fee,
+                    "tick_spacing": p.key.tick_spacing,
+                    "hooks": p.key.hooks,
+                    "liquidity": p.liquidity,
+                }
+                for p in pools
+            ]
+        except Exception as exc:  # noqa: BLE001
+            return False, str(exc)
+
+    async def v4_quote(
+        self, token_in: str, token_out: str, amount_in: int
+    ) -> tuple[bool, Any]:
+        try:
+            pool = await best_pool(self.chain_id, token_in, token_out)
+            if pool is None:
+                return False, "No v4 pool with liquidity for this pair"
+            amount_out = await quote_exact_in(
+                self.chain_id, pool.key, token_in, int(amount_in)
+            )
+            return True, {
+                "amount_out": amount_out,
+                "pool_id": pool.key.pool_id,
+                "fee": pool.key.fee,
+                "liquidity": pool.liquidity,
+            }
+        except Exception as exc:  # noqa: BLE001
+            return False, str(exc)
+
+    async def v4_swap_exact_in(
+        self,
+        *,
+        token_in: str,
+        token_out: str,
+        amount_in: int,
+        slippage_bps: int = 50,
+        deadline_seconds: int = 600,
+    ) -> tuple[bool, Any]:
+        """Execute an exact-in v4 swap through the Universal Router.
+
+        Native input rides as msg.value; ERC-20 input is approved to Permit2
+        and Permit2-approved to the router (the v4 settle path pulls via
+        Permit2). Output min is the quote minus `slippage_bps`.
+        """
+        try:
+            chain_id = self.chain_id
+            if chain_id not in UNISWAP_V4_UNIVERSAL_ROUTER:
+                return False, f"Uniswap v4 not configured for chain {chain_id}"
+
+            pool = await best_pool(chain_id, token_in, token_out)
+            if pool is None:
+                return False, "No v4 pool with liquidity for this pair"
+
+            amount_out = await quote_exact_in(
+                chain_id, pool.key, token_in, int(amount_in)
+            )
+            if amount_out <= 0:
+                return False, "Quoter returned zero output"
+            min_out = amount_out * (10_000 - int(slippage_bps)) // 10_000
+
+            input_currency = _normalize_currency(token_in)
+            output_currency = _normalize_currency(token_out)
+            zero_for_one = input_currency == pool.key.currency0
+            router = UNISWAP_V4_UNIVERSAL_ROUTER[chain_id]
+            native_in = input_currency == NATIVE_ADDRESS
+
+            if not native_in:
+                # v4 settles ERC-20 inputs through Permit2: approve token→Permit2
+                # (unlimited, idempotent) then Permit2→router for this amount.
+                await ensure_allowance(
+                    token_address=input_currency,
+                    owner=self.owner,
+                    spender=UNISWAP_PERMIT2,
+                    amount=int(amount_in),
+                    chain_id=chain_id,
+                    signing_callback=self.sign_callback,
+                )
+                await self._permit2_approve(input_currency, router)
+
+            swap_input = _encode_swap_inputs(
+                pool.key,
+                zero_for_one,
+                int(amount_in),
+                min_out,
+                input_currency,
+                output_currency,
+            )
+            deadline = await self._chain_deadline(chain_id, deadline_seconds)
+
+            async with web3_from_chain_id(chain_id) as web3:
+                contract = web3.eth.contract(
+                    address=to_checksum_address(router), abi=_UNIVERSAL_ROUTER_ABI
+                )
+                data = contract.encode_abi(
+                    "execute", [bytes([_UR_V4_SWAP]), [swap_input], deadline]
+                )
+                nonce = await web3.eth.get_transaction_count(
+                    to_checksum_address(self.owner)
+                )
+            tx = {
+                "chainId": chain_id,
+                "from": to_checksum_address(self.owner),
+                "to": to_checksum_address(router),
+                "data": data,
+                "value": int(amount_in) if native_in else 0,
+                "nonce": nonce,
+            }
+            tx_hash = await send_transaction(tx, self.sign_callback)
+            return True, {
+                "tx_hash": tx_hash,
+                "pool_id": pool.key.pool_id,
+                "amount_in": int(amount_in),
+                "expected_out": amount_out,
+                "min_out": min_out,
+            }
+        except Exception as exc:  # noqa: BLE001
+            return False, str(exc)
+
+    async def _permit2_approve(self, token: str, spender: str) -> None:
+        async with web3_from_chain_id(self.chain_id) as web3:
+            contract = web3.eth.contract(
+                address=to_checksum_address(UNISWAP_PERMIT2), abi=_PERMIT2_ABI
+            )
+            data = contract.encode_abi(
+                "approve",
+                [
+                    to_checksum_address(token),
+                    to_checksum_address(spender),
+                    _UINT160_MAX,
+                    _UINT48_MAX,
+                ],
+            )
+            nonce = await web3.eth.get_transaction_count(
+                to_checksum_address(self.owner)
+            )
+        tx = {
+            "chainId": self.chain_id,
+            "from": to_checksum_address(self.owner),
+            "to": to_checksum_address(UNISWAP_PERMIT2),
+            "data": data,
+            "value": 0,
+            "nonce": nonce,
+        }
+        await send_transaction(tx, self.sign_callback)
+
+    @staticmethod
+    async def _chain_deadline(chain_id: int, deadline_seconds: int) -> int:
+        async with web3_from_chain_id(chain_id) as web3:
+            block = await web3.eth.get_block("latest")
+        return int(block["timestamp"]) + int(deadline_seconds)

--- a/wayfinder_paths/core/constants/contracts.py
+++ b/wayfinder_paths/core/constants/contracts.py
@@ -107,6 +107,31 @@ LIFI_GENERIC = to_checksum_address("0x31a9b1835864706Af10103b31Ea2b79bdb995F5F")
 
 ROBINHOOD_WETH = to_checksum_address("0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73")
 
+# Uniswap v4 deployments. All addresses verified live on Robinhood (4663):
+# PoolManager owner + code confirmed, V4Quoter returns real quotes, StateView
+# getSlot0/getLiquidity resolve, UniversalRouter is Blockscout-verified, and
+# the reconstructed INDEX/ETH PoolKey hashes to the on-chain poolId. Permit2 is
+# Uniswap's canonical singleton (same address on every chain). Structured
+# per-chain so Base/Ethereum v4 can be added later.
+UNISWAP_V4_POOL_MANAGER: dict[int, str] = {
+    4663: to_checksum_address("0x8366a39CC670B4001A1121B8F6A443A643e40951"),
+}
+
+UNISWAP_V4_UNIVERSAL_ROUTER: dict[int, str] = {
+    4663: to_checksum_address("0x8876789976DEcbFcBBBe364623c63652Db8C0904"),
+}
+
+UNISWAP_V4_QUOTER: dict[int, str] = {
+    4663: to_checksum_address("0x97627e46420bbc4bc5Df7e72D6Bb653345506b2f"),
+}
+
+UNISWAP_V4_STATE_VIEW: dict[int, str] = {
+    4663: to_checksum_address("0xF3334192D15450CdD385c8B70e03f9A6bD9E673b"),
+}
+
+# Canonical Uniswap Permit2 — same address on virtually every chain.
+UNISWAP_PERMIT2 = to_checksum_address("0x000000000022D473030F116dDEE9F6B43aC78BA3")
+
 TOKENS_REQUIRING_APPROVAL_RESET: set[tuple[int, str]] = {
     (1, USDT_ETHEREUM),
     (137, USDT_POLYGON),

--- a/wayfinder_paths/core/constants/contracts.py
+++ b/wayfinder_paths/core/constants/contracts.py
@@ -107,25 +107,38 @@ LIFI_GENERIC = to_checksum_address("0x31a9b1835864706Af10103b31Ea2b79bdb995F5F")
 
 ROBINHOOD_WETH = to_checksum_address("0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73")
 
-# Uniswap v4 deployments. All addresses verified live on Robinhood (4663):
-# PoolManager owner + code confirmed, V4Quoter returns real quotes, StateView
-# getSlot0/getLiquidity resolve, UniversalRouter is Blockscout-verified, and
-# the reconstructed INDEX/ETH PoolKey hashes to the on-chain poolId. Permit2 is
-# Uniswap's canonical singleton (same address on every chain). Structured
-# per-chain so Base/Ethereum v4 can be added later.
+# Uniswap v4 deployments. Every address verified live before pinning:
+# each has code on-chain, and a native-token → USDC exact-in quote through the
+# V4Quoter (which exercises PoolManager + StateView + the pinned Quoter) returns
+# a sane amount on each chain. Robinhood addresses also confirmed via the
+# INDEX/ETH PoolKey → on-chain poolId match and a Blockscout-verified router.
+# Mainnet/Base/Arbitrum are Uniswap's official canonical v4 deployments
+# (docs.uniswap.org), which is why their code sizes match across chains.
 UNISWAP_V4_POOL_MANAGER: dict[int, str] = {
+    1: to_checksum_address("0x000000000004444c5dc75cB358380D2e3dE08A90"),
+    8453: to_checksum_address("0x498581fF718922c3f8e6A244956aF099B2652b2b"),
+    42161: to_checksum_address("0x360E68faCcca8cA495c1B759Fd9EEe466db9FB32"),
     4663: to_checksum_address("0x8366a39CC670B4001A1121B8F6A443A643e40951"),
 }
 
 UNISWAP_V4_UNIVERSAL_ROUTER: dict[int, str] = {
+    1: to_checksum_address("0x66a9893cC07D91D95644AEDD05D03f95e1dBA8Af"),
+    8453: to_checksum_address("0x6fF5693b99212Da76ad316178A184AB56D299b43"),
+    42161: to_checksum_address("0xA51afAFe0263b40EdaEf0Df8781eA9aa03E381a3"),
     4663: to_checksum_address("0x8876789976DEcbFcBBBe364623c63652Db8C0904"),
 }
 
 UNISWAP_V4_QUOTER: dict[int, str] = {
+    1: to_checksum_address("0x52F0E24D1c21C8A0cB1e5a5dD6198556BD9E1203"),
+    8453: to_checksum_address("0x0d5e0F971ED27FBfF6c2837bf31316121532048D"),
+    42161: to_checksum_address("0x3972c00f7Ed4885e145823eB7C655375D275A1c5"),
     4663: to_checksum_address("0x97627e46420bbc4bc5Df7e72D6Bb653345506b2f"),
 }
 
 UNISWAP_V4_STATE_VIEW: dict[int, str] = {
+    1: to_checksum_address("0x7fFE42C4a5DEeA5b0feC41C94C136Cf115597227"),
+    8453: to_checksum_address("0xA3c0c9b65baD0b08107Aa264b0f3dB444b867A71"),
+    42161: to_checksum_address("0x76Fd297e2D437cd7f76d50F01Afe6160f86e9990"),
     4663: to_checksum_address("0xF3334192D15450CdD385c8B70e03f9A6bD9E673b"),
 }
 

--- a/wayfinder_paths/core/constants/uniswap_v4_abi.py
+++ b/wayfinder_paths/core/constants/uniswap_v4_abi.py
@@ -1,0 +1,31 @@
+# Minimal ABIs for Uniswap V4 execution: Universal Router (V4_SWAP command)
+# and the canonical Permit2 approve used to fund ERC-20 inputs.
+
+UNIVERSAL_ROUTER_ABI = [
+    {
+        "type": "function",
+        "name": "execute",
+        "stateMutability": "payable",
+        "inputs": [
+            {"name": "commands", "type": "bytes"},
+            {"name": "inputs", "type": "bytes[]"},
+            {"name": "deadline", "type": "uint256"},
+        ],
+        "outputs": [],
+    }
+]
+
+PERMIT2_ABI = [
+    {
+        "type": "function",
+        "name": "approve",
+        "stateMutability": "nonpayable",
+        "inputs": [
+            {"name": "token", "type": "address"},
+            {"name": "spender", "type": "address"},
+            {"name": "amount", "type": "uint160"},
+            {"name": "expiration", "type": "uint48"},
+        ],
+        "outputs": [],
+    }
+]


### PR DESCRIPTION
## Problem

A prod agent tried to buy **INDEX** on Robinhood (4663) and couldn't: BRAP/LiFi returned zero quotes at real size and a 30–38% haircut on dust, and the agent wrongly concluded "Robinhood chain is not available." Root cause: **aggregators have no Uniswap v4 coverage on Robinhood**, and INDEX's real liquidity is a v4 pool they can't reach. The aggregator's only INDEX route runs through a dust pool.

## Fix — direct v4 on the Uniswap adapter

New `v4.py` module (mixed into `UniswapAdapter`), live on **Ethereum (1), Base (8453), Arbitrum (42161), and Robinhood (4663)**:

- **`v4_find_pools(a, b)`** — hybrid discovery, ranked deepest-first. **Selection is by liquidity, never fee tier** — v4 lets anyone open a pool at any fee, so the 10/20/50% pools are dust traps.
  - *Standard hookless tiers* (100/500/2500/3000/10000) are enumerated by poolId + StateView liquidity — **scan-free**, so it works on large chains where a from-genesis `Initialize` log scan is infeasible. Covers mainstream pairs (ETH/USDC).
  - *Full `Initialize` log scan* (currencies indexed → cheap topic filter) is gated to small chains (Robinhood) to also catch hooked/custom-tier meme pools like INDEX.
  - Both paths merge, dedupe by poolId, and read live liquidity from StateView. Verified live: INDEX has a 20% and a 15% trap pool with **178×–1817× less liquidity** than the real 1% pool.
- **`v4_quote(in, out, amount)`** — exact-in via V4Quoter (`eth_call`).
- **`v4_swap_exact_in(...)`** — Universal Router `V4_SWAP` (`SWAP_EXACT_IN_SINGLE` + `SETTLE_ALL` + `TAKE_ALL`); native input as `msg.value`, ERC-20 via Permit2; `min_out` = quote − slippage.

## Verification

- **Addresses (all 4 chains)**: PoolManager, Universal Router, V4Quoter, StateView, canonical Permit2 — each pinned only after verifying code is present **and** a native→USDC quote returns. Mainnet/Base/Arbitrum use Uniswap's official canonical deployments; Robinhood uses its chain deployment.
  - Mainnet/Base/Arbitrum all quote `0.01 ETH → 18.00 USDC`; Robinhood quotes `0.003 ETH → 7,288 INDEX`.
- **Encoding correctness gate**: the reconstructed INDEX/ETH `PoolKey` hashes to the **exact on-chain poolId** `0x00dd2df2…46edf3` (asserted in tests), and the swap-input actions/params decode back correctly.
- **The thesis, live**: v4 direct returns **9,549 INDEX per 0.003 ETH vs the aggregator's 7,661 (~24% more)**, and `find_pools` correctly ranks the deep 1% pool over the two dust traps.

## Tests

`test_v4.py` (10): poolId matches the live pool, native→currency0 ordering, swap-input action/param encoding, liquidity-based pool selection (not fee), quote success/missing-pool, all four configured chains supported, all address maps agree on the chain set, and scan-free standard-tier discovery (asserts mainnet finds ETH/USDC *without* a log scan). Full uniswap suite 29 green — v3 path untouched.

## Notes

- Execution (`v4_swap_exact_in`) is encoded and unit-covered but not yet fork-executed end-to-end; a Gorlami vnet sim of the full buy is a fast follow. The read/quote path is live-verified on all four chains.
- Some data sources label native-ETH v4 pools as "WETH" but on-chain they use native ETH (`address(0)`) — handled.
- Rides the next shell-image pin bump (queue with #455/#458/#459/#460).
