### PR TITLE
Solana - SVM support (chain 900): utils, wallets, token resolver, MCP balances

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -187,6 +187,18 @@ yarl = ">=1.17.0,<2.0"
 speedups = ["Brotli (>=1.2) ; platform_python_implementation == \"CPython\"", "aiodns (>=3.3.0)", "backports.zstd ; platform_python_implementation == \"CPython\" and python_version < \"3.14\"", "brotlicffi (>=1.2) ; platform_python_implementation != \"CPython\""]
 
 [[package]]
+name = "aiolimiter"
+version = "1.2.1"
+description = "asyncio rate limiter, a leaky bucket implementation"
+optional = false
+python-versions = "<4.0,>=3.8"
+groups = ["main"]
+files = [
+    {file = "aiolimiter-1.2.1-py3-none-any.whl", hash = "sha256:d3f249e9059a20badcb56b61601a83556133655c11d1eb3dd3e04ff069e5f3c7"},
+    {file = "aiolimiter-1.2.1.tar.gz", hash = "sha256:e02a37ea1a855d9e832252a105420ad4d15011505512a1a1d814647451b5cca9"},
+]
+
+[[package]]
 name = "aiosignal"
 version = "1.4.0"
 description = "aiosignal: a list of registered asynchronous callbacks"
@@ -824,6 +836,37 @@ files = [
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
 markers = {main = "sys_platform == \"win32\" or platform_system == \"Windows\"", dev = "platform_system == \"Windows\" or sys_platform == \"win32\""}
+
+[[package]]
+name = "construct"
+version = "2.10.70"
+description = "A powerful declarative symmetric parser/builder for binary data"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "construct-2.10.70-py3-none-any.whl", hash = "sha256:c80be81ef595a1a821ec69dc16099550ed22197615f4320b57cc9ce2a672cb30"},
+    {file = "construct-2.10.70.tar.gz", hash = "sha256:4d2472f9684731e58cc9c56c463be63baa1447d674e0d66aeb5627b22f512c29"},
+]
+
+[package.extras]
+extras = ["arrow", "cloudpickle", "cryptography", "lz4", "numpy", "ruamel.yaml"]
+
+[[package]]
+name = "construct-typing"
+version = "0.7.0"
+description = "Extension for the python package 'construct' that adds typing features"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "construct_typing-0.7.0-py3-none-any.whl", hash = "sha256:c92383c6e8e5d07ba25811c8d5163820458d821e73bb1006541f43f89788646c"},
+    {file = "construct_typing-0.7.0.tar.gz", hash = "sha256:71d110dedff39bd3b603c734077032a7065bc597a49db1f5b03a211d05dbac23"},
+]
+
+[package.dependencies]
+construct = "2.10.70"
+typing_extensions = ">=4.6.0"
 
 [[package]]
 name = "contourpy"
@@ -1855,6 +1898,28 @@ socks = ["socksio (==1.*)"]
 trio = ["trio (>=0.22.0,<1.0)"]
 
 [[package]]
+name = "httpcore2"
+version = "2.5.0"
+description = "A minimal low-level HTTP client."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "httpcore2-2.5.0-py3-none-any.whl", hash = "sha256:5ce35188de461d31e8d000bfb8ef8bf22c6c16587a211e5571deaa5e9bdf842a"},
+    {file = "httpcore2-2.5.0.tar.gz", hash = "sha256:88aa170137c17328d5ac44234f9fd10706466d5fb347f3edac4d39b91137b09d"},
+]
+
+[package.dependencies]
+h11 = ">=0.16"
+truststore = ">=0.10"
+
+[package.extras]
+asyncio = ["anyio (>=4.5.0,<5.0)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+trio = ["trio (>=0.22.0,<1.0)"]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 description = "The next generation HTTP client."
@@ -1891,6 +1956,33 @@ files = [
     {file = "httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc"},
     {file = "httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d"},
 ]
+
+[[package]]
+name = "httpx2"
+version = "2.5.0"
+description = "The next generation HTTP client."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "httpx2-2.5.0-py3-none-any.whl", hash = "sha256:3d2d4d9cf4b61f1a1f46a95947cfdb47e80cb56a2f91c6256ac8f58e4891df41"},
+    {file = "httpx2-2.5.0.tar.gz", hash = "sha256:e2df9cb4611021527ff8a675b1c320b610a2ec397acc8d6fe6e91df2d9b33c29"},
+]
+
+[package.dependencies]
+anyio = "*"
+h2 = {version = ">=3,<5", optional = true, markers = "extra == \"http2\""}
+httpcore2 = "2.5.0"
+idna = ">=3.18"
+truststore = ">=0.10"
+typing-extensions = {version = ">=4.5.0", markers = "python_version < \"3.13\""}
+
+[package.extras]
+brotli = ["brotli ; platform_python_implementation == \"CPython\"", "brotlicffi ; platform_python_implementation != \"CPython\""]
+cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<16)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+zstd = ["zstandard (>=0.18.0) ; python_version <= \"3.13\""]
 
 [[package]]
 name = "hyperframe"
@@ -1945,18 +2037,18 @@ test = ["coverage[toml]", "pretend", "pytest", "pytest-cov"]
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea"},
-    {file = "idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"},
+    {file = "idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"},
+    {file = "idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"},
 ]
 
 [package.extras]
-all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
+all = ["mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
 name = "iniconfig"
@@ -2069,6 +2161,18 @@ MarkupSafe = ">=2.0"
 
 [package.extras]
 i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "jsonalias"
+version = "0.1.1"
+description = "A microlibrary that defines a Json type alias for Python."
+optional = false
+python-versions = ">=3.7,<4.0"
+groups = ["main"]
+files = [
+    {file = "jsonalias-0.1.1-py3-none-any.whl", hash = "sha256:a56d2888e6397812c606156504e861e8ec00e188005af149f003c787db3d3f18"},
+    {file = "jsonalias-0.1.1.tar.gz", hash = "sha256:64f04d935397d579fc94509e1fcb6212f2d081235d9d6395bd10baedf760a769"},
+]
 
 [[package]]
 name = "jsonschema"
@@ -3691,19 +3795,19 @@ files = [
 
 [[package]]
 name = "pydantic"
-version = "2.12.5"
+version = "2.13.4"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d"},
-    {file = "pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49"},
+    {file = "pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba"},
+    {file = "pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6"},
 ]
 
 [package.dependencies]
 annotated-types = ">=0.6.0"
-pydantic-core = "2.41.5"
+pydantic-core = "2.46.4"
 typing-extensions = ">=4.14.1"
 typing-inspection = ">=0.4.2"
 
@@ -3713,133 +3817,132 @@ timezone = ["tzdata ; python_version >= \"3.9\" and platform_system == \"Windows
 
 [[package]]
 name = "pydantic-core"
-version = "2.41.5"
+version = "2.46.4"
 description = "Core functionality for Pydantic validation and serialization"
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "pydantic_core-2.41.5-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:77b63866ca88d804225eaa4af3e664c5faf3568cea95360d21f4725ab6e07146"},
-    {file = "pydantic_core-2.41.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dfa8a0c812ac681395907e71e1274819dec685fec28273a28905df579ef137e2"},
-    {file = "pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5921a4d3ca3aee735d9fd163808f5e8dd6c6972101e4adbda9a4667908849b97"},
-    {file = "pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e25c479382d26a2a41b7ebea1043564a937db462816ea07afa8a44c0866d52f9"},
-    {file = "pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f547144f2966e1e16ae626d8ce72b4cfa0caedc7fa28052001c94fb2fcaa1c52"},
-    {file = "pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6f52298fbd394f9ed112d56f3d11aabd0d5bd27beb3084cc3d8ad069483b8941"},
-    {file = "pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:100baa204bb412b74fe285fb0f3a385256dad1d1879f0a5cb1499ed2e83d132a"},
-    {file = "pydantic_core-2.41.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:05a2c8852530ad2812cb7914dc61a1125dc4e06252ee98e5638a12da6cc6fb6c"},
-    {file = "pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:29452c56df2ed968d18d7e21f4ab0ac55e71dc59524872f6fc57dcf4a3249ed2"},
-    {file = "pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:d5160812ea7a8a2ffbe233d8da666880cad0cbaf5d4de74ae15c313213d62556"},
-    {file = "pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:df3959765b553b9440adfd3c795617c352154e497a4eaf3752555cfb5da8fc49"},
-    {file = "pydantic_core-2.41.5-cp310-cp310-win32.whl", hash = "sha256:1f8d33a7f4d5a7889e60dc39856d76d09333d8a6ed0f5f1190635cbec70ec4ba"},
-    {file = "pydantic_core-2.41.5-cp310-cp310-win_amd64.whl", hash = "sha256:62de39db01b8d593e45871af2af9e497295db8d73b085f6bfd0b18c83c70a8f9"},
-    {file = "pydantic_core-2.41.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a3a52f6156e73e7ccb0f8cced536adccb7042be67cb45f9562e12b319c119da6"},
-    {file = "pydantic_core-2.41.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7f3bf998340c6d4b0c9a2f02d6a400e51f123b59565d74dc60d252ce888c260b"},
-    {file = "pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:378bec5c66998815d224c9ca994f1e14c0c21cb95d2f52b6021cc0b2a58f2a5a"},
-    {file = "pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b576130c69225432866fe2f4a469a85a54ade141d96fd396dffcf607b558f8"},
-    {file = "pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6cb58b9c66f7e4179a2d5e0f849c48eff5c1fca560994d6eb6543abf955a149e"},
-    {file = "pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:88942d3a3dff3afc8288c21e565e476fc278902ae4d6d134f1eeda118cc830b1"},
-    {file = "pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f31d95a179f8d64d90f6831d71fa93290893a33148d890ba15de25642c5d075b"},
-    {file = "pydantic_core-2.41.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c1df3d34aced70add6f867a8cf413e299177e0c22660cc767218373d0779487b"},
-    {file = "pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4009935984bd36bd2c774e13f9a09563ce8de4abaa7226f5108262fa3e637284"},
-    {file = "pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:34a64bc3441dc1213096a20fe27e8e128bd3ff89921706e83c0b1ac971276594"},
-    {file = "pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c9e19dd6e28fdcaa5a1de679aec4141f691023916427ef9bae8584f9c2fb3b0e"},
-    {file = "pydantic_core-2.41.5-cp311-cp311-win32.whl", hash = "sha256:2c010c6ded393148374c0f6f0bf89d206bf3217f201faa0635dcd56bd1520f6b"},
-    {file = "pydantic_core-2.41.5-cp311-cp311-win_amd64.whl", hash = "sha256:76ee27c6e9c7f16f47db7a94157112a2f3a00e958bc626e2f4ee8bec5c328fbe"},
-    {file = "pydantic_core-2.41.5-cp311-cp311-win_arm64.whl", hash = "sha256:4bc36bbc0b7584de96561184ad7f012478987882ebf9f9c389b23f432ea3d90f"},
-    {file = "pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7"},
-    {file = "pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0"},
-    {file = "pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69"},
-    {file = "pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75"},
-    {file = "pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05"},
-    {file = "pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc"},
-    {file = "pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c"},
-    {file = "pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5"},
-    {file = "pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c"},
-    {file = "pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294"},
-    {file = "pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1"},
-    {file = "pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d"},
-    {file = "pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815"},
-    {file = "pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3"},
-    {file = "pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9"},
-    {file = "pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34"},
-    {file = "pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0"},
-    {file = "pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33"},
-    {file = "pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e"},
-    {file = "pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2"},
-    {file = "pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586"},
-    {file = "pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d"},
-    {file = "pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740"},
-    {file = "pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e"},
-    {file = "pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858"},
-    {file = "pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36"},
-    {file = "pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11"},
-    {file = "pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd"},
-    {file = "pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a"},
-    {file = "pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14"},
-    {file = "pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1"},
-    {file = "pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66"},
-    {file = "pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869"},
-    {file = "pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2"},
-    {file = "pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375"},
-    {file = "pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553"},
-    {file = "pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90"},
-    {file = "pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07"},
-    {file = "pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb"},
-    {file = "pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23"},
-    {file = "pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf"},
-    {file = "pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0"},
-    {file = "pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a"},
-    {file = "pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3"},
-    {file = "pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c"},
-    {file = "pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612"},
-    {file = "pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d"},
-    {file = "pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9"},
-    {file = "pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660"},
-    {file = "pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9"},
-    {file = "pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3"},
-    {file = "pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf"},
-    {file = "pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470"},
-    {file = "pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa"},
-    {file = "pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c"},
-    {file = "pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008"},
-    {file = "pydantic_core-2.41.5-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:8bfeaf8735be79f225f3fefab7f941c712aaca36f1128c9d7e2352ee1aa87bdf"},
-    {file = "pydantic_core-2.41.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:346285d28e4c8017da95144c7f3acd42740d637ff41946af5ce6e5e420502dd5"},
-    {file = "pydantic_core-2.41.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a75dafbf87d6276ddc5b2bf6fae5254e3d0876b626eb24969a574fff9149ee5d"},
-    {file = "pydantic_core-2.41.5-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7b93a4d08587e2b7e7882de461e82b6ed76d9026ce91ca7915e740ecc7855f60"},
-    {file = "pydantic_core-2.41.5-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e8465ab91a4bd96d36dde3263f06caa6a8a6019e4113f24dc753d79a8b3a3f82"},
-    {file = "pydantic_core-2.41.5-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:299e0a22e7ae2b85c1a57f104538b2656e8ab1873511fd718a1c1c6f149b77b5"},
-    {file = "pydantic_core-2.41.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:707625ef0983fcfb461acfaf14de2067c5942c6bb0f3b4c99158bed6fedd3cf3"},
-    {file = "pydantic_core-2.41.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f41eb9797986d6ebac5e8edff36d5cef9de40def462311b3eb3eeded1431e425"},
-    {file = "pydantic_core-2.41.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0384e2e1021894b1ff5a786dbf94771e2986ebe2869533874d7e43bc79c6f504"},
-    {file = "pydantic_core-2.41.5-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:f0cd744688278965817fd0839c4a4116add48d23890d468bc436f78beb28abf5"},
-    {file = "pydantic_core-2.41.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:753e230374206729bf0a807954bcc6c150d3743928a73faffee51ac6557a03c3"},
-    {file = "pydantic_core-2.41.5-cp39-cp39-win32.whl", hash = "sha256:873e0d5b4fb9b89ef7c2d2a963ea7d02879d9da0da8d9d4933dee8ee86a8b460"},
-    {file = "pydantic_core-2.41.5-cp39-cp39-win_amd64.whl", hash = "sha256:e4f4a984405e91527a0d62649ee21138f8e3d0ef103be488c1dc11a80d7f184b"},
-    {file = "pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b96d5f26b05d03cc60f11a7761a5ded1741da411e7fe0909e27a5e6a0cb7b034"},
-    {file = "pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:634e8609e89ceecea15e2d61bc9ac3718caaaa71963717bf3c8f38bfde64242c"},
-    {file = "pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93e8740d7503eb008aa2df04d3b9735f845d43ae845e6dcd2be0b55a2da43cd2"},
-    {file = "pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f15489ba13d61f670dcc96772e733aad1a6f9c429cc27574c6cdaed82d0146ad"},
-    {file = "pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd"},
-    {file = "pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc"},
-    {file = "pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56"},
-    {file = "pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b"},
-    {file = "pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b5819cd790dbf0c5eb9f82c73c16b39a65dd6dd4d1439dcdea7816ec9adddab8"},
-    {file = "pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:5a4e67afbc95fa5c34cf27d9089bca7fcab4e51e57278d710320a70b956d1b9a"},
-    {file = "pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ece5c59f0ce7d001e017643d8d24da587ea1f74f6993467d85ae8a5ef9d4f42b"},
-    {file = "pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:16f80f7abe3351f8ea6858914ddc8c77e02578544a0ebc15b4c2e1a0e813b0b2"},
-    {file = "pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:33cb885e759a705b426baada1fe68cbb0a2e68e34c5d0d0289a364cf01709093"},
-    {file = "pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:c8d8b4eb992936023be7dee581270af5c6e0697a8559895f527f5b7105ecd36a"},
-    {file = "pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:242a206cd0318f95cd21bdacff3fcc3aab23e79bba5cac3db5a841c9ef9c6963"},
-    {file = "pydantic_core-2.41.5-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d3a978c4f57a597908b7e697229d996d77a6d3c94901e9edee593adada95ce1a"},
-    {file = "pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b2379fa7ed44ddecb5bfe4e48577d752db9fc10be00a6b7446e9663ba143de26"},
-    {file = "pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:266fb4cbf5e3cbd0b53669a6d1b039c45e3ce651fd5442eff4d07c2cc8d66808"},
-    {file = "pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58133647260ea01e4d0500089a8c4f07bd7aa6ce109682b1426394988d8aaacc"},
-    {file = "pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:287dad91cfb551c363dc62899a80e9e14da1f0e2b6ebde82c806612ca2a13ef1"},
-    {file = "pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:03b77d184b9eb40240ae9fd676ca364ce1085f203e1b1256f8ab9984dca80a84"},
-    {file = "pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770"},
-    {file = "pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f"},
-    {file = "pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51"},
-    {file = "pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a396dcc17e5a0b164dbe026896245a4fa9ff402edca1dff0be3d53a517f74de4"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da4b951fe36dc7c3a1ccb4e3cd1747c3542b8c9ceede8fc86cae054e764485f5"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb63e0198ca18aad131c089b9204c23079c3afa95487e561f4c522d519e55aba"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f47286a97f0bc9b8859519809077b91b2cefe4ae47fcbf5e466a009c1c5d742b"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:905a0ed8ea6f2d61c1738835f99b699348d7857379083e5fc497fa0c967a407c"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea793e075b70290d89d8142074262885d3f7da19634845135751bd6344f73b50"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:395aebd9183f9d112f569aeb5b2214d1a10a33bec8456447f7fbdfa51d38d4cd"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:b078afbc25f3a1436c7a1d2cd3e322497ee99615ba97c563566fdf46aff1ee01"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f747929cf940cddb5b3668a390056ddd5ba2e5010615ea2dcf4f9c4f3ab8791d"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:daa27d92c36f24388fe3ad306b174781c747627f134452e4f128ea00ce1fe8c4"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:19e51f073cd3df251856a8a4189fbdf1de4012c3ebacfb1884f94f1eb406079f"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c1747f85cee84c26985853c6f3d9bd3e75da5212912443fa111c113b9c246f39"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-win32.whl", hash = "sha256:2f84c03c8607173d16b5a854ec68a2f9079ae03237a54fb506d13af47e1d018d"},
+    {file = "pydantic_core-2.46.4-cp310-cp310-win_amd64.whl", hash = "sha256:8358a950c8909158e3df31538a7e4edc2d7265a7c54b47f0864d9e5bae9dcebf"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33"},
+    {file = "pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89"},
+    {file = "pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292"},
+    {file = "pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac"},
+    {file = "pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5"},
+    {file = "pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:fd8b3d9fd264be37976686c7f65cd52a83f5e84f4bfd2adf9c1d469676bbb6ae"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9f444c499b3eefd3a92e348059471ea0c3a6e303d9c1cec09fa748fd9f895201"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3447661d99f75a3683a4cf5c87da72f2161964611864dbbeac7fbb118bb4bfc0"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8b9bab013d1c7a79d3501ff86d0bc9c31bf587db4551677b96bec07df78c6b15"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d995260fdf4e1db774581b4900e0f832abe3c7c84996726bbc161b19c8f29e76"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f13a646d65d09fbf1bc6b3a9635d30095c8e7e5cc419ff35ecc563c5fd04cd49"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:432c179df7874eeb73307aad2df0755e1ae0efa61ff0ea89b93e194411ae3928"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-manylinux_2_31_riscv64.whl", hash = "sha256:e68b7a074f65a2fd746c52a7ce6142ab7006074ac269ace0c25cd8ba171f8066"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4a05d69cba51d852c5c3e92758653245a50c0b646ced0cf05bd793ed592839d6"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:228ee9bae8bef5b1e97ec58302f80357c37199e0d0a99174e138d28e6957b9d9"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:10e17cbb10a330363733efc4d7c4d0dd827ac0909b8f6a6542298fed1ea62f29"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:91a06d2e259ecfbd8c901d70c3c507900458498142b3026a296b7de4d1322cc9"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-win32.whl", hash = "sha256:d80ee3d731373b24cebbc10d689ca4ee1875caf0d5703a245db18efd4dd37fc1"},
+    {file = "pydantic_core-2.46.4-cp39-cp39-win_amd64.whl", hash = "sha256:3be77f45df024d789a672ae34f8b06fb346c4f9f46ea714956660ea4862e89ac"},
+    {file = "pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c"},
+    {file = "pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b"},
+    {file = "pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b"},
+    {file = "pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea"},
+    {file = "pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7"},
+    {file = "pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df"},
+    {file = "pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526"},
+    {file = "pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc"},
+    {file = "pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983"},
+    {file = "pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1"},
 ]
 
 [package.dependencies]
@@ -4770,6 +4873,50 @@ files = [
 ]
 
 [[package]]
+name = "solana"
+version = "0.40.0"
+description = "Solana.py"
+optional = false
+python-versions = ">=3.11"
+groups = ["main"]
+files = [
+    {file = "solana-0.40.0-py3-none-any.whl", hash = "sha256:885abb5ba5ef56610a6a4c78587aef83c752dda6d3e877fd8e8c6dfb18fb4ef1"},
+    {file = "solana-0.40.0.tar.gz", hash = "sha256:be515af392490021de5666b74f7036cf03d45321355c9dba9ff0fab60fcd75e3"},
+]
+
+[package.dependencies]
+aiolimiter = ">=1.1.0"
+construct-typing = ">=0.6.2,<0.8.0"
+httpx2 = {version = ">=2.4.0", extras = ["http2"]}
+pydantic = ">=2.13.4"
+solders = ">=0.23,<0.28"
+typing-extensions = ">=4.5.0"
+websockets = ">=14.0"
+
+[[package]]
+name = "solders"
+version = "0.27.1"
+description = "Python bindings for Solana Rust tools"
+optional = false
+python-versions = "<4.0,>=3.8"
+groups = ["main"]
+files = [
+    {file = "solders-0.27.1-cp38-abi3-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:4dcd8e766bab24afbe9e0ae363d86f9810457e04b00c8a9149f69ca939ed587c"},
+    {file = "solders-0.27.1-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5d87b145cc0129095f9cff8c7f28d2e910bc5b5a4cf257c263b08a4b95f111dd"},
+    {file = "solders-0.27.1-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6082bbe46b7b1b2b005d046011f89fcae75fc5ea4f1a0ef5c2e9dfb5fe7930ce"},
+    {file = "solders-0.27.1-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ccb821c2e4af43d976f312086f248a67352b3986e5f4c87af41cfeac6d8b5683"},
+    {file = "solders-0.27.1-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:663a10566ae81f67c4515d4db5fbf51b735204741728c1a5cde11c4e019a51df"},
+    {file = "solders-0.27.1-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:d14f05a77dbbf7966fb26f255c81302e6127550bdb66c2fdc99f522043fdf376"},
+    {file = "solders-0.27.1-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f778eeab411acec0a765a01c7b772f8eca8a8543d98276bd83cb826960da211b"},
+    {file = "solders-0.27.1-cp38-abi3-win_amd64.whl", hash = "sha256:f3b787c29570a46d219c7a67543d8b0fadc73abda346653aa20e8eccd839e78b"},
+    {file = "solders-0.27.1.tar.gz", hash = "sha256:7d8a24ad2f193afcdc02d6f3975917a7358b0f0ab7f4b3695b135ff2008222c8"},
+]
+
+[package.dependencies]
+jsonalias = "0.1.1"
+typing-extensions = ">=4.2.0"
+
+[[package]]
 name = "sse-starlette"
 version = "3.3.3"
 description = "SSE plugin for Starlette"
@@ -4833,6 +4980,18 @@ markers = "implementation_name == \"pypy\" or implementation_name == \"cpython\"
 files = [
     {file = "toolz-1.1.0-py3-none-any.whl", hash = "sha256:15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8"},
     {file = "toolz-1.1.0.tar.gz", hash = "sha256:27a5c770d068c110d9ed9323f24f1543e83b2f300a687b7891c1a6d56b697b5b"},
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+description = "Verify certificates using native system trust stores"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981"},
+    {file = "truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301"},
 ]
 
 [[package]]
@@ -5257,4 +5416,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "4bc32246ae778d7e32fd44fd4fc33c5f5f5b9070f2eae85266aa17fcde3a49b9"
+content-hash = "3c4d2c212e4fdce29da53e71af783c1ce2da62bbbb9932f74b223b2c853151b4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ py-order-utils = "0.3.2"
 packaging = "^25.0"
 py-clob-client-v2-felix = "1.0.2"
 croniter = "^6.0.0"
+solana = "^0.40.0"
+solders = "^0.27.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.4.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,8 @@ pydantic-settings>=2.7.0
 # Blockchain/Web3
 web3>=7.13.0
 eth-account>=0.13.7
+solana>=0.40.0
+solders>=0.27.0
 
 # HTTP client
 httpx>=0.28.1

--- a/wayfinder_paths/core/constants/__init__.py
+++ b/wayfinder_paths/core/constants/__init__.py
@@ -35,10 +35,12 @@ from wayfinder_paths.core.constants.chains import (
     CHAIN_ID_PLASMA,
     CHAIN_ID_POLYGON,
     CHAIN_ID_ROBINHOOD,
+    CHAIN_ID_SOLANA,
     CHAIN_ID_SONIC,
     POA_MIDDLEWARE_CHAIN_IDS,
     PRE_EIP_1559_CHAIN_IDS,
     SUPPORTED_CHAINS,
+    SVM_CHAIN_IDS,
 )
 from wayfinder_paths.core.constants.contracts import (
     BOROS_MERKLE_DISTRIBUTOR,
@@ -108,6 +110,8 @@ __all__ = [
     "CHAIN_ID_MONAD",
     "CHAIN_ID_MEGAETH",
     "CHAIN_ID_ROBINHOOD",
+    "CHAIN_ID_SOLANA",
+    "SVM_CHAIN_IDS",
     "SUPPORTED_CHAINS",
     "POA_MIDDLEWARE_CHAIN_IDS",
     "PRE_EIP_1559_CHAIN_IDS",

--- a/wayfinder_paths/core/constants/chains.py
+++ b/wayfinder_paths/core/constants/chains.py
@@ -12,9 +12,8 @@ CHAIN_ID_MONAD = 143
 CHAIN_ID_MEGAETH = 4326
 CHAIN_ID_ROBINHOOD = 4663
 
-# Internal Wayfinder chain id for Solana mainnet-beta (matches FE ChainId.Solana
-# and BE SOLANA_CHAIN_ID). Li.Fi's external id 1151111081099710 maps to/from 900
-# at service boundaries only.
+# Internal chain id for Solana mainnet-beta. Li.Fi's external id
+# 1151111081099710 maps to/from 900 at service boundaries only.
 CHAIN_ID_SOLANA = 900
 
 CHAIN_CODE_TO_ID = {
@@ -42,11 +41,10 @@ CHAIN_ID_TO_CODE: dict[int, str] = {
 
 # SVM (Solana Virtual Machine) chains. Deliberately kept OUT of the EVM-only
 # sets below (SUPPORTED_CHAINS, GAS_SPONSORED_CHAIN_IDS, POA/pre-1559 sets):
-# those gate web3/EVM code paths (nonce/gas handling, backend EVM broadcast,
-# middleware). Solana flows go through wayfinder_paths.core.utils.svm instead.
+# those gate EVM code paths (nonce/gas handling, middleware). Solana flows go
+# through wayfinder_paths.core.utils.svm instead.
 SVM_CHAIN_IDS: set[int] = {CHAIN_ID_SOLANA}
 
-# EVM chains supported by the web3/EVM transaction pipeline.
 SUPPORTED_CHAINS = [
     CHAIN_ID_ETHEREUM,
     CHAIN_ID_BASE,

--- a/wayfinder_paths/core/constants/chains.py
+++ b/wayfinder_paths/core/constants/chains.py
@@ -12,6 +12,11 @@ CHAIN_ID_MONAD = 143
 CHAIN_ID_MEGAETH = 4326
 CHAIN_ID_ROBINHOOD = 4663
 
+# Internal Wayfinder chain id for Solana mainnet-beta (matches FE ChainId.Solana
+# and BE SOLANA_CHAIN_ID). Li.Fi's external id 1151111081099710 maps to/from 900
+# at service boundaries only.
+CHAIN_ID_SOLANA = 900
+
 CHAIN_CODE_TO_ID = {
     "base": CHAIN_ID_BASE,
     "arbitrum": CHAIN_ID_ARBITRUM,
@@ -28,12 +33,20 @@ CHAIN_CODE_TO_ID = {
     "monad": CHAIN_ID_MONAD,
     "megaeth": CHAIN_ID_MEGAETH,
     "robinhood": CHAIN_ID_ROBINHOOD,
+    "solana": CHAIN_ID_SOLANA,
 }
 
 CHAIN_ID_TO_CODE: dict[int, str] = {
     v: k for k, v in CHAIN_CODE_TO_ID.items() if k not in ("arbitrum-one", "mainnet")
 }
 
+# SVM (Solana Virtual Machine) chains. Deliberately kept OUT of the EVM-only
+# sets below (SUPPORTED_CHAINS, GAS_SPONSORED_CHAIN_IDS, POA/pre-1559 sets):
+# those gate web3/EVM code paths (nonce/gas handling, backend EVM broadcast,
+# middleware). Solana flows go through wayfinder_paths.core.utils.svm instead.
+SVM_CHAIN_IDS: set[int] = {CHAIN_ID_SOLANA}
+
+# EVM chains supported by the web3/EVM transaction pipeline.
 SUPPORTED_CHAINS = [
     CHAIN_ID_ETHEREUM,
     CHAIN_ID_BASE,

--- a/wayfinder_paths/core/utils/svm.py
+++ b/wayfinder_paths/core/utils/svm.py
@@ -1,24 +1,19 @@
 """Solana (SVM) chain utilities.
 
-Mirrors the EVM helpers in ``core/utils/web3.py`` for chain id 900:
-RPC resolution goes through the same config override / Wayfinder RPC proxy
-fallback, and balances / transaction send / confirmation are exposed as
-small async helpers built on solana-py's ``AsyncClient``.
+Mirrors the EVM helpers in ``core/utils/web3.py`` for chain id 900: RPC
+resolution goes through the same config override / Wayfinder RPC proxy
+fallback, and native/SPL balances are exposed as small async helpers built
+on solana-py's ``AsyncClient``. Transaction broadcast/confirmation live in
+``svm_transaction.py``.
 """
 
 from __future__ import annotations
 
-import asyncio
-import base64
 from contextlib import asynccontextmanager
-from typing import Any
 
 from solana.rpc.async_api import AsyncClient
 from solana.rpc.commitment import Commitment, Confirmed
-from solana.rpc.models import TxOpts
 from solders.pubkey import Pubkey
-from solders.signature import Signature
-from solders.transaction_status import TransactionConfirmationStatus
 from spl.token._layouts import MINT_LAYOUT
 from spl.token.constants import (
     ASSOCIATED_TOKEN_PROGRAM_ID,
@@ -28,21 +23,12 @@ from spl.token.constants import (
 
 from wayfinder_paths.core.config import get_api_key
 from wayfinder_paths.core.constants.chains import CHAIN_ID_SOLANA, SVM_CHAIN_IDS
+from wayfinder_paths.core.utils.tokens import is_native_token
 from wayfinder_paths.core.utils.web3 import _get_rpcs_for_chain_id, _is_wayfinder_rpc
 
-# Native SOL sentinel (system program id format, per the shared cross-repo
-# contract) plus the EVM-style aliases the token resolver produces.
 SOL_NATIVE_SENTINEL = "11111111111111111111111111111111"
 WRAPPED_SOL_MINT = "So11111111111111111111111111111111111111112"
 SOL_DECIMALS = 9
-
-_NATIVE_SOL_ALIASES = {
-    "",
-    "native",
-    SOL_NATIVE_SENTINEL.lower(),
-    "0x0000000000000000000000000000000000000000",
-    "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
-}
 
 
 def is_solana_chain(chain_id: int | str | None) -> bool:
@@ -50,12 +36,6 @@ def is_solana_chain(chain_id: int | str | None) -> bool:
         return int(chain_id) in SVM_CHAIN_IDS  # type: ignore[arg-type]
     except (TypeError, ValueError):
         return False
-
-
-def is_native_sol(token_address: str | None) -> bool:
-    if token_address is None:
-        return True
-    return str(token_address).strip().lower() in _NATIVE_SOL_ALIASES
 
 
 def _require_solana_chain(chain_id: int) -> int:
@@ -164,14 +144,14 @@ async def get_spl_token_balance(
 async def get_solana_token_balance(
     wallet_address: str, token_address: str, chain_id: int = CHAIN_ID_SOLANA
 ) -> int:
-    if is_native_sol(token_address):
+    if is_native_token(token_address):
         return await get_sol_balance(wallet_address, chain_id)
     return await get_spl_token_balance(wallet_address, token_address, chain_id)
 
 
 async def get_spl_mint_decimals(mint: str, chain_id: int = CHAIN_ID_SOLANA) -> int:
     """Decimals for an SPL mint (native SOL sentinel returns 9)."""
-    if is_native_sol(mint):
+    if is_native_token(mint):
         return SOL_DECIMALS
     async with solana_client_from_chain_id(chain_id) as client:
         info = await _get_mint_account(client, Pubkey.from_string(mint))
@@ -179,77 +159,3 @@ async def get_spl_mint_decimals(mint: str, chain_id: int = CHAIN_ID_SOLANA) -> i
         if len(data) < MINT_LAYOUT.sizeof():
             raise ValueError(f"Account {mint} does not look like an SPL mint")
         return int(MINT_LAYOUT.parse(data).decimals)
-
-
-async def send_solana_transaction(
-    serialized_b64: str,
-    chain_id: int = CHAIN_ID_SOLANA,
-    skip_preflight: bool = False,
-) -> str:
-    """Broadcast a base64-encoded, fully signed transaction.
-
-    Accepts both legacy and versioned transactions (the wire encoding is
-    opaque to the RPC). Returns the base58 transaction signature — used
-    wherever EVM code passes ``tx_hash``.
-
-    Preflight simulation is ON by default so simulation-detectable failures
-    (insufficient funds, rent violations, program errors) surface as
-    immediate RPC errors instead of confirmation timeouts. Pass
-    ``skip_preflight=True`` to opt out (e.g. latency-sensitive sends where
-    the transaction was already simulated).
-    """
-    raw = base64.b64decode(serialized_b64)
-    async with solana_client_from_chain_id(chain_id) as client:
-        resp = await client.send_raw_transaction(
-            raw, opts=TxOpts(skip_preflight=skip_preflight)
-        )
-        return str(resp.value)
-
-
-async def confirm_solana_signature(
-    signature: str,
-    chain_id: int = CHAIN_ID_SOLANA,
-    timeout_s: float = 60,
-) -> dict[str, Any]:
-    """Poll signature status until confirmed/finalized, errored, or timeout.
-
-    Returns ``{"signature", "slot", "err", "confirmation_status", "confirmed"}``.
-    ``confirmed`` is True only when the transaction landed without error.
-    Raises ``TimeoutError`` if no confirmation within ``timeout_s``.
-    """
-    sig = Signature.from_string(signature)
-    loop = asyncio.get_running_loop()
-    deadline = loop.time() + timeout_s
-    async with solana_client_from_chain_id(chain_id) as client:
-        while True:
-            # search_transaction_history covers signatures older than the
-            # node's recent-status cache (~150 blocks); without it, confirming
-            # anything but a just-sent transaction times out.
-            resp = await client.get_signature_statuses(
-                [sig], search_transaction_history=True
-            )
-            status = resp.value[0]
-            if status is not None:
-                err = status.err
-                confirmation_status = status.confirmation_status
-                done = err is not None or confirmation_status in (
-                    TransactionConfirmationStatus.Confirmed,
-                    TransactionConfirmationStatus.Finalized,
-                )
-                if done:
-                    return {
-                        "signature": signature,
-                        "slot": int(status.slot),
-                        "err": str(err) if err is not None else None,
-                        "confirmation_status": (
-                            str(confirmation_status).rsplit(".", 1)[-1].lower()
-                            if confirmation_status is not None
-                            else None
-                        ),
-                        "confirmed": err is None,
-                    }
-            if loop.time() >= deadline:
-                raise TimeoutError(
-                    f"Timed out after {timeout_s}s waiting for Solana signature {signature}"
-                )
-            await asyncio.sleep(1)

--- a/wayfinder_paths/core/utils/svm.py
+++ b/wayfinder_paths/core/utils/svm.py
@@ -100,13 +100,17 @@ async def solana_client_from_chain_id(
 
     RPC resolution mirrors ``web3_from_chain_id``: explicit ``rpc_urls``
     config overrides win, otherwise the Wayfinder RPC proxy is used
-    (authenticated with the configured API key).
+    (authenticated with the configured API key). Only the first resolved
+    RPC gets a client — constructing one per RPC would leak the unused
+    httpx sessions.
     """
-    clients = get_solana_clients_from_chain_id(chain_id, commitment)
+    _require_solana_chain(chain_id)
+    rpcs = _get_rpcs_for_chain_id(chain_id)
+    client = _client_for_rpc(rpcs[0], commitment)
     try:
-        yield clients[0]
+        yield client
     finally:
-        await clients[0].close()
+        await client.close()
 
 
 def get_associated_token_address(
@@ -193,13 +197,19 @@ async def get_spl_mint_decimals(mint: str, chain_id: int = CHAIN_ID_SOLANA) -> i
 async def send_solana_transaction(
     serialized_b64: str,
     chain_id: int = CHAIN_ID_SOLANA,
-    skip_preflight: bool = True,
+    skip_preflight: bool = False,
 ) -> str:
     """Broadcast a base64-encoded, fully signed transaction.
 
     Accepts both legacy and versioned transactions (the wire encoding is
     opaque to the RPC). Returns the base58 transaction signature — used
     wherever EVM code passes ``tx_hash``.
+
+    Preflight simulation is ON by default so simulation-detectable failures
+    (insufficient funds, rent violations, program errors) surface as
+    immediate RPC errors instead of confirmation timeouts. Pass
+    ``skip_preflight=True`` to opt out (e.g. latency-sensitive sends where
+    the transaction was already simulated).
     """
     raw = base64.b64decode(serialized_b64)
     async with solana_client_from_chain_id(chain_id) as client:

--- a/wayfinder_paths/core/utils/svm.py
+++ b/wayfinder_paths/core/utils/svm.py
@@ -1,0 +1,253 @@
+"""Solana (SVM) chain utilities.
+
+Mirrors the EVM helpers in ``core/utils/web3.py`` for chain id 900:
+RPC resolution goes through the same config override / Wayfinder RPC proxy
+fallback, and balances / transaction send / confirmation are exposed as
+small async helpers built on solana-py's ``AsyncClient``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from contextlib import asynccontextmanager
+from typing import Any
+
+from solana.rpc.async_api import AsyncClient
+from solana.rpc.commitment import Commitment, Confirmed
+from solana.rpc.models import TxOpts
+from solders.pubkey import Pubkey
+from solders.signature import Signature
+from solders.transaction_status import TransactionConfirmationStatus
+from spl.token._layouts import MINT_LAYOUT
+from spl.token.constants import (
+    ASSOCIATED_TOKEN_PROGRAM_ID,
+    TOKEN_2022_PROGRAM_ID,
+    TOKEN_PROGRAM_ID,
+)
+
+from wayfinder_paths.core.config import get_api_key
+from wayfinder_paths.core.constants.chains import CHAIN_ID_SOLANA, SVM_CHAIN_IDS
+from wayfinder_paths.core.utils.web3 import _get_rpcs_for_chain_id, _is_wayfinder_rpc
+
+# Native SOL sentinel (system program id format, per the shared cross-repo
+# contract) plus the EVM-style aliases the token resolver produces.
+SOL_NATIVE_SENTINEL = "11111111111111111111111111111111"
+WRAPPED_SOL_MINT = "So11111111111111111111111111111111111111112"
+SOL_DECIMALS = 9
+
+_NATIVE_SOL_ALIASES = {
+    "",
+    "native",
+    SOL_NATIVE_SENTINEL.lower(),
+    "0x0000000000000000000000000000000000000000",
+    "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+}
+
+
+def is_solana_chain(chain_id: int | str | None) -> bool:
+    """True when ``chain_id`` is an SVM (Solana) chain."""
+    try:
+        return int(chain_id) in SVM_CHAIN_IDS  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return False
+
+
+def is_native_sol(token_address: str | None) -> bool:
+    """True when ``token_address`` denotes native SOL (not an SPL mint)."""
+    if token_address is None:
+        return True
+    return str(token_address).strip().lower() in _NATIVE_SOL_ALIASES
+
+
+def _require_solana_chain(chain_id: int) -> int:
+    if not is_solana_chain(chain_id):
+        raise ValueError(
+            f"chain_id {chain_id} is not a Solana chain (expected one of {sorted(SVM_CHAIN_IDS)})"
+        )
+    return int(chain_id)
+
+
+def _client_for_rpc(rpc: str, commitment: Commitment | None) -> AsyncClient:
+    extra_headers: dict[str, str] | None = None
+    if _is_wayfinder_rpc(rpc):
+        api_key = get_api_key()
+        if api_key:
+            extra_headers = {"X-API-KEY": api_key}
+    return AsyncClient(
+        rpc,
+        commitment=commitment or Confirmed,
+        extra_headers=extra_headers,
+    )
+
+
+def get_solana_clients_from_chain_id(
+    chain_id: int = CHAIN_ID_SOLANA,
+    commitment: Commitment | None = None,
+) -> list[AsyncClient]:
+    """One ``AsyncClient`` per resolved RPC (config override or proxy pool)."""
+    _require_solana_chain(chain_id)
+    rpcs = _get_rpcs_for_chain_id(chain_id)
+    return [_client_for_rpc(rpc, commitment) for rpc in rpcs]
+
+
+@asynccontextmanager
+async def solana_client_from_chain_id(
+    chain_id: int = CHAIN_ID_SOLANA,
+    commitment: Commitment | None = None,
+):
+    """Async context manager yielding an ``AsyncClient`` for ``chain_id``.
+
+    RPC resolution mirrors ``web3_from_chain_id``: explicit ``rpc_urls``
+    config overrides win, otherwise the Wayfinder RPC proxy is used
+    (authenticated with the configured API key).
+    """
+    clients = get_solana_clients_from_chain_id(chain_id, commitment)
+    try:
+        yield clients[0]
+    finally:
+        await clients[0].close()
+
+
+def get_associated_token_address(
+    owner: Pubkey, mint: Pubkey, program_id: Pubkey | None = None
+) -> Pubkey:
+    """Derive the associated token account address for ``owner``/``mint``.
+
+    ``program_id`` selects the owning token program (classic SPL Token by
+    default, pass ``TOKEN_2022_PROGRAM_ID`` for Token-2022 mints).
+    """
+    if program_id is None:
+        program_id = TOKEN_PROGRAM_ID
+    key, _ = Pubkey.find_program_address(
+        seeds=[bytes(owner), bytes(program_id), bytes(mint)],
+        program_id=ASSOCIATED_TOKEN_PROGRAM_ID,
+    )
+    return key
+
+
+async def _get_mint_account(client: AsyncClient, mint: Pubkey):
+    info = (await client.get_account_info(mint)).value
+    if info is None:
+        raise ValueError(f"Token mint account not found: {mint}")
+    return info
+
+
+async def _resolve_token_program_id(client: AsyncClient, mint: Pubkey) -> Pubkey:
+    info = await _get_mint_account(client, mint)
+    return (
+        TOKEN_2022_PROGRAM_ID
+        if info.owner == TOKEN_2022_PROGRAM_ID
+        else TOKEN_PROGRAM_ID
+    )
+
+
+async def get_sol_balance(wallet_address: str, chain_id: int = CHAIN_ID_SOLANA) -> int:
+    """Native SOL balance in lamports."""
+    async with solana_client_from_chain_id(chain_id) as client:
+        resp = await client.get_balance(Pubkey.from_string(wallet_address))
+        return int(resp.value)
+
+
+async def get_spl_token_balance(
+    wallet_address: str, mint: str, chain_id: int = CHAIN_ID_SOLANA
+) -> int:
+    """SPL token balance (raw base units) held in the owner's ATA.
+
+    Token-2022 aware: the token program is resolved from the mint account's
+    owner. Returns 0 when the associated token account does not exist.
+    """
+    async with solana_client_from_chain_id(chain_id) as client:
+        owner = Pubkey.from_string(wallet_address)
+        mint_pubkey = Pubkey.from_string(mint)
+        program_id = await _resolve_token_program_id(client, mint_pubkey)
+        ata = get_associated_token_address(owner, mint_pubkey, program_id)
+        ata_info = (await client.get_account_info(ata)).value
+        if ata_info is None:
+            return 0
+        resp = await client.get_token_account_balance(ata)
+        return int(resp.value.amount)
+
+
+async def get_solana_token_balance(
+    wallet_address: str, token_address: str, chain_id: int = CHAIN_ID_SOLANA
+) -> int:
+    """Dispatch native SOL vs SPL token balance based on ``token_address``."""
+    if is_native_sol(token_address):
+        return await get_sol_balance(wallet_address, chain_id)
+    return await get_spl_token_balance(wallet_address, token_address, chain_id)
+
+
+async def get_spl_mint_decimals(mint: str, chain_id: int = CHAIN_ID_SOLANA) -> int:
+    """Decimals for an SPL mint (native SOL sentinel returns 9)."""
+    if is_native_sol(mint):
+        return SOL_DECIMALS
+    async with solana_client_from_chain_id(chain_id) as client:
+        info = await _get_mint_account(client, Pubkey.from_string(mint))
+        data = bytes(info.data)
+        if len(data) < MINT_LAYOUT.sizeof():
+            raise ValueError(f"Account {mint} does not look like an SPL mint")
+        return int(MINT_LAYOUT.parse(data).decimals)
+
+
+async def send_solana_transaction(
+    serialized_b64: str,
+    chain_id: int = CHAIN_ID_SOLANA,
+    skip_preflight: bool = True,
+) -> str:
+    """Broadcast a base64-encoded, fully signed transaction.
+
+    Accepts both legacy and versioned transactions (the wire encoding is
+    opaque to the RPC). Returns the base58 transaction signature — used
+    wherever EVM code passes ``tx_hash``.
+    """
+    raw = base64.b64decode(serialized_b64)
+    async with solana_client_from_chain_id(chain_id) as client:
+        resp = await client.send_raw_transaction(
+            raw, opts=TxOpts(skip_preflight=skip_preflight)
+        )
+        return str(resp.value)
+
+
+async def confirm_solana_signature(
+    signature: str,
+    chain_id: int = CHAIN_ID_SOLANA,
+    timeout_s: float = 60,
+) -> dict[str, Any]:
+    """Poll signature status until confirmed/finalized, errored, or timeout.
+
+    Returns ``{"signature", "slot", "err", "confirmation_status", "confirmed"}``.
+    ``confirmed`` is True only when the transaction landed without error.
+    Raises ``TimeoutError`` if no confirmation within ``timeout_s``.
+    """
+    sig = Signature.from_string(signature)
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_s
+    async with solana_client_from_chain_id(chain_id) as client:
+        while True:
+            resp = await client.get_signature_statuses([sig])
+            status = resp.value[0]
+            if status is not None:
+                err = status.err
+                confirmation_status = status.confirmation_status
+                done = err is not None or confirmation_status in (
+                    TransactionConfirmationStatus.Confirmed,
+                    TransactionConfirmationStatus.Finalized,
+                )
+                if done:
+                    return {
+                        "signature": signature,
+                        "slot": int(status.slot),
+                        "err": str(err) if err is not None else None,
+                        "confirmation_status": (
+                            str(confirmation_status).rsplit(".", 1)[-1].lower()
+                            if confirmation_status is not None
+                            else None
+                        ),
+                        "confirmed": err is None,
+                    }
+            if loop.time() >= deadline:
+                raise TimeoutError(
+                    f"Timed out after {timeout_s}s waiting for Solana signature {signature}"
+                )
+            await asyncio.sleep(1)

--- a/wayfinder_paths/core/utils/svm.py
+++ b/wayfinder_paths/core/utils/svm.py
@@ -46,7 +46,6 @@ _NATIVE_SOL_ALIASES = {
 
 
 def is_solana_chain(chain_id: int | str | None) -> bool:
-    """True when ``chain_id`` is an SVM (Solana) chain."""
     try:
         return int(chain_id) in SVM_CHAIN_IDS  # type: ignore[arg-type]
     except (TypeError, ValueError):
@@ -54,7 +53,6 @@ def is_solana_chain(chain_id: int | str | None) -> bool:
 
 
 def is_native_sol(token_address: str | None) -> bool:
-    """True when ``token_address`` denotes native SOL (not an SPL mint)."""
     if token_address is None:
         return True
     return str(token_address).strip().lower() in _NATIVE_SOL_ALIASES
@@ -79,16 +77,6 @@ def _client_for_rpc(rpc: str, commitment: Commitment | None) -> AsyncClient:
         commitment=commitment or Confirmed,
         extra_headers=extra_headers,
     )
-
-
-def get_solana_clients_from_chain_id(
-    chain_id: int = CHAIN_ID_SOLANA,
-    commitment: Commitment | None = None,
-) -> list[AsyncClient]:
-    """One ``AsyncClient`` per resolved RPC (config override or proxy pool)."""
-    _require_solana_chain(chain_id)
-    rpcs = _get_rpcs_for_chain_id(chain_id)
-    return [_client_for_rpc(rpc, commitment) for rpc in rpcs]
 
 
 @asynccontextmanager
@@ -176,7 +164,6 @@ async def get_spl_token_balance(
 async def get_solana_token_balance(
     wallet_address: str, token_address: str, chain_id: int = CHAIN_ID_SOLANA
 ) -> int:
-    """Dispatch native SOL vs SPL token balance based on ``token_address``."""
     if is_native_sol(token_address):
         return await get_sol_balance(wallet_address, chain_id)
     return await get_spl_token_balance(wallet_address, token_address, chain_id)
@@ -238,7 +225,9 @@ async def confirm_solana_signature(
             # search_transaction_history covers signatures older than the
             # node's recent-status cache (~150 blocks); without it, confirming
             # anything but a just-sent transaction times out.
-            resp = await client.get_signature_statuses([sig], search_transaction_history=True)
+            resp = await client.get_signature_statuses(
+                [sig], search_transaction_history=True
+            )
             status = resp.value[0]
             if status is not None:
                 err = status.err

--- a/wayfinder_paths/core/utils/svm.py
+++ b/wayfinder_paths/core/utils/svm.py
@@ -235,7 +235,10 @@ async def confirm_solana_signature(
     deadline = loop.time() + timeout_s
     async with solana_client_from_chain_id(chain_id) as client:
         while True:
-            resp = await client.get_signature_statuses([sig])
+            # search_transaction_history covers signatures older than the
+            # node's recent-status cache (~150 blocks); without it, confirming
+            # anything but a just-sent transaction times out.
+            resp = await client.get_signature_statuses([sig], search_transaction_history=True)
             status = resp.value[0]
             if status is not None:
                 err = status.err

--- a/wayfinder_paths/core/utils/svm.py
+++ b/wayfinder_paths/core/utils/svm.py
@@ -1,9 +1,9 @@
-"""Solana (SVM) chain utilities.
+"""Solana (SVM) RPC client resolution.
 
-Mirrors the EVM helpers in ``core/utils/web3.py`` for chain id 900: RPC
+Mirrors the EVM client layer in ``core/utils/web3.py`` for chain id 900: RPC
 resolution goes through the same config override / Wayfinder RPC proxy
-fallback, and native/SPL balances are exposed as small async helpers built
-on solana-py's ``AsyncClient``. Transaction broadcast/confirmation live in
+fallback, exposed as an ``AsyncClient`` context manager. Token balances live
+in ``svm_tokens.py``; transaction broadcast/confirmation in
 ``svm_transaction.py``.
 """
 
@@ -13,22 +13,10 @@ from contextlib import asynccontextmanager
 
 from solana.rpc.async_api import AsyncClient
 from solana.rpc.commitment import Commitment, Confirmed
-from solders.pubkey import Pubkey
-from spl.token._layouts import MINT_LAYOUT
-from spl.token.constants import (
-    ASSOCIATED_TOKEN_PROGRAM_ID,
-    TOKEN_2022_PROGRAM_ID,
-    TOKEN_PROGRAM_ID,
-)
 
 from wayfinder_paths.core.config import get_api_key
 from wayfinder_paths.core.constants.chains import CHAIN_ID_SOLANA, SVM_CHAIN_IDS
-from wayfinder_paths.core.utils.tokens import is_native_token
 from wayfinder_paths.core.utils.web3 import _get_rpcs_for_chain_id, _is_wayfinder_rpc
-
-SOL_NATIVE_SENTINEL = "11111111111111111111111111111111"
-WRAPPED_SOL_MINT = "So11111111111111111111111111111111111111112"
-SOL_DECIMALS = 9
 
 
 def is_solana_chain(chain_id: int | str | None) -> bool:
@@ -79,83 +67,3 @@ async def solana_client_from_chain_id(
         yield client
     finally:
         await client.close()
-
-
-def get_associated_token_address(
-    owner: Pubkey, mint: Pubkey, program_id: Pubkey | None = None
-) -> Pubkey:
-    """Derive the associated token account address for ``owner``/``mint``.
-
-    ``program_id`` selects the owning token program (classic SPL Token by
-    default, pass ``TOKEN_2022_PROGRAM_ID`` for Token-2022 mints).
-    """
-    if program_id is None:
-        program_id = TOKEN_PROGRAM_ID
-    key, _ = Pubkey.find_program_address(
-        seeds=[bytes(owner), bytes(program_id), bytes(mint)],
-        program_id=ASSOCIATED_TOKEN_PROGRAM_ID,
-    )
-    return key
-
-
-async def _get_mint_account(client: AsyncClient, mint: Pubkey):
-    info = (await client.get_account_info(mint)).value
-    if info is None:
-        raise ValueError(f"Token mint account not found: {mint}")
-    return info
-
-
-async def _resolve_token_program_id(client: AsyncClient, mint: Pubkey) -> Pubkey:
-    info = await _get_mint_account(client, mint)
-    return (
-        TOKEN_2022_PROGRAM_ID
-        if info.owner == TOKEN_2022_PROGRAM_ID
-        else TOKEN_PROGRAM_ID
-    )
-
-
-async def get_sol_balance(wallet_address: str, chain_id: int = CHAIN_ID_SOLANA) -> int:
-    """Native SOL balance in lamports."""
-    async with solana_client_from_chain_id(chain_id) as client:
-        resp = await client.get_balance(Pubkey.from_string(wallet_address))
-        return int(resp.value)
-
-
-async def get_spl_token_balance(
-    wallet_address: str, mint: str, chain_id: int = CHAIN_ID_SOLANA
-) -> int:
-    """SPL token balance (raw base units) held in the owner's ATA.
-
-    Token-2022 aware: the token program is resolved from the mint account's
-    owner. Returns 0 when the associated token account does not exist.
-    """
-    async with solana_client_from_chain_id(chain_id) as client:
-        owner = Pubkey.from_string(wallet_address)
-        mint_pubkey = Pubkey.from_string(mint)
-        program_id = await _resolve_token_program_id(client, mint_pubkey)
-        ata = get_associated_token_address(owner, mint_pubkey, program_id)
-        ata_info = (await client.get_account_info(ata)).value
-        if ata_info is None:
-            return 0
-        resp = await client.get_token_account_balance(ata)
-        return int(resp.value.amount)
-
-
-async def get_solana_token_balance(
-    wallet_address: str, token_address: str, chain_id: int = CHAIN_ID_SOLANA
-) -> int:
-    if is_native_token(token_address):
-        return await get_sol_balance(wallet_address, chain_id)
-    return await get_spl_token_balance(wallet_address, token_address, chain_id)
-
-
-async def get_spl_mint_decimals(mint: str, chain_id: int = CHAIN_ID_SOLANA) -> int:
-    """Decimals for an SPL mint (native SOL sentinel returns 9)."""
-    if is_native_token(mint):
-        return SOL_DECIMALS
-    async with solana_client_from_chain_id(chain_id) as client:
-        info = await _get_mint_account(client, Pubkey.from_string(mint))
-        data = bytes(info.data)
-        if len(data) < MINT_LAYOUT.sizeof():
-            raise ValueError(f"Account {mint} does not look like an SPL mint")
-        return int(MINT_LAYOUT.parse(data).decimals)

--- a/wayfinder_paths/core/utils/svm_tokens.py
+++ b/wayfinder_paths/core/utils/svm_tokens.py
@@ -1,0 +1,105 @@
+"""Solana (SVM) token balances and mint metadata.
+
+Mirrors the EVM token layer in ``core/utils/tokens.py`` for chain id 900:
+native SOL + SPL balances and mint decimals, built on the ``AsyncClient``
+context manager in ``svm.py``. Token-2022 aware.
+"""
+
+from __future__ import annotations
+
+from solana.rpc.async_api import AsyncClient
+from solders.pubkey import Pubkey
+from spl.token._layouts import MINT_LAYOUT
+from spl.token.constants import (
+    ASSOCIATED_TOKEN_PROGRAM_ID,
+    TOKEN_2022_PROGRAM_ID,
+    TOKEN_PROGRAM_ID,
+)
+
+from wayfinder_paths.core.constants.chains import CHAIN_ID_SOLANA
+from wayfinder_paths.core.utils.svm import solana_client_from_chain_id
+from wayfinder_paths.core.utils.tokens import is_native_token
+
+SOL_NATIVE_SENTINEL = "11111111111111111111111111111111"
+WRAPPED_SOL_MINT = "So11111111111111111111111111111111111111112"
+SOL_DECIMALS = 9
+
+
+def get_associated_token_address(
+    owner: Pubkey, mint: Pubkey, program_id: Pubkey | None = None
+) -> Pubkey:
+    """Derive the associated token account address for ``owner``/``mint``.
+
+    ``program_id`` selects the owning token program (classic SPL Token by
+    default, pass ``TOKEN_2022_PROGRAM_ID`` for Token-2022 mints).
+    """
+    if program_id is None:
+        program_id = TOKEN_PROGRAM_ID
+    key, _ = Pubkey.find_program_address(
+        seeds=[bytes(owner), bytes(program_id), bytes(mint)],
+        program_id=ASSOCIATED_TOKEN_PROGRAM_ID,
+    )
+    return key
+
+
+async def _get_mint_account(client: AsyncClient, mint: Pubkey):
+    info = (await client.get_account_info(mint)).value
+    if info is None:
+        raise ValueError(f"Token mint account not found: {mint}")
+    return info
+
+
+async def _resolve_token_program_id(client: AsyncClient, mint: Pubkey) -> Pubkey:
+    info = await _get_mint_account(client, mint)
+    return (
+        TOKEN_2022_PROGRAM_ID
+        if info.owner == TOKEN_2022_PROGRAM_ID
+        else TOKEN_PROGRAM_ID
+    )
+
+
+async def get_sol_balance(wallet_address: str, chain_id: int = CHAIN_ID_SOLANA) -> int:
+    """Native SOL balance in lamports."""
+    async with solana_client_from_chain_id(chain_id) as client:
+        resp = await client.get_balance(Pubkey.from_string(wallet_address))
+        return int(resp.value)
+
+
+async def get_spl_token_balance(
+    wallet_address: str, mint: str, chain_id: int = CHAIN_ID_SOLANA
+) -> int:
+    """SPL token balance (raw base units) held in the owner's ATA.
+
+    Token-2022 aware: the token program is resolved from the mint account's
+    owner. Returns 0 when the associated token account does not exist.
+    """
+    async with solana_client_from_chain_id(chain_id) as client:
+        owner = Pubkey.from_string(wallet_address)
+        mint_pubkey = Pubkey.from_string(mint)
+        program_id = await _resolve_token_program_id(client, mint_pubkey)
+        ata = get_associated_token_address(owner, mint_pubkey, program_id)
+        ata_info = (await client.get_account_info(ata)).value
+        if ata_info is None:
+            return 0
+        resp = await client.get_token_account_balance(ata)
+        return int(resp.value.amount)
+
+
+async def get_solana_token_balance(
+    wallet_address: str, token_address: str, chain_id: int = CHAIN_ID_SOLANA
+) -> int:
+    if is_native_token(token_address):
+        return await get_sol_balance(wallet_address, chain_id)
+    return await get_spl_token_balance(wallet_address, token_address, chain_id)
+
+
+async def get_spl_mint_decimals(mint: str, chain_id: int = CHAIN_ID_SOLANA) -> int:
+    """Decimals for an SPL mint (native SOL sentinel returns 9)."""
+    if is_native_token(mint):
+        return SOL_DECIMALS
+    async with solana_client_from_chain_id(chain_id) as client:
+        info = await _get_mint_account(client, Pubkey.from_string(mint))
+        data = bytes(info.data)
+        if len(data) < MINT_LAYOUT.sizeof():
+            raise ValueError(f"Account {mint} does not look like an SPL mint")
+        return int(MINT_LAYOUT.parse(data).decimals)

--- a/wayfinder_paths/core/utils/svm_transaction.py
+++ b/wayfinder_paths/core/utils/svm_transaction.py
@@ -1,0 +1,93 @@
+"""Solana (SVM) transaction broadcast and confirmation.
+
+Built on the ``AsyncClient`` lifecycle in ``svm.py``. Kept separate from the
+balance/ATA read helpers so the send/confirm surface — the fund-moving part —
+stays isolated.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from typing import Any
+
+from solana.rpc.models import TxOpts
+from solders.signature import Signature
+from solders.transaction_status import TransactionConfirmationStatus
+
+from wayfinder_paths.core.constants.chains import CHAIN_ID_SOLANA
+from wayfinder_paths.core.utils.svm import solana_client_from_chain_id
+
+
+async def send_solana_transaction(
+    serialized_b64: str,
+    chain_id: int = CHAIN_ID_SOLANA,
+    skip_preflight: bool = False,
+) -> str:
+    """Broadcast a base64-encoded, fully signed transaction.
+
+    Accepts both legacy and versioned transactions (the wire encoding is
+    opaque to the RPC). Returns the base58 transaction signature — used
+    wherever EVM code passes ``tx_hash``.
+
+    Preflight simulation is ON by default so simulation-detectable failures
+    (insufficient funds, rent violations, program errors) surface as
+    immediate RPC errors instead of confirmation timeouts. Pass
+    ``skip_preflight=True`` to opt out (e.g. latency-sensitive sends where
+    the transaction was already simulated).
+    """
+    raw = base64.b64decode(serialized_b64)
+    async with solana_client_from_chain_id(chain_id) as client:
+        resp = await client.send_raw_transaction(
+            raw, opts=TxOpts(skip_preflight=skip_preflight)
+        )
+        return str(resp.value)
+
+
+async def confirm_solana_signature(
+    signature: str,
+    chain_id: int = CHAIN_ID_SOLANA,
+    timeout_s: float = 60,
+) -> dict[str, Any]:
+    """Poll signature status until confirmed/finalized, errored, or timeout.
+
+    Returns ``{"signature", "slot", "err", "confirmation_status", "confirmed"}``.
+    ``confirmed`` is True only when the transaction landed without error.
+    Raises ``TimeoutError`` if no confirmation within ``timeout_s``.
+    """
+    sig = Signature.from_string(signature)
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_s
+    async with solana_client_from_chain_id(chain_id) as client:
+        while True:
+            # search_transaction_history covers signatures older than the
+            # node's recent-status cache (~150 blocks); without it, confirming
+            # anything but a just-sent transaction times out.
+            resp = await client.get_signature_statuses(
+                [sig], search_transaction_history=True
+            )
+            status = resp.value[0]
+            if status is not None:
+                err = status.err
+                confirmation_status = status.confirmation_status
+                done = err is not None or confirmation_status in (
+                    TransactionConfirmationStatus.Confirmed,
+                    TransactionConfirmationStatus.Finalized,
+                )
+                if done:
+                    return {
+                        "signature": signature,
+                        "slot": int(status.slot),
+                        "err": str(err) if err is not None else None,
+                        "confirmation_status": (
+                            str(confirmation_status).rsplit(".", 1)[-1].lower()
+                            if confirmation_status is not None
+                            else None
+                        ),
+                        "confirmed": err is None,
+                    }
+            if loop.time() >= deadline:
+                raise TimeoutError(
+                    f"Timed out after {timeout_s}s waiting for Solana signature {signature}"
+                )
+            await asyncio.sleep(1)

--- a/wayfinder_paths/core/utils/token_refs.py
+++ b/wayfinder_paths/core/utils/token_refs.py
@@ -1,8 +1,20 @@
 from __future__ import annotations
 
+import re
+
 from eth_utils import is_address
 
 from wayfinder_paths.core.constants.chains import CHAIN_CODE_TO_ID
+
+# Base58 (no 0, O, I, l), 32-44 chars — the shared cross-repo Solana
+# address/mint validation regex.
+_SOLANA_ADDRESS_RE = re.compile(r"^[1-9A-HJ-NP-Za-km-z]{32,44}$")
+
+
+def looks_like_solana_address(value: str | None) -> bool:
+    if value is None:
+        return False
+    return bool(_SOLANA_ADDRESS_RE.match(str(value).strip()))
 
 
 def looks_like_evm_address(value: str | None) -> bool:

--- a/wayfinder_paths/core/utils/token_resolver.py
+++ b/wayfinder_paths/core/utils/token_resolver.py
@@ -153,14 +153,7 @@ def _select_chain_and_address(
 
 
 def _is_solana_mint_query(query: str, chain_id: int | None) -> bool:
-    """True when ``query`` is a base58 mint address and the chain hint is SVM."""
-    if chain_id is None:
-        return False
-    try:
-        chain_id_i = int(chain_id)
-    except (TypeError, ValueError):
-        return False
-    return chain_id_i in SVM_CHAIN_IDS and looks_like_solana_address(query)
+    return chain_id in SVM_CHAIN_IDS and looks_like_solana_address(query)
 
 
 class TokenResolver:

--- a/wayfinder_paths/core/utils/token_resolver.py
+++ b/wayfinder_paths/core/utils/token_resolver.py
@@ -6,9 +6,14 @@ from typing import Any, cast
 from wayfinder_paths.core.clients.TokenClient import TOKEN_CLIENT
 from wayfinder_paths.core.constants import ZERO_ADDRESS
 from wayfinder_paths.core.constants.base import NATIVE_COINGECKO_IDS, NATIVE_GAS_SYMBOLS
-from wayfinder_paths.core.constants.chains import CHAIN_CODE_TO_ID, CHAIN_ID_TO_CODE
+from wayfinder_paths.core.constants.chains import (
+    CHAIN_CODE_TO_ID,
+    CHAIN_ID_TO_CODE,
+    SVM_CHAIN_IDS,
+)
 from wayfinder_paths.core.utils.token_refs import (
     looks_like_evm_address,
+    looks_like_solana_address,
     parse_token_id_to_chain_and_address,
 )
 from wayfinder_paths.core.utils.tokens import get_token_decimals, is_native_token
@@ -147,6 +152,17 @@ def _select_chain_and_address(
     return chain_id, token_address_out
 
 
+def _is_solana_mint_query(query: str, chain_id: int | None) -> bool:
+    """True when ``query`` is a base58 mint address and the chain hint is SVM."""
+    if chain_id is None:
+        return False
+    try:
+        chain_id_i = int(chain_id)
+    except (TypeError, ValueError):
+        return False
+    return chain_id_i in SVM_CHAIN_IDS and looks_like_solana_address(query)
+
+
 class TokenResolver:
     _token_details_cache: dict[str, dict[str, Any]] = {}
     _gas_token_cache: dict[str, dict[str, Any]] = {}
@@ -208,6 +224,13 @@ class TokenResolver:
             return int(parsed_chain_id), addr
 
         if looks_like_evm_address(q_raw):
+            chain_id_i = cls._validate_chain_id_hint(chain_id, query=q_raw)
+            addr = _normalize_token_address(q_raw)
+            if not addr:
+                raise ValueError(f"Cannot resolve token: {query}")
+            return chain_id_i, addr
+
+        if _is_solana_mint_query(q_raw, chain_id):
             chain_id_i = cls._validate_chain_id_hint(chain_id, query=q_raw)
             addr = _normalize_token_address(q_raw)
             if not addr:
@@ -277,6 +300,23 @@ class TokenResolver:
             if not addr:
                 raise ValueError(f"Cannot resolve token: {query}")
             decimals = await get_token_decimals(addr, int(chain_id_i))
+            return {
+                "token_id": q_raw,
+                "symbol": q_raw,
+                "decimals": int(decimals),
+                "chain_id": int(chain_id_i),
+                "address": addr,
+                "metadata": {"source": "address"},
+            }
+
+        if _is_solana_mint_query(q_raw, chain_id):
+            chain_id_i = cls._validate_chain_id_hint(chain_id, query=q_raw)
+            addr = _normalize_token_address(q_raw)
+            if not addr:
+                raise ValueError(f"Cannot resolve token: {query}")
+            from wayfinder_paths.core.utils import svm as svm_utils
+
+            decimals = await svm_utils.get_spl_mint_decimals(q_raw, chain_id_i)
             return {
                 "token_id": q_raw,
                 "symbol": q_raw,

--- a/wayfinder_paths/core/utils/token_resolver.py
+++ b/wayfinder_paths/core/utils/token_resolver.py
@@ -307,9 +307,9 @@ class TokenResolver:
             addr = _normalize_token_address(q_raw)
             if not addr:
                 raise ValueError(f"Cannot resolve token: {query}")
-            from wayfinder_paths.core.utils import svm as svm_utils
+            from wayfinder_paths.core.utils import svm_tokens
 
-            decimals = await svm_utils.get_spl_mint_decimals(q_raw, chain_id_i)
+            decimals = await svm_tokens.get_spl_mint_decimals(q_raw, chain_id_i)
             return {
                 "token_id": q_raw,
                 "symbol": q_raw,

--- a/wayfinder_paths/core/utils/wallets.py
+++ b/wayfinder_paths/core/utils/wallets.py
@@ -1,3 +1,4 @@
+import base64
 import json
 from pathlib import Path
 from typing import Any
@@ -5,6 +6,11 @@ from typing import Any
 from eth_account import Account
 from eth_account.messages import encode_typed_data
 from loguru import logger
+from solders.keypair import Keypair
+from solders.message import to_bytes_versioned
+from solders.signature import Signature
+from solders.transaction import Transaction as SoldersLegacyTransaction
+from solders.transaction import VersionedTransaction
 
 from wayfinder_paths.core.clients.WalletClient import WALLET_CLIENT
 from wayfinder_paths.core.config import (
@@ -20,7 +26,16 @@ from wayfinder_paths.policies.session import build_session_policy, build_strateg
 
 _DEFAULT_EVM_ACCOUNT_PATH_TEMPLATE = "m/44'/60'/0'/0/{index}"
 
+CHAIN_TYPE_ETHEREUM = "ethereum"
+CHAIN_TYPE_SOLANA = "solana"
+
 Account.enable_unaudited_hdwallet_features()
+
+
+def wallet_chain_type(wallet: dict[str, Any]) -> str:
+    """Wallet's chain type; defaults to "ethereum" when absent (legacy configs)."""
+    chain_type = str(wallet.get("chain_type") or "").strip().lower()
+    return chain_type or CHAIN_TYPE_ETHEREUM
 
 
 # ---------------------------------------------------------------------------
@@ -114,6 +129,7 @@ def get_local_sign_callback(private_key: str):
     # None means local key — send_transaction() never routes it through the
     # sponsored backend broadcast.
     sign_callback.wallet_address = None
+    sign_callback.chain_type = CHAIN_TYPE_ETHEREUM
     return sign_callback
 
 
@@ -138,6 +154,79 @@ def get_local_sign_hash_callback(private_key: str):
         return "0x" + signed.signature.hex()
 
     return sign_hash
+
+
+# ---------------------------------------------------------------------------
+# Signing callbacks (local, Solana)
+# ---------------------------------------------------------------------------
+
+
+def solana_keypair_from_base58(private_key: str) -> Keypair:
+    return Keypair.from_base58_string(str(private_key).strip())
+
+
+def _coerce_solana_transaction(
+    transaction: Any,
+) -> VersionedTransaction | SoldersLegacyTransaction:
+    """Accept a solders transaction object, raw bytes, or a base64 string."""
+    if isinstance(transaction, (VersionedTransaction, SoldersLegacyTransaction)):
+        return transaction
+    if isinstance(transaction, str):
+        transaction = base64.b64decode(transaction)
+    if isinstance(transaction, (bytes, bytearray)):
+        raw = bytes(transaction)
+        try:
+            return VersionedTransaction.from_bytes(raw)
+        except Exception:
+            return SoldersLegacyTransaction.from_bytes(raw)
+    raise TypeError(
+        f"Unsupported Solana transaction type: {type(transaction).__name__}"
+    )
+
+
+def _sign_versioned_transaction(
+    tx: VersionedTransaction, keypair: Keypair
+) -> VersionedTransaction:
+    message = tx.message
+    signature = keypair.sign_message(to_bytes_versioned(message))
+    num_required = message.header.num_required_signatures
+    signer_keys = list(message.account_keys)[:num_required]
+    try:
+        signer_index = signer_keys.index(keypair.pubkey())
+    except ValueError as exc:
+        raise ValueError(
+            f"Wallet {keypair.pubkey()} is not a required signer for this transaction"
+        ) from exc
+    existing = list(tx.signatures)
+    signatures = [
+        existing[i] if i < len(existing) else Signature.default()
+        for i in range(num_required)
+    ]
+    signatures[signer_index] = signature
+    return VersionedTransaction.populate(message, signatures)
+
+
+def get_local_solana_sign_callback(private_key: str):
+    """Sign callback for a local Solana wallet (base58 private key).
+
+    The callback accepts a solders ``VersionedTransaction`` / legacy
+    ``Transaction`` (or its serialized bytes / base64 string), signs the
+    transaction message with the wallet keypair, and returns the fully
+    serialized signed transaction bytes.
+    """
+    keypair = solana_keypair_from_base58(private_key)
+
+    async def sign_callback(transaction: Any) -> bytes:
+        tx = _coerce_solana_transaction(transaction)
+        if isinstance(tx, VersionedTransaction):
+            return bytes(_sign_versioned_transaction(tx, keypair))
+        tx.partial_sign([keypair], tx.message.recent_blockhash)
+        return bytes(tx)
+
+    # Sign-callback contract: `wallet_address` is None for local keys.
+    sign_callback.wallet_address = None
+    sign_callback.chain_type = CHAIN_TYPE_SOLANA
+    return sign_callback
 
 
 # ---------------------------------------------------------------------------
@@ -186,6 +275,7 @@ def get_remote_sign_callback(wallet_address: str):
     # Sign-callback contract: send_transaction() reads this to route
     # gas-sponsored chains through the backend broadcast.
     sign_callback.wallet_address = wallet_address
+    sign_callback.chain_type = CHAIN_TYPE_ETHEREUM
     return sign_callback
 
 
@@ -234,6 +324,16 @@ def _require_wallet_address(wallet: dict[str, Any], label: str) -> str:
 
 def _build_signing_callback(wallet: dict[str, Any], label: str):
     address = _require_wallet_address(wallet, label)
+    chain_type = wallet_chain_type(wallet)
+    if chain_type == CHAIN_TYPE_SOLANA:
+        if wallet.get("type") == "remote":
+            raise ValueError(
+                f"Wallet '{label}': remote Solana wallet signing is not supported yet."
+            )
+        pk = get_private_key(wallet)
+        if not pk:
+            raise ValueError(f"Wallet '{label}' is missing private_key.")
+        return get_local_solana_sign_callback(pk), address
     if wallet.get("type") == "remote":
         return get_remote_sign_callback(address), address
     else:
@@ -245,6 +345,10 @@ def _build_signing_callback(wallet: dict[str, Any], label: str):
 
 def _build_typed_data_callback(wallet: dict[str, Any], label: str):
     address = _require_wallet_address(wallet, label)
+    if wallet_chain_type(wallet) == CHAIN_TYPE_SOLANA:
+        raise ValueError(
+            f"Wallet '{label}' is a Solana wallet; EIP-712 typed-data signing is EVM-only."
+        )
     if wallet.get("type") == "remote":
         return get_remote_sign_typed_data_callback(address), address
     pk = get_private_key(wallet)
@@ -255,6 +359,10 @@ def _build_typed_data_callback(wallet: dict[str, Any], label: str):
 
 def _build_sign_hash_callback(wallet: dict[str, Any], label: str):
     address = _require_wallet_address(wallet, label)
+    if wallet_chain_type(wallet) == CHAIN_TYPE_SOLANA:
+        raise ValueError(
+            f"Wallet '{label}' is a Solana wallet; raw hash signing is EVM-only."
+        )
     if wallet.get("type") == "remote":
         return get_remote_sign_hash_callback(address), address
     pk = get_private_key(wallet)

--- a/wayfinder_paths/mcp/tools/wallets.py
+++ b/wayfinder_paths/mcp/tools/wallets.py
@@ -416,42 +416,13 @@ async def core_wallets(
             return err("invalid_request", f"Unknown action: {action}")
 
 
-def _balance_usd(entry: dict[str, Any]) -> float:
-    val = entry.get("balanceUSD", 0)
-    try:
-        return float(val or 0)
-    except (TypeError, ValueError):
-        return 0.0
-
-
-def _strip_solana(data: Any) -> Any:
-    """Drop Solana entries from an enriched-balances response (EVM-only view)."""
-    if not isinstance(data, dict) or not isinstance(data.get("balances"), list):
-        return data
-    balances_list = [b for b in data["balances"] if isinstance(b, dict)]
-    filtered = [
-        b for b in balances_list if str(b.get("network", "")).lower() != "solana"
-    ]
-    if len(filtered) == len(balances_list):
-        return data
-    out = dict(data)
-    out["balances"] = filtered
-    out["total_balance_usd"] = sum(_balance_usd(b) for b in filtered)
-    breakdown: dict[str, float] = {}
-    for b in filtered:
-        net = str(b.get("network") or "").strip()
-        if net:
-            breakdown[net] = breakdown.get(net, 0.0) + _balance_usd(b)
-    out["chain_breakdown"] = breakdown
-    return out
-
-
 async def _fetch_balances(address: str) -> dict[str, Any] | None:
+    # Solana entries are included: SVM chains are first-class now
+    # (see wayfinder_paths.core.utils.svm).
     try:
-        data = await BALANCE_CLIENT.get_enriched_wallet_balances(
+        return await BALANCE_CLIENT.get_enriched_wallet_balances(
             wallet_address=address, exclude_spam_tokens=True
         )
-        return _strip_solana(data)
     except Exception as exc:  # noqa: BLE001
         return {"error": str(exc)}
 

--- a/wayfinder_paths/mcp/utils.py
+++ b/wayfinder_paths/mcp/utils.py
@@ -210,6 +210,7 @@ def public_wallet_view(w: dict[str, Any]) -> dict[str, Any]:
     return {
         "label": w.get("label"),
         "address": w.get("address"),
+        "chain_type": w.get("chain_type") or "ethereum",
         "wallet_type": w.get("wallet_type"),
         "session_expires_at": w.get("session_expires_at"),
         "session_expires_in": w.get("session_expires_in"),

--- a/wayfinder_paths/tests/test_mcp_balances.py
+++ b/wayfinder_paths/tests/test_mcp_balances.py
@@ -13,7 +13,8 @@ def mock_wallet():
 
 
 @pytest.mark.asyncio
-async def test_get_wallets_filters_solana(mock_wallet):
+async def test_get_wallets_includes_solana(mock_wallet):
+    """Solana is a supported chain now: balances must NOT be stripped."""
     fake_client = AsyncMock()
     fake_client.get_enriched_wallet_balances = AsyncMock(
         return_value={
@@ -39,10 +40,13 @@ async def test_get_wallets_filters_solana(mock_wallet):
     data = out["result"]
     assert len(data["wallets"]) == 1
     balances_data = data["wallets"][0]["balances"]
-    assert balances_data["total_balance_usd"] == pytest.approx(3.5)
-    assert balances_data["chain_breakdown"]["base"] == pytest.approx(1.5)
-    assert balances_data["chain_breakdown"]["arbitrum"] == pytest.approx(2.0)
-    assert all(b["network"].lower() != "solana" for b in balances_data["balances"])
+    networks = [b["network"].lower() for b in balances_data["balances"]]
+    assert "solana" in networks
+    assert balances_data["total_balance_usd"] == pytest.approx(1002.5)
+    solana_entry = next(
+        b for b in balances_data["balances"] if b["network"].lower() == "solana"
+    )
+    assert solana_entry["balanceUSD"] == pytest.approx(999.0)
 
 
 @pytest.mark.asyncio

--- a/wayfinder_paths/tests/test_solana_wallets.py
+++ b/wayfinder_paths/tests/test_solana_wallets.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import base64
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from solders.hash import Hash
+from solders.keypair import Keypair
+from solders.message import Message, MessageV0, to_bytes_versioned
+from solders.signature import Signature
+from solders.system_program import TransferParams, transfer
+from solders.transaction import Transaction as SoldersLegacyTransaction
+from solders.transaction import VersionedTransaction
+
+from wayfinder_paths.core.utils.wallets import (
+    get_local_solana_sign_callback,
+    get_wallet_sign_hash_callback,
+    get_wallet_sign_typed_data_callback,
+    get_wallet_signing_callback,
+    solana_keypair_from_base58,
+    wallet_chain_type,
+)
+
+
+@pytest.fixture
+def solana_keypair() -> Keypair:
+    return Keypair()
+
+
+def _unsigned_v0_transaction(payer: Keypair) -> VersionedTransaction:
+    ix = transfer(
+        TransferParams(
+            from_pubkey=payer.pubkey(),
+            to_pubkey=Keypair().pubkey(),
+            lamports=1_000,
+        )
+    )
+    message = MessageV0.try_compile(payer.pubkey(), [ix], [], Hash.default())
+    return VersionedTransaction.populate(message, [Signature.default()])
+
+
+def _unsigned_legacy_transaction(payer: Keypair) -> SoldersLegacyTransaction:
+    ix = transfer(
+        TransferParams(
+            from_pubkey=payer.pubkey(),
+            to_pubkey=Keypair().pubkey(),
+            lamports=1_000,
+        )
+    )
+    return SoldersLegacyTransaction.new_unsigned(Message([ix], payer.pubkey()))
+
+
+def _solana_wallet(keypair: Keypair, label: str = "sol") -> dict:
+    return {
+        "label": label,
+        "address": str(keypair.pubkey()),
+        "chain_type": "solana",
+        "private_key": str(keypair),  # base58-encoded 64-byte keypair
+    }
+
+
+# ---------------------------------------------------------------------------
+# chain_type handling
+# ---------------------------------------------------------------------------
+
+
+def test_wallet_chain_type_defaults_to_ethereum():
+    assert wallet_chain_type({}) == "ethereum"
+    assert wallet_chain_type({"chain_type": None}) == "ethereum"
+    assert wallet_chain_type({"chain_type": ""}) == "ethereum"
+    assert wallet_chain_type({"chain_type": "Solana"}) == "solana"
+    assert wallet_chain_type({"chain_type": "ethereum"}) == "ethereum"
+
+
+def test_solana_keypair_from_base58_roundtrip(solana_keypair):
+    kp = solana_keypair_from_base58(str(solana_keypair))
+    assert kp.pubkey() == solana_keypair.pubkey()
+
+
+# ---------------------------------------------------------------------------
+# Local solana sign callback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_solana_sign_callback_versioned_transaction(solana_keypair):
+    callback = get_local_solana_sign_callback(str(solana_keypair))
+    assert callback.wallet_address is None
+    assert callback.chain_type == "solana"
+
+    unsigned = _unsigned_v0_transaction(solana_keypair)
+    signed_bytes = await callback(unsigned)
+
+    signed = VersionedTransaction.from_bytes(signed_bytes)
+    sig = signed.signatures[0]
+    assert sig != Signature.default()
+    assert sig.verify(solana_keypair.pubkey(), to_bytes_versioned(signed.message))
+
+
+@pytest.mark.asyncio
+async def test_solana_sign_callback_accepts_bytes_and_base64(solana_keypair):
+    callback = get_local_solana_sign_callback(str(solana_keypair))
+    unsigned = _unsigned_v0_transaction(solana_keypair)
+
+    from_bytes = await callback(bytes(unsigned))
+    from_b64 = await callback(base64.b64encode(bytes(unsigned)).decode())
+
+    assert from_bytes == from_b64
+    signed = VersionedTransaction.from_bytes(from_bytes)
+    assert signed.signatures[0].verify(
+        solana_keypair.pubkey(), to_bytes_versioned(signed.message)
+    )
+
+
+@pytest.mark.asyncio
+async def test_solana_sign_callback_legacy_transaction(solana_keypair):
+    callback = get_local_solana_sign_callback(str(solana_keypair))
+    unsigned = _unsigned_legacy_transaction(solana_keypair)
+
+    signed_bytes = await callback(unsigned)
+
+    signed = SoldersLegacyTransaction.from_bytes(signed_bytes)
+    sig = signed.signatures[0]
+    assert sig != Signature.default()
+    assert sig.verify(solana_keypair.pubkey(), bytes(signed.message))
+
+
+@pytest.mark.asyncio
+async def test_solana_sign_callback_rejects_non_signer(solana_keypair):
+    other = Keypair()
+    callback = get_local_solana_sign_callback(str(other))
+    unsigned = _unsigned_v0_transaction(solana_keypair)
+
+    with pytest.raises(ValueError, match="not a required signer"):
+        await callback(unsigned)
+
+
+@pytest.mark.asyncio
+async def test_solana_sign_callback_rejects_bad_input(solana_keypair):
+    callback = get_local_solana_sign_callback(str(solana_keypair))
+    with pytest.raises(TypeError, match="Unsupported Solana transaction type"):
+        await callback(12345)
+
+
+# ---------------------------------------------------------------------------
+# Wallet resolution → signing callback dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_wallet_signing_callback_local_solana(solana_keypair):
+    wallet = _solana_wallet(solana_keypair)
+    with patch(
+        "wayfinder_paths.core.utils.wallets.find_wallet_by_label",
+        new=AsyncMock(return_value=wallet),
+    ):
+        callback, address = await get_wallet_signing_callback("sol")
+
+    assert address == str(solana_keypair.pubkey())
+    assert callback.chain_type == "solana"
+    assert callback.wallet_address is None
+
+    unsigned = _unsigned_v0_transaction(solana_keypair)
+    signed = VersionedTransaction.from_bytes(await callback(unsigned))
+    assert signed.signatures[0].verify(
+        solana_keypair.pubkey(), to_bytes_versioned(signed.message)
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_wallet_signing_callback_remote_solana_unsupported(solana_keypair):
+    wallet = {
+        "label": "sol-remote",
+        "address": str(solana_keypair.pubkey()),
+        "chain_type": "solana",
+        "type": "remote",
+    }
+    with patch(
+        "wayfinder_paths.core.utils.wallets.find_wallet_by_label",
+        new=AsyncMock(return_value=wallet),
+    ):
+        with pytest.raises(ValueError, match="remote Solana wallet signing"):
+            await get_wallet_signing_callback("sol-remote")
+
+
+@pytest.mark.asyncio
+async def test_get_wallet_signing_callback_solana_missing_key(solana_keypair):
+    wallet = {
+        "label": "sol-nokey",
+        "address": str(solana_keypair.pubkey()),
+        "chain_type": "solana",
+    }
+    with patch(
+        "wayfinder_paths.core.utils.wallets.find_wallet_by_label",
+        new=AsyncMock(return_value=wallet),
+    ):
+        with pytest.raises(ValueError, match="missing private_key"):
+            await get_wallet_signing_callback("sol-nokey")
+
+
+@pytest.mark.asyncio
+async def test_get_wallet_signing_callback_evm_unchanged():
+    """EVM wallets without chain_type behave exactly as before."""
+    wallet = {
+        "label": "evm",
+        "address": "0x000000000000000000000000000000000000dEaD",
+        "private_key_hex": "0x" + "11" * 32,
+    }
+    with patch(
+        "wayfinder_paths.core.utils.wallets.find_wallet_by_label",
+        new=AsyncMock(return_value=wallet),
+    ):
+        callback, address = await get_wallet_signing_callback("evm")
+
+    assert address == wallet["address"]
+    assert callback.wallet_address is None
+    assert callback.chain_type == "ethereum"
+
+
+@pytest.mark.asyncio
+async def test_typed_data_and_hash_callbacks_reject_solana(solana_keypair):
+    wallet = _solana_wallet(solana_keypair)
+    with patch(
+        "wayfinder_paths.core.utils.wallets.find_wallet_by_label",
+        new=AsyncMock(return_value=wallet),
+    ):
+        with pytest.raises(ValueError, match="EVM-only"):
+            await get_wallet_sign_typed_data_callback("sol")
+        with pytest.raises(ValueError, match="EVM-only"):
+            await get_wallet_sign_hash_callback("sol")

--- a/wayfinder_paths/tests/test_svm_utils.py
+++ b/wayfinder_paths/tests/test_svm_utils.py
@@ -349,6 +349,9 @@ async def test_confirm_solana_signature_success():
     assert out["err"] is None
     assert out["confirmation_status"] == "confirmed"
     assert out["signature"] == sig
+    # must search history so signatures older than the recent-status cache resolve
+    for call in fake.get_signature_statuses.call_args_list:
+        assert call.kwargs.get("search_transaction_history") is True
 
 
 @pytest.mark.asyncio

--- a/wayfinder_paths/tests/test_svm_utils.py
+++ b/wayfinder_paths/tests/test_svm_utils.py
@@ -19,6 +19,10 @@ from wayfinder_paths.core.constants.chains import (
     SVM_CHAIN_IDS,
 )
 from wayfinder_paths.core.utils.svm import (
+    is_solana_chain,
+    solana_client_from_chain_id,
+)
+from wayfinder_paths.core.utils.svm_tokens import (
     SOL_NATIVE_SENTINEL,
     WRAPPED_SOL_MINT,
     get_associated_token_address,
@@ -26,8 +30,6 @@ from wayfinder_paths.core.utils.svm import (
     get_solana_token_balance,
     get_spl_mint_decimals,
     get_spl_token_balance,
-    is_solana_chain,
-    solana_client_from_chain_id,
 )
 from wayfinder_paths.core.utils.svm_transaction import (
     confirm_solana_signature,
@@ -49,7 +51,10 @@ def _patch_client(fake_client):
         yield fake_client
 
     with (
-        patch("wayfinder_paths.core.utils.svm.solana_client_from_chain_id", fake_ctx),
+        patch(
+            "wayfinder_paths.core.utils.svm_tokens.solana_client_from_chain_id",
+            fake_ctx,
+        ),
         patch(
             "wayfinder_paths.core.utils.svm_transaction.solana_client_from_chain_id",
             fake_ctx,
@@ -419,7 +424,7 @@ async def test_token_resolver_meta_solana_mint():
     from wayfinder_paths.core.utils.token_resolver import TokenResolver
 
     with patch(
-        "wayfinder_paths.core.utils.svm.get_spl_mint_decimals",
+        "wayfinder_paths.core.utils.svm_tokens.get_spl_mint_decimals",
         new=AsyncMock(return_value=6),
     ):
         meta = await TokenResolver.resolve_token_meta(

--- a/wayfinder_paths/tests/test_svm_utils.py
+++ b/wayfinder_paths/tests/test_svm_utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import base64
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, contextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -21,16 +21,17 @@ from wayfinder_paths.core.constants.chains import (
 from wayfinder_paths.core.utils.svm import (
     SOL_NATIVE_SENTINEL,
     WRAPPED_SOL_MINT,
-    confirm_solana_signature,
     get_associated_token_address,
     get_sol_balance,
     get_solana_token_balance,
     get_spl_mint_decimals,
     get_spl_token_balance,
-    is_native_sol,
     is_solana_chain,
-    send_solana_transaction,
     solana_client_from_chain_id,
+)
+from wayfinder_paths.core.utils.svm_transaction import (
+    confirm_solana_signature,
+    send_solana_transaction,
 )
 from wayfinder_paths.core.utils.token_refs import looks_like_solana_address
 
@@ -41,12 +42,20 @@ EXPECTED_USDC_ATA = "F8biqkCRK2tHR6EncrcXDGgVTkGRrtojqyW39w41Qspn"
 EXPECTED_USDC_ATA_2022 = "8UQrn3SEPVqkggQ7Y7QEpGxutSyYQgJVFsgSxzwge858"
 
 
+@contextmanager
 def _patch_client(fake_client):
     @asynccontextmanager
     async def fake_ctx(chain_id=CHAIN_ID_SOLANA, commitment=None):
         yield fake_client
 
-    return patch("wayfinder_paths.core.utils.svm.solana_client_from_chain_id", fake_ctx)
+    with (
+        patch("wayfinder_paths.core.utils.svm.solana_client_from_chain_id", fake_ctx),
+        patch(
+            "wayfinder_paths.core.utils.svm_transaction.solana_client_from_chain_id",
+            fake_ctx,
+        ),
+    ):
+        yield
 
 
 # ---------------------------------------------------------------------------
@@ -61,17 +70,6 @@ def test_is_solana_chain():
     assert not is_solana_chain(CHAIN_ID_BASE)
     assert not is_solana_chain(None)
     assert not is_solana_chain("solana")
-
-
-def test_is_native_sol():
-    assert is_native_sol(SOL_NATIVE_SENTINEL)
-    assert is_native_sol("native")
-    assert is_native_sol("")
-    assert is_native_sol(None)
-    assert is_native_sol("0x0000000000000000000000000000000000000000")
-    # Wrapped SOL is an SPL mint, not native.
-    assert not is_native_sol(WRAPPED_SOL_MINT)
-    assert not is_native_sol(USDC_MINT)
 
 
 def test_looks_like_solana_address():
@@ -340,7 +338,9 @@ async def test_confirm_solana_signature_success():
     fake.get_signature_statuses = AsyncMock(side_effect=[pending, confirmed])
     with (
         _patch_client(fake),
-        patch("wayfinder_paths.core.utils.svm.asyncio.sleep", new=AsyncMock()),
+        patch(
+            "wayfinder_paths.core.utils.svm_transaction.asyncio.sleep", new=AsyncMock()
+        ),
     ):
         out = await confirm_solana_signature(sig, timeout_s=30)
 

--- a/wayfinder_paths/tests/test_svm_utils.py
+++ b/wayfinder_paths/tests/test_svm_utils.py
@@ -142,6 +142,34 @@ async def test_solana_client_uses_resolved_rpcs():
     mock_rpcs.assert_called_once_with(CHAIN_ID_SOLANA)
 
 
+@pytest.mark.asyncio
+async def test_solana_client_multi_rpc_no_leak():
+    """With multiple resolved RPCs, only ONE client is built and it is closed."""
+    fake_client = AsyncMock()
+    with (
+        patch(
+            "wayfinder_paths.core.utils.svm._get_rpcs_for_chain_id",
+            return_value=[
+                "https://rpc-0.example.com/",
+                "https://rpc-1.example.com/",
+                "https://rpc-2.example.com/",
+            ],
+        ),
+        patch(
+            "wayfinder_paths.core.utils.svm._client_for_rpc",
+            return_value=fake_client,
+        ) as mock_factory,
+    ):
+        async with solana_client_from_chain_id(CHAIN_ID_SOLANA) as client:
+            assert client is fake_client
+
+    # Exactly one client constructed — for the first RPC only.
+    mock_factory.assert_called_once()
+    assert mock_factory.call_args.args[0] == "https://rpc-0.example.com/"
+    # And that one client was closed on exit.
+    fake_client.close.assert_awaited_once()
+
+
 # ---------------------------------------------------------------------------
 # Balances (mocked RPC)
 # ---------------------------------------------------------------------------
@@ -277,20 +305,22 @@ async def test_send_solana_transaction():
     assert out == str(signature)
     args, kwargs = fake.send_raw_transaction.await_args
     assert args[0] == raw
-    assert kwargs["opts"].skip_preflight is True
+    # Preflight simulation runs by default so send failures surface
+    # immediately instead of as confirmation timeouts.
+    assert kwargs["opts"].skip_preflight is False
 
 
 @pytest.mark.asyncio
-async def test_send_solana_transaction_preflight():
+async def test_send_solana_transaction_skip_preflight_opt_out():
     fake = AsyncMock()
     fake.send_raw_transaction = AsyncMock(
         return_value=SimpleNamespace(value=Signature.default())
     )
     with _patch_client(fake):
         await send_solana_transaction(
-            base64.b64encode(b"tx").decode(), skip_preflight=False
+            base64.b64encode(b"tx").decode(), skip_preflight=True
         )
-    assert fake.send_raw_transaction.await_args.kwargs["opts"].skip_preflight is False
+    assert fake.send_raw_transaction.await_args.kwargs["opts"].skip_preflight is True
 
 
 @pytest.mark.asyncio

--- a/wayfinder_paths/tests/test_svm_utils.py
+++ b/wayfinder_paths/tests/test_svm_utils.py
@@ -1,0 +1,399 @@
+from __future__ import annotations
+
+import base64
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from solders.pubkey import Pubkey
+from solders.signature import Signature
+from solders.transaction_status import TransactionConfirmationStatus
+from spl.token._layouts import MINT_LAYOUT
+from spl.token.constants import TOKEN_2022_PROGRAM_ID, TOKEN_PROGRAM_ID
+from spl.token.instructions import get_associated_token_address as spl_reference_ata
+
+from wayfinder_paths.core.constants.chains import (
+    CHAIN_ID_BASE,
+    CHAIN_ID_SOLANA,
+    SVM_CHAIN_IDS,
+)
+from wayfinder_paths.core.utils.svm import (
+    SOL_NATIVE_SENTINEL,
+    WRAPPED_SOL_MINT,
+    confirm_solana_signature,
+    get_associated_token_address,
+    get_sol_balance,
+    get_solana_token_balance,
+    get_spl_mint_decimals,
+    get_spl_token_balance,
+    is_native_sol,
+    is_solana_chain,
+    send_solana_transaction,
+    solana_client_from_chain_id,
+)
+from wayfinder_paths.core.utils.token_refs import looks_like_solana_address
+
+USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+OWNER = "4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T"
+# Derived offline with solana-py's reference implementation.
+EXPECTED_USDC_ATA = "F8biqkCRK2tHR6EncrcXDGgVTkGRrtojqyW39w41Qspn"
+EXPECTED_USDC_ATA_2022 = "8UQrn3SEPVqkggQ7Y7QEpGxutSyYQgJVFsgSxzwge858"
+
+
+def _patch_client(fake_client):
+    @asynccontextmanager
+    async def fake_ctx(chain_id=CHAIN_ID_SOLANA, commitment=None):
+        yield fake_client
+
+    return patch("wayfinder_paths.core.utils.svm.solana_client_from_chain_id", fake_ctx)
+
+
+# ---------------------------------------------------------------------------
+# Chain / address predicates
+# ---------------------------------------------------------------------------
+
+
+def test_is_solana_chain():
+    assert is_solana_chain(CHAIN_ID_SOLANA)
+    assert is_solana_chain("900")
+    assert CHAIN_ID_SOLANA in SVM_CHAIN_IDS
+    assert not is_solana_chain(CHAIN_ID_BASE)
+    assert not is_solana_chain(None)
+    assert not is_solana_chain("solana")
+
+
+def test_is_native_sol():
+    assert is_native_sol(SOL_NATIVE_SENTINEL)
+    assert is_native_sol("native")
+    assert is_native_sol("")
+    assert is_native_sol(None)
+    assert is_native_sol("0x0000000000000000000000000000000000000000")
+    # Wrapped SOL is an SPL mint, not native.
+    assert not is_native_sol(WRAPPED_SOL_MINT)
+    assert not is_native_sol(USDC_MINT)
+
+
+def test_looks_like_solana_address():
+    assert looks_like_solana_address(USDC_MINT)
+    assert looks_like_solana_address(SOL_NATIVE_SENTINEL)
+    assert looks_like_solana_address(WRAPPED_SOL_MINT)
+    assert not looks_like_solana_address(None)
+    assert not looks_like_solana_address("")
+    assert not looks_like_solana_address("usdc")
+    assert not looks_like_solana_address("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913")
+    # base58 excludes 0, O, I, l
+    assert not looks_like_solana_address("0" * 40)
+
+
+# ---------------------------------------------------------------------------
+# ATA derivation (fully offline)
+# ---------------------------------------------------------------------------
+
+
+def test_ata_derivation_known_vector():
+    owner = Pubkey.from_string(OWNER)
+    mint = Pubkey.from_string(USDC_MINT)
+    assert str(get_associated_token_address(owner, mint)) == EXPECTED_USDC_ATA
+    assert (
+        str(get_associated_token_address(owner, mint, TOKEN_PROGRAM_ID))
+        == EXPECTED_USDC_ATA
+    )
+
+
+def test_ata_derivation_token_2022_known_vector():
+    owner = Pubkey.from_string(OWNER)
+    mint = Pubkey.from_string(USDC_MINT)
+    assert (
+        str(get_associated_token_address(owner, mint, TOKEN_2022_PROGRAM_ID))
+        == EXPECTED_USDC_ATA_2022
+    )
+
+
+def test_ata_derivation_matches_spl_reference():
+    owner = Pubkey.from_string(OWNER)
+    mint = Pubkey.from_string(WRAPPED_SOL_MINT)
+    assert get_associated_token_address(owner, mint) == spl_reference_ata(owner, mint)
+    assert get_associated_token_address(
+        owner, mint, TOKEN_2022_PROGRAM_ID
+    ) == spl_reference_ata(owner, mint, TOKEN_2022_PROGRAM_ID)
+
+
+# ---------------------------------------------------------------------------
+# Client factory
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_solana_client_rejects_evm_chain():
+    with pytest.raises(ValueError, match="not a Solana chain"):
+        async with solana_client_from_chain_id(CHAIN_ID_BASE):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_solana_client_uses_resolved_rpcs():
+    with patch(
+        "wayfinder_paths.core.utils.svm._get_rpcs_for_chain_id",
+        return_value=["https://solana.example.com/rpc"],
+    ) as mock_rpcs:
+        async with solana_client_from_chain_id(CHAIN_ID_SOLANA) as client:
+            assert client is not None
+    mock_rpcs.assert_called_once_with(CHAIN_ID_SOLANA)
+
+
+# ---------------------------------------------------------------------------
+# Balances (mocked RPC)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_sol_balance():
+    fake = AsyncMock()
+    fake.get_balance = AsyncMock(return_value=SimpleNamespace(value=1_500_000_000))
+    with _patch_client(fake):
+        assert await get_sol_balance(OWNER) == 1_500_000_000
+    (pubkey,) = fake.get_balance.await_args.args
+    assert pubkey == Pubkey.from_string(OWNER)
+
+
+@pytest.mark.asyncio
+async def test_get_spl_token_balance_missing_ata_returns_zero():
+    fake = AsyncMock()
+    mint_account = SimpleNamespace(owner=TOKEN_PROGRAM_ID, data=b"")
+    fake.get_account_info = AsyncMock(
+        side_effect=[
+            SimpleNamespace(value=mint_account),  # mint lookup
+            SimpleNamespace(value=None),  # ATA missing
+        ]
+    )
+    with _patch_client(fake):
+        assert await get_spl_token_balance(OWNER, USDC_MINT) == 0
+    fake.get_token_account_balance.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_spl_token_balance_token_2022():
+    fake = AsyncMock()
+    mint_account = SimpleNamespace(owner=TOKEN_2022_PROGRAM_ID, data=b"")
+    ata_account = SimpleNamespace(owner=TOKEN_2022_PROGRAM_ID, data=b"")
+    fake.get_account_info = AsyncMock(
+        side_effect=[
+            SimpleNamespace(value=mint_account),
+            SimpleNamespace(value=ata_account),
+        ]
+    )
+    fake.get_token_account_balance = AsyncMock(
+        return_value=SimpleNamespace(value=SimpleNamespace(amount="123456"))
+    )
+    with _patch_client(fake):
+        assert await get_spl_token_balance(OWNER, USDC_MINT) == 123456
+
+    # The balance must have been read from the Token-2022 ATA.
+    (ata_pubkey,) = fake.get_token_account_balance.await_args.args
+    expected = get_associated_token_address(
+        Pubkey.from_string(OWNER),
+        Pubkey.from_string(USDC_MINT),
+        TOKEN_2022_PROGRAM_ID,
+    )
+    assert ata_pubkey == expected
+
+
+@pytest.mark.asyncio
+async def test_get_spl_token_balance_missing_mint_raises():
+    fake = AsyncMock()
+    fake.get_account_info = AsyncMock(return_value=SimpleNamespace(value=None))
+    with _patch_client(fake):
+        with pytest.raises(ValueError, match="mint account not found"):
+            await get_spl_token_balance(OWNER, USDC_MINT)
+
+
+@pytest.mark.asyncio
+async def test_get_solana_token_balance_dispatch():
+    fake = AsyncMock()
+    fake.get_balance = AsyncMock(return_value=SimpleNamespace(value=42))
+    with _patch_client(fake):
+        assert await get_solana_token_balance(OWNER, SOL_NATIVE_SENTINEL) == 42
+        assert await get_solana_token_balance(OWNER, "native") == 42
+    fake.get_account_info.assert_not_awaited()
+
+    fake_spl = AsyncMock()
+    mint_account = SimpleNamespace(owner=TOKEN_PROGRAM_ID, data=b"")
+    ata_account = SimpleNamespace(owner=TOKEN_PROGRAM_ID, data=b"")
+    fake_spl.get_account_info = AsyncMock(
+        side_effect=[
+            SimpleNamespace(value=mint_account),
+            SimpleNamespace(value=ata_account),
+        ]
+    )
+    fake_spl.get_token_account_balance = AsyncMock(
+        return_value=SimpleNamespace(value=SimpleNamespace(amount="7"))
+    )
+    with _patch_client(fake_spl):
+        assert await get_solana_token_balance(OWNER, USDC_MINT) == 7
+
+
+@pytest.mark.asyncio
+async def test_get_spl_mint_decimals():
+    mint_data = MINT_LAYOUT.build(
+        {
+            "mint_authority_option": 0,
+            "mint_authority": bytes(32),
+            "supply": 1_000_000,
+            "decimals": 6,
+            "is_initialized": 1,
+            "freeze_authority_option": 0,
+            "freeze_authority": bytes(32),
+        }
+    )
+    fake = AsyncMock()
+    fake.get_account_info = AsyncMock(
+        return_value=SimpleNamespace(
+            value=SimpleNamespace(owner=TOKEN_PROGRAM_ID, data=mint_data)
+        )
+    )
+    with _patch_client(fake):
+        assert await get_spl_mint_decimals(USDC_MINT) == 6
+    # Native SOL needs no RPC call.
+    assert await get_spl_mint_decimals(SOL_NATIVE_SENTINEL) == 9
+
+
+# ---------------------------------------------------------------------------
+# Send / confirm (mocked RPC)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_solana_transaction():
+    raw = b"\x01" * 100
+    serialized_b64 = base64.b64encode(raw).decode()
+    signature = Signature.default()
+
+    fake = AsyncMock()
+    fake.send_raw_transaction = AsyncMock(return_value=SimpleNamespace(value=signature))
+    with _patch_client(fake):
+        out = await send_solana_transaction(serialized_b64)
+
+    assert out == str(signature)
+    args, kwargs = fake.send_raw_transaction.await_args
+    assert args[0] == raw
+    assert kwargs["opts"].skip_preflight is True
+
+
+@pytest.mark.asyncio
+async def test_send_solana_transaction_preflight():
+    fake = AsyncMock()
+    fake.send_raw_transaction = AsyncMock(
+        return_value=SimpleNamespace(value=Signature.default())
+    )
+    with _patch_client(fake):
+        await send_solana_transaction(
+            base64.b64encode(b"tx").decode(), skip_preflight=False
+        )
+    assert fake.send_raw_transaction.await_args.kwargs["opts"].skip_preflight is False
+
+
+@pytest.mark.asyncio
+async def test_confirm_solana_signature_success():
+    sig = str(Signature.default())
+    pending = SimpleNamespace(value=[None])
+    confirmed = SimpleNamespace(
+        value=[
+            SimpleNamespace(
+                slot=123,
+                err=None,
+                confirmation_status=TransactionConfirmationStatus.Confirmed,
+            )
+        ]
+    )
+    fake = AsyncMock()
+    fake.get_signature_statuses = AsyncMock(side_effect=[pending, confirmed])
+    with (
+        _patch_client(fake),
+        patch("wayfinder_paths.core.utils.svm.asyncio.sleep", new=AsyncMock()),
+    ):
+        out = await confirm_solana_signature(sig, timeout_s=30)
+
+    assert out["confirmed"] is True
+    assert out["slot"] == 123
+    assert out["err"] is None
+    assert out["confirmation_status"] == "confirmed"
+    assert out["signature"] == sig
+
+
+@pytest.mark.asyncio
+async def test_confirm_solana_signature_error():
+    sig = str(Signature.default())
+    errored = SimpleNamespace(
+        value=[
+            SimpleNamespace(
+                slot=99,
+                err={"InstructionError": [0, "Custom"]},
+                confirmation_status=TransactionConfirmationStatus.Processed,
+            )
+        ]
+    )
+    fake = AsyncMock()
+    fake.get_signature_statuses = AsyncMock(return_value=errored)
+    with _patch_client(fake):
+        out = await confirm_solana_signature(sig, timeout_s=30)
+
+    assert out["confirmed"] is False
+    assert out["slot"] == 99
+    assert "InstructionError" in out["err"]
+
+
+@pytest.mark.asyncio
+async def test_confirm_solana_signature_timeout():
+    sig = str(Signature.default())
+    fake = AsyncMock()
+    fake.get_signature_statuses = AsyncMock(return_value=SimpleNamespace(value=[None]))
+    with _patch_client(fake):
+        with pytest.raises(TimeoutError, match="Timed out"):
+            await confirm_solana_signature(sig, timeout_s=0)
+
+
+# ---------------------------------------------------------------------------
+# Token resolver integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_token_resolver_accepts_solana_mint():
+    from wayfinder_paths.core.utils.token_resolver import TokenResolver
+
+    chain_id, address = await TokenResolver.resolve_token(
+        USDC_MINT, chain_id=CHAIN_ID_SOLANA
+    )
+    assert chain_id == CHAIN_ID_SOLANA
+    assert address == USDC_MINT
+
+
+@pytest.mark.asyncio
+async def test_token_resolver_solana_native_sentinel():
+    from wayfinder_paths.core.constants import ZERO_ADDRESS
+    from wayfinder_paths.core.utils.token_resolver import TokenResolver
+
+    chain_id, address = await TokenResolver.resolve_token(
+        SOL_NATIVE_SENTINEL, chain_id=CHAIN_ID_SOLANA
+    )
+    assert chain_id == CHAIN_ID_SOLANA
+    assert address == ZERO_ADDRESS
+
+
+@pytest.mark.asyncio
+async def test_token_resolver_meta_solana_mint():
+    from wayfinder_paths.core.utils.token_resolver import TokenResolver
+
+    with patch(
+        "wayfinder_paths.core.utils.svm.get_spl_mint_decimals",
+        new=AsyncMock(return_value=6),
+    ):
+        meta = await TokenResolver.resolve_token_meta(
+            USDC_MINT, chain_id=CHAIN_ID_SOLANA
+        )
+
+    assert meta["chain_id"] == CHAIN_ID_SOLANA
+    assert meta["address"] == USDC_MINT
+    assert meta["decimals"] == 6
+    assert meta["metadata"]["source"] == "address"


### PR DESCRIPTION
### Summary
Adds Solana (SVM) support to the SDK.

- Registers chain `900` and an `SVM_CHAIN_IDS` set; keeps it out of the EVM-only chain sets (supported/gas-sponsored/middleware) so it doesn't route through the web3 nonce/gas pipeline.
- Adds `core/utils/svm.py`: RPC client lifecycle, native + SPL balance reads, associated-token-account derivation (classic + Token-2022), mint-decimals resolution, transaction send, and signature confirmation (searches transaction history when polling status).
- Adds Solana local sign callback and remote-wallet `chain_type` handling in `core/utils/wallets.py`.
- Teaches the token resolver / token refs to recognize base58 mint queries on SVM chains.
- Surfaces Solana balances through the MCP `wallets` tool.
- Adds `solana` + `solders` dependencies.
- Tests for SVM utils and Solana wallet handling.