### PR TITLE
jobs MCP: isolate heavy ops in a child process (server was OOM-dying)

### DIFF
--- a/wayfinder_paths/jobs/execution/op_runner.py
+++ b/wayfinder_paths/jobs/execution/op_runner.py
@@ -1,0 +1,71 @@
+"""Run one heavy jobs operation in an isolated child process.
+
+The MCP server is a long-lived asyncio process sharing a small (2 GB / 2 vCPU)
+box with the agent runtime. Running a backtest inside it — even offloaded to a
+worker thread — has two observed failure modes:
+
+1. GIL contention with the server's event loop slows the tick loop ~28x
+   (measured live: 15 bars/s in-server vs 429 bars/s standalone).
+2. The memory spike of a full run gets the WHOLE server OOM-killed, silently
+   dropping every wayfinder tool for the session (observed live: server died
+   at backtest completion with no traceback, opencode timed out the call at
+   300s, and the next call failed with "unable to connect").
+
+Child-process isolation fixes both: the server's loop stays free, and a killed
+child surfaces as a clean tool error instead of a dead server.
+
+Protocol: JSON ``{"op": ..., "kwargs": {...}}`` on stdin; the result as JSON on
+stdout. stdout carries ONLY the result JSON — backtest progress already goes to
+stderr. Failures propagate as a traceback on stderr with a non-zero exit.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+
+def _run(op: str, kwargs: dict[str, Any]) -> Any:
+    # Imports live inside each branch so the child only pays for what it runs.
+    if op == "__echo__":
+        # Health-check / test op: round-trips kwargs through the full pipe.
+        return kwargs
+    if op == "fetch_dataset":
+        from wayfinder_paths.jobs.execution.preflight import build_live_dataset
+
+        return build_live_dataset(kwargs.pop("job_id"), **kwargs)
+    if op == "backtest_job":
+        from wayfinder_paths.jobs.execution.job import (
+            backtest_execution_job,
+            summarize_backtest_payload,
+        )
+
+        full = kwargs.pop("full", False)
+        payload = backtest_execution_job(kwargs.pop("job_id"), **kwargs)
+        return payload if full else summarize_backtest_payload(payload)
+    if op == "experiments":
+        from wayfinder_paths.jobs.execution.experiments import run_experiment
+        from wayfinder_paths.jobs.execution.job import summarize_backtest_payload
+
+        full = kwargs.pop("full", False)
+        result = run_experiment(kwargs.pop("job_id"), kwargs.pop("grid"), **kwargs)
+        backtest = result.get("backtest")
+        if isinstance(backtest, dict) and not full:
+            result["backtest"] = summarize_backtest_payload(backtest)
+        return result
+    if op == "promote_params":
+        from wayfinder_paths.jobs.execution.experiments import promote_params
+
+        return promote_params(kwargs.pop("job_id"), **kwargs)
+    raise ValueError(f"unknown op: {op}")
+
+
+def main() -> None:
+    request = json.load(sys.stdin)
+    result = _run(request["op"], dict(request.get("kwargs") or {}))
+    json.dump(result, sys.stdout, default=str)
+
+
+if __name__ == "__main__":
+    main()

--- a/wayfinder_paths/mcp/tools/jobs.py
+++ b/wayfinder_paths/mcp/tools/jobs.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import sys
 from typing import Any, Literal
 
 from wayfinder_paths.jobs.application import (
@@ -11,16 +13,7 @@ from wayfinder_paths.jobs.application import (
 )
 from wayfinder_paths.jobs.backtest_artifacts import diagnose_backtest
 from wayfinder_paths.jobs.compiler import JobCompiler
-from wayfinder_paths.jobs.execution.experiments import (
-    list_experiments,
-    promote_params,
-    run_experiment,
-)
-from wayfinder_paths.jobs.execution.job import (
-    backtest_execution_job,
-    summarize_backtest_payload,
-)
-from wayfinder_paths.jobs.execution.preflight import build_live_dataset
+from wayfinder_paths.jobs.execution.experiments import list_experiments
 from wayfinder_paths.jobs.execution.validation import validate_execution_job
 from wayfinder_paths.jobs.halt import clear_halt, request_halt
 from wayfinder_paths.jobs.models import (
@@ -63,6 +56,42 @@ JobAction = Literal[
     "delete",
     "sync",
 ]
+
+
+async def _run_job_op(op: str, kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Run a heavy jobs operation in an isolated child process.
+
+    Backtests/experiments must NOT run inside this long-lived MCP server
+    process: GIL contention with the event loop slows the tick loop ~28x, and
+    the memory spike can get the whole server OOM-killed — which silently
+    drops every wayfinder tool for the session (opencode never reconnects).
+    A child process keeps the server responsive and turns a killed run into a
+    clean tool error. See op_runner for the protocol.
+    """
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-m",
+        "wayfinder_paths.jobs.execution.op_runner",
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate(
+        json.dumps({"op": op, "kwargs": kwargs}).encode()
+    )
+    if proc.returncode != 0:
+        lines = (stderr or b"").decode(errors="replace").strip().splitlines()
+        tail = " | ".join(lines[-3:]) if lines else None
+        if proc.returncode < 0:  # killed by signal — on this box, usually OOM
+            return err(
+                "job_op_killed",
+                f"{op} process was killed (signal {-proc.returncode}) — likely "
+                "out of memory; retry with fewer bars (quick_bars) or a smaller "
+                "grid",
+                tail,
+            )
+        return err("job_op_failed", f"{op} failed (exit {proc.returncode})", tail)
+    return ok(json.loads(stdout.decode()))
 
 
 @catch_errors
@@ -208,18 +237,16 @@ async def core_jobs(
         return ok(validate_execution_job(job_id, strict=strict, store=store))
 
     if action == "fetch_dataset":
-        # Network + disk bound and fully sync — off the MCP loop it goes.
-        return ok(
-            await asyncio.to_thread(
-                build_live_dataset,
-                job_id,
-                days=days,
-                store=store,
-                source=dataset_source,
-                exchange=exchange,
-                market_type=market_type,
-                quote=quote,
-            )
+        return await _run_job_op(
+            "fetch_dataset",
+            {
+                "job_id": job_id,
+                "days": days,
+                "source": dataset_source,
+                "exchange": exchange,
+                "market_type": market_type,
+                "quote": quote,
+            },
         )
 
     if action == "experiments":
@@ -236,54 +263,45 @@ async def core_jobs(
                 "folds": wf_folds,
                 "anchored": False,
             }
-        result = await asyncio.to_thread(
-            run_experiment,
-            job_id,
-            chosen_grid,
-            rank_by=rank_by,
-            workers=workers,
-            parallel=parallel,
-            walk_forward=walk_forward,
-            store=store,
+        return await _run_job_op(
+            "experiments",
+            {
+                "job_id": job_id,
+                "grid": chosen_grid,
+                "rank_by": rank_by,
+                "workers": workers,
+                "parallel": parallel,
+                "walk_forward": walk_forward,
+                "full": full,
+            },
         )
-        backtest = result.get("backtest")
-        if isinstance(backtest, dict) and not full:
-            result["backtest"] = summarize_backtest_payload(backtest)
-        return ok(result)
 
     if action == "promote_params":
-        return ok(
-            await asyncio.to_thread(
-                promote_params,
-                job_id,
-                grid_id=grid_id,
-                run_id=run_id,
-                params=execution_params,
-                via_proposal=via_proposal,
-                store=store,
-            )
+        return await _run_job_op(
+            "promote_params",
+            {
+                "job_id": job_id,
+                "grid_id": grid_id,
+                "run_id": run_id,
+                "params": execution_params,
+                "via_proposal": via_proposal,
+            },
         )
 
     if action == "backtest_job":
-        # Run the (sync, CPU-bound) simulator in a worker thread. It guards
-        # against running inside an event loop (simulator raises if
-        # asyncio.get_running_loop() succeeds), so calling it inline here — in
-        # this async tool — would fail; to_thread also keeps it from blocking
-        # the MCP loop. Without this the agent has no working backtest tool and
-        # falls back to fighting the CLI / raw Python.
-        payload = await asyncio.to_thread(
-            backtest_execution_job,
-            job_id,
-            grid_path=grid_path,
-            workers=workers,
-            parallel=parallel,
-            quick_bars=quick_bars,
-            store=store,
+        # The child summarizes unless full=True — the compact summary is ~2 KB
+        # vs ~8 MB of per-bar arrays (all persisted under results/backtest/).
+        return await _run_job_op(
+            "backtest_job",
+            {
+                "job_id": job_id,
+                "grid_path": grid_path,
+                "workers": workers,
+                "parallel": parallel,
+                "quick_bars": quick_bars,
+                "full": full,
+            },
         )
-        # Default to the compact summary (~2 KB) — the full payload is ~8 MB of
-        # per-bar arrays already persisted to results/backtest/. Pass full=True
-        # to return everything.
-        return ok(payload if full else summarize_backtest_payload(payload))
 
     if action == "backtest_diagnose":
         return ok(diagnose_backtest(job_id, proposal_id=proposal_id, store=store))

--- a/wayfinder_paths/tests/test_backtest_profile_and_summary.py
+++ b/wayfinder_paths/tests/test_backtest_profile_and_summary.py
@@ -417,37 +417,36 @@ def test_simulator_runs_from_async_only_via_thread() -> None:
     assert "net_return" in res.stats
 
 
-def test_mcp_loop_actions_run_off_loop_and_summarize(monkeypatch) -> None:
-    """The full strategy-dev loop (fetch_dataset / experiments / promote_params)
-    is reachable via the async MCP tool: each sync step must execute OFF the
-    event loop (to_thread), and the experiments backtest payload comes back
-    summarized (heavy arrays stripped, in-sample note attached)."""
+def test_mcp_job_ops_run_in_isolated_subprocess() -> None:
+    """Heavy job ops (backtest/experiments/fetch/promote) run in a CHILD
+    process, not inside the MCP server: in-server runs contend with the event
+    loop for the GIL (~28x slowdown observed) and a memory spike OOM-kills the
+    whole server, silently dropping every wayfinder tool. This drives the real
+    subprocess pipe end-to-end (echo op) and asserts failures come back as
+    clean tool errors instead of a dead server."""
     import asyncio
 
     from wayfinder_paths.mcp.tools import jobs as mcp_jobs
 
-    def _off_loop_marker(name):
-        def stub(*args, **kwargs):
-            try:
-                asyncio.get_running_loop()
-            except RuntimeError:
-                return {"stub": name}
-            raise AssertionError(f"{name} ran ON the event loop")
+    async def drive():
+        echoed = await mcp_jobs._run_job_op("__echo__", {"a": 1, "b": [2, 3]})
+        failed = await mcp_jobs._run_job_op("__nope__", {})
+        return echoed, failed
 
-        return stub
+    echoed, failed = asyncio.run(drive())
+    assert echoed == {"ok": True, "result": {"a": 1, "b": [2, 3]}}
+    assert failed["ok"] is False
+    assert failed["error"]["code"] == "job_op_failed"
+    # The child's traceback tail is surfaced so real errors stay debuggable.
+    assert "unknown op" in str(failed["error"]["details"])
 
-    monkeypatch.setattr(
-        mcp_jobs, "build_live_dataset", _off_loop_marker("fetch_dataset")
-    )
-    monkeypatch.setattr(mcp_jobs, "promote_params", _off_loop_marker("promote"))
 
-    def fake_experiment(*args, **kwargs):
-        try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            pass
-        else:
-            raise AssertionError("run_experiment ran ON the event loop")
+def test_op_runner_summarizes_experiments_backtest(monkeypatch) -> None:
+    """The child summarizes the experiments backtest payload (heavy arrays
+    stripped, in-sample note attached) so only ~2 KB crosses the pipe."""
+    from wayfinder_paths.jobs.execution import op_runner
+
+    def fake_experiment(job_id, grid, **kwargs):
         return {
             "experiment": {"id": "e1"},
             "backtest": {
@@ -468,22 +467,12 @@ def test_mcp_loop_actions_run_off_loop_and_summarize(monkeypatch) -> None:
             },
         }
 
-    monkeypatch.setattr(mcp_jobs, "run_experiment", fake_experiment)
+    import wayfinder_paths.jobs.execution.experiments as experiments_mod
 
-    async def drive():
-        fetched = await mcp_jobs.core_jobs(action="fetch_dataset", job_id="j")
-        promoted = await mcp_jobs.core_jobs(
-            action="promote_params", job_id="j", grid_id="g1"
-        )
-        exp = await mcp_jobs.core_jobs(
-            action="experiments", job_id="j", grid={"a": [1, 2]}
-        )
-        return fetched, promoted, exp
-
-    fetched, promoted, exp = asyncio.run(drive())
-    assert fetched == {"ok": True, "result": {"stub": "fetch_dataset"}}
-    assert promoted == {"ok": True, "result": {"stub": "promote"}}
-    backtest = exp["result"]["backtest"]
-    # Summarized: heavy per-run arrays stripped + in-sample note attached.
+    monkeypatch.setattr(experiments_mod, "run_experiment", fake_experiment)
+    result = op_runner._run(
+        "experiments", {"job_id": "j", "grid": {"a": [1, 2]}, "full": False}
+    )
+    backtest = result["backtest"]
     assert "equity_curve" not in backtest["result"]["ranked"][0]
     assert "note" in backtest


### PR DESCRIPTION
## What the live test found

Driving the Strategy Lab agent through a fresh ETH mean-reversion build (on #489), the **first-ever real `backtest_job` through the MCP server** exposed two linked failures:

1. **~28x slowdown in-server** — 15 bars/s (tick p95 160ms) vs 429 bars/s standalone for the same job: the sim worker thread fights the server's event loop for the GIL.
2. **Silent server death** — at backtest completion the MCP server process died with *no traceback* (the OOM-killer signature on the shared 2 GB box). opencode timed the call out at exactly 300s, and every subsequent wayfinder tool call failed with *"Unable to connect"* — the entrypoint has no restart, so the session **permanently lost all wayfinder tools**. The agent only survived via the #487 CLI fallback.

Reproduced 1:1 on a scratch server (port 8001): same slowdown curve, same silent death, `curl exit 18`.

## Fix

Run the four heavy ops (`fetch_dataset` / `backtest_job` / `experiments` / `promote_params`) in an **isolated child process**:

- New `wayfinder_paths/jobs/execution/op_runner.py` — `{"op", "kwargs"}` JSON on stdin → result JSON on stdout (stdout carries only the JSON; sim progress already goes to stderr). The child summarizes backtest payloads so ~2 KB crosses the pipe.
- `core_jobs` spawns it via `asyncio.create_subprocess_exec` (`_run_job_op`): the server loop stays free, the sim runs at full standalone speed, and a killed child maps to a clean `job_op_killed — likely out of memory` tool error (crash tracebacks surfaced in `details`) instead of a dead server.

## Tests
Real subprocess round-trip (echo op) + error mapping; child-side experiments summarization. Suite green (14).

Companion harness PR adds a restart loop around the MCP server as defense-in-depth.