### PR TITLE
Solana - Create SVM wallets from the MCP wallets tool (chain_type)

### DIFF
--- a/wayfinder_paths/mcp/tools/wallets.py
+++ b/wayfinder_paths/mcp/tools/wallets.py
@@ -182,6 +182,7 @@ async def core_wallets(
     remote: bool = False,
     policies: list[dict] = [],  # noqa: B006
     wallet_type: str | None = None,
+    chain_type: str = "ethereum",
 ) -> dict[str, Any]:
     """Create wallets, annotate wallet profiles, and discover cross-protocol portfolios.
 
@@ -209,6 +210,7 @@ async def core_wallets(
         remote: True → remote (managed) wallet on `create`. Required on Shells.
         policies: Remote-wallet signing policies (passed through to the wallet service).
         wallet_type: "session" or "strategy" — required when `remote=True`.
+        chain_type: "ethereum" (default) or "solana" — the chain family of a remote wallet.
 
     Supported protocols for `discover_portfolio`: hyperliquid, hyperlend, moonwell, morpho,
     boros, pendle, polymarket, aave.
@@ -244,8 +246,15 @@ async def core_wallets(
                     "wallet_type is required for remote wallets (one of: session, policy, strategy)",
                     wallet_type,
                 )
+                if chain_type not in ("ethereum", "solana"):
+                    raise ValueError(
+                        f"chain_type must be 'ethereum' or 'solana', got {chain_type!r}"
+                    )
                 result = await create_remote_wallet(
-                    label=want, wallet_type=wallet_type, policies=policies
+                    label=want,
+                    wallet_type=wallet_type,
+                    chain_type=chain_type,
+                    policies=policies,
                 )
                 refreshed = await load_wallets()
                 return ok(
@@ -254,6 +263,7 @@ async def core_wallets(
                         "created": {
                             "label": result.get("label", want),
                             "address": result["wallet_address"],
+                            "chain_type": result.get("chain_type", chain_type),
                         },
                     }
                 )

--- a/wayfinder_paths/mcp/utils.py
+++ b/wayfinder_paths/mcp/utils.py
@@ -211,6 +211,7 @@ def public_wallet_view(w: dict[str, Any]) -> dict[str, Any]:
         "label": w.get("label"),
         "address": w.get("address"),
         "wallet_type": w.get("wallet_type"),
+        "chain_type": w.get("chain_type"),
         "session_expires_at": w.get("session_expires_at"),
         "session_expires_in": w.get("session_expires_in"),
     }


### PR DESCRIPTION
### Summary
Lets an agent/user create Solana (SVM) managed wallets via `core_wallets(action="create")`, with the same TTL policy as EVM.

- `core_wallets` accepts `chain_type` ("ethereum" default | "solana"), validates it, and forwards to `create_remote_wallet` (which already threads it to `WalletClient.create_wallet`).
- The create response and `public_wallet_view` (`core_get_wallets`) now surface `chain_type`, so listed wallets show their chain.

Create + list are the reachable operations from the SDK's API-key auth. TTL-refresh and delete are not SDK-doable today (refresh needs a signed authorization the SDK can't produce; managed wallets aren't deletable) — unchanged by this PR.