### PR TITLE
jobs backtest: steer strategy tuning to walk-forward OOS validation

### DIFF
--- a/.claude/skills/developing-jobs-v1-strategies/SKILL.md
+++ b/.claude/skills/developing-jobs-v1-strategies/SKILL.md
@@ -20,11 +20,21 @@ wayfinder job fetch-dataset <id> --days 180
 wayfinder job backtest <id> --quick 1000      # fast iteration: last 1000 bars, ~2 KB summary
 wayfinder job backtest-diagnose <id>          # win/PnL by exit reason, hour, side — READ THIS, don't recompute
 # tune params, repeat backtest --quick / diagnose
-wayfinder job experiments <id> --grid grid.json   # sweep several params at once (bounded, CPU-safe)
-wayfinder job backtest <id>                   # full-history confirmation run
+# THE decision step — tune AND validate out-of-sample in one shot (never trust an in-sample grid):
+wayfinder job experiments <id> --grid grid.json --wf-test-bars 240 --wf-folds 4
+wayfinder job backtest <id>                   # full-history confirmation of the promoted params
 ```
 
 The `backtest` output is a compact stats summary (`stats` + `profile` + artifact paths). Add `--full` only if you truly need the raw curves; they're always on disk (`job backtest-view`).
+
+## Judge a strategy out-of-sample, or you're just curve-fitting
+
+A single backtest tunes and scores on the **same** data — its Sharpe / profit factor are **not evidence of an edge**. A "great" in-sample result (Sharpe 6+, PF 10+) almost always means you overfit. The only number that means anything is **out-of-sample**:
+
+- Run `job experiments <id> --grid grid.json --wf-test-bars 240 --wf-folds 4`. This picks params on each fold's train window and scores them on the **held-out** window it never saw.
+- Read the walk-forward report and judge on: **`decay_ratio`** (OOS mean ÷ IS mean — want it near 1; ≪ 1 = overfit), **`oos_positive_folds`** (want most folds profitable OOS), and OOS mean return vs IS mean. If OOS collapses vs IS, the strategy is fit to noise — go back to the idea, don't tune harder.
+- Also sanity-check the *regime*: if you're shorting an asset that fell 50% over the window, most of the "edge" is the trend, not the strategy — confirm it holds on a flat/up stretch too.
+- **Model costs.** Set `fee_bps` / `slippage_bps` in `execution_params`; a strategy with hundreds of trades and `total_fees: 0` is fiction.
 
 ## The strategy contract (copy this skeleton)
 
@@ -69,6 +79,6 @@ Put `metadata={"exit_reason": "..."}` on close intents — `backtest-diagnose` b
 
 1. **Keep `decide()` cheap.** Compute indicators on the handed frame only (it's bounded to `warmup_bars`). Never re-slice the full history or `copy()` a growing frame every bar. If a backtest is slow, the `profile.hint` tells you why — set/lower `warmup_bars`.
 2. **Never recompute PnL/stats by hand.** Ad-hoc pandas drifts from the framework and confuses everyone ("why is your PnL different than the framework?"). Read `job backtest` `stats` and `job backtest-diagnose`. They are the source of truth.
-3. **Sweep parameters with `job experiments` / `--grid`, not manual edit-and-rerun.** It's CPU-safe (bounded to the box's cores) and runs several params at once. Add `--quick` while exploring.
+3. **Tune AND validate with `job experiments --grid … --wf-test-bars N --wf-folds K`, not manual edit-and-rerun.** It's CPU-safe (bounded to the box's cores), sweeps several params at once, and — crucially — scores them **out-of-sample**. A plain grid or a hand-tuned single backtest is in-sample only; its metrics are not an edge. Decide with `decay_ratio` and `oos_positive_folds`, not in-sample Sharpe.
 4. **The dev box is small (2 vCPU).** Iterate on `--quick 1000`; only do the full-history run to confirm a candidate. Don't wrap backtests in `timeout` — read the ETA on the progress line.
 5. **The strategy lives in the job's script**, not `.wayfinder_runs/`. Edit that file, then `wayfinder job backtest` — don't maintain a scratch copy.

--- a/wayfinder_paths/jobs/execution/job.py
+++ b/wayfinder_paths/jobs/execution/job.py
@@ -61,6 +61,15 @@ def summarize_backtest_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
                 {k: v for k, v in row.items() if k not in _HEAVY_RESULT_KEYS}
                 for row in (result.get("ranked") or [])[:10]
             ]
+            # In-sample grids overfit: the top params were picked AND scored on
+            # the same data, so their metrics are not evidence of an edge.
+            if "walk_forward" not in payload:
+                summary["note"] = (
+                    "In-sample ranking only — these params were tuned and scored "
+                    "on the same data. Validate out-of-sample before trusting "
+                    "them: `job experiments <id> --grid <file> --wf-test-bars N "
+                    "--wf-folds K`, then judge on decay_ratio / oos_positive_folds."
+                )
         else:  # single run — the ~8 MB case
             summary["result"] = {
                 k: result[k]

--- a/wayfinder_paths/tests/test_backtest_profile_and_summary.py
+++ b/wayfinder_paths/tests/test_backtest_profile_and_summary.py
@@ -154,6 +154,32 @@ def test_summarize_backtest_payload_drops_heavy_arrays() -> None:
     )
 
 
+def test_grid_summary_flags_in_sample_only() -> None:
+    """A grid with no walk-forward is in-sample only — the summary must say so
+    (and strip the heavy per-run arrays), so the agent validates OOS instead of
+    trusting a curve-fit ranking."""
+    grid_payload = {
+        "type": "grid",
+        "result": {
+            "grid_id": "g1",
+            "rank_by": "net_return",
+            "runs": [{}, {}],
+            "invalid": [],
+            "ranked": [
+                {"params": {"x": 1}, "net_return": 0.4, "equity_curve": [1, 2, 3]}
+            ],
+        },
+    }
+    summary = summarize_backtest_payload(grid_payload)
+    assert "note" in summary and "out-of-sample" in summary["note"]
+    assert "equity_curve" not in summary["result"]["ranked"][0]  # heavy key stripped
+    # Once validated out-of-sample, the overfit note goes away.
+    validated = summarize_backtest_payload(
+        {**grid_payload, "walk_forward": {"summary": {"decay_ratio": 0.9}}}
+    )
+    assert "note" not in validated
+
+
 def test_effective_workers_never_oversubscribes(monkeypatch) -> None:
     from wayfinder_paths.jobs.execution import simulator as sim
 


### PR DESCRIPTION
## Why

Follow-up to #479/#480 (the create-a-strategy CPU-peg + diagnosability fixes). In the transcript that motivated that work, the agent tuned an IMX strategy on a **plain grid** and treated the in-sample Sharpe as an edge. A grid picks *and* scores params on the same data — that's curve-fitting, not validation. The walk-forward capability already exists (`job experiments --grid … --wf-test-bars N --wf-folds K` → `decay_ratio`, `oos_positive_folds`), but it was opt-in and under-emphasized, so the agent never reached for it.

This PR makes out-of-sample validation the default path — one code nudge and one docs nudge.

## Changes

- **`summarize_backtest_payload` (job.py):** a grid result with no `walk_forward` block now carries a `note`: *"In-sample ranking only — validate out-of-sample with `job experiments <id> --grid <file> --wf-test-bars N --wf-folds K`, then judge on decay_ratio / oos_positive_folds."* The note disappears once a walk-forward run is present. Heavy per-run arrays are still stripped.
- **`developing-jobs-v1-strategies` skill:** the loop's tuning step and rule #3 now require walk-forward experiments and say to decide on `decay_ratio` / `oos_positive_folds`, not in-sample Sharpe. New section *"Judge a strategy out-of-sample, or you're just curve-fitting"* covers `decay_ratio`, `oos_positive_folds`, a regime sanity-check, and modeling `fee_bps` / `slippage_bps`.

## Tests

- `test_grid_summary_flags_in_sample_only`: grid-with-no-walk-forward gets the note and drops heavy arrays; note is absent once `walk_forward` is present.
- Full `test_backtest_profile_and_summary.py` suite green (8 passed).