### PR TITLE
Solana 4/4: BRAP and transfer execution for SVM

### DIFF
--- a/wayfinder_paths/adapters/balance_adapter/adapter.py
+++ b/wayfinder_paths/adapters/balance_adapter/adapter.py
@@ -8,6 +8,10 @@ from wayfinder_paths.core.adapters.BaseAdapter import BaseAdapter
 from wayfinder_paths.core.clients.TokenClient import TOKEN_CLIENT
 from wayfinder_paths.core.constants.erc20_abi import ERC20_ABI
 from wayfinder_paths.core.utils.evm_helpers import resolve_chain_id
+from wayfinder_paths.core.utils.svm import is_solana_chain
+from wayfinder_paths.core.utils.svm_transaction import (
+    send_solana_versioned_transaction,
+)
 from wayfinder_paths.core.utils.token_resolver import TokenResolver
 from wayfinder_paths.core.utils.tokens import (
     build_send_transaction,
@@ -219,8 +223,29 @@ class BalanceAdapter(BaseAdapter):
             chain_id=chain_id,
             amount=amount,
         )
-        tx_hash = await send_transaction(tx, signing_callback)
+        tx_hash = await self._dispatch_send(tx, chain_id, signing_callback)
         return True, tx_hash
+
+    async def _dispatch_send(
+        self,
+        transaction: dict[str, Any],
+        chain_id: int,
+        signing_callback,
+    ) -> str:
+        """Broadcast a built transfer on the right stack.
+
+        On Solana chains ``build_send_transaction`` returns the transaction
+        envelope, so the serialized transaction is routed through the SVM
+        send flow (sponsored vs. local signing handled internally); everything
+        else is an EVM transaction dict.
+        """
+        if is_solana_chain(chain_id):
+            return await send_solana_versioned_transaction(
+                transaction["serializedTransaction"],
+                signing_callback,
+                chain_id=int(chain_id),
+            )
+        return await send_transaction(transaction, signing_callback)
 
     async def _move_between_wallets(
         self,
@@ -254,7 +279,7 @@ class BalanceAdapter(BaseAdapter):
             and from_address.lower() == self.main_wallet_address.lower()
             else self.strategy_sign_callback
         )
-        tx_hash = await send_transaction(transaction, callback)
+        tx_hash = await self._dispatch_send(transaction, chain_id, callback)
 
         if ledger_method:
             wallet_for_ledger = from_address if ledger_wallet == "from" else to_address

--- a/wayfinder_paths/adapters/balance_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/balance_adapter/test_adapter.py
@@ -5,6 +5,21 @@ import pytest
 from wayfinder_paths.adapters.balance_adapter.adapter import BalanceAdapter
 from wayfinder_paths.core.utils.token_resolver import TokenResolver
 
+_ADAPTER_MODULE = "wayfinder_paths.adapters.balance_adapter.adapter"
+
+SOL_OWNER = "4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T"
+SOL_RECIPIENT = "7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE"
+USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+
+
+def _solana_envelope() -> dict:
+    return {
+        "chainType": "solana",
+        "chainId": 900,
+        "serializedTransaction": "c2VyaWFsaXplZC10eA==",
+        "lastValidBlockHeight": 250_000_000,
+    }
+
 
 @pytest.fixture(autouse=True)
 def _clear_token_resolver_cache():
@@ -220,3 +235,159 @@ class TestBalanceAdapter:
         )
 
         assert balance == 2.0
+
+    @pytest.mark.asyncio
+    async def test_send_to_address_solana(self, adapter):
+        signing_callback = AsyncMock()
+        token_info = {
+            "token_id": "usd-coin-solana",
+            "address": USDC_MINT,
+            "decimals": 6,
+            "chain": {"id": 900},
+        }
+        envelope = _solana_envelope()
+
+        with (
+            patch(
+                f"{_ADAPTER_MODULE}.TOKEN_CLIENT.get_token_details",
+                new=AsyncMock(return_value=token_info),
+            ),
+            patch(
+                f"{_ADAPTER_MODULE}.build_send_transaction",
+                new=AsyncMock(return_value=envelope),
+            ) as mock_build,
+            patch(
+                f"{_ADAPTER_MODULE}.send_solana_versioned_transaction",
+                new=AsyncMock(return_value="Base58Signature"),
+            ) as mock_svm_send,
+            patch(f"{_ADAPTER_MODULE}.send_transaction", new=AsyncMock()) as mock_evm,
+        ):
+            ok, tx_hash = await adapter.send_to_address(
+                token_id="usd-coin-solana",
+                amount=5_000_000,
+                from_wallet={"address": SOL_OWNER},
+                to_address=SOL_RECIPIENT,
+                signing_callback=signing_callback,
+            )
+
+        assert ok is True
+        assert tx_hash == "Base58Signature"
+        mock_build.assert_awaited_once_with(
+            from_address=SOL_OWNER,
+            to_address=SOL_RECIPIENT,
+            token_address=USDC_MINT,
+            chain_id=900,
+            amount=5_000_000,
+        )
+        mock_svm_send.assert_awaited_once_with(
+            "c2VyaWFsaXplZC10eA==", signing_callback, chain_id=900
+        )
+        mock_evm.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_send_to_address_evm_regression(self, adapter):
+        signing_callback = AsyncMock()
+        token_info = {
+            "token_id": "usd-coin-base",
+            "address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "decimals": 6,
+            "chain": {"id": 8453},
+        }
+        evm_tx = {
+            "to": token_info["address"],
+            "from": "0xWallet",
+            "data": "0xdeadbeef",
+            "chainId": 8453,
+        }
+
+        with (
+            patch(
+                f"{_ADAPTER_MODULE}.TOKEN_CLIENT.get_token_details",
+                new=AsyncMock(return_value=token_info),
+            ),
+            patch(
+                f"{_ADAPTER_MODULE}.build_send_transaction",
+                new=AsyncMock(return_value=evm_tx),
+            ) as mock_build,
+            patch(
+                f"{_ADAPTER_MODULE}.send_transaction",
+                new=AsyncMock(return_value="0xevmhash"),
+            ) as mock_evm,
+            patch(
+                f"{_ADAPTER_MODULE}.send_solana_versioned_transaction",
+                new=AsyncMock(),
+            ) as mock_svm_send,
+        ):
+            ok, tx_hash = await adapter.send_to_address(
+                token_id="usd-coin-base",
+                amount=5_000_000,
+                from_wallet={"address": "0xWallet"},
+                to_address="0xRecipient",
+                signing_callback=signing_callback,
+            )
+
+        assert ok is True
+        assert tx_hash == "0xevmhash"
+        mock_build.assert_awaited_once_with(
+            from_address="0xWallet",
+            to_address="0xRecipient",
+            token_address=token_info["address"],
+            chain_id=8453,
+            amount=5_000_000,
+        )
+        mock_evm.assert_awaited_once_with(evm_tx, signing_callback)
+        mock_svm_send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_move_between_wallets_solana(self):
+        main_callback = AsyncMock()
+        strategy_callback = AsyncMock()
+        adapter = BalanceAdapter(
+            config={},
+            main_sign_callback=main_callback,
+            strategy_sign_callback=strategy_callback,
+            main_wallet_address=SOL_OWNER,
+            strategy_wallet_address=SOL_RECIPIENT,
+        )
+        token_info = {
+            "token_id": "usd-coin-solana",
+            "address": USDC_MINT,
+            "decimals": 6,
+            "chain": {"id": 900},
+        }
+        envelope = _solana_envelope()
+
+        with (
+            patch(
+                f"{_ADAPTER_MODULE}.TOKEN_CLIENT.get_token_details",
+                new=AsyncMock(return_value=token_info),
+            ),
+            patch(
+                f"{_ADAPTER_MODULE}.build_send_transaction",
+                new=AsyncMock(return_value=envelope),
+            ) as mock_build,
+            patch(
+                f"{_ADAPTER_MODULE}.send_solana_versioned_transaction",
+                new=AsyncMock(return_value="MoveSignature"),
+            ) as mock_svm_send,
+            patch(f"{_ADAPTER_MODULE}.send_transaction", new=AsyncMock()) as mock_evm,
+        ):
+            ok, tx_hash = await adapter.move_from_main_wallet_to_strategy_wallet(
+                token_id="usd-coin-solana",
+                amount=1.5,
+                skip_ledger=True,
+            )
+
+        assert ok is True
+        assert tx_hash == "MoveSignature"
+        mock_build.assert_awaited_once_with(
+            from_address=SOL_OWNER,
+            to_address=SOL_RECIPIENT,
+            token_address=USDC_MINT,
+            chain_id=900,
+            amount=1_500_000,
+        )
+        mock_svm_send.assert_awaited_once_with(
+            "c2VyaWFsaXplZC10eA==", main_callback, chain_id=900
+        )
+        mock_evm.assert_not_awaited()

--- a/wayfinder_paths/adapters/brap_adapter/adapter.py
+++ b/wayfinder_paths/adapters/brap_adapter/adapter.py
@@ -11,6 +11,11 @@ from wayfinder_paths.core.adapters.models import SWAP
 from wayfinder_paths.core.clients.BRAPClient import BRAP_CLIENT
 from wayfinder_paths.core.clients.LedgerClient import TransactionRecord
 from wayfinder_paths.core.clients.TokenClient import TOKEN_CLIENT
+from wayfinder_paths.core.constants.chains import CHAIN_ID_SOLANA
+from wayfinder_paths.core.utils.svm import is_solana_chain
+from wayfinder_paths.core.utils.svm_transaction import (
+    send_solana_versioned_transaction,
+)
 from wayfinder_paths.core.utils.tokens import (
     ensure_allowance,
     is_native_token,
@@ -158,44 +163,68 @@ class BRAPAdapter(BaseAdapter):
         quote: dict[str, Any],
         strategy_name: str | None = None,
     ) -> tuple[bool, Any]:
-        chain_id = from_token["chain"]["id"]
-
         calldata = quote.get("calldata")
-        if not calldata or not calldata.get("data"):
-            return (False, "Quote missing calldata")
-
-        transaction = {
-            **calldata,
-            "chainId": chain_id,
-            "from": Web3.to_checksum_address(from_address),
-        }
-        if "value" in calldata:
-            transaction["value"] = int(calldata["value"])
-
-        approve_amount = (
-            quote.get("input_amount")
-            or quote.get("inputAmount")
-            or transaction.get("value")
+        is_solana_quote = bool(calldata) and (
+            calldata.get("chainType") == "solana"
+            or is_solana_chain(calldata.get("chainId"))
         )
-        token_address = from_token.get("address")
 
-        spender = transaction.get("to")
-        if (
-            token_address
-            and spender
-            and approve_amount
-            and not is_native_token(token_address)
-        ):
-            await ensure_allowance(
-                token_address=token_address,
-                owner=from_address,
-                spender=spender,
-                amount=int(approve_amount),
-                chain_id=chain_id,
-                signing_callback=self.sign_callback,
+        if is_solana_quote:
+            # Solana quotes carry a pre-built transaction envelope: no
+            # checksumming (base58 addresses) and no allowance step (SPL
+            # transfers are authorized by the transaction signature itself).
+            serialized = calldata.get("serializedTransaction")
+            if not serialized:
+                return (False, "Quote missing serializedTransaction")
+            raw_chain_id = calldata.get("chainId")
+            if raw_chain_id is None:
+                raw_chain_id = (from_token.get("chain") or {}).get("id")
+            chain_id = (
+                int(raw_chain_id) if raw_chain_id is not None else CHAIN_ID_SOLANA
             )
+            txn_hash = await send_solana_versioned_transaction(
+                serialized,
+                self.sign_callback,
+                chain_id=chain_id,
+            )
+        else:
+            chain_id = from_token["chain"]["id"]
 
-        txn_hash = await send_transaction(transaction, self.sign_callback)
+            if not calldata or not calldata.get("data"):
+                return (False, "Quote missing calldata")
+
+            transaction = {
+                **calldata,
+                "chainId": chain_id,
+                "from": Web3.to_checksum_address(from_address),
+            }
+            if "value" in calldata:
+                transaction["value"] = int(calldata["value"])
+
+            approve_amount = (
+                quote.get("input_amount")
+                or quote.get("inputAmount")
+                or transaction.get("value")
+            )
+            token_address = from_token.get("address")
+
+            spender = transaction.get("to")
+            if (
+                token_address
+                and spender
+                and approve_amount
+                and not is_native_token(token_address)
+            ):
+                await ensure_allowance(
+                    token_address=token_address,
+                    owner=from_address,
+                    spender=spender,
+                    amount=int(approve_amount),
+                    chain_id=chain_id,
+                    signing_callback=self.sign_callback,
+                )
+
+            txn_hash = await send_transaction(transaction, self.sign_callback)
         self.logger.info(f"Swap broadcast: tx={txn_hash}")
 
         try:

--- a/wayfinder_paths/adapters/brap_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/brap_adapter/test_adapter.py
@@ -1,8 +1,45 @@
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from wayfinder_paths.adapters.brap_adapter.adapter import BRAPAdapter
+
+_ADAPTER_MODULE = "wayfinder_paths.adapters.brap_adapter.adapter"
+
+SOL_OWNER = "4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T"
+USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+WRAPPED_SOL_MINT = "So11111111111111111111111111111111111111112"
+
+SOLANA_FROM_TOKEN = {
+    "id": 101,
+    "token_id": "solana",
+    "address": WRAPPED_SOL_MINT,
+    "decimals": 9,
+    "chain": {"id": 900},
+}
+SOLANA_TO_TOKEN = {
+    "id": 102,
+    "token_id": "usd-coin-solana",
+    "address": USDC_MINT,
+    "decimals": 6,
+    "chain": {"id": 900},
+}
+
+
+def _solana_quote() -> dict:
+    return {
+        "provider": "jupiter",
+        "input_amount": 1_000_000_000,
+        "output_amount": 150_000_000,
+        "from_amount_usd": 150.0,
+        "to_amount_usd": 149.5,
+        "calldata": {
+            "chainType": "solana",
+            "chainId": 900,
+            "serializedTransaction": "c2VyaWFsaXplZC10eA==",
+            "lastValidBlockHeight": 250_000_000,
+        },
+    }
 
 
 class TestBRAPAdapter:
@@ -94,3 +131,160 @@ class TestBRAPAdapter:
 
     def test_adapter_type(self, adapter):
         assert adapter.adapter_type == "BRAP"
+
+    @pytest.mark.asyncio
+    async def test_swap_from_quote_solana_envelope(self):
+        sign_callback = AsyncMock()
+        adapter = BRAPAdapter(sign_callback=sign_callback, wallet_address=SOL_OWNER)
+        adapter.ledger_adapter.record_operation = AsyncMock(
+            return_value=(True, {"id": "ledger-1"})
+        )
+        quote = _solana_quote()
+        signature = "5SigBase58SignatureFromSvmSend"
+
+        with (
+            patch(
+                f"{_ADAPTER_MODULE}.send_solana_versioned_transaction",
+                new=AsyncMock(return_value=signature),
+            ) as mock_svm_send,
+            patch(
+                f"{_ADAPTER_MODULE}.send_transaction", new=AsyncMock()
+            ) as mock_evm_send,
+            patch(
+                f"{_ADAPTER_MODULE}.ensure_allowance", new=AsyncMock()
+            ) as mock_allowance,
+            patch(f"{_ADAPTER_MODULE}.Web3", new=MagicMock()) as mock_web3,
+        ):
+            success, payload = await adapter.swap_from_quote(
+                from_token=SOLANA_FROM_TOKEN,
+                to_token=SOLANA_TO_TOKEN,
+                from_address=SOL_OWNER,
+                quote=quote,
+            )
+
+        assert success is True
+        assert payload["tx_hash"] == signature
+        assert payload["from_amount"] == quote["input_amount"]
+        assert payload["to_amount"] == quote["output_amount"]
+        assert payload["ledger_record"] == {"id": "ledger-1"}
+
+        # Envelope routed straight to the SVM send flow.
+        mock_svm_send.assert_awaited_once_with(
+            "c2VyaWFsaXplZC10eA==", sign_callback, chain_id=900
+        )
+        # No EVM machinery: no checksumming, no allowance, no EVM broadcast.
+        mock_web3.to_checksum_address.assert_not_called()
+        mock_allowance.assert_not_awaited()
+        mock_evm_send.assert_not_awaited()
+
+        # Swap operation recorded with the base58 signature as the tx hash.
+        adapter.ledger_adapter.record_operation.assert_awaited_once()
+        record_kwargs = adapter.ledger_adapter.record_operation.await_args.kwargs
+        assert record_kwargs["wallet_address"] == SOL_OWNER
+        operation = record_kwargs["operation_data"]
+        assert operation.transaction_hash == signature
+        assert operation.transaction_chain_id == 900
+        assert operation.from_amount == str(quote["input_amount"])
+        assert operation.to_amount == str(quote["output_amount"])
+
+    @pytest.mark.asyncio
+    async def test_swap_from_quote_solana_missing_serialized_transaction(self):
+        adapter = BRAPAdapter(sign_callback=AsyncMock(), wallet_address=SOL_OWNER)
+        quote = _solana_quote()
+        del quote["calldata"]["serializedTransaction"]
+
+        with patch(
+            f"{_ADAPTER_MODULE}.send_solana_versioned_transaction", new=AsyncMock()
+        ) as mock_svm_send:
+            success, error = await adapter.swap_from_quote(
+                from_token=SOLANA_FROM_TOKEN,
+                to_token=SOLANA_TO_TOKEN,
+                from_address=SOL_OWNER,
+                quote=quote,
+            )
+
+        assert success is False
+        assert error == "Quote missing serializedTransaction"
+        mock_svm_send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_swap_from_quote_evm_regression(self):
+        sign_callback = AsyncMock()
+        from_address = "0x1234567890123456789012345678901234567890"
+        from_token = {
+            "id": 1,
+            "token_id": "usd-coin-base",
+            "address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "decimals": 6,
+            "chain": {"id": 8453},
+        }
+        to_token = {
+            "id": 2,
+            "token_id": "weth-base",
+            "address": "0x4200000000000000000000000000000000000006",
+            "decimals": 18,
+            "chain": {"id": 8453},
+        }
+        quote = {
+            "provider": "enso",
+            "input_amount": 1_000_000,
+            "output_amount": 400_000_000_000_000,
+            "from_amount_usd": 1.0,
+            "to_amount_usd": 0.99,
+            "calldata": {
+                "data": "0xdeadbeef",
+                "to": "0x1111111111111111111111111111111111111111",
+                "value": "0",
+                "chainId": 8453,
+            },
+        }
+        adapter = BRAPAdapter(sign_callback=sign_callback, wallet_address=from_address)
+        adapter.ledger_adapter.record_operation = AsyncMock(
+            return_value=(True, {"id": "ledger-2"})
+        )
+
+        with (
+            patch(
+                f"{_ADAPTER_MODULE}.send_transaction",
+                new=AsyncMock(return_value="0xevmhash"),
+            ) as mock_evm_send,
+            patch(
+                f"{_ADAPTER_MODULE}.ensure_allowance", new=AsyncMock()
+            ) as mock_allowance,
+            patch(
+                f"{_ADAPTER_MODULE}.send_solana_versioned_transaction",
+                new=AsyncMock(),
+            ) as mock_svm_send,
+        ):
+            success, payload = await adapter.swap_from_quote(
+                from_token=from_token,
+                to_token=to_token,
+                from_address=from_address,
+                quote=quote,
+            )
+
+        assert success is True
+        assert payload["tx_hash"] == "0xevmhash"
+        mock_svm_send.assert_not_awaited()
+
+        mock_allowance.assert_awaited_once_with(
+            token_address=from_token["address"],
+            owner=from_address,
+            spender="0x1111111111111111111111111111111111111111",
+            amount=1_000_000,
+            chain_id=8453,
+            signing_callback=sign_callback,
+        )
+
+        mock_evm_send.assert_awaited_once()
+        transaction = mock_evm_send.await_args.args[0]
+        assert transaction["chainId"] == 8453
+        assert transaction["from"] == from_address
+        assert transaction["data"] == "0xdeadbeef"
+        assert transaction["value"] == 0
+
+        operation = adapter.ledger_adapter.record_operation.await_args.kwargs[
+            "operation_data"
+        ]
+        assert operation.transaction_hash == "0xevmhash"
+        assert operation.transaction_chain_id == 8453

--- a/wayfinder_paths/core/utils/svm_tokens.py
+++ b/wayfinder_paths/core/utils/svm_tokens.py
@@ -1,20 +1,30 @@
-"""Solana (SVM) token balances and mint metadata.
+"""Solana (SVM) token balances, mint metadata, and transfer envelopes.
 
 Mirrors the EVM token layer in ``core/utils/tokens.py`` for chain id 900:
-native SOL + SPL balances and mint decimals, built on the ``AsyncClient``
-context manager in ``svm.py``. Token-2022 aware.
+native SOL + SPL balances, mint decimals, and the unsigned transfer envelope
+builder, built on the ``AsyncClient`` context manager in ``svm.py``.
+Token-2022 aware.
 """
 
 from __future__ import annotations
 
+import base64
+
 from solana.rpc.async_api import AsyncClient
+from solders.instruction import Instruction
+from solders.message import MessageV0
 from solders.pubkey import Pubkey
+from solders.signature import Signature
+from solders.system_program import TransferParams, transfer
+from solders.transaction import VersionedTransaction
 from spl.token._layouts import MINT_LAYOUT
 from spl.token.constants import (
     ASSOCIATED_TOKEN_PROGRAM_ID,
     TOKEN_2022_PROGRAM_ID,
     TOKEN_PROGRAM_ID,
 )
+from spl.token.instructions import create_associated_token_account, transfer_checked
+from spl.token.models import TransferCheckedParams
 
 from wayfinder_paths.core.constants.chains import CHAIN_ID_SOLANA
 from wayfinder_paths.core.utils.svm import solana_client_from_chain_id
@@ -86,20 +96,159 @@ async def get_spl_token_balance(
 
 
 async def get_solana_token_balance(
-    wallet_address: str, token_address: str, chain_id: int = CHAIN_ID_SOLANA
+    wallet_address: str, token_address: str | None, chain_id: int = CHAIN_ID_SOLANA
 ) -> int:
     if is_native_token(token_address):
         return await get_sol_balance(wallet_address, chain_id)
+    assert token_address is not None  # is_native_token(None) is True
     return await get_spl_token_balance(wallet_address, token_address, chain_id)
 
 
-async def get_spl_mint_decimals(mint: str, chain_id: int = CHAIN_ID_SOLANA) -> int:
+async def _get_mint_decimals(client: AsyncClient, mint: Pubkey) -> int:
+    info = await _get_mint_account(client, mint)
+    data = bytes(info.data)
+    if len(data) < MINT_LAYOUT.sizeof():
+        raise ValueError(f"Account {mint} does not look like an SPL mint")
+    return int(MINT_LAYOUT.parse(data).decimals)
+
+
+async def get_spl_mint_decimals(
+    mint: str | None, chain_id: int = CHAIN_ID_SOLANA
+) -> int:
     """Decimals for an SPL mint (native SOL sentinel returns 9)."""
     if is_native_token(mint):
         return SOL_DECIMALS
+    assert mint is not None  # is_native_token(None) is True
     async with solana_client_from_chain_id(chain_id) as client:
-        info = await _get_mint_account(client, Pubkey.from_string(mint))
-        data = bytes(info.data)
-        if len(data) < MINT_LAYOUT.sizeof():
-            raise ValueError(f"Account {mint} does not look like an SPL mint")
-        return int(MINT_LAYOUT.parse(data).decimals)
+        return await _get_mint_decimals(client, Pubkey.from_string(mint))
+
+
+def _serialize_unsigned(message: MessageV0) -> str:
+    """Serialize a compiled message as an unsigned VersionedTransaction (base64)."""
+    placeholder_signatures = [
+        Signature.default() for _ in range(message.header.num_required_signatures)
+    ]
+    tx = VersionedTransaction.populate(message, placeholder_signatures)
+    return base64.b64encode(bytes(tx)).decode("ascii")
+
+
+def _create_ata_idempotent_instruction(
+    payer: Pubkey, owner: Pubkey, mint: Pubkey, token_program_id: Pubkey
+) -> Instruction:
+    """CreateIdempotent variant of the associated-token-account instruction.
+
+    The installed spl helper only emits plain Create (empty instruction data),
+    which fails if the account already exists. CreateIdempotent (discriminator
+    ``1``) is a no-op in that case, so a transfer built while the recipient's
+    ATA was missing cannot be raced by a concurrent ATA creation.
+    """
+    base = create_associated_token_account(
+        payer=payer, owner=owner, mint=mint, token_program_id=token_program_id
+    )
+    return Instruction(
+        program_id=base.program_id, data=bytes([1]), accounts=base.accounts
+    )
+
+
+async def build_solana_send_transaction(
+    from_address: str,
+    to_address: str,
+    token_address: str | None,
+    amount: int,
+    chain_id: int = CHAIN_ID_SOLANA,
+) -> dict:
+    """Build an unsigned SOL/SPL transfer and return the Solana tx envelope.
+
+    Returns the shared Solana transaction envelope used across the stack:
+
+        {
+            "chainType": "solana",
+            "chainId": 900,
+            "serializedTransaction": "<base64>",
+            "lastValidBlockHeight": <int>,
+        }
+
+    The transaction is serialized UNSIGNED (placeholder signatures) with the
+    sender as fee payer. Native SOL uses a system transfer; SPL tokens use
+    ``transfer_checked``, prepended with an idempotent ATA-create for the
+    recipient when their associated token account does not exist yet (rent
+    paid by the sender). Token-2022 aware via the mint account's owner.
+
+    Args:
+        from_address: Sender (and fee payer) base58 address.
+        to_address: Recipient base58 address.
+        token_address: SPL mint address, or a native sentinel/None for SOL.
+        amount: Amount in raw base units (lamports for SOL).
+        chain_id: Internal Solana chain id (900).
+    """
+    if amount <= 0:
+        raise ValueError("Transfer amount must be positive")
+
+    from_pubkey = Pubkey.from_string(from_address)
+    to_pubkey = Pubkey.from_string(to_address)
+
+    async with solana_client_from_chain_id(chain_id) as client:
+        instructions: list[Instruction] = []
+
+        if is_native_token(token_address):
+            instructions.append(
+                transfer(
+                    TransferParams(
+                        from_pubkey=from_pubkey,
+                        to_pubkey=to_pubkey,
+                        lamports=amount,
+                    )
+                )
+            )
+        else:
+            assert token_address is not None  # is_native_token(None) is True
+            mint = Pubkey.from_string(token_address)
+            program_id = await _resolve_token_program_id(client, mint)
+            source_ata = get_associated_token_address(from_pubkey, mint, program_id)
+            dest_ata = get_associated_token_address(to_pubkey, mint, program_id)
+
+            dest_info = (await client.get_account_info(dest_ata)).value
+            if dest_info is None:
+                # Recipient has no associated token account yet — the sender
+                # pays rent to create it as part of the same transaction.
+                instructions.append(
+                    _create_ata_idempotent_instruction(
+                        payer=from_pubkey,
+                        owner=to_pubkey,
+                        mint=mint,
+                        token_program_id=program_id,
+                    )
+                )
+
+            decimals = await _get_mint_decimals(client, mint)
+            instructions.append(
+                transfer_checked(
+                    TransferCheckedParams(
+                        program_id=program_id,
+                        source=source_ata,
+                        mint=mint,
+                        dest=dest_ata,
+                        owner=from_pubkey,
+                        amount=amount,
+                        decimals=decimals,
+                    )
+                )
+            )
+
+        blockhash_resp = await client.get_latest_blockhash()
+        recent_blockhash = blockhash_resp.value.blockhash
+        last_valid_block_height = int(blockhash_resp.value.last_valid_block_height)
+
+    message = MessageV0.try_compile(
+        payer=from_pubkey,
+        instructions=instructions,
+        address_lookup_table_accounts=[],
+        recent_blockhash=recent_blockhash,
+    )
+
+    return {
+        "chainType": "solana",
+        "chainId": int(chain_id),
+        "serializedTransaction": _serialize_unsigned(message),
+        "lastValidBlockHeight": last_valid_block_height,
+    }

--- a/wayfinder_paths/core/utils/tokens.py
+++ b/wayfinder_paths/core/utils/tokens.py
@@ -93,6 +93,16 @@ async def get_token_balance(
     web3: AsyncWeb3 | None = None,
     block_identifier: str | int = "pending",
 ) -> int:
+    # Local imports: svm_tokens imports is_native_token from this module at
+    # module level, so a top-level reverse import would create a cycle.
+    from wayfinder_paths.core.utils.svm import is_solana_chain
+
+    if is_solana_chain(chain_id):
+        # web3/block_identifier are EVM-only and ignored on this branch.
+        from wayfinder_paths.core.utils.svm_tokens import get_solana_token_balance
+
+        return await get_solana_token_balance(wallet_address, token_address, chain_id)
+
     async def _read_with_web3(w3: AsyncWeb3) -> int:
         checksum_wallet = w3.to_checksum_address(wallet_address)
 
@@ -127,6 +137,16 @@ async def get_token_decimals(
     block_identifier: str | int = "latest",
     default_native_decimals: int = 18,
 ) -> int:
+    from wayfinder_paths.core.utils.svm import is_solana_chain
+
+    if is_solana_chain(chain_id):
+        # Native SOL is always 9 decimals (the sentinel check inside returns
+        # 9 without an RPC call); web3/block_identifier/default_native_decimals
+        # are EVM-only and ignored on this branch.
+        from wayfinder_paths.core.utils.svm_tokens import get_spl_mint_decimals
+
+        return await get_spl_mint_decimals(token_address, chain_id)
+
     async def _read_with_web3(w3: AsyncWeb3) -> int:
         if is_native_token(token_address):
             return int(default_native_decimals)
@@ -157,6 +177,22 @@ async def get_token_balance_with_decimals(
     decimals_block_identifier: str | int = "latest",
     default_native_decimals: int = 18,
 ) -> tuple[int, int]:
+    from wayfinder_paths.core.utils.svm import is_solana_chain
+
+    if is_solana_chain(chain_id):
+        # web3/block identifiers/default_native_decimals are EVM-only and
+        # ignored on this branch (native SOL is always 9 decimals).
+        from wayfinder_paths.core.utils.svm_tokens import (
+            get_solana_token_balance,
+            get_spl_mint_decimals,
+        )
+
+        balance, decimals = await asyncio.gather(
+            get_solana_token_balance(wallet_address, token_address, chain_id),
+            get_spl_mint_decimals(token_address, chain_id),
+        )
+        return int(balance), int(decimals)
+
     async def _read_with_web3(w3: AsyncWeb3) -> tuple[int, int]:
         checksum_wallet = w3.to_checksum_address(wallet_address)
 
@@ -233,6 +269,21 @@ async def build_send_transaction(
     chain_id: int,
     amount: int,
 ) -> dict:
+    from wayfinder_paths.core.utils.svm import is_solana_chain
+
+    if is_solana_chain(chain_id):
+        # Returns the Solana transaction envelope:
+        # {"chainType", "chainId", "serializedTransaction", "lastValidBlockHeight"}
+        from wayfinder_paths.core.utils.svm_tokens import build_solana_send_transaction
+
+        return await build_solana_send_transaction(
+            from_address=from_address,
+            to_address=to_address,
+            token_address=token_address,
+            amount=amount,
+            chain_id=chain_id,
+        )
+
     async with web3_from_chain_id(chain_id) as web3:
         from_checksum = web3.to_checksum_address(from_address)
         to_checksum = web3.to_checksum_address(to_address)

--- a/wayfinder_paths/tests/test_svm_utils.py
+++ b/wayfinder_paths/tests/test_svm_utils.py
@@ -3,21 +3,32 @@ from __future__ import annotations
 import base64
 from contextlib import asynccontextmanager, contextmanager
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from solders.hash import Hash
 from solders.pubkey import Pubkey
 from solders.signature import Signature
+from solders.system_program import ID as SYS_PROGRAM_ID
+from solders.system_program import TransferParams, transfer
+from solders.transaction import VersionedTransaction
 from solders.transaction_status import TransactionConfirmationStatus
 from spl.token._layouts import MINT_LAYOUT
-from spl.token.constants import TOKEN_2022_PROGRAM_ID, TOKEN_PROGRAM_ID
+from spl.token.constants import (
+    ASSOCIATED_TOKEN_PROGRAM_ID,
+    TOKEN_2022_PROGRAM_ID,
+    TOKEN_PROGRAM_ID,
+)
 from spl.token.instructions import get_associated_token_address as spl_reference_ata
+from spl.token.instructions import transfer_checked
+from spl.token.models import TransferCheckedParams
 
 from wayfinder_paths.core.constants.chains import (
     CHAIN_ID_BASE,
     CHAIN_ID_SOLANA,
     SVM_CHAIN_IDS,
 )
+from wayfinder_paths.core.utils import tokens
 from wayfinder_paths.core.utils.svm import (
     is_solana_chain,
     solana_client_from_chain_id,
@@ -25,6 +36,7 @@ from wayfinder_paths.core.utils.svm import (
 from wayfinder_paths.core.utils.svm_tokens import (
     SOL_NATIVE_SENTINEL,
     WRAPPED_SOL_MINT,
+    build_solana_send_transaction,
     get_associated_token_address,
     get_sol_balance,
     get_solana_token_balance,
@@ -39,9 +51,33 @@ from wayfinder_paths.core.utils.token_refs import looks_like_solana_address
 
 USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
 OWNER = "4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T"
+RECIPIENT = str(Pubkey.from_bytes(b"\x07" * 32))
 # Derived offline with solana-py's reference implementation.
 EXPECTED_USDC_ATA = "F8biqkCRK2tHR6EncrcXDGgVTkGRrtojqyW39w41Qspn"
 EXPECTED_USDC_ATA_2022 = "8UQrn3SEPVqkggQ7Y7QEpGxutSyYQgJVFsgSxzwge858"
+
+
+def _mint_data(decimals: int) -> bytes:
+    return MINT_LAYOUT.build(
+        {
+            "mint_authority_option": 0,
+            "mint_authority": bytes(32),
+            "supply": 1_000_000,
+            "decimals": decimals,
+            "is_initialized": 1,
+            "freeze_authority_option": 0,
+            "freeze_authority": bytes(32),
+        }
+    )
+
+
+def _blockhash_resp(last_valid_block_height: int = 250_000_000) -> SimpleNamespace:
+    return SimpleNamespace(
+        value=SimpleNamespace(
+            blockhash=Hash.default(),
+            last_valid_block_height=last_valid_block_height,
+        )
+    )
 
 
 @contextmanager
@@ -266,17 +302,7 @@ async def test_get_solana_token_balance_dispatch():
 
 @pytest.mark.asyncio
 async def test_get_spl_mint_decimals():
-    mint_data = MINT_LAYOUT.build(
-        {
-            "mint_authority_option": 0,
-            "mint_authority": bytes(32),
-            "supply": 1_000_000,
-            "decimals": 6,
-            "is_initialized": 1,
-            "freeze_authority_option": 0,
-            "freeze_authority": bytes(32),
-        }
-    )
+    mint_data = _mint_data(decimals=6)
     fake = AsyncMock()
     fake.get_account_info = AsyncMock(
         return_value=SimpleNamespace(
@@ -435,3 +461,361 @@ async def test_token_resolver_meta_solana_mint():
     assert meta["address"] == USDC_MINT
     assert meta["decimals"] == 6
     assert meta["metadata"]["source"] == "address"
+
+
+# ---------------------------------------------------------------------------
+# Transfer envelope builder (mocked RPC)
+# ---------------------------------------------------------------------------
+
+
+def _decode_envelope(envelope: dict) -> VersionedTransaction:
+    assert envelope["chainType"] == "solana"
+    assert envelope["chainId"] == CHAIN_ID_SOLANA
+    return VersionedTransaction.from_bytes(
+        base64.b64decode(envelope["serializedTransaction"])
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("token_address", [None, SOL_NATIVE_SENTINEL, "native"])
+async def test_build_solana_send_transaction_native(token_address):
+    fake = AsyncMock()
+    fake.get_latest_blockhash = AsyncMock(return_value=_blockhash_resp())
+    with _patch_client(fake):
+        envelope = await build_solana_send_transaction(
+            OWNER, RECIPIENT, token_address, 1_000_000
+        )
+
+    assert envelope["lastValidBlockHeight"] == 250_000_000
+    tx = _decode_envelope(envelope)
+    msg = tx.message
+
+    # Sender is fee payer; single system transfer instruction.
+    assert msg.account_keys[0] == Pubkey.from_string(OWNER)
+    assert len(msg.instructions) == 1
+    ix = msg.instructions[0]
+    assert msg.account_keys[ix.program_id_index] == SYS_PROGRAM_ID
+    expected = transfer(
+        TransferParams(
+            from_pubkey=Pubkey.from_string(OWNER),
+            to_pubkey=Pubkey.from_string(RECIPIENT),
+            lamports=1_000_000,
+        )
+    )
+    assert bytes(ix.data) == bytes(expected.data)
+
+    # Unsigned envelope: placeholder signatures only.
+    assert len(tx.signatures) == msg.header.num_required_signatures
+    assert all(sig == Signature.default() for sig in tx.signatures)
+    # Native path needs no account reads.
+    fake.get_account_info.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_build_solana_send_transaction_spl_existing_ata():
+    mint_account = SimpleNamespace(owner=TOKEN_PROGRAM_ID, data=_mint_data(decimals=6))
+    fake = AsyncMock()
+    fake.get_account_info = AsyncMock(
+        side_effect=[
+            SimpleNamespace(value=mint_account),  # token program resolve
+            SimpleNamespace(value=SimpleNamespace(owner=TOKEN_PROGRAM_ID)),  # dest ATA
+            SimpleNamespace(value=mint_account),  # decimals
+        ]
+    )
+    fake.get_latest_blockhash = AsyncMock(return_value=_blockhash_resp())
+    with _patch_client(fake):
+        envelope = await build_solana_send_transaction(
+            OWNER, RECIPIENT, USDC_MINT, 2_500_000
+        )
+
+    tx = _decode_envelope(envelope)
+    msg = tx.message
+
+    owner = Pubkey.from_string(OWNER)
+    recipient = Pubkey.from_string(RECIPIENT)
+    mint = Pubkey.from_string(USDC_MINT)
+    dest_ata = get_associated_token_address(recipient, mint, TOKEN_PROGRAM_ID)
+
+    # Existing ATA: no create instruction, just transfer_checked.
+    assert len(msg.instructions) == 1
+    ix = msg.instructions[0]
+    assert msg.account_keys[ix.program_id_index] == TOKEN_PROGRAM_ID
+    expected = transfer_checked(
+        TransferCheckedParams(
+            program_id=TOKEN_PROGRAM_ID,
+            source=get_associated_token_address(owner, mint, TOKEN_PROGRAM_ID),
+            mint=mint,
+            dest=dest_ata,
+            owner=owner,
+            amount=2_500_000,
+            decimals=6,
+        )
+    )
+    assert bytes(ix.data) == bytes(expected.data)
+    assert dest_ata in list(msg.account_keys)
+    # The existence probe hit the derived destination ATA.
+    assert fake.get_account_info.await_args_list[1].args[0] == dest_ata
+
+
+@pytest.mark.asyncio
+async def test_build_solana_send_transaction_spl_missing_ata():
+    mint_account = SimpleNamespace(owner=TOKEN_PROGRAM_ID, data=_mint_data(decimals=6))
+    fake = AsyncMock()
+    fake.get_account_info = AsyncMock(
+        side_effect=[
+            SimpleNamespace(value=mint_account),  # token program resolve
+            SimpleNamespace(value=None),  # dest ATA missing
+            SimpleNamespace(value=mint_account),  # decimals
+        ]
+    )
+    fake.get_latest_blockhash = AsyncMock(return_value=_blockhash_resp())
+    with _patch_client(fake):
+        envelope = await build_solana_send_transaction(OWNER, RECIPIENT, USDC_MINT, 42)
+
+    tx = _decode_envelope(envelope)
+    msg = tx.message
+
+    # Missing ATA: idempotent create for the recipient, then transfer_checked.
+    assert len(msg.instructions) == 2
+    create_ix, transfer_ix = msg.instructions
+    assert msg.account_keys[create_ix.program_id_index] == ASSOCIATED_TOKEN_PROGRAM_ID
+    assert bytes(create_ix.data) == bytes([1])  # CreateIdempotent discriminator
+    assert msg.account_keys[transfer_ix.program_id_index] == TOKEN_PROGRAM_ID
+    assert bytes(transfer_ix.data)[0] == 12  # TransferChecked discriminator
+
+    # The create instruction's payer is the sender.
+    assert msg.account_keys[create_ix.accounts[0]] == Pubkey.from_string(OWNER)
+
+
+@pytest.mark.asyncio
+async def test_build_solana_send_transaction_token_2022():
+    mint_account = SimpleNamespace(
+        owner=TOKEN_2022_PROGRAM_ID, data=_mint_data(decimals=9)
+    )
+    fake = AsyncMock()
+    fake.get_account_info = AsyncMock(
+        side_effect=[
+            SimpleNamespace(value=mint_account),  # token program resolve
+            SimpleNamespace(value=None),  # dest ATA missing
+            SimpleNamespace(value=mint_account),  # decimals
+        ]
+    )
+    fake.get_latest_blockhash = AsyncMock(return_value=_blockhash_resp())
+    with _patch_client(fake):
+        envelope = await build_solana_send_transaction(OWNER, RECIPIENT, USDC_MINT, 10)
+
+    tx = _decode_envelope(envelope)
+    msg = tx.message
+
+    recipient = Pubkey.from_string(RECIPIENT)
+    mint = Pubkey.from_string(USDC_MINT)
+
+    assert len(msg.instructions) == 2
+    create_ix, transfer_ix = msg.instructions
+    # Transfer runs under Token-2022, and the ATA is derived under Token-2022.
+    assert msg.account_keys[transfer_ix.program_id_index] == TOKEN_2022_PROGRAM_ID
+    dest_ata_2022 = get_associated_token_address(recipient, mint, TOKEN_2022_PROGRAM_ID)
+    assert dest_ata_2022 in list(msg.account_keys)
+    assert get_associated_token_address(recipient, mint, TOKEN_PROGRAM_ID) not in list(
+        msg.account_keys
+    )
+    assert bytes(create_ix.data) == bytes([1])
+    assert bytes(transfer_ix.data)[9] == 9  # transfer_checked decimals byte
+
+
+@pytest.mark.asyncio
+async def test_build_solana_send_transaction_rejects_nonpositive_amount():
+    with pytest.raises(ValueError, match="must be positive"):
+        await build_solana_send_transaction(OWNER, RECIPIENT, None, 0)
+    with pytest.raises(ValueError, match="must be positive"):
+        await build_solana_send_transaction(OWNER, RECIPIENT, USDC_MINT, -1)
+
+
+# ---------------------------------------------------------------------------
+# tokens.py choke-point dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_token_balance_dispatches_to_solana():
+    mock_solana = AsyncMock(return_value=42)
+    with (
+        patch(
+            "wayfinder_paths.core.utils.svm_tokens.get_solana_token_balance",
+            new=mock_solana,
+        ),
+        patch("wayfinder_paths.core.utils.tokens.web3_from_chain_id") as mock_web3,
+    ):
+        out = await tokens.get_token_balance(USDC_MINT, CHAIN_ID_SOLANA, OWNER)
+
+    assert out == 42
+    mock_solana.assert_awaited_once_with(OWNER, USDC_MINT, CHAIN_ID_SOLANA)
+    mock_web3.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_token_decimals_solana_native_is_nine():
+    with patch("wayfinder_paths.core.utils.tokens.web3_from_chain_id") as mock_web3:
+        assert await tokens.get_token_decimals(None, CHAIN_ID_SOLANA) == 9
+        assert (
+            await tokens.get_token_decimals(SOL_NATIVE_SENTINEL, CHAIN_ID_SOLANA) == 9
+        )
+        # The EVM-only default_native_decimals is ignored on the Solana branch.
+        assert (
+            await tokens.get_token_decimals(
+                None, CHAIN_ID_SOLANA, default_native_decimals=18
+            )
+            == 9
+        )
+    mock_web3.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_token_decimals_dispatches_to_solana_mint():
+    mock_decimals = AsyncMock(return_value=6)
+    with (
+        patch(
+            "wayfinder_paths.core.utils.svm_tokens.get_spl_mint_decimals",
+            new=mock_decimals,
+        ),
+        patch("wayfinder_paths.core.utils.tokens.web3_from_chain_id") as mock_web3,
+    ):
+        assert await tokens.get_token_decimals(USDC_MINT, CHAIN_ID_SOLANA) == 6
+
+    mock_decimals.assert_awaited_once_with(USDC_MINT, CHAIN_ID_SOLANA)
+    mock_web3.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_token_balance_with_decimals_dispatches_to_solana():
+    with (
+        patch(
+            "wayfinder_paths.core.utils.svm_tokens.get_solana_token_balance",
+            new=AsyncMock(return_value=123_456),
+        ) as mock_balance,
+        patch(
+            "wayfinder_paths.core.utils.svm_tokens.get_spl_mint_decimals",
+            new=AsyncMock(return_value=6),
+        ) as mock_decimals,
+        patch("wayfinder_paths.core.utils.tokens.web3_from_chain_id") as mock_web3,
+    ):
+        out = await tokens.get_token_balance_with_decimals(
+            USDC_MINT, CHAIN_ID_SOLANA, OWNER
+        )
+
+    assert out == (123_456, 6)
+    mock_balance.assert_awaited_once_with(OWNER, USDC_MINT, CHAIN_ID_SOLANA)
+    mock_decimals.assert_awaited_once_with(USDC_MINT, CHAIN_ID_SOLANA)
+    mock_web3.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_build_send_transaction_dispatches_to_solana():
+    envelope = {
+        "chainType": "solana",
+        "chainId": CHAIN_ID_SOLANA,
+        "serializedTransaction": "AAo=",
+        "lastValidBlockHeight": 1,
+    }
+    mock_build = AsyncMock(return_value=envelope)
+    with (
+        patch(
+            "wayfinder_paths.core.utils.svm_tokens.build_solana_send_transaction",
+            new=mock_build,
+        ),
+        patch("wayfinder_paths.core.utils.tokens.web3_from_chain_id") as mock_web3,
+    ):
+        out = await tokens.build_send_transaction(
+            from_address=OWNER,
+            to_address=RECIPIENT,
+            token_address=USDC_MINT,
+            chain_id=CHAIN_ID_SOLANA,
+            amount=5,
+        )
+
+    assert out is envelope
+    mock_build.assert_awaited_once_with(
+        from_address=OWNER,
+        to_address=RECIPIENT,
+        token_address=USDC_MINT,
+        amount=5,
+        chain_id=CHAIN_ID_SOLANA,
+    )
+    mock_web3.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_token_balance_evm_path_bypasses_solana_dispatch():
+    fake_w3 = MagicMock()
+    fake_w3.to_checksum_address = lambda addr: addr
+    fake_w3.eth.get_balance = AsyncMock(return_value=5)
+    with patch(
+        "wayfinder_paths.core.utils.svm_tokens.get_solana_token_balance",
+        new=AsyncMock(),
+    ) as mock_solana:
+        out = await tokens.get_token_balance(
+            None, CHAIN_ID_BASE, "0xWallet", web3=fake_w3
+        )
+
+    assert out == 5
+    mock_solana.assert_not_awaited()
+    fake_w3.eth.get_balance.assert_awaited_once_with(
+        "0xWallet", block_identifier="pending"
+    )
+
+
+# ---------------------------------------------------------------------------
+# BalanceAdapter via the choke-point dispatch (mocked svm clients)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_balance_adapter_get_balance_solana():
+    from wayfinder_paths.adapters.balance_adapter.adapter import BalanceAdapter
+
+    adapter = BalanceAdapter(config={})
+    mock_balance = AsyncMock(return_value=999)
+    with patch(
+        "wayfinder_paths.core.utils.svm_tokens.get_solana_token_balance",
+        new=mock_balance,
+    ):
+        ok, balance = await adapter.get_balance(
+            wallet_address=OWNER,
+            token_address=USDC_MINT,
+            chain_id=CHAIN_ID_SOLANA,
+        )
+
+    assert ok is True
+    assert balance == 999
+    mock_balance.assert_awaited_once_with(OWNER, USDC_MINT, CHAIN_ID_SOLANA)
+
+
+@pytest.mark.asyncio
+async def test_balance_adapter_get_balance_details_solana():
+    from wayfinder_paths.adapters.balance_adapter.adapter import BalanceAdapter
+
+    adapter = BalanceAdapter(config={})
+    with (
+        patch(
+            "wayfinder_paths.core.utils.svm_tokens.get_solana_token_balance",
+            new=AsyncMock(return_value=1_234_567),
+        ),
+        patch(
+            "wayfinder_paths.core.utils.svm_tokens.get_spl_mint_decimals",
+            new=AsyncMock(return_value=6),
+        ),
+    ):
+        ok, out = await adapter.get_balance_details(
+            wallet_address=OWNER,
+            token_address=USDC_MINT,
+            chain_id=CHAIN_ID_SOLANA,
+        )
+
+    assert ok is True
+    assert isinstance(out, dict)
+    assert out["chain_id"] == CHAIN_ID_SOLANA
+    assert out["token_address"] == USDC_MINT
+    assert out["wallet_address"] == OWNER
+    assert out["balance_raw"] == 1_234_567
+    assert out["decimals"] == 6
+    assert out["balance_decimal"] == pytest.approx(1.234567)


### PR DESCRIPTION
Stacked on 2/4 and merges 3/4 (both required). `brap_adapter.swap_from_quote` executes Solana envelope quotes via `send_solana_versioned_transaction` (no checksum, no allowance — approvals don't exist on Solana); `balance_adapter` transfer paths (`send_to_address`, `_move_between_wallets`) route Solana envelopes through the same flow. EVM paths unchanged with regression tests.

Tests: targeted 768 passed; full suite 2712 passed with only pre-existing environmental failures (mcp package shadowing on py3.14, proven identical on the base branch).