### PR TITLE
jobs walk-forward: default to a bounded rolling window (fast OOS validation)

### DIFF
--- a/.claude/skills/developing-jobs-v1-strategies/SKILL.md
+++ b/.claude/skills/developing-jobs-v1-strategies/SKILL.md
@@ -44,7 +44,7 @@ Severity ladder: `blocking` (too few trades / liquidated — fix first, nothing 
 
 A single backtest tunes and scores on the **same** data — its Sharpe / profit factor are **not evidence of an edge**. A "great" in-sample result (Sharpe 6+, PF 10+) almost always means you overfit. The only number that means anything is **out-of-sample**:
 
-- Run `job experiments <id> --grid grid.json --wf-test-bars 240 --wf-folds 4`. This picks params on each fold's train window and scores them on the **held-out** window it never saw.
+- Run `job experiments <id> --grid grid.json --wf-test-bars 240 --wf-folds 4`. This picks params on each fold's train window and scores them on the **held-out** window it never saw. It defaults to a **bounded rolling** train window, so it stays fast (seconds–low minutes) even on a full dataset — don't pass `--wf-anchored` (expanding window, ~4x slower) unless you specifically want anchored folds, and don't hand-shrink the dataset to make it finish.
 - Read the walk-forward report and judge on: **`decay_ratio`** (OOS mean ÷ IS mean — want it near 1; ≪ 1 = overfit), **`oos_positive_folds`** (want most folds profitable OOS), and OOS mean return vs IS mean. If OOS collapses vs IS, the strategy is fit to noise — go back to the idea, don't tune harder.
 - Also sanity-check the *regime*: if you're shorting an asset that fell 50% over the window, most of the "edge" is the trend, not the strategy — confirm it holds on a flat/up stretch too.
 - **Model costs.** Set `fee_bps` / `slippage_bps` in `execution_params`; a strategy with hundreds of trades and `total_fees: 0` is fiction.

--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -417,7 +417,10 @@ def experiments_cmd(
             "train_bars": wf_train_bars,
             "folds": wf_folds,
             "warmup_bars": wf_warmup_bars,
-            "anchored": wf_anchored or wf_train_bars is None,
+            # Anchor (expanding train window) ONLY when explicitly asked. Default
+            # (no --wf-train-bars) → run_walk_forward's bounded rolling window,
+            # which is ~4x faster than expanding on a full dataset.
+            "anchored": wf_anchored,
         }
     optuna_options = (
         {"n_trials": n_trials, "seed": seed} if optimizer == "optuna" else None

--- a/wayfinder_paths/jobs/execution/walk_forward.py
+++ b/wayfinder_paths/jobs/execution/walk_forward.py
@@ -27,6 +27,12 @@ from wayfinder_paths.jobs.execution.simulator import (
     simulate_execution,
 )
 
+# Rolling train window = this many test windows. Bounds each fold's cost to a
+# fixed size regardless of dataset length, so walk-forward stays fast enough for
+# interactive validation. Anchored/expanding windows (opt-in) re-replay all prior
+# history every fold — ~4x slower on a full dataset.
+DEFAULT_WF_TRAIN_MULTIPLE = 4
+
 
 def run_walk_forward(
     script_entrypoint: str | Path | Callable[..., Any],
@@ -51,7 +57,10 @@ def run_walk_forward(
     if folds <= 0:
         raise ValueError("walk-forward requires folds > 0")
     if train_bars is None and not anchored:
-        raise ValueError("pass train_bars or anchored=True")
+        # Default to a bounded rolling window instead of erroring — keeps fold
+        # cost independent of dataset size (fast) and removes a footgun that made
+        # callers fall back to the slow anchored path.
+        train_bars = max(warmup_bars, DEFAULT_WF_TRAIN_MULTIPLE * test_bars)
 
     timestamps = dataset.bars.timestamps  # unique + sorted (multi-symbol safe)
     total = len(timestamps)

--- a/wayfinder_paths/tests/test_backtest_profile_and_summary.py
+++ b/wayfinder_paths/tests/test_backtest_profile_and_summary.py
@@ -360,3 +360,37 @@ def test_recommendations_validate_path_points_to_walk_forward(tmp_path) -> None:
     assert "decay_ratio" in validate[0]["suggest"]
     # No blocking/high issue on a clean promising run.
     assert diag["recommendations"][0]["severity"] == "validate"
+
+
+def test_walk_forward_default_is_bounded_rolling_not_anchored() -> None:
+    """Walk-forward with only folds/test_bars must NOT raise and must use a
+    bounded ROLLING train window (constant size across folds) — the fast path.
+    Previously this raised, pushing callers to the ~4x-slower anchored/expanding
+    window that made OOS validation blow past the interactive time budget."""
+    from wayfinder_paths.jobs.execution.walk_forward import (
+        DEFAULT_WF_TRAIN_MULTIPLE,
+        run_walk_forward,
+    )
+
+    ds = _dataset(500)
+    rep = run_walk_forward(
+        _build_strategy, ds, SPEC, [{}], folds=3, test_bars=60, warmup_bars=60
+    )
+    ok = [f for f in rep["folds"] if f["status"] == "ok"]
+    assert len(ok) == 3
+    # Rolling: every fold trains on the same bounded window (4 x test_bars).
+    assert {f["train"]["bars"] for f in ok} == {DEFAULT_WF_TRAIN_MULTIPLE * 60}
+
+    # Anchored is opt-in and expands — later folds train on strictly more bars.
+    anchored = run_walk_forward(
+        _build_strategy,
+        ds,
+        SPEC,
+        [{}],
+        folds=3,
+        test_bars=60,
+        warmup_bars=60,
+        anchored=True,
+    )
+    a_sizes = [f["train"]["bars"] for f in anchored["folds"] if f["status"] == "ok"]
+    assert a_sizes[-1] > a_sizes[0]


### PR DESCRIPTION
## Why

Found by driving the cloud agent live on the dev box (the create-a-strategy loop). The agent correctly reached the out-of-sample validation step (`job experiments --wf-test-bars N --wf-folds K`) — but it ran **4+ minutes** on a full dataset, and the agent itself reacted with *"Too slow on full dataset. Let me constrain the training window."* That blows past the user's 1-3 min budget for a backtest-family operation.

**Root cause:** cli.py set `anchored = wf_anchored or wf_train_bars is None`. So the **default** (no `--wf-train-bars`) forced an *anchored, expanding* train window that re-replays all prior history every fold — ~3-4x slower than a bounded rolling window. Measured locally: **3.1s (anchored) vs 1.0s (bounded rolling)** for folds=4 on 4320 bars. On the throttled 2-vCPU box that 3x is the difference between ">3 min" and "<1 min".

## Fix (bounded rolling is the default; anchored is opt-in)

- **cli.py:** `anchored` is now set *only* by an explicit `--wf-anchored`.
- **walk_forward.py:** when neither `train_bars` nor `anchored` is given, default `train_bars = max(warmup_bars, 4 * test_bars)` — a bounded rolling window — instead of raising `ValueError` (the footgun that pushed callers onto the anchored path in the first place). Rolling walk-forward is a standard, arguably more regime-robust choice.
- **skill:** notes the walk-forward is fast-by-default; don't pass `--wf-anchored` or hand-shrink the dataset to make it finish.

## Test
`test_walk_forward_default_is_bounded_rolling_not_anchored`: the default (folds/test_bars only) no longer raises and trains a **constant bounded** window across folds; anchored (opt-in) still expands. Full `test_backtest_profile_and_summary.py` green (11 passed); ruff + format clean.