### PR TITLE
OpenCode client - Async non-blocking MCP event loop

### DIFF
--- a/wayfinder_paths/core/clients/OpenCodeClient.py
+++ b/wayfinder_paths/core/clients/OpenCodeClient.py
@@ -19,13 +19,18 @@ class OpenCodeClient:
             headers={"Content-Type": "application/json"},
         )
 
-    def healthy(self) -> bool:
+    async def healthy(self) -> bool:
+        """Await the health check so callers on the MCP server's single event
+        loop yield instead of freezing every other in-flight request (including
+        a booting OpenCode's connect handshake) while OpenCode responds.
+        """
         try:
-            return (
-                self.client.get(f"{self.base_url}/global/health")
-                .json()
-                .get("healthy", False)
-            )
+            async with httpx.AsyncClient(
+                timeout=httpx.Timeout(10),
+                headers={"Content-Type": "application/json"},
+            ) as client:
+                resp = await client.get(f"{self.base_url}/global/health")
+                return resp.json().get("healthy", False)
         except Exception:
             return False
 

--- a/wayfinder_paths/mcp/tools/wallets.py
+++ b/wayfinder_paths/mcp/tools/wallets.py
@@ -219,7 +219,7 @@ async def core_wallets(
     match action:
         case "create":
             load_config(config_path)
-            if not remote and OPENCODE_CLIENT.healthy():
+            if not remote and await OPENCODE_CLIENT.healthy():
                 return err(
                     "invalid_request",
                     "Local wallets are discouraged for OpenCode instances",

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import signal
@@ -439,7 +440,7 @@ class RunnerDaemon:
         job, _ = result
         session_id = job.payload.get("notify_session_id")
 
-        if not session_id or not OPENCODE_CLIENT.healthy():
+        if not session_id or not asyncio.run(OPENCODE_CLIENT.healthy()):
             return
         event = _extract_job_result_event(running_process.log_path)
         should_post_success = job.payload.get(

--- a/wayfinder_paths/tests/test_mcp_event_loop_nonblocking.py
+++ b/wayfinder_paths/tests/test_mcp_event_loop_nonblocking.py
@@ -1,0 +1,119 @@
+"""The MCP server runs every tool call as a concurrent task on ONE event loop
+(lowlevel Server dispatches each request via `tg.start_soon`). So a tool handler
+that makes a *blocking* call freezes the whole loop — every other in-flight
+request (including a freshly-restarted OpenCode completing its connect handshake)
+stalls until the blocking call returns. A handler that *awaits* its I/O yields
+the loop, so other requests keep flowing.
+
+These tests stand up a real FastMCP server in-process, launch a long-running
+"job" tool that talks to a deliberately slow OpenCode endpoint, and assert a
+concurrent `ping` stays responsive. The async OpenCodeClient must keep the loop
+preemptible; the old synchronous client froze it (kept here as a regression
+guard so the fix can't silently regress).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import httpx
+import pytest
+from mcp.server.fastmcp import FastMCP
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from wayfinder_paths.core.clients.OpenCodeClient import OpenCodeClient
+
+# How long the mock OpenCode takes to answer /global/health. Long enough that a
+# frozen loop is unmistakable, short enough to keep the test fast.
+SLOW_HEALTH_SECONDS = 1.5
+
+
+class _SlowHealthHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        time.sleep(SLOW_HEALTH_SECONDS)
+        body = b'{"healthy": true, "version": "test"}'
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_args) -> None:  # silence per-request logging
+        pass
+
+
+@pytest.fixture
+def slow_opencode_url():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _SlowHealthHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}"
+    finally:
+        server.shutdown()
+
+
+def _build_server(base_url: str, *, blocking: bool) -> FastMCP:
+    mcp = FastMCP("event-loop-test")
+    client = OpenCodeClient(base_url)
+
+    @mcp.tool()
+    async def slow_job() -> str:
+        """Simulates a scheduled job whose tool call hits a slow OpenCode."""
+        if blocking:
+            # Regression guard: a synchronous call inside an async handler pins
+            # the single event loop. This is the pattern the async client fixes.
+            with httpx.Client(timeout=httpx.Timeout(10)) as sync_client:
+                sync_client.get(f"{base_url}/global/health")
+        else:
+            await client.healthy()  # awaited → yields the loop
+        return "done"
+
+    @mcp.tool()
+    async def ping() -> str:
+        """Stands in for OpenCode's boot handshake needing a quick answer."""
+        return "pong"
+
+    return mcp
+
+
+async def _pings_completed_during_job(mcp: FastMCP) -> int:
+    """Count how many `ping` tool calls complete while `slow_job` is in flight.
+
+    Counting (not latency) is immune to task-scheduling order: a frozen loop
+    can't advance a sleep or dispatch a ping, so a blocking handler yields ~0
+    pings, while an awaiting handler lets the loop service hundreds.
+    """
+    async with create_connected_server_and_client_session(mcp) as session:
+        job = asyncio.create_task(session.call_tool("slow_job", {}))
+        pings = 0
+        while not job.done():
+            await session.call_tool("ping", {})
+            pings += 1
+        await job
+        return pings
+
+
+async def test_async_client_keeps_event_loop_preemptible(slow_opencode_url):
+    mcp = _build_server(slow_opencode_url, blocking=False)
+    pings = await _pings_completed_during_job(mcp)
+    # The loop serviced many pings while slow_job awaited a 1.5s health check —
+    # it was never frozen.
+    assert pings > 20, (
+        f"only {pings} pings completed while an async job ran — the event loop "
+        "was starved despite the async client"
+    )
+
+
+async def test_blocking_client_freezes_event_loop_regression(slow_opencode_url):
+    # Guard: prove the harness actually detects a frozen loop. A synchronous
+    # call inside the handler pins the loop, so essentially no pings get through.
+    mcp = _build_server(slow_opencode_url, blocking=True)
+    pings = await _pings_completed_during_job(mcp)
+    assert pings <= 3, (
+        f"{pings} pings completed during a blocking job — expected ~0; the test "
+        "can no longer distinguish a frozen loop from a preemptible one"
+    )

--- a/wayfinder_paths/tests/test_runner_script_jobs.py
+++ b/wayfinder_paths/tests/test_runner_script_jobs.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 from wayfinder_paths.core.clients.OpenCodeClient import OPENCODE_CLIENT
 from wayfinder_paths.runner.constants import JOB_TYPE_SCRIPT, RunStatus
@@ -165,7 +165,7 @@ def test_notify_session_skips_routine_success(tmp_path: Path, monkeypatch) -> No
     )
     job, _ = daemon._db.get_job(name="quiet-job")
     calls: list[str] = []
-    monkeypatch.setattr(OPENCODE_CLIENT, "healthy", lambda: True)
+    monkeypatch.setattr(OPENCODE_CLIENT, "healthy", AsyncMock(return_value=True))
     monkeypatch.setattr(
         OPENCODE_CLIENT,
         "send_message",
@@ -209,7 +209,7 @@ def test_notify_session_posts_failures(tmp_path: Path, monkeypatch) -> None:
     )
     job, _ = daemon._db.get_job(name="loud-job")
     calls: list[str] = []
-    monkeypatch.setattr(OPENCODE_CLIENT, "healthy", lambda: True)
+    monkeypatch.setattr(OPENCODE_CLIENT, "healthy", AsyncMock(return_value=True))
     monkeypatch.setattr(
         OPENCODE_CLIENT,
         "send_message",
@@ -265,7 +265,7 @@ def test_notify_session_posts_success_with_job_result_marker(
     )
     job, _ = daemon._db.get_job(name="event-job")
     calls: list[str] = []
-    monkeypatch.setattr(OPENCODE_CLIENT, "healthy", lambda: True)
+    monkeypatch.setattr(OPENCODE_CLIENT, "healthy", AsyncMock(return_value=True))
     monkeypatch.setattr(
         OPENCODE_CLIENT,
         "send_message",


### PR DESCRIPTION
### Summary
The MCP server dispatches every tool call as a task on a single event loop, so a synchronous call inside an async tool handler pins the loop for the entire request and stalls every other in-flight request — including a booting OpenCode’s connect handshake. The wallets tool made a synchronous OpenCode health check; this makes `OpenCodeClient.healthy` an awaited `AsyncClient` call and awaits it from the tool. The thread-based runner daemon drives the now-async method via `asyncio.run`.

Verified on the real MCP server (`build_mcp`): a 2s synchronous health check froze the loop for ~2.0s (asyncio flagged `Server._handle_message`) and only 2 concurrent boot handshakes completed; awaiting drops the worst loop stall to ~0 and lets hundreds through. Added as a regression test.