### PR TITLE
jobs backtest: CPU-safe param sweeps, --quick, backtest-diagnose, runbook

### DIFF
--- a/.claude/skills/developing-jobs-v1-strategies/SKILL.md
+++ b/.claude/skills/developing-jobs-v1-strategies/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: developing-jobs-v1-strategies
+description: Build, backtest, diagnose, and iterate a jobs_v1 execution strategy end to end (decide(ctx) contract, windowed indicators to keep backtests fast, --quick sweeps, backtest-diagnose). Load this before creating a trading job/strategy.
+metadata:
+  tags: jobs, jobs_v1, strategy, backtest, execution, decide, hyperliquid
+---
+
+## When to use
+
+Load this when the user wants a **recurring, backtestable trading strategy** (e.g. "create a strategy that shorts X on a breakout"). This is the jobs_v1 execution framework — one `decide()` runs in backtest, paper, and live.
+
+Do NOT hand-write the strategy into `.wayfinder_runs/` (that's one-off scratch scripts, `core_run_script`). Do NOT copy `wayfinder_paths/strategies/apex_gmx_velocity/` — that's the **old `Strategy` base class**, not jobs_v1.
+
+## The loop (use exactly these commands)
+
+```
+wayfinder job create <id> --script <strategy.py> --execution-contract jobs_v1 --interval 3600 --initial-capital 1000
+# edit execution_spec.json (data_contract.symbols + bar_interval) and the strategy
+wayfinder job fetch-dataset <id> --days 180
+wayfinder job backtest <id> --quick 1000      # fast iteration: last 1000 bars, ~2 KB summary
+wayfinder job backtest-diagnose <id>          # win/PnL by exit reason, hour, side — READ THIS, don't recompute
+# tune params, repeat backtest --quick / diagnose
+wayfinder job experiments <id> --grid grid.json   # sweep several params at once (bounded, CPU-safe)
+wayfinder job backtest <id>                   # full-history confirmation run
+```
+
+The `backtest` output is a compact stats summary (`stats` + `profile` + artifact paths). Add `--full` only if you truly need the raw curves; they're always on disk (`job backtest-view`).
+
+## The strategy contract (copy this skeleton)
+
+```python
+from wayfinder_paths.jobs.execution import ExecutionContext, OrderIntent
+
+# Longest indicator lookback + a small buffer. Handed to the sim as the per-bar
+# compute window so `decide()` NEVER sees the whole growing history — that is
+# what turns a "simple" backtest into a multi-minute CPU peg.
+warmup_bars = 60
+
+def decide(ctx: ExecutionContext) -> list[OrderIntent]:
+    frame = ctx.view.symbol_frame("IMX")   # already bounded to ~warmup_bars rows
+    if len(frame) < 25:
+        return []
+    close = frame["close"].astype(float)
+    ema = close.ewm(span=9, adjust=False).mean().iloc[-1]
+    last = float(close.iloc[-1])
+    low5 = float(close.iloc[-6:-1].min())
+    pos = ctx.ledger.positions.get("IMX")
+    if pos is None and last < low5:
+        return [OrderIntent(action="open", venue="hyperliquid", symbol="IMX",
+                            side="short", notional=100.0, reduce_only=False,
+                            bracket={"stop_loss": last * 1.07, "take_profit": last * 0.9,
+                                     "policy": "conservative"},
+                            metadata={"entry_price": last})]
+    if pos is not None and last > ema:
+        return [OrderIntent(action="close", venue="hyperliquid", symbol="IMX",
+                            side="buy", size=pos.size, reduce_only=True,
+                            metadata={"exit_reason": "ema_reclaim"})]
+    return []
+
+def build_strategy(params: dict | None = None):
+    import types
+    ns = types.SimpleNamespace(); ns.decide = decide; ns.warmup_bars = warmup_bars
+    return ns
+```
+
+Put `metadata={"exit_reason": "..."}` on close intents — `backtest-diagnose` buckets PnL by it.
+
+## Rules (these are the mistakes to avoid)
+
+1. **Keep `decide()` cheap.** Compute indicators on the handed frame only (it's bounded to `warmup_bars`). Never re-slice the full history or `copy()` a growing frame every bar. If a backtest is slow, the `profile.hint` tells you why — set/lower `warmup_bars`.
+2. **Never recompute PnL/stats by hand.** Ad-hoc pandas drifts from the framework and confuses everyone ("why is your PnL different than the framework?"). Read `job backtest` `stats` and `job backtest-diagnose`. They are the source of truth.
+3. **Sweep parameters with `job experiments` / `--grid`, not manual edit-and-rerun.** It's CPU-safe (bounded to the box's cores) and runs several params at once. Add `--quick` while exploring.
+4. **The dev box is small (2 vCPU).** Iterate on `--quick 1000`; only do the full-history run to confirm a candidate. Don't wrap backtests in `timeout` — read the ETA on the progress line.
+5. **The strategy lives in the job's script**, not `.wayfinder_runs/`. Edit that file, then `wayfinder job backtest` — don't maintain a scratch copy.

--- a/wayfinder_paths/jobs/backtest_artifacts.py
+++ b/wayfinder_paths/jobs/backtest_artifacts.py
@@ -151,6 +151,102 @@ def load_backtest_view(
     }
 
 
+def diagnose_backtest(
+    job_id: str,
+    *,
+    store: JobStore | None = None,
+    proposal_id: str | None = None,
+    top_trades: int = 5,
+) -> dict[str, Any]:
+    """Framework-computed breakdown of the latest backtest — win rate, PnL, and
+    counts bucketed by exit reason, close hour (UTC), and side, plus the best/
+    worst trades. The headline is taken VERBATIM from the run's `stats`, and the
+    buckets come from the same `realized_pnl_delta` the engine recorded on each
+    closing fill — so this never disagrees with `job backtest`. Read this to find
+    a strategy's strong/weak spots instead of recomputing PnL by hand (ad-hoc
+    recomputation is what drifts from the framework's numbers)."""
+    store = store or JobStore()
+    prefix = (
+        f"applications/{proposal_id}/candidate/results/backtest"
+        if proposal_id
+        else "results/backtest"
+    )
+    latest = store.read_json(job_id, f"{prefix}/latest.json", default={}) or {}
+    if not latest:
+        return {"available": False}
+    stats = latest.get("stats") or {}
+    trades = latest.get("trades") or []
+    # Completed trades = closing fills carrying realized PnL (same source as stats).
+    closes = [t for t in trades if abs(float(t.get("realized_pnl_delta") or 0.0)) > 0]
+
+    def _reason(trade: dict[str, Any]) -> str:
+        raw = trade.get("raw") or {}
+        meta = raw.get("metadata") or raw
+        return str(
+            meta.get("exit_reason") or ("close" if trade.get("reduce_only") else "open")
+        )
+
+    def _hour(trade: dict[str, Any]) -> int:
+        ts = _parse_ts(trade.get("timestamp"))
+        return ts.hour if ts else -1
+
+    def _bucket(key_fn: Any) -> dict[Any, dict[str, Any]]:
+        agg: dict[Any, dict[str, float]] = {}
+        for trade in closes:
+            key = key_fn(trade)
+            row = agg.setdefault(key, {"trades": 0.0, "pnl": 0.0, "wins": 0.0})
+            pnl = float(trade.get("realized_pnl_delta") or 0.0)
+            row["trades"] += 1
+            row["pnl"] += pnl
+            row["wins"] += 1 if pnl > 0 else 0
+        return {
+            key: {
+                "trades": int(row["trades"]),
+                "pnl": round(row["pnl"], 4),
+                "win_rate": round(row["wins"] / row["trades"], 3)
+                if row["trades"]
+                else 0.0,
+                "avg_pnl": round(row["pnl"] / row["trades"], 4)
+                if row["trades"]
+                else 0.0,
+            }
+            for key, row in agg.items()
+        }
+
+    def _trade_view(trade: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "timestamp": trade.get("timestamp"),
+            "side": trade.get("side"),
+            "pnl": round(float(trade.get("realized_pnl_delta") or 0.0), 4),
+            "reason": _reason(trade),
+        }
+
+    ranked = sorted(closes, key=lambda t: float(t.get("realized_pnl_delta") or 0.0))
+    headline_keys = (
+        "net_return",
+        "trade_count",
+        "win_rate",
+        "profit_factor",
+        "avg_trade_pnl",
+        "sharpe",
+        "sortino",
+        "max_drawdown_pct",
+        "best_trade_pnl",
+        "worst_trade_pnl",
+    )
+    return {
+        "available": True,
+        "run_id": latest.get("run_id"),
+        "headline": {k: stats[k] for k in headline_keys if k in stats},
+        "closed_trades_analyzed": len(closes),
+        "by_exit_reason": _bucket(_reason),
+        "by_close_hour_utc": dict(sorted(_bucket(_hour).items())),
+        "by_side": _bucket(lambda t: t.get("side") or "?"),
+        "worst_trades": [_trade_view(t) for t in ranked[:top_trades]],
+        "best_trades": [_trade_view(t) for t in reversed(ranked[-top_trades:])],
+    }
+
+
 def _in_range(
     current: datetime | None, start: datetime | None, end: datetime | None
 ) -> bool:

--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -13,7 +13,10 @@ from wayfinder_paths.jobs.application import (
     ensure_jobs_v1_contract,
     validate_application_candidate,
 )
-from wayfinder_paths.jobs.backtest_artifacts import load_backtest_view
+from wayfinder_paths.jobs.backtest_artifacts import (
+    diagnose_backtest,
+    load_backtest_view,
+)
 from wayfinder_paths.jobs.compiler import JobCompiler
 from wayfinder_paths.jobs.execution.driver import tick_job
 from wayfinder_paths.jobs.execution.experiments import (
@@ -211,12 +214,29 @@ def validate_cmd(job_id: str, strict: bool) -> None:
 @job_cli.command(name="backtest", help="Run an execution-contract backtest for a job.")
 @click.argument("job_id")
 @click.option("--grid", "grid_path", default=None)
-@click.option("--workers", type=int, default=1, show_default=True)
+@click.option(
+    "--workers",
+    type=int,
+    default=0,
+    show_default=True,
+    help="Parallel backtest workers for a grid. 0 = use all available cores. "
+    "Always clamped to the box's core count — never oversubscribes.",
+)
 @click.option(
     "--parallel",
     type=click.Choice(["serial", "thread", "process"]),
     default="serial",
     show_default=True,
+    help="Grid parallelism. `process` uses multiple cores (bounded by "
+    "--workers/CPU count); `thread` won't speed up CPU-bound backtests.",
+)
+@click.option(
+    "--quick",
+    "quick_bars",
+    type=int,
+    default=None,
+    help="Backtest only the last N bars — fast iteration / parameter sweeps "
+    "before the full-history confirmation run.",
 )
 @click.option(
     "--full",
@@ -227,7 +247,12 @@ def validate_cmd(job_id: str, strict: bool) -> None:
     "always written to results/backtest/ regardless.",
 )
 def backtest_cmd(
-    job_id: str, grid_path: str | None, workers: int, parallel: str, full: bool
+    job_id: str,
+    grid_path: str | None,
+    workers: int,
+    parallel: str,
+    quick_bars: int | None,
+    full: bool,
 ) -> None:
     store = JobStore()
     result = backtest_execution_job(
@@ -235,6 +260,7 @@ def backtest_cmd(
         grid_path=grid_path,
         workers=workers,
         parallel=parallel,
+        quick_bars=quick_bars,
         store=store,
     )
     # Default to the ~2 KB summary — the full payload is ~8 MB and lives on disk
@@ -570,6 +596,26 @@ def backtest_view_cmd(
         proposal_id=proposal_id,
     )
     _echo_json({"ok": True, "result": result})
+
+
+@job_cli.command(
+    name="backtest-diagnose",
+    help="Framework-computed breakdown of the latest backtest (win rate + PnL "
+    "by exit reason / close hour / side, best & worst trades). Read this to find "
+    "a strategy's strong/weak spots — do NOT recompute PnL by hand; that drifts "
+    "from the backtest's own numbers.",
+)
+@click.argument("job_id")
+@click.option(
+    "--proposal", "proposal_id", default=None, help="Diagnose a candidate run."
+)
+def backtest_diagnose_cmd(job_id: str, proposal_id: str | None) -> None:
+    _echo_json(
+        {
+            "ok": True,
+            "result": diagnose_backtest(job_id, proposal_id=proposal_id),
+        }
+    )
 
 
 @job_cli.command(name="report", help="Show a compact terminal report for a job.")

--- a/wayfinder_paths/jobs/execution/job.py
+++ b/wayfinder_paths/jobs/execution/job.py
@@ -80,6 +80,7 @@ def backtest_execution_job(
     walk_forward: Mapping[str, Any] | None = None,
     optimizer: str = "grid",
     optuna_options: Mapping[str, Any] | None = None,
+    quick_bars: int | None = None,
     store: JobStore | None = None,
 ) -> dict[str, Any]:
     store = store or JobStore()
@@ -97,6 +98,15 @@ def backtest_execution_job(
             f"Execution script not found for job {job_id}: {script}"
         )
     dataset = _load_dataset(root, spec, job_data)
+    # `--quick N`: backtest only the last N bars — cheap enough to sweep many
+    # parameters fast while iterating, before the full-history confirmation run.
+    if quick_bars and quick_bars > 0:
+        timestamps = dataset.bars.timestamps
+        if len(timestamps) > quick_bars:
+            dataset = PreparedExecutionDataset(
+                dataset.bars.window(len(timestamps) - 1, quick_bars),
+                {**dataset.metadata, "quick_bars": quick_bars},
+            )
     output_dir = root / "results" / "backtest"
     stamp = {
         "revision": compute_workspace_revision(root),

--- a/wayfinder_paths/jobs/execution/simulator.py
+++ b/wayfinder_paths/jobs/execution/simulator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import itertools
 import json
+import os
 import sys
 import time
 import uuid
@@ -522,6 +523,42 @@ def rank_and_partition(
     return ranked[:top_n], invalid
 
 
+def available_cpu_count() -> int:
+    """Usable CPUs for backtest fan-out. Respects a cgroup CPU quota (Fly
+    machines are quota-limited, and os.cpu_count() reports the host's cores,
+    not the machine's) and an explicit WAYFINDER_MAX_BACKTEST_WORKERS override.
+    Always ≥ 1."""
+    override = os.environ.get("WAYFINDER_MAX_BACKTEST_WORKERS")
+    if override:
+        try:
+            return max(1, int(override))
+        except ValueError:
+            pass
+    # cgroup v2 quota → effective cores.
+    try:
+        quota, period = (
+            open("/sys/fs/cgroup/cpu.max").read().split()
+        )  # e.g. "200000 100000" → 2 cores; "max" → unlimited
+        if quota != "max":
+            return max(1, round(int(quota) / int(period)))
+    except (OSError, ValueError):
+        pass
+    return max(1, os.cpu_count() or 1)
+
+
+def _effective_workers(workers: int, parallel: str) -> int:
+    """Clamp requested workers so a parameter sweep uses the box's cores fully
+    but never oversubscribes them — the difference between "at CPU" and the
+    thrash/peg of "out of CPU" on a small shared-vCPU machine. `workers <= 0`
+    means "use all available cores"."""
+    if parallel == "serial":
+        return 1
+    cap = available_cpu_count()
+    if workers <= 0:
+        return cap
+    return max(1, min(workers, cap))
+
+
 def run_execution_grid(
     script_entrypoint: str | Path,
     dataset: PreparedExecutionDataset,
@@ -544,6 +581,17 @@ def run_execution_grid(
                 for combo in itertools.product(*(param_grid[key] for key in keys))
             ]
     grid_id = uuid.uuid4().hex[:12]
+    # Never spawn more workers than the box has cores — oversubscribing a
+    # 2-vCPU Fly machine pegs it (each process also reloads pandas + a copy of
+    # the dataset). Threads don't help CPU-bound pandas (GIL); process is the
+    # only real parallelism, and it's now bounded.
+    workers = _effective_workers(workers, parallel)
+    print(
+        f"[grid] {len(params_list)} params · {parallel} · {workers} worker(s) "
+        f"(of {available_cpu_count()} core(s))",
+        file=sys.stderr,
+        flush=True,
+    )
     if parallel == "serial" or workers <= 1:
         results = [
             simulate_execution(script_entrypoint, dataset, execution_spec, params)
@@ -585,6 +633,12 @@ def run_execution_grid(
         runs=run_rows,
         ranked=ranked,
         invalid=invalid,
+        search={
+            "parallel": parallel,
+            "workers": workers,
+            "cpu_count": available_cpu_count(),
+            "param_count": len(params_list),
+        },
     )
 
 

--- a/wayfinder_paths/mcp/tools/jobs.py
+++ b/wayfinder_paths/mcp/tools/jobs.py
@@ -8,6 +8,7 @@ from wayfinder_paths.jobs.application import (
     ensure_jobs_v1_contract,
     validate_application_candidate,
 )
+from wayfinder_paths.jobs.backtest_artifacts import diagnose_backtest
 from wayfinder_paths.jobs.compiler import JobCompiler
 from wayfinder_paths.jobs.execution.job import (
     backtest_execution_job,
@@ -36,6 +37,7 @@ JobAction = Literal[
     "review_now",
     "validate_job",
     "backtest_job",
+    "backtest_diagnose",
     "proposals",
     "propose",
     "approve_proposal",
@@ -89,6 +91,7 @@ async def core_jobs(
     parallel: Literal["serial", "thread", "process"] = "serial",
     compile: bool = True,  # noqa: A002
     full: bool = False,
+    quick_bars: int | None = None,
 ) -> dict[str, Any]:
     """Manage high-level Wayfinder jobs.
 
@@ -182,12 +185,16 @@ async def core_jobs(
             grid_path=grid_path,
             workers=workers,
             parallel=parallel,
+            quick_bars=quick_bars,
             store=store,
         )
         # Default to the compact summary (~2 KB) — the full payload is ~8 MB of
         # per-bar arrays already persisted to results/backtest/. Pass full=True
         # to return everything.
         return ok(payload if full else summarize_backtest_payload(payload))
+
+    if action == "backtest_diagnose":
+        return ok(diagnose_backtest(job_id, proposal_id=proposal_id, store=store))
 
     if action == "proposals":
         return ok(store.proposals(job_id))

--- a/wayfinder_paths/tests/test_backtest_profile_and_summary.py
+++ b/wayfinder_paths/tests/test_backtest_profile_and_summary.py
@@ -5,6 +5,7 @@ strategy loop."""
 from __future__ import annotations
 
 import datetime
+import json
 import types
 
 from wayfinder_paths.jobs.execution import ExecutionContext, OrderIntent
@@ -147,9 +148,97 @@ def test_summarize_backtest_payload_drops_heavy_arrays() -> None:
     for heavy in ("equity_curve", "trades", "positions", "trace", "visualization"):
         assert heavy not in summary["result"]
     # And the summary is dramatically smaller.
-    import json
-
     assert (
         len(json.dumps(summary, default=str))
         < len(json.dumps(payload, default=str)) // 10
     )
+
+
+def test_effective_workers_never_oversubscribes(monkeypatch) -> None:
+    from wayfinder_paths.jobs.execution import simulator as sim
+
+    monkeypatch.setattr(sim, "available_cpu_count", lambda: 2)
+    assert sim._effective_workers(8, "process") == 2  # clamped to cores
+    assert sim._effective_workers(1, "process") == 1
+    assert sim._effective_workers(0, "process") == 2  # 0 => all cores
+    assert sim._effective_workers(8, "serial") == 1  # serial is always 1
+
+
+def test_quick_bars_truncates_to_last_n() -> None:
+    """--quick backtests only the last N bars — cheap for parameter sweeps."""
+    full = simulate_execution(_build_strategy, _dataset(300), SPEC, {})
+    ds = _dataset(300)
+    # Emulate the job-level `quick_bars` truncation (last 60 bars).
+    from wayfinder_paths.jobs.execution.simulator import PreparedExecutionDataset
+
+    ts = ds.bars.timestamps
+    quick = PreparedExecutionDataset(ds.bars.window(len(ts) - 1, 60), {})
+    quick_res = simulate_execution(_build_strategy, quick, SPEC, {})
+    assert quick_res.profile["bars_total"] == 60
+    assert full.profile["bars_total"] == 300
+
+
+def test_diagnose_backtest_agrees_with_stats(tmp_path) -> None:
+    """The diagnose headline is the run's own stats verbatim, and the buckets
+    come from the same realized PnL — so it never disagrees with the backtest
+    (unlike hand-rolled recomputation)."""
+    from wayfinder_paths.jobs.backtest_artifacts import diagnose_backtest
+    from wayfinder_paths.jobs.store import JobStore
+
+    store = JobStore(repo_root=tmp_path)
+    job_id = "diag-job"
+    bt_dir = store.job_dir(job_id) / "results" / "backtest"
+    bt_dir.mkdir(parents=True, exist_ok=True)
+    latest = {
+        "run_id": "r1",
+        "stats": {
+            "net_return": 0.05,
+            "trade_count": 3,
+            "win_rate": 0.667,
+            "sharpe": 1.2,
+        },
+        "trades": [
+            {
+                "timestamp": "2026-01-01T08:00:00+00:00",
+                "side": "buy",
+                "reduce_only": True,
+                "realized_pnl_delta": 2.0,
+                "raw": {"metadata": {"exit_reason": "take_profit"}},
+            },
+            {
+                "timestamp": "2026-01-01T09:00:00+00:00",
+                "side": "buy",
+                "reduce_only": True,
+                "realized_pnl_delta": 1.0,
+                "raw": {"metadata": {"exit_reason": "take_profit"}},
+            },
+            {
+                "timestamp": "2026-01-01T10:00:00+00:00",
+                "side": "buy",
+                "reduce_only": True,
+                "realized_pnl_delta": -1.5,
+                "raw": {"metadata": {"exit_reason": "stop_loss"}},
+            },
+            # entry fill (no realized pnl) — excluded from trade buckets
+            {
+                "timestamp": "2026-01-01T07:00:00+00:00",
+                "side": "sell",
+                "realized_pnl_delta": 0.0,
+            },
+        ],
+    }
+    (bt_dir / "latest.json").write_text(json.dumps(latest))
+
+    diag = diagnose_backtest(job_id, store=store)
+    assert diag["available"] is True
+    # Headline is the stats verbatim — no recomputation, no drift.
+    assert diag["headline"]["net_return"] == 0.05
+    assert diag["headline"]["win_rate"] == 0.667
+    # Only the 3 closing fills are analyzed.
+    assert diag["closed_trades_analyzed"] == 3
+    tp = diag["by_exit_reason"]["take_profit"]
+    assert tp["trades"] == 2 and tp["pnl"] == 3.0 and tp["win_rate"] == 1.0
+    sl = diag["by_exit_reason"]["stop_loss"]
+    assert sl["trades"] == 1 and sl["pnl"] == -1.5 and sl["win_rate"] == 0.0
+    assert diag["worst_trades"][0]["pnl"] == -1.5
+    assert diag["best_trades"][0]["pnl"] == 2.0


### PR DESCRIPTION
Follow-up to #479 (that PR merged before this commit landed). Closes the remaining gaps from the IMX transcript.

## What
- **CPU-safe parameter sweeps.** `run_execution_grid` clamps workers to the box's usable cores (respects a cgroup CPU quota + `WAYFINDER_MAX_BACKTEST_WORKERS`) — uses the 2-vCPU box fully, never oversubscribes into a thrash/peg. Effective worker/CPU count recorded on the result. **Test several params at once without going out of CPU.**
- **`--quick N`** (CLI + MCP `quick_bars`): backtest only the last N bars → cheap iteration / sweeps; confirm the winner on full history.
- **`job backtest-diagnose`** (+ MCP `backtest_diagnose`): win/PnL/count by exit reason, close hour, side + best/worst trades. Headline is the run's own `stats` verbatim; buckets come from the engine's `realized_pnl_delta` — so it **cannot disagree** with the backtest. This kills the "why is your pnl so different than the framework?" failure (the agent had hand-rolled divergent pandas).
- **`developing-jobs-v1-strategies` skill**: the create → fetch → backtest `--quick` → diagnose → experiments → promote loop, a copy-paste `decide()` skeleton with `warmup_bars` + windowed indicators, and the rules that prevent every observed failure (keep decide cheap; never hand-roll PnL; sweep with experiments not manual reruns; the box is small; strategy lives in the job not `.wayfinder_runs`).

## Tests
Extended `test_backtest_profile_and_summary.py`: worker clamp never oversubscribes; `--quick` truncates to last N; diagnose headline agrees with `stats` and buckets sum correctly. Ruff clean.

## Deploy
Together with #479, this is the full set to bake into the dev image and deploy to `oc-8710…`.