### PR TITLE
jobs backtest: recommendation engine — diagnose tells you what to try next

### DIFF
--- a/.claude/skills/developing-jobs-v1-strategies/SKILL.md
+++ b/.claude/skills/developing-jobs-v1-strategies/SKILL.md
@@ -18,14 +18,27 @@ wayfinder job create <id> --script <strategy.py> --execution-contract jobs_v1 --
 # edit execution_spec.json (data_contract.symbols + bar_interval) and the strategy
 wayfinder job fetch-dataset <id> --days 180
 wayfinder job backtest <id> --quick 1000      # fast iteration: last 1000 bars, ~2 KB summary
-wayfinder job backtest-diagnose <id>          # win/PnL by exit reason, hour, side — READ THIS, don't recompute
-# tune params, repeat backtest --quick / diagnose
+wayfinder job backtest-diagnose <id>          # READ next_step + recommendations — the framework tells you what to try
+# apply the ONE change next_step names, repeat backtest --quick / diagnose (see "the improve loop" below)
 # THE decision step — tune AND validate out-of-sample in one shot (never trust an in-sample grid):
 wayfinder job experiments <id> --grid grid.json --wf-test-bars 240 --wf-folds 4
 wayfinder job backtest <id>                   # full-history confirmation of the promoted params
 ```
 
 The `backtest` output is a compact stats summary (`stats` + `profile` + artifact paths). Add `--full` only if you truly need the raw curves; they're always on disk (`job backtest-view`).
+
+## The improve loop — read the recommendations, change ONE thing (don't thrash)
+
+`backtest-diagnose` returns a **`next_step`** (the single most important action) and a ranked **`recommendations`** list, each with the `evidence` (the actual stats/buckets) that triggered it — computed by the framework, so you never hand-roll `json.load(latest.json)` one-liners again. The loop that keeps churn low:
+
+1. Run `backtest --quick`, then `backtest-diagnose`.
+2. Read `next_step`. Apply **exactly one** change it names (widen the stop, add an entry filter, cut leverage, loosen entry…). Changing three things at once means you can't tell which one helped.
+3. Re-run `backtest --quick` and compare the headline. Kept the gain? Keep the change. Otherwise revert it.
+4. Repeat until `recommendations[0].severity == "validate"` (a promising in-sample result) — then go to the decision step.
+
+Severity ladder: `blocking` (too few trades / liquidated — fix first, nothing downstream matters) → `high` (no edge / poor payoff) → `medium` (trend-riding / costs / stop bleed) → `low` (side or session skew) → `validate` (good enough to prove out-of-sample). A `blocking` rec means **stop tuning params** and fix that first.
+
+**Limited churn:** iterate on `--quick`, one change per loop, and let `job experiments` do parameter sweeps in one CPU-safe pass. A full-history `backtest` is only for confirming a promoted candidate — re-running it after every tweak is the churn that pegs the box. If `--quick 1000` takes more than ~1–2 minutes, lower `warmup_bars` or the quick window; that's a signal, not something to wait out.
 
 ## Judge a strategy out-of-sample, or you're just curve-fitting
 
@@ -35,6 +48,17 @@ A single backtest tunes and scores on the **same** data — its Sharpe / profit 
 - Read the walk-forward report and judge on: **`decay_ratio`** (OOS mean ÷ IS mean — want it near 1; ≪ 1 = overfit), **`oos_positive_folds`** (want most folds profitable OOS), and OOS mean return vs IS mean. If OOS collapses vs IS, the strategy is fit to noise — go back to the idea, don't tune harder.
 - Also sanity-check the *regime*: if you're shorting an asset that fell 50% over the window, most of the "edge" is the trend, not the strategy — confirm it holds on a flat/up stretch too.
 - **Model costs.** Set `fee_bps` / `slippage_bps` in `execution_params`; a strategy with hundreds of trades and `total_fees: 0` is fiction.
+
+## Ship it — offer to deploy once (and only once) it validates
+
+When a candidate clears walk-forward (`decay_ratio` near 1, most `oos_positive_folds`), it's earned a deploy. Do this, don't skip to it:
+
+1. `wayfinder job promote-params <id> --grid <grid_id>` — writes the winning params into the job's `execution_params`.
+2. `wayfinder job backtest <id>` — one full-history confirmation on the promoted params.
+3. **Offer the deploy to the user** — summarize the OOS numbers (net, decay_ratio, oos_positive_folds, max drawdown) and *ask* before making it live. Going live is fund-moving; never enable it unprompted.
+4. On a yes: enable the runner loop (`wayfinder job set-mode <id> --mode monitor` / `wayfinder job resume <id>`, or `core_runner` add-job) so `update` runs on the interval.
+
+Do NOT offer to deploy a strategy that only looks good in-sample — that's the curve-fit trap the whole loop exists to avoid.
 
 ## The strategy contract (copy this skeleton)
 

--- a/wayfinder_paths/jobs/backtest_artifacts.py
+++ b/wayfinder_paths/jobs/backtest_artifacts.py
@@ -234,17 +234,224 @@ def diagnose_backtest(
         "best_trade_pnl",
         "worst_trade_pnl",
     )
+    by_exit_reason = _bucket(_reason)
+    by_close_hour = dict(sorted(_bucket(_hour).items()))
+    by_side = _bucket(lambda t: t.get("side") or "?")
+    recommendations = _recommendations(
+        stats, by_exit_reason, by_side, by_close_hour, len(closes)
+    )
     return {
         "available": True,
         "run_id": latest.get("run_id"),
         "headline": {k: stats[k] for k in headline_keys if k in stats},
         "closed_trades_analyzed": len(closes),
-        "by_exit_reason": _bucket(_reason),
-        "by_close_hour_utc": dict(sorted(_bucket(_hour).items())),
-        "by_side": _bucket(lambda t: t.get("side") or "?"),
+        # The single most important thing to do next — read this first.
+        "next_step": recommendations[0]["suggest"] if recommendations else None,
+        "recommendations": recommendations,
+        "by_exit_reason": by_exit_reason,
+        "by_close_hour_utc": by_close_hour,
+        "by_side": by_side,
         "worst_trades": [_trade_view(t) for t in ranked[:top_trades]],
         "best_trades": [_trade_view(t) for t in reversed(ranked[-top_trades:])],
     }
+
+
+# Severity rank → sort order for recommendations (blocking first).
+_REC_RANK = {"blocking": 0, "high": 1, "medium": 2, "low": 3, "validate": 4}
+
+
+def _recommendations(
+    stats: dict[str, Any],
+    by_reason: dict[Any, dict[str, Any]],
+    by_side: dict[Any, dict[str, Any]],
+    by_hour: dict[Any, dict[str, Any]],
+    n_closes: int,
+) -> list[dict[str, Any]]:
+    """Turn the run's own stats + trade buckets into ranked, evidence-backed
+    next actions — so a bad backtest yields concrete things to try instead of a
+    hand-rolled recompute. Every recommendation quotes the numbers that triggered
+    it (never invented); the top one is echoed as `next_step`. This is what makes
+    the diagnose→improve loop good: read `recommendations`, change ONE thing, and
+    re-run `--quick` rather than thrashing across many full backtests."""
+
+    def pct(value: Any) -> str:
+        return (
+            f"{float(value) * 100:.1f}%" if isinstance(value, (int, float)) else "n/a"
+        )
+
+    def num(value: Any, places: int = 2) -> str:
+        return (
+            f"{float(value):.{places}f}" if isinstance(value, (int, float)) else "n/a"
+        )
+
+    net = stats.get("net_return")
+    sharpe = stats.get("sharpe")
+    pf = stats.get("profit_factor")
+    wr = stats.get("win_rate")
+    tc = int(stats.get("trade_count") or 0)
+    avg = stats.get("avg_trade_pnl")
+    fees = float(stats.get("total_fees") or 0.0)
+    bh = stats.get("buy_hold_return")
+    liq = int(stats.get("liquidation_count") or 0)
+    recs: list[dict[str, Any]] = []
+
+    def add(severity: str, issue: str, evidence: str, suggest: str) -> None:
+        recs.append(
+            {
+                "severity": severity,
+                "issue": issue,
+                "evidence": evidence,
+                "suggest": suggest,
+            }
+        )
+
+    # Blocking: can't conclude anything from too few trades — don't tune on noise.
+    if tc < 10:
+        add(
+            "blocking",
+            "Too few trades to judge or tune",
+            f"trade_count={tc}",
+            "Loosen the entry condition (or fetch a longer dataset) so there are "
+            "≥20 trades. Tuning params on this few is fitting to noise."
+            if tc > 0
+            else "Entry never triggered — check the symbol, the threshold, and that "
+            "the frame has enough bars before `decide()` returns an intent.",
+        )
+    # Blocking: forced liquidation means the sizing/stop is wrong before anything else.
+    if liq > 0:
+        add(
+            "blocking",
+            "Position was liquidated",
+            f"liquidation_count={liq}",
+            "Reduce leverage and/or widen the stop — the position is force-closed "
+            "before the thesis can play out. Fix this before tuning entries.",
+        )
+    # High: negative base — params rarely rescue a signal with no edge.
+    if tc >= 10 and net is not None and net <= 0:
+        add(
+            "high",
+            "No edge on this data (net loss)",
+            f"net_return={pct(net)}, sharpe={num(sharpe)}, profit_factor={num(pf)}",
+            "Change the entry/exit idea or add a regime filter — a negative base "
+            "rarely turns positive from parameter tuning alone. Re-think the trigger "
+            "before sweeping params.",
+        )
+    # High: wins often but the losers are bigger — a payoff problem, not an entry one.
+    if wr is not None and wr > 0.55 and pf is not None and pf < 1.1:
+        add(
+            "high",
+            "Winners smaller than losers (poor payoff)",
+            f"win_rate={pct(wr)}, profit_factor={num(pf)}",
+            "Tighten the stop or add a take-profit / trailing exit — you win often "
+            "but give it back on the losses. Do NOT loosen entry.",
+        )
+    # Medium: most of the P&L is just the market trend, not alpha.
+    if (
+        bh is not None
+        and abs(float(bh)) > 0.20
+        and (net is None or abs(float(net)) <= abs(float(bh)))
+    ):
+        add(
+            "medium",
+            "Result may be mostly market trend, not edge",
+            f"buy_hold_return={pct(bh)} vs net_return={pct(net)}",
+            "The underlying moved a lot over this window, so a large share of any "
+            "P&L is beta. Re-test on a flat or opposite-regime slice before trusting it.",
+        )
+    # Medium: trading costs eat a big share of gross — cut trade count.
+    gross = abs(float(avg) * tc) if isinstance(avg, (int, float)) and tc else 0.0
+    if fees > 0 and gross > 0 and fees >= 0.3 * gross:
+        add(
+            "medium",
+            "Trading costs eat a large share of P&L",
+            f"total_fees={num(fees)} vs gross≈{num(gross)} over {tc} trades",
+            "Cut trade count with an entry filter or cooldown; confirm fee_bps / "
+            "slippage_bps are set so the net number is realistic.",
+        )
+    # Medium: losses concentrate in one exit path (often stop-outs). Only worth
+    # flagging when losses are an actual drag — a clean winner's losses are all
+    # stops by construction and don't need a nag.
+    losing = {k: v for k, v in by_reason.items() if v.get("pnl", 0) < 0}
+    losses_hurt = net is None or net <= 0 or (pf is not None and pf < 1.5)
+    if losing and losses_hurt:
+        gross_loss = sum(abs(v["pnl"]) for v in losing.values())
+        worst_key = min(losing, key=lambda k: losing[k]["pnl"])
+        worst = losing[worst_key]
+        if gross_loss > 0 and abs(worst["pnl"]) >= 0.5 * gross_loss:
+            is_stop = "stop" in str(worst_key).lower()
+            add(
+                "medium",
+                f"Losses concentrate in one exit: {worst_key}",
+                f"{worst_key}: {worst['trades']} trades, pnl={num(worst['pnl'])} "
+                f"({worst['pnl'] / -gross_loss * -1:.0%} of gross loss)",
+                "You're getting stopped out — widen the stop or add an entry filter "
+                "so you're not stopped on entry noise."
+                if is_stop
+                else f"Revisit the {worst_key} exit rule — that's where the losses are.",
+            )
+    # Low: the edge is one-directional.
+    losing_sides = {k: v for k, v in by_side.items() if v.get("pnl", 0) < 0}
+    winning_sides = {k: v for k, v in by_side.items() if v.get("pnl", 0) > 0}
+    if losing_sides and winning_sides:
+        side_key = min(losing_sides, key=lambda k: losing_sides[k]["pnl"])
+        add(
+            "low",
+            f"One direction loses money: {side_key}",
+            f"{side_key}: {losing_sides[side_key]['trades']} trades, "
+            f"pnl={num(losing_sides[side_key]['pnl'])}",
+            f"The edge is one-directional — consider trading only the profitable "
+            f"side or filtering {side_key} entries.",
+        )
+    # Low: P&L concentrates in a few hours — a session filter may help.
+    net_hour = sum(v.get("pnl", 0) for v in by_hour.values())
+    if net_hour > 0 and len(by_hour) >= 6:
+        top3 = sorted((v.get("pnl", 0) for v in by_hour.values()), reverse=True)[:3]
+        if sum(top3) >= 0.7 * net_hour:
+            hot = [
+                str(k)
+                for k, v in sorted(
+                    by_hour.items(), key=lambda kv: kv[1].get("pnl", 0), reverse=True
+                )[:3]
+            ]
+            add(
+                "low",
+                "P&L concentrates in a few hours (UTC)",
+                f"hours {', '.join(hot)} hold ≥70% of net P&L",
+                "A session / time-of-day entry filter may cut the flat or negative "
+                "hours and lift risk-adjusted return.",
+            )
+    # Validate: promising in-sample → the ONLY next step is out-of-sample proof.
+    if (
+        net is not None
+        and net > 0
+        and sharpe is not None
+        and sharpe > 0.5
+        and pf is not None
+        and pf > 1.2
+        and tc >= 20
+    ):
+        add(
+            "validate",
+            "In-sample looks promising — validate out-of-sample",
+            f"net_return={pct(net)}, sharpe={num(sharpe)}, profit_factor={num(pf)}, "
+            f"{tc} trades",
+            "Prove it out-of-sample before trusting it: `job experiments <id> --grid "
+            "grid.json --wf-test-bars N --wf-folds K`. Keep it only if decay_ratio "
+            "stays near 1 and most folds are positive — then offer to deploy.",
+        )
+
+    if not recs:
+        add(
+            "low",
+            "Result is inconclusive / mediocre",
+            f"net_return={pct(net)}, sharpe={num(sharpe)}, {tc} trades",
+            "Change ONE structural thing (an entry filter or an exit rule), re-run "
+            "`backtest --quick`, and compare — or validate out-of-sample if you "
+            "believe the edge is real.",
+        )
+
+    recs.sort(key=lambda r: _REC_RANK.get(r["severity"], 9))
+    return recs[:4]
 
 
 def _in_range(

--- a/wayfinder_paths/tests/test_backtest_profile_and_summary.py
+++ b/wayfinder_paths/tests/test_backtest_profile_and_summary.py
@@ -268,3 +268,95 @@ def test_diagnose_backtest_agrees_with_stats(tmp_path) -> None:
     assert sl["trades"] == 1 and sl["pnl"] == -1.5 and sl["win_rate"] == 0.0
     assert diag["worst_trades"][0]["pnl"] == -1.5
     assert diag["best_trades"][0]["pnl"] == 2.0
+    # 3 trades → the top recommendation is the blocking "too few trades" one.
+    assert diag["recommendations"][0]["severity"] == "blocking"
+    assert diag["next_step"] == diag["recommendations"][0]["suggest"]
+
+
+def _write_latest(store, job_id: str, stats: dict, trades: list) -> None:
+    bt_dir = store.job_dir(job_id) / "results" / "backtest"
+    bt_dir.mkdir(parents=True, exist_ok=True)
+    (bt_dir / "latest.json").write_text(
+        json.dumps({"run_id": "r1", "stats": stats, "trades": trades})
+    )
+
+
+def _closes(pnls_reasons_sides: list) -> list:
+    """Build closing fills (reduce_only, non-zero pnl) from (pnl, reason, side)."""
+    out = []
+    for i, (pnl, reason, side) in enumerate(pnls_reasons_sides):
+        out.append(
+            {
+                "timestamp": f"2026-01-01T{i % 24:02d}:00:00+00:00",
+                "side": side,
+                "reduce_only": True,
+                "realized_pnl_delta": pnl,
+                "raw": {"metadata": {"exit_reason": reason}},
+            }
+        )
+    return out
+
+
+def test_recommendations_flag_poor_payoff_high_winrate(tmp_path) -> None:
+    """Win often but lose more per loss (PF < 1.1) → a HIGH 'poor payoff' rec
+    that says tighten exits, not loosen entry — evidence quotes the real stats."""
+    from wayfinder_paths.jobs.backtest_artifacts import diagnose_backtest
+    from wayfinder_paths.jobs.store import JobStore
+
+    store = JobStore(repo_root=tmp_path)
+    # 24 trades, 70% winners but a poor profit factor.
+    trades = _closes(
+        [(1.0, "take_profit", "buy")] * 17 + [(-3.0, "stop_loss", "buy")] * 7
+    )
+    _write_latest(
+        store,
+        "payoff",
+        {
+            "net_return": -0.04,
+            "trade_count": 24,
+            "win_rate": 17 / 24,
+            "profit_factor": 17.0 / 21.0,
+            "avg_trade_pnl": (17 - 21) / 24,
+            "sharpe": -0.3,
+        },
+        trades,
+    )
+    diag = diagnose_backtest("payoff", store=store)
+    sevs = [r["severity"] for r in diag["recommendations"]]
+    issues = " ".join(r["issue"] for r in diag["recommendations"]).lower()
+    assert "high" in sevs
+    assert "payoff" in issues or "losers" in issues
+    # Stop-outs are the whole loss → a stop-bleed rec appears too.
+    assert any("stop" in r["suggest"].lower() for r in diag["recommendations"])
+
+
+def test_recommendations_validate_path_points_to_walk_forward(tmp_path) -> None:
+    """A promising in-sample result yields the 'validate out-of-sample' rec
+    naming job experiments / decay_ratio — the offer-to-deploy gate."""
+    from wayfinder_paths.jobs.backtest_artifacts import diagnose_backtest
+    from wayfinder_paths.jobs.store import JobStore
+
+    store = JobStore(repo_root=tmp_path)
+    trades = _closes(
+        [(3.0, "take_profit", "short")] * 22 + [(-1.0, "stop_loss", "short")] * 8
+    )
+    _write_latest(
+        store,
+        "good",
+        {
+            "net_return": 0.31,
+            "trade_count": 30,
+            "win_rate": 22 / 30,
+            "profit_factor": 66.0 / 8.0,
+            "avg_trade_pnl": (66 - 8) / 30,
+            "sharpe": 2.1,
+        },
+        trades,
+    )
+    diag = diagnose_backtest("good", store=store)
+    validate = [r for r in diag["recommendations"] if r["severity"] == "validate"]
+    assert validate, diag["recommendations"]
+    assert "experiments" in validate[0]["suggest"]
+    assert "decay_ratio" in validate[0]["suggest"]
+    # No blocking/high issue on a clean promising run.
+    assert diag["recommendations"][0]["severity"] == "validate"


### PR DESCRIPTION
## Why

Continues the create-a-strategy loop fixes (#479/#480/#481). Those made backtests fast and diagnosable and steered tuning to walk-forward OOS. The remaining weak spot was the **diagnose→improve** step: on a bad result the agent hand-rolled ~30 `json.load(latest.json)` one-liners and thrashed across full backtests instead of making a focused change. This makes the framework hand the agent concrete, ranked next actions.

## Changes

**`diagnose_backtest` → recommendation engine.** The diagnose output now includes:
- `recommendations`: a ranked list (`blocking → high → medium → low → validate`), each `{severity, issue, evidence, suggest}` where `evidence` quotes the actual stats/buckets that triggered it — synthesized mechanically from the run's own `stats` + exit-reason/side/hour buckets, so it can never disagree with the backtest.
- `next_step`: the single top action, echoed for convenience.

Rule coverage: too-few-trades (blocking — don't tune on noise), forced liquidation (blocking), no-edge net loss, poor payoff (high win-rate + PF<1.1 → tighten exits, not entry), trend-riding vs `buy_hold_return`, cost drag (fees vs gross), stop-out concentration (gated so a clean winner isn't nagged), one-sided edge, session concentration, and the promising→**validate-OOS** path (names `job experiments … --wf-test-bars`/`decay_ratio`).

**Skill (`developing-jobs-v1-strategies`):**
- New "improve loop" section: read `next_step`, change **one** thing, re-run `--quick`, compare — limited churn by construction. Full-history backtests are only for confirming a promoted candidate.
- New "ship it" section: once it clears walk-forward, `promote-params` → confirm → **offer to deploy** (going live is fund-moving; never unprompted). Never offer to deploy an in-sample-only result.

## Tests
- too-few-trades → `blocking` top rec + `next_step` mirrors it
- poor-payoff (70% win, PF<1) → `high` payoff rec + stop-bleed suggestion
- promising run → `validate` rec naming `job experiments` / `decay_ratio`, no false blocking/high
- Full `test_backtest_profile_and_summary.py` green (10 passed); ruff + format clean.