### PR TITLE
jobs MCP: run backtest_job in a thread so it works from async

### DIFF
--- a/wayfinder_paths/mcp/tools/jobs.py
+++ b/wayfinder_paths/mcp/tools/jobs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any, Literal
 
 from wayfinder_paths.jobs.application import (
@@ -180,7 +181,14 @@ async def core_jobs(
         return ok(validate_execution_job(job_id, strict=strict, store=store))
 
     if action == "backtest_job":
-        payload = backtest_execution_job(
+        # Run the (sync, CPU-bound) simulator in a worker thread. It guards
+        # against running inside an event loop (simulator raises if
+        # asyncio.get_running_loop() succeeds), so calling it inline here — in
+        # this async tool — would fail; to_thread also keeps it from blocking
+        # the MCP loop. Without this the agent has no working backtest tool and
+        # falls back to fighting the CLI / raw Python.
+        payload = await asyncio.to_thread(
+            backtest_execution_job,
             job_id,
             grid_path=grid_path,
             workers=workers,

--- a/wayfinder_paths/tests/test_backtest_profile_and_summary.py
+++ b/wayfinder_paths/tests/test_backtest_profile_and_summary.py
@@ -394,3 +394,24 @@ def test_walk_forward_default_is_bounded_rolling_not_anchored() -> None:
     )
     a_sizes = [f["train"]["bars"] for f in anchored["folds"] if f["status"] == "ok"]
     assert a_sizes[-1] > a_sizes[0]
+
+
+def test_simulator_runs_from_async_only_via_thread() -> None:
+    """The simulator refuses to run inside a live event loop, so the async MCP
+    backtest tool MUST offload it to a thread. Guards that contract: inline
+    raises, `to_thread` works. If the guard or the MCP wrapper regresses, the
+    agent loses its only working backtest tool and falls back to fighting the
+    CLI / raw Python (the failure this fix removes)."""
+    import asyncio
+
+    import pytest
+
+    async def run():
+        with pytest.raises(RuntimeError, match="event loop"):
+            simulate_execution(_build_strategy, _dataset(120), SPEC, {})
+        return await asyncio.to_thread(
+            simulate_execution, _build_strategy, _dataset(120), SPEC, {}
+        )
+
+    res = asyncio.run(run())
+    assert "net_return" in res.stats


### PR DESCRIPTION
Mined from a live Strategy Lab transcript. The agent had **no working way to run a backtest**:
- `core_jobs(action="backtest_job")` is async and called the **sync** `backtest_execution_job` inline; the simulator guards with `asyncio.get_running_loop()` and raises inside a live loop → the MCP tool errored (*'does not support async simulation'*).
- The `wayfinder` CLI isn't on `PATH` either.

With both natural paths dead, the agent burned ~15 tool calls fighting `pip install -e .` (timed out), raw-Python `asyncio.run(main())` (event-loop error), CliRunner, subprocess+ThreadPool, and finally ProcessPoolExecutor to run a single backtest.

**Fix:** offload `backtest_execution_job` to a worker thread via `asyncio.to_thread` in the MCP tool. The sim then runs with no live loop in that thread (guard passes) and doesn't block the MCP loop — so `core_jobs(action="backtest_job")` just works, and the agent uses the same tool family it already uses for list/diagnose.

Test guards the contract (inline raises inside a loop, to_thread works). Suite green (12).

Complements #487 (told the agent the full CLI path + no reinstall/raw-Python). A separate harness change to symlink `wayfinder` onto PATH would make the CLI path work too.