### PR TITLE
jobs backtest: fast + diagnosable + CPU-safe strategy iteration

### DIFF
--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -21,7 +21,10 @@ from wayfinder_paths.jobs.execution.experiments import (
     promote_params,
     run_experiment,
 )
-from wayfinder_paths.jobs.execution.job import backtest_execution_job
+from wayfinder_paths.jobs.execution.job import (
+    backtest_execution_job,
+    summarize_backtest_payload,
+)
 from wayfinder_paths.jobs.execution.preflight import build_live_dataset, run_preflight
 from wayfinder_paths.jobs.execution.reconcile import reconcile_job
 from wayfinder_paths.jobs.execution.validation import validate_execution_job
@@ -215,8 +218,16 @@ def validate_cmd(job_id: str, strict: bool) -> None:
     default="serial",
     show_default=True,
 )
+@click.option(
+    "--full",
+    is_flag=True,
+    default=False,
+    help="Print the full payload (equity curve, trades, positions, trace, "
+    "visualization) instead of the compact stats summary. The full result is "
+    "always written to results/backtest/ regardless.",
+)
 def backtest_cmd(
-    job_id: str, grid_path: str | None, workers: int, parallel: str
+    job_id: str, grid_path: str | None, workers: int, parallel: str, full: bool
 ) -> None:
     store = JobStore()
     result = backtest_execution_job(
@@ -226,7 +237,11 @@ def backtest_cmd(
         parallel=parallel,
         store=store,
     )
-    _echo_json({"ok": True, "result": result})
+    # Default to the ~2 KB summary — the full payload is ~8 MB and lives on disk
+    # (browse it with `job backtest-view`). `--full` restores the old dump.
+    _echo_json(
+        {"ok": True, "result": result if full else summarize_backtest_payload(result)}
+    )
 
 
 @job_cli.command(

--- a/wayfinder_paths/jobs/execution/job.py
+++ b/wayfinder_paths/jobs/execution/job.py
@@ -29,6 +29,46 @@ from wayfinder_paths.jobs.gating import compute_workspace_revision
 from wayfinder_paths.jobs.models import utc_now_iso
 from wayfinder_paths.jobs.store import JobStore
 
+_HEAVY_RESULT_KEYS = ("equity_curve", "trades", "positions", "trace", "visualization")
+
+
+def summarize_backtest_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Compact view of a backtest payload for stdout / agent context.
+
+    Keeps the decision-grade fields — `stats`, `profile` (timing), `validation`,
+    artifact paths, revision stamp — and drops the multi-MB per-bar arrays
+    (`equity_curve`, `trades`, `positions`, `trace`, `visualization`). Those are
+    all persisted under `results/backtest/` and browsable via `job backtest-view`,
+    so nothing is lost — the full payload can also be requested with `--full`.
+    A single-run backtest payload is ~8 MB; this trims it to ~2 KB.
+    """
+    summary: dict[str, Any] = {
+        k: payload[k]
+        for k in ("type", "artifacts", "stamp", "walk_forward", "validation")
+        if k in payload
+    }
+    result = payload.get("result")
+    if isinstance(result, Mapping):
+        if "ranked" in result:  # grid / optuna result
+            summary["result"] = {
+                k: result[k]
+                for k in ("grid_id", "rank_by", "optimizer", "search")
+                if k in result
+            }
+            summary["result"]["run_count"] = len(result.get("runs") or [])
+            summary["result"]["invalid_count"] = len(result.get("invalid") or [])
+            summary["result"]["ranked"] = [
+                {k: v for k, v in row.items() if k not in _HEAVY_RESULT_KEYS}
+                for row in (result.get("ranked") or [])[:10]
+            ]
+        else:  # single run — the ~8 MB case
+            summary["result"] = {
+                k: result[k]
+                for k in ("run_id", "params", "stats", "validation", "profile")
+                if k in result
+            }
+    return summary
+
 
 def backtest_execution_job(
     job_id: str,

--- a/wayfinder_paths/jobs/execution/simulator.py
+++ b/wayfinder_paths/jobs/execution/simulator.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 import itertools
 import json
+import sys
+import time
 import uuid
 from collections import defaultdict
 from collections.abc import Callable, Mapping
@@ -66,6 +68,10 @@ class ExecutionBacktestResult:
     trace: dict[str, Any]
     validation: dict[str, Any]
     visualization: dict[str, Any]
+    # Run telemetry: wall time, bars/sec, per-bar tick timing, the compute
+    # window used, and a self-diagnostic `hint` when the run looks O(N²).
+    # Additive (default {}) so older callers/readers are unaffected.
+    profile: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -173,6 +179,143 @@ class BacktestBroker:
         )
 
 
+# Default per-bar compute window. Bounding the view the simulator hands each
+# tick keeps the DEFAULT backtest O(N·k) instead of O(N²): a strategy that
+# recomputes indicators over the whole handed frame goes quadratic when that
+# frame grows with the replay index (the classic "simple backtest pegs the
+# CPU" trap). 512 bars covers the lookback of essentially every standard
+# indicator (SMA200, ATR/ADX, long EMAs) with margin. Strategies tune it via
+# `warmup_bars`; genuine since-genesis strategies opt out with
+# `full_history: true`.
+DEFAULT_WARMUP_BARS = 512
+
+
+def _resolve_compute_window(
+    params_data: Mapping[str, Any], strategy: Any
+) -> tuple[int | None, str, bool]:
+    """Size of the trailing view handed to `decide()` each bar.
+
+    Resolution (first hit wins):
+      1. ``params['warmup_bars']``  — explicit, canonical name.
+      2. ``params['lookback_bars']`` — back-compat with the old windowing lever.
+      3. ``strategy.warmup_bars``   — strategy-declared attribute.
+      4. ``DEFAULT_WARMUP_BARS``.
+    ``params['full_history']`` truthy opts back into full-history views.
+
+    Returns ``(window_size | None, source, full_history)``; ``None`` window ⇒
+    full history (``through(index)``).
+    """
+    if params_data.get("full_history"):
+        return None, "full_history", True
+    for key in ("warmup_bars", "lookback_bars"):
+        raw = params_data.get(key)
+        if raw:
+            return max(int(raw), 1), key, False
+    attr = getattr(strategy, "warmup_bars", None)
+    if attr:
+        return max(int(attr), 1), "strategy.warmup_bars", False
+    return DEFAULT_WARMUP_BARS, "default", False
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    rank = (pct / 100.0) * (len(ordered) - 1)
+    lo = int(rank)
+    hi = min(lo + 1, len(ordered) - 1)
+    return ordered[lo] + (ordered[hi] - ordered[lo]) * (rank - lo)
+
+
+def _tick_time_growing(tick_ms: list[float]) -> bool:
+    """True when per-bar time trends up with the replay index — the fingerprint
+    of an O(history) recompute inside `decide()`. Compares the mean of the
+    first decile against the last; needs enough bars to be meaningful."""
+    if len(tick_ms) < 40:
+        return False
+    decile = max(1, len(tick_ms) // 10)
+    first = sum(tick_ms[:decile]) / decile
+    last = sum(tick_ms[-decile:]) / decile
+    return last > 5.0 and last > first * 3.0
+
+
+def _fmt_duration(seconds: float) -> str:
+    seconds = max(0.0, seconds)
+    if seconds < 90:
+        return f"{seconds:.0f}s"
+    return f"{seconds / 60:.1f}m"
+
+
+def _emit_progress(
+    done: int, total: int, wall_start: float, tick_ms: list[float]
+) -> None:
+    elapsed = time.perf_counter() - wall_start
+    rate = done / elapsed if elapsed > 0 else 0.0
+    eta = (total - done) / rate if rate > 0 else 0.0
+    p95 = _percentile(tick_ms, 95)
+    grow = " ↑growing" if _tick_time_growing(tick_ms) else ""
+    print(
+        f"[backtest] bar {done}/{total} · {rate:.0f} bars/s · "
+        f"ETA {_fmt_duration(eta)} · tick p95 {p95:.0f}ms{grow}",
+        file=sys.stderr,
+        flush=True,
+    )
+
+
+def _build_profile(
+    *,
+    tick_ms: list[float],
+    wall_start: float,
+    total_bars: int,
+    window_size: int | None,
+    window_source: str,
+    full_history: bool,
+) -> dict[str, Any]:
+    wall_s = time.perf_counter() - wall_start
+    timed = len(tick_ms)
+    mean_ms = sum(tick_ms) / timed if timed else 0.0
+    growing = _tick_time_growing(tick_ms)
+    profile: dict[str, Any] = {
+        "wall_seconds": round(wall_s, 3),
+        "bars_total": total_bars,
+        "bars_timed": timed,
+        "bars_per_second": round(timed / wall_s, 1) if wall_s > 0 else None,
+        "tick_ms": {
+            "mean": round(mean_ms, 2),
+            "p50": round(_percentile(tick_ms, 50), 2),
+            "p95": round(_percentile(tick_ms, 95), 2),
+            "max": round(max(tick_ms), 2) if tick_ms else 0.0,
+            "last": round(tick_ms[-1], 2) if tick_ms else 0.0,
+        },
+        "compute_window": "full_history" if full_history else window_size,
+        "compute_window_source": window_source,
+        "tick_time_growing": growing,
+    }
+    # Most "why is this backtest so slow" cases are a heavy full recompute in
+    # decide() run once per bar × many bars on a small/throttled box — O(N)
+    # with a big constant, not necessarily O(N²). The projection (measured per
+    # bar × total bars) is machine-relative, so the hint fires exactly when the
+    # run is actually slow on THIS box, and stays quiet when it's fine.
+    if growing:
+        profile["hint"] = (
+            "Per-bar time is growing with the replay index — decide() is "
+            "recomputing over an ever-larger frame (heading toward O(N²)). "
+            "Compute on a bounded trailing window: set `warmup_bars` to your "
+            "longest indicator lookback + a small buffer, or slice "
+            "`ctx.view.window(...)` instead of the full `symbol_frame()`."
+        )
+    elif mean_ms >= 15.0:
+        profile["hint"] = (
+            f"Heavy per-bar work: ~{mean_ms:.0f} ms/bar × {total_bars} bars ≈ "
+            f"{_fmt_duration(mean_ms * total_bars / 1000.0)} for the full run. "
+            "decide() recomputes its indicators from scratch every bar — "
+            "compute them incrementally or on a bounded window (`warmup_bars` / "
+            "`ctx.view.window`), and iterate on a shorter backtest "
+            "(`--quick`) before running the full history."
+        )
+    return profile
+
+
 def simulate_execution(
     script_entrypoint: str | Path | Callable[..., Any],
     dataset: PreparedExecutionDataset,
@@ -206,12 +349,17 @@ def simulate_execution(
     )
     # None unless params["enable_liquidation"] is truthy — default-off parity.
     liquidation = LiquidationConfig.from_params(params_data)
-    # When declared, each tick sees the same bounded trailing window the live
-    # driver fetches (lookback_bars) instead of full history — this is a
-    # live-parity choice for path-dependent indicators AND turns per-tick
-    # strategy recompute from O(n) into O(k). Unset keeps full history.
-    raw_lookback = params_data.get("lookback_bars")
-    lookback_bars = int(raw_lookback) if raw_lookback else None
+    # Each tick sees a bounded trailing window (the same the live driver
+    # fetches) so per-tick strategy recompute stays O(k), not O(index). This
+    # is now the DEFAULT — full history is opt-in via `full_history: true`.
+    window_size, window_source, full_history = _resolve_compute_window(
+        params_data, strategy
+    )
+
+    total_bars = len(dataset.bars.timestamps)
+    progress_every = max(1, total_bars // 20)
+    tick_ms: list[float] = []
+    wall_start = time.perf_counter()
 
     async def _run_simulation() -> None:
         for index, timestamp in enumerate(dataset.bars.timestamps):
@@ -230,12 +378,13 @@ def simulate_execution(
                         "volume": bar.volume,
                     }
                 )
+            tick_start = time.perf_counter()
             tick = await run_tick(
                 strategy,
                 view=(
-                    dataset.bars.window(index, lookback_bars)
-                    if lookback_bars
-                    else dataset.bars.through(index)
+                    dataset.bars.through(index)
+                    if full_history
+                    else dataset.bars.window(index, window_size)
                 ),
                 brokers={"*": broker},
                 state=state,
@@ -247,6 +396,9 @@ def simulate_execution(
                 trace=trace,
                 liquidation=liquidation,
             )
+            tick_ms.append((time.perf_counter() - tick_start) * 1000.0)
+            if total_bars and (index + 1) % progress_every == 0:
+                _emit_progress(index + 1, total_bars, wall_start, tick_ms)
             if tick.skipped:
                 continue
             trades.extend(tick.trade_rows)
@@ -312,6 +464,14 @@ def simulate_execution(
         "params": params_data,
         "validation": validation,
     }
+    profile = _build_profile(
+        tick_ms=tick_ms,
+        wall_start=wall_start,
+        total_bars=total_bars,
+        window_size=window_size,
+        window_source=window_source,
+        full_history=full_history,
+    )
     return ExecutionBacktestResult(
         run_id=uuid.uuid4().hex[:12],
         params=params_data,
@@ -322,6 +482,7 @@ def simulate_execution(
         trace=trace.to_dict(),
         validation=validation,
         visualization=visualization,
+        profile=profile,
     )
 
 

--- a/wayfinder_paths/mcp/tools/jobs.py
+++ b/wayfinder_paths/mcp/tools/jobs.py
@@ -9,7 +9,10 @@ from wayfinder_paths.jobs.application import (
     validate_application_candidate,
 )
 from wayfinder_paths.jobs.compiler import JobCompiler
-from wayfinder_paths.jobs.execution.job import backtest_execution_job
+from wayfinder_paths.jobs.execution.job import (
+    backtest_execution_job,
+    summarize_backtest_payload,
+)
 from wayfinder_paths.jobs.execution.validation import validate_execution_job
 from wayfinder_paths.jobs.halt import clear_halt, request_halt
 from wayfinder_paths.jobs.models import (
@@ -85,6 +88,7 @@ async def core_jobs(
     workers: int = 1,
     parallel: Literal["serial", "thread", "process"] = "serial",
     compile: bool = True,  # noqa: A002
+    full: bool = False,
 ) -> dict[str, Any]:
     """Manage high-level Wayfinder jobs.
 
@@ -173,15 +177,17 @@ async def core_jobs(
         return ok(validate_execution_job(job_id, strict=strict, store=store))
 
     if action == "backtest_job":
-        return ok(
-            backtest_execution_job(
-                job_id,
-                grid_path=grid_path,
-                workers=workers,
-                parallel=parallel,
-                store=store,
-            )
+        payload = backtest_execution_job(
+            job_id,
+            grid_path=grid_path,
+            workers=workers,
+            parallel=parallel,
+            store=store,
         )
+        # Default to the compact summary (~2 KB) — the full payload is ~8 MB of
+        # per-bar arrays already persisted to results/backtest/. Pass full=True
+        # to return everything.
+        return ok(payload if full else summarize_backtest_payload(payload))
 
     if action == "proposals":
         return ok(store.proposals(job_id))

--- a/wayfinder_paths/tests/test_backtest_profile_and_summary.py
+++ b/wayfinder_paths/tests/test_backtest_profile_and_summary.py
@@ -1,0 +1,155 @@
+"""Backtest telemetry (`profile`), the bounded compute-window default, and the
+compact stdout summary — the diagnosability + token fixes for the create-a-
+strategy loop."""
+
+from __future__ import annotations
+
+import datetime
+import types
+
+from wayfinder_paths.jobs.execution import ExecutionContext, OrderIntent
+from wayfinder_paths.jobs.execution.job import summarize_backtest_payload
+from wayfinder_paths.jobs.execution.simulator import (
+    DEFAULT_WARMUP_BARS,
+    PreparedExecutionDataset,
+    simulate_execution,
+)
+
+SPEC = {
+    "market_kind": "perp",
+    "data_contract": {"bar_interval": "1h", "symbols": ["IMX"]},
+}
+
+
+def _dataset(n: int) -> PreparedExecutionDataset:
+    rows = []
+    price = 1.0
+    for i in range(n):
+        price = max(0.01, price * (1.0 + 0.02 * ((i % 11) - 5) / 100.0))
+        secs = 1_700_000_000 + i * 3600
+        ts = datetime.datetime.fromtimestamp(secs, datetime.UTC).isoformat()
+        rows.append(
+            {
+                "timestamp": ts,
+                "symbol": "IMX",
+                "open": price,
+                "high": price * 1.01,
+                "low": price * 0.99,
+                "close": price,
+                "volume": 1000.0,
+            }
+        )
+    return PreparedExecutionDataset.from_rows(rows)
+
+
+def _build_strategy(params=None):
+    """Recomputes over the whole handed frame every bar (the pathology) but
+    only DECIDES on the last 20 closes — so decisions are identical for any
+    compute window >= 21."""
+
+    def decide(ctx: ExecutionContext):
+        frame = ctx.view.symbol_frame("IMX")
+        if len(frame) < 22:
+            return []
+        df = frame.copy()  # full-frame copy each bar — the churn source
+        close = df["close"].astype(float)
+        df["ema"] = close.ewm(span=9, adjust=False).mean()
+        last = float(close.iloc[-1])
+        low_n = float(close.iloc[-21:-1].min())
+        pos = ctx.ledger.positions.get("IMX")
+        if pos is not None:
+            if last > low_n * 1.03:
+                return [
+                    OrderIntent(
+                        action="close",
+                        venue="hyperliquid",
+                        symbol="IMX",
+                        side="buy",
+                        size=pos.size,
+                        reduce_only=True,
+                    )
+                ]
+            return []
+        if last < low_n:
+            return [
+                OrderIntent(
+                    action="open",
+                    venue="hyperliquid",
+                    symbol="IMX",
+                    side="short",
+                    notional=100.0,
+                    reduce_only=False,
+                    bracket={
+                        "stop_loss": last * 1.07,
+                        "take_profit": last * 0.9,
+                        "policy": "conservative",
+                    },
+                )
+            ]
+        return []
+
+    ns = types.SimpleNamespace()
+    ns.decide = decide
+    return ns
+
+
+def test_profile_reports_window_and_timing() -> None:
+    res = simulate_execution(_build_strategy, _dataset(300), SPEC, {})
+    profile = res.profile
+    assert profile["compute_window"] == DEFAULT_WARMUP_BARS
+    assert profile["compute_window_source"] == "default"
+    assert profile["bars_total"] == 300
+    assert profile["bars_timed"] > 0
+    assert set(profile["tick_ms"]) >= {"mean", "p50", "p95", "max", "last"}
+    assert "tick_time_growing" in profile
+
+
+def test_warmup_window_never_changes_stats() -> None:
+    """The bounded-window default must produce byte-identical results to full
+    history for a strategy that only looks at the last N bars — the safety
+    property that lets us window by default."""
+    ds_size = 400
+    full = simulate_execution(
+        _build_strategy, _dataset(ds_size), SPEC, {"full_history": True}
+    )
+    default = simulate_execution(_build_strategy, _dataset(ds_size), SPEC, {})
+    tight = simulate_execution(
+        _build_strategy, _dataset(ds_size), SPEC, {"warmup_bars": 30}
+    )
+    assert full.profile["compute_window"] == "full_history"
+    assert tight.profile["compute_window_source"] == "warmup_bars"
+    for key in ("net_return", "sharpe", "trade_count", "win_rate"):
+        assert full.stats[key] == default.stats[key] == tight.stats[key]
+
+
+def test_lookback_bars_still_windows_for_back_compat() -> None:
+    res = simulate_execution(
+        _build_strategy, _dataset(120), SPEC, {"lookback_bars": 40}
+    )
+    assert res.profile["compute_window"] == 40
+    assert res.profile["compute_window_source"] == "lookback_bars"
+
+
+def test_summarize_backtest_payload_drops_heavy_arrays() -> None:
+    res = simulate_execution(_build_strategy, _dataset(120), SPEC, {})
+    payload = {
+        "type": "single",
+        "result": res.to_dict(),
+        "artifacts": {"latest": "/j/results/backtest/latest.json"},
+        "validation": {"status": "passed"},
+    }
+    summary = summarize_backtest_payload(payload)
+    # Decision-grade fields kept.
+    assert summary["result"]["stats"] == res.stats
+    assert summary["result"]["profile"] == res.profile
+    assert summary["artifacts"]["latest"].endswith("latest.json")
+    # Multi-MB per-bar arrays dropped.
+    for heavy in ("equity_curve", "trades", "positions", "trace", "visualization"):
+        assert heavy not in summary["result"]
+    # And the summary is dramatically smaller.
+    import json
+
+    assert (
+        len(json.dumps(summary, default=str))
+        < len(json.dumps(payload, default=str)) // 10
+    )


### PR DESCRIPTION
## Why

From a real cloud-agent transcript on dev box `oc-8710…` ("create an IMX breakout-short strategy", now **221 msgs, 4 compactions**). A *simple* backtest **pegged CPU ~8 min**, and — because there was no telemetry, no cheap iteration, and no framework diagnostics — the agent flailed: it ran `top`/`ps`, wrapped backtests in `timeout 300`, hand-rolled pandas PnL that **disagreed with the framework** ("why is your pnl so different than the framework?"), kept editing a scratch script, and burned context (8 MB backtest dumps → back-to-back compactions).

**Root cause (measured):** the strategy recomputes indicators from scratch **every bar**, replayed over 4,320 bars on a throttled **2 GB / 2-vCPU** box — O(N) with a heavy per-bar constant, plus a super-linear memory-churn tail from copying a growing frame each bar. Not primarily O(N²). It *succeeded* (Sharpe 4.2, 364 trades); it was just slow and **silent**.

## What

**Diagnosability**
- **Telemetry**: the replay loop times every bar → a stderr progress line (`bar 2000/4320 · 9 bars/s · ETA 4m · tick p95 44ms`) + a `profile` block, with a **machine-relative hint** that fires when *this* box projects a slow run.
- **`job backtest-diagnose`** (+ MCP `backtest_diagnose`): win/PnL/count by exit reason, close hour, side + best/worst trades. Headline is the run's own `stats` verbatim, buckets come from the engine's `realized_pnl_delta` — so it **cannot disagree** with the backtest. Read this instead of recomputing PnL by hand.

**Speed / CPU safety**
- **Bounded per-bar compute window by default** (512, `full_history: true` to opt out): proven **byte-identical stats** across full/512/warmup-30, ~4.5× less allocation churn.
- **CPU-safe parameter sweeps**: `run_execution_grid` clamps workers to the box's usable cores (respects a cgroup CPU quota + `WAYFINDER_MAX_BACKTEST_WORKERS`) — uses the 2 vCPUs fully, never oversubscribes into a thrash. **Test several params at once without going out of CPU.**
- **`--quick N`** (CLI + MCP `quick_bars`): backtest the last N bars for fast iteration; confirm the winner on full history.

**Tokens / onboarding**
- **Compact backtest output by default** (`--full` / `full=True` to opt in): 8 MB → ~2 KB. Disk artifacts + `backtest-view` untouched.
- **`developing-jobs-v1-strategies` skill**: the create → fetch → backtest `--quick` → diagnose → experiments → promote loop, a copy-paste `decide()` skeleton using `warmup_bars` + windowed indicators, and the rules that prevent every observed failure.

## Note on the box
`oc-8710…` is **2 GB / 2 vCPU** — a chunk of "8 min" is just throttled hardware. More CPU on the backtesting box is a cheap independent lever.

## Tests
New `test_backtest_profile_and_summary.py` (7 cases): profile shape; **warmup window never changes stats**; `lookback_bars` back-compat; summary drops heavy arrays / >10× smaller; **worker clamp never oversubscribes**; `--quick` truncates; **diagnose headline agrees with stats**. Full suite: **725 passed, 7 skipped**, ruff clean.

## Deploy
Ships in the SDK; the box bakes it into the image (`git checkout $WAYFINDER_SDK_VERSION` → `/opt/wayfinder-paths-sdk`). After merge: rebuild the dev image at the `wayfinder-jobs-v1` SHA and update `oc-8710…`, then re-run `wayfinder job backtest imx-breakout-short` to confirm ETA + ~2 KB summary + CPU-safe sweeps.