### PR TITLE
jobs research: pair admission gate + signal event-study (test before build)

### DIFF
--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -47,6 +47,7 @@ from wayfinder_paths.jobs.models import (
     normalize_agent_mode,
 )
 from wayfinder_paths.jobs.proposals import propose_change
+from wayfinder_paths.jobs.research import pair_check_job, signal_check_job
 from wayfinder_paths.jobs.runner_bridge import RunnerBridge
 from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.jobs.sync import snapshot_job, sync_all_jobs
@@ -547,6 +548,64 @@ def fetch_dataset_cmd(
         exchange=exchange,
         market_type=market_type,
         quote=quote,
+    )
+    _echo_json({"ok": True, "result": result})
+
+
+@job_cli.command(
+    name="pair-check",
+    help="Pre-trade pair admission gate: cointegration both directions, "
+    "rolling stability, half-life, cost hurdle, funding carry — PASS/REJECT "
+    "with numbers. Run BEFORE building any pair/spread strategy.",
+)
+@click.argument("job_id")
+@click.option("--symbols", default=None, help="Comma-separated pair, e.g. ETH,SOL.")
+@click.option("--days", type=int, default=720, show_default=True)
+@click.option("--bar", "bar_interval", default=None, help="Bar interval override.")
+@click.option("--exchange", default="binance", show_default=True)
+@click.option("--fee-bps", "fee_bps", type=float, default=None)
+@click.option("--slippage-bps", "slippage_bps", type=float, default=None)
+def pair_check_cmd(
+    job_id: str,
+    symbols: str | None,
+    days: int,
+    bar_interval: str | None,
+    exchange: str,
+    fee_bps: float | None,
+    slippage_bps: float | None,
+) -> None:
+    store = JobStore()
+    result = pair_check_job(
+        job_id,
+        symbols=[s.strip() for s in symbols.split(",")] if symbols else None,
+        days=days,
+        bar_interval=bar_interval,
+        exchange=exchange,
+        fee_bps=fee_bps,
+        slippage_bps=slippage_bps,
+        store=store,
+    )
+    _echo_json({"ok": True, "result": result})
+
+
+@job_cli.command(
+    name="signal-check",
+    help="Event-study a strategy's precomputed signal column against forward "
+    "returns (vs the series' own drift) — run BEFORE building a strategy "
+    "around the signal.",
+)
+@click.argument("job_id")
+@click.option("--column", required=True, help="Precomputed signal column name.")
+@click.option(
+    "--horizons", default=None, help="Comma-separated forward horizons in bars."
+)
+def signal_check_cmd(job_id: str, column: str, horizons: str | None) -> None:
+    store = JobStore()
+    result = signal_check_job(
+        job_id,
+        column=column,
+        horizons=[int(h) for h in horizons.split(",")] if horizons else None,
+        store=store,
     )
     _echo_json({"ok": True, "result": result})
 

--- a/wayfinder_paths/jobs/execution/driver.py
+++ b/wayfinder_paths/jobs/execution/driver.py
@@ -17,9 +17,9 @@ from wayfinder_paths.jobs.execution.engine import (
     run_tick,
 )
 from wayfinder_paths.jobs.execution.features import (
+    apply_precompute,
     feature_staleness,
     load_feature_rows,
-    apply_precompute,
     merge_features,
     parse_feature_specs,
 )

--- a/wayfinder_paths/jobs/execution/op_runner.py
+++ b/wayfinder_paths/jobs/execution/op_runner.py
@@ -39,6 +39,14 @@ def _run(op: str, kwargs: dict[str, Any]) -> Any:
         from wayfinder_paths.jobs.execution.preflight import fetch_funding_features
 
         return fetch_funding_features(kwargs.pop("job_id"), **kwargs)
+    if op == "pair_check":
+        from wayfinder_paths.jobs.research import pair_check_job
+
+        return pair_check_job(kwargs.pop("job_id"), **kwargs)
+    if op == "signal_check":
+        from wayfinder_paths.jobs.research import signal_check_job
+
+        return signal_check_job(kwargs.pop("job_id"), **kwargs)
     if op == "backtest_job":
         from wayfinder_paths.jobs.execution.job import (
             backtest_execution_job,

--- a/wayfinder_paths/jobs/research.py
+++ b/wayfinder_paths/jobs/research.py
@@ -1,0 +1,778 @@
+"""Pre-trade statistical research toolkit: signal checks and pair admission.
+
+Why this exists: live sessions showed the strategy agent building six parameter
+variants of signals that never had predictive power, and pair trades on
+correlated-but-not-cointegrated majors (ETH/SOL) where no parameter could
+rescue a spread that doesn't mean-revert. The cheap fix is to test the SIGNAL
+or the PAIR before building the strategy — a REJECT here is the methodology
+working, not failing.
+
+Layout contract: everything above `pair_admission_gate` is PURE (numpy/pandas
+only — importable from a strategy `precompute()` inside the purity sandbox).
+`*_job` orchestrators at the bottom do I/O (JobStore, ccxt) with function-local
+imports, mirroring op_runner.
+
+Statistical caveats (documented, deliberate):
+- Engle-Granger critical values are hard-coded MacKinnon case-2 asymptotic
+  anchors (constant, two variables): 1% = -3.90, 5% = -3.34, 10% = -3.04.
+  Small-sample corrections at n>=1500 bars shift t by <0.05 — ignored.
+- Multiple testing: at the 5% level, ~1 in 20 random pairs "passes"
+  cointegration by chance. The rolling-stability majority requirement is the
+  main defense; reports carry an explicit note. Scan wide, trade few.
+
+Stats functions adapted with thanks from
+examples/paths/spread-radar-reference/scripts/lib.py (ou_half_life,
+engle_granger residual test, stability idea) and
+examples/paths/hedge-finder/scripts/lib.py (adf_statistic, beta) — copied,
+not imported: examples/ is not a runtime package.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+# MacKinnon case-2 (constant, 2 variables) critical values for the
+# Engle-Granger residual t-stat. The upstream example labeled -3.34 as
+# p=0.03; it is the 5% critical value — corrected here.
+EG_CRITICAL = {"1%": -3.90, "5%": -3.34, "10%": -3.04}
+# Plain ADF (single series, constant) 5% critical value, n≈500.
+ADF_CRITICAL_5PCT = -2.86
+
+BAR_90D_SECONDS = 90 * 86_400
+
+
+# ── pure statistics ──────────────────────────────────────────────────────────
+
+
+def ou_half_life(spread: np.ndarray) -> float:
+    """Ornstein-Uhlenbeck half-life in BARS via AR(1). inf = not mean-reverting."""
+    spread = np.asarray(spread, dtype=float)
+    y, x = spread[1:], spread[:-1]
+    if len(x) < 20:
+        return float("inf")
+    xm = x.mean()
+    denom = np.sum((x - xm) ** 2)
+    if denom == 0:
+        return float("inf")
+    b = np.sum((x - xm) * (y - xm)) / denom
+    if b >= 1 or b <= 0:
+        return float("inf")
+    return float(np.log(2) / (-np.log(b)))
+
+
+def adf_stat(series: np.ndarray) -> float:
+    """ADF(1) t-statistic with constant. More negative = more stationary.
+    5% critical ≈ -2.86 (n≈500). Returns 0.0 when the series is too short."""
+    y = np.asarray(series, dtype=float)
+    y = y[~np.isnan(y)]
+    if len(y) < 24:
+        return 0.0
+    dy = np.diff(y)
+    y_lag = y[:-1]
+    dy_lag = np.concatenate([[0.0], dy[:-1]])
+    n = len(dy)
+    x = np.column_stack([np.ones(n), y_lag, dy_lag])
+    try:
+        coeffs, _, _, _ = np.linalg.lstsq(x, dy, rcond=None)
+    except np.linalg.LinAlgError:
+        return 0.0
+    b = coeffs[1]
+    resid = dy - x @ coeffs
+    s2 = float((resid**2).sum()) / max(n - 3, 1)
+    xtx_inv = np.linalg.pinv(x.T @ x)
+    se = math.sqrt(max(s2 * xtx_inv[1, 1], 1e-30))
+    return float(b / se)
+
+
+def _residual_adf_t(resid: np.ndarray) -> float:
+    """Engle-Granger step 2: ADF t-stat on regression residuals (no constant —
+    residuals are mean-zero by construction)."""
+    dy, yl = np.diff(resid), resid[:-1]
+    denom = np.sum(yl**2)
+    if denom == 0 or len(dy) < 2:
+        return 0.0
+    rho = np.sum(yl * dy) / denom
+    se = np.sqrt(np.sum((dy - rho * yl) ** 2) / (len(dy) - 1)) / np.sqrt(denom)
+    if se == 0:
+        return 0.0
+    return float(rho / se)
+
+
+def engle_granger(
+    y: np.ndarray, x: np.ndarray, *, log_prices: bool = True
+) -> dict[str, Any]:
+    """Engle-Granger cointegration test of y on x.
+
+    Returns hedge_ratio (regression slope), residual ADF t-stat, the critical
+    bucket it clears, a 5% pass flag, and the residual half-life in bars.
+    """
+    y = np.asarray(y, dtype=float)
+    x = np.asarray(x, dtype=float)
+    if log_prices:
+        y, x = np.log(y), np.log(x)
+    n = len(y)
+    if n < 50 or n != len(x):
+        return {
+            "hedge_ratio": None,
+            "t_stat": 0.0,
+            "level": None,
+            "cointegrated_5pct": False,
+            "half_life_bars": float("inf"),
+        }
+    design = np.column_stack([np.ones(n), x])
+    coeffs = np.linalg.lstsq(design, y, rcond=None)[0]
+    resid = y - design @ coeffs
+    t = _residual_adf_t(resid)
+    level = None
+    for name, crit in EG_CRITICAL.items():
+        if t < crit:
+            level = name
+            break
+    return {
+        "hedge_ratio": float(coeffs[1]),
+        "t_stat": t,
+        "level": level,
+        "cointegrated_5pct": t < EG_CRITICAL["5%"],
+        "half_life_bars": ou_half_life(resid),
+    }
+
+
+def engle_granger_both(a: np.ndarray, b: np.ndarray) -> dict[str, Any]:
+    """EG in both directions (the test is order-sensitive). Pass = both clear
+    the 5% critical value on log prices."""
+    ab = engle_granger(a, b)
+    ba = engle_granger(b, a)
+    return {
+        "ab": ab,
+        "ba": ba,
+        "pass": bool(ab["cointegrated_5pct"] and ba["cointegrated_5pct"]),
+    }
+
+
+def hurst_exponent(series: np.ndarray, max_lag: int = 100) -> float:
+    """Hurst exponent via variance of differences. H < 0.5 mean-reverting,
+    H ≈ 0.5 random walk, H > 0.5 trending."""
+    x = np.asarray(series, dtype=float)
+    x = x[~np.isnan(x)]
+    max_lag = min(max_lag, len(x) // 4)
+    if max_lag < 8:
+        return 0.5
+    lags = np.unique(np.geomspace(2, max_lag, num=12).astype(int))
+    taus = []
+    for lag in lags:
+        diff = x[lag:] - x[:-lag]
+        std = diff.std()
+        taus.append(std if std > 0 else 1e-12)
+    slope = np.polyfit(np.log(lags), np.log(taus), 1)[0]
+    return float(slope)
+
+
+def rolling_hedge_ratio(y: pd.Series, x: pd.Series, window: int) -> dict[str, Any]:
+    """Rolling OLS slope of log(y) on log(x) — the cointegration-vector hedge
+    ratio (never size a pair 1:1 by dollars)."""
+    ly = np.log(pd.Series(y, dtype=float))
+    lx = np.log(pd.Series(x, dtype=float))
+    cov = ly.rolling(window).cov(lx)
+    var = lx.rolling(window).var()
+    ratio = (cov / var.replace(0, np.nan)).dropna()
+    if ratio.empty:
+        return {"current": None, "mean": None, "std": None, "window": window}
+    return {
+        "current": float(ratio.iloc[-1]),
+        "mean": float(ratio.mean()),
+        "std": float(ratio.std()),
+        "window": window,
+    }
+
+
+def mean_crossings(spread: np.ndarray) -> int:
+    """Number of times the spread crosses its own mean."""
+    x = np.asarray(spread, dtype=float)
+    x = x[~np.isnan(x)]
+    if len(x) < 2:
+        return 0
+    centered = x - x.mean()
+    return int(np.sum(np.sign(centered[1:]) != np.sign(centered[:-1])))
+
+
+def rolling_stability(
+    log_a: np.ndarray,
+    log_b: np.ndarray,
+    *,
+    window_bars: int,
+    step_bars: int,
+) -> dict[str, Any]:
+    """Slide a window over the pair and test cointegration in each — a
+    relationship that only appears in one window is likely spurious. Windows
+    use the 10% critical value (less power at smaller n); the gate requires a
+    majority of windows to pass."""
+    a = np.asarray(log_a, dtype=float)
+    b = np.asarray(log_b, dtype=float)
+    n = len(a)
+    results = []
+    start = 0
+    while start + window_bars <= n:
+        seg_t = engle_granger(
+            a[start : start + window_bars],
+            b[start : start + window_bars],
+            log_prices=False,
+        )["t_stat"]
+        results.append(bool(seg_t < EG_CRITICAL["10%"]))
+        start += step_bars
+    if not results:
+        return {"windows": 0, "pass_fraction": 0.0}
+    return {
+        "windows": len(results),
+        "pass_fraction": float(np.mean(results)),
+        "per_window": results,
+    }
+
+
+def cost_hurdle(
+    spread_sigma: float,
+    *,
+    z_entry: float,
+    z_exit: float,
+    fee_bps: float,
+    slippage_bps: float,
+    legs: int = 2,
+) -> dict[str, Any]:
+    """Expected capture per trade vs total round-trip cost across all legs.
+    Practitioner floor: capture should be >= 3x cost."""
+    expected_capture = (z_entry - z_exit) * spread_sigma
+    round_trip_cost = legs * 2 * (fee_bps + slippage_bps) / 1e4
+    multiple = (
+        expected_capture / round_trip_cost if round_trip_cost > 0 else float("inf")
+    )
+    return {
+        "expected_capture": float(expected_capture),
+        "round_trip_cost": float(round_trip_cost),
+        "multiple": float(multiple),
+        "pass": bool(multiple >= 3.0),
+    }
+
+
+def net_funding_carry(
+    funding_long: pd.Series,
+    funding_short: pd.Series,
+    *,
+    hedge_ratio: float = 1.0,
+    periods_per_year: float = 365 * 3,
+) -> dict[str, Any]:
+    """Annualized net funding carry of long-A / short-B. Longs PAY positive
+    funding; shorts RECEIVE it. Positive result = the position is paid to wait."""
+    fl = pd.Series(funding_long, dtype=float).dropna()
+    fs = pd.Series(funding_short, dtype=float).dropna()
+    if fl.empty or fs.empty:
+        return {"available": False, "annualized": None}
+    per_period = -fl.mean() + hedge_ratio * fs.mean()
+    return {
+        "available": True,
+        "annualized": float(per_period * periods_per_year),
+        "long_leg_mean": float(fl.mean()),
+        "short_leg_mean": float(fs.mean()),
+    }
+
+
+def rolling_adf_kill(
+    spread: pd.Series, *, window: int, threshold: float = ADF_CRITICAL_5PCT
+) -> pd.Series:
+    """Causal rolling ADF stat of the spread — the live kill-switch column.
+    Strategies compute this in precompute() and stand down when it rises above
+    the threshold (cointegration breakdown is THE tail risk of pair trading)."""
+    s = pd.Series(spread, dtype=float)
+    out = pd.Series(np.nan, index=s.index)
+    values = s.to_numpy()
+    for i in range(window, len(values) + 1):
+        out.iloc[i - 1] = adf_stat(values[i - window : i])
+    return out
+
+
+def event_study(
+    frame: pd.DataFrame,
+    signal: str | pd.Series,
+    horizons: list[int] | None = None,
+) -> dict[str, Any]:
+    """Does an entry signal predict forward returns AT ALL? Run this before
+    building a strategy around it — if the signal doesn't beat the series'
+    own unconditional drift, no exit/sizing engineering can save it.
+
+    For each horizon h: mean forward log-return after signal bars vs the
+    unconditional mean forward return of the whole series (the random-entry
+    baseline), with a t-stat on the difference and the event count. n < 30 is
+    flagged insufficient — never treated as evidence of edge.
+    """
+    horizons = horizons or [1, 4, 12, 24, 48]
+    close = frame["close"].astype(float).to_numpy()
+    if isinstance(signal, str):
+        if signal not in frame.columns:
+            raise KeyError(
+                f"signal column {signal!r} not in frame; available: "
+                f"{sorted(c for c in frame.columns)}"
+            )
+        sig = frame[signal]
+    else:
+        sig = signal
+    sig = pd.Series(sig).fillna(False).astype(bool).to_numpy()
+    n = len(close)
+    per_horizon = []
+    any_edge = False
+    for h in sorted({int(h) for h in horizons}):
+        if h <= 0 or h >= n:
+            continue
+        fwd = np.log(close[h:] / close[:-h])  # forward return starting at t
+        events = sig[: n - h]
+        event_returns = fwd[events]
+        n_events = int(events.sum())
+        drift = float(fwd.mean())
+        if n_events == 0:
+            per_horizon.append({"horizon": h, "n": 0, "verdict": "no events"})
+            continue
+        mean_r = float(event_returns.mean())
+        std_r = float(event_returns.std(ddof=1)) if n_events > 1 else 0.0
+        sem = (
+            std_r / math.sqrt(n_events) if n_events > 1 and std_r > 0 else float("inf")
+        )
+        t = (mean_r - drift) / sem if math.isfinite(sem) else 0.0
+        edge = bool(t >= 2.0 and n_events >= 30)
+        any_edge = any_edge or edge
+        per_horizon.append(
+            {
+                "horizon": h,
+                "n": n_events,
+                "mean_fwd_return": mean_r,
+                "drift_baseline": drift,
+                "hit_rate": float((event_returns > 0).mean()),
+                "t_stat_vs_drift": float(t),
+                "edge": edge,
+                "note": "insufficient sample (n<30)" if n_events < 30 else None,
+            }
+        )
+    return {
+        "horizons": per_horizon,
+        "has_edge": any_edge,
+        "read": (
+            "signal beats the series' own drift at one or more horizons — "
+            "worth building and validating"
+            if any_edge
+            else "no horizon beats the unconditional drift with t>=2 and "
+            "n>=30 — the entry has no measured predictive power; change the "
+            "idea, not the parameters"
+        ),
+        "multiple_testing_note": (
+            "testing many signals inflates false positives — at t>=2, roughly "
+            "1 in 20 random signals looks good by chance; prefer fewer, "
+            "stronger hypotheses"
+        ),
+    }
+
+
+# ── pair admission gate (pure: DataFrames in, dict out) ──────────────────────
+
+
+def pair_admission_gate(
+    prices: pd.DataFrame,
+    *,
+    bar_seconds: int,
+    funding: pd.DataFrame | None = None,
+    fee_bps: float = 5.0,
+    slippage_bps: float = 3.5,
+    z_entry: float = 2.0,
+    z_exit: float = 0.5,
+    half_life_band_hours: tuple[float, float] = (12.0, 480.0),
+    stability_window_days: int = 75,
+    min_stability_fraction: float = 0.6,
+    min_crossings_per_90d: int = 15,
+    min_days: int = 365,
+) -> dict[str, Any]:
+    """The hard admission gate for any two-legged (pair/spread) idea.
+
+    REJECT if any hard check fails (cointegration both directions, rolling
+    stability, half-life band, cost hurdle, data sufficiency); MARGINAL when
+    only advisory checks fail (hurst, crossings); PASS otherwise. A REJECT is
+    a successful outcome — it saves days of tuning a spread that cannot work.
+    """
+    if prices.shape[1] != 2:
+        raise ValueError("pair_admission_gate expects exactly 2 price columns")
+    sym_a, sym_b = [str(c) for c in prices.columns]
+    clean = prices.dropna()
+    a = clean[sym_a].astype(float).to_numpy()
+    b = clean[sym_b].astype(float).to_numpy()
+    n_bars = len(clean)
+    days = n_bars * bar_seconds / 86_400
+    bars_per_day = 86_400 / bar_seconds
+
+    checks: list[dict[str, Any]] = []
+
+    # 1) data sufficiency (hard)
+    data_ok = days >= min_days
+    checks.append(
+        {
+            "name": "data_sufficiency",
+            "hard": True,
+            "pass": bool(data_ok),
+            "value": {"bars": n_bars, "days": round(days, 1)},
+            "threshold": {"min_days": min_days},
+            "detail": "multiple regimes needed; one trending regime cannot "
+            "validate mean reversion",
+        }
+    )
+
+    # 2) cointegration, both directions (hard)
+    eg = engle_granger_both(a, b)
+    checks.append(
+        {
+            "name": "engle_granger_both_directions",
+            "hard": True,
+            "pass": eg["pass"],
+            "value": {
+                "ab_t": round(eg["ab"]["t_stat"], 3),
+                "ba_t": round(eg["ba"]["t_stat"], 3),
+            },
+            "threshold": EG_CRITICAL["5%"],
+            "detail": "log-price residual ADF t vs MacKinnon 5% critical, "
+            "both regressions",
+        }
+    )
+    hedge = eg["ab"]["hedge_ratio"]
+
+    # spread on the estimated hedge ratio (fallback 1.0 when degenerate)
+    ratio = hedge if hedge and math.isfinite(hedge) and hedge > 0 else 1.0
+    spread = np.log(a) - ratio * np.log(b)
+
+    # 3) half-life within tradeable band (hard)
+    hl_bars = ou_half_life(spread)
+    hl_hours = hl_bars * bar_seconds / 3600 if math.isfinite(hl_bars) else None
+    lo, hi = half_life_band_hours
+    hl_ok = hl_hours is not None and lo <= hl_hours <= hi
+    checks.append(
+        {
+            "name": "half_life",
+            "hard": True,
+            "pass": bool(hl_ok),
+            "value": round(hl_hours, 1) if hl_hours is not None else None,
+            "band_hours": [lo, hi],
+            "detail": "OU half-life of the hedge-ratio spread; sets lookback "
+            "(3-5x) and time stop (2-3x)",
+        }
+    )
+
+    # 4) rolling stability (hard)
+    window_bars = max(50, int(stability_window_days * bars_per_day))
+    stability = rolling_stability(
+        np.log(a),
+        np.log(b),
+        window_bars=window_bars,
+        step_bars=max(1, window_bars // 3),
+    )
+    stab_ok = (
+        stability["windows"] >= 3
+        and stability["pass_fraction"] >= min_stability_fraction
+    )
+    checks.append(
+        {
+            "name": "rolling_stability",
+            "hard": True,
+            "pass": bool(stab_ok),
+            "value": round(stability["pass_fraction"], 2),
+            "threshold": min_stability_fraction,
+            "detail": f"cointegrated in {int(stability['pass_fraction'] * stability['windows'])}"
+            f"/{stability['windows']} {stability_window_days}d windows",
+        }
+    )
+
+    # 5) cost hurdle (hard)
+    sigma = float(
+        np.std(
+            spread
+            - pd.Series(spread)
+            .rolling(max(20, int(4 * hl_bars)) if math.isfinite(hl_bars) else 20)
+            .mean()
+            .to_numpy(),
+            ddof=0,
+        )
+    )
+    if not math.isfinite(sigma) or sigma == 0:
+        sigma = float(np.std(spread, ddof=0))
+    hurdle = cost_hurdle(
+        sigma,
+        z_entry=z_entry,
+        z_exit=z_exit,
+        fee_bps=fee_bps,
+        slippage_bps=slippage_bps,
+    )
+    checks.append(
+        {
+            "name": "cost_hurdle",
+            "hard": True,
+            "pass": hurdle["pass"],
+            "value": round(hurdle["multiple"], 2),
+            "threshold": 3.0,
+            "detail": f"expected capture {hurdle['expected_capture']:.4f} vs "
+            f"{hurdle['round_trip_cost']:.4f} round-trip on 2 legs",
+        }
+    )
+
+    # 6) hurst (advisory)
+    hurst = hurst_exponent(spread)
+    checks.append(
+        {
+            "name": "hurst",
+            "hard": False,
+            "pass": bool(hurst < 0.5),
+            "value": round(hurst, 3),
+            "threshold": 0.5,
+            "detail": "spread Hurst exponent; >0.5 = trending spread",
+        }
+    )
+
+    # 7) mean crossings (advisory)
+    crossings = mean_crossings(spread)
+    per_90d = crossings * BAR_90D_SECONDS / (n_bars * bar_seconds) if n_bars else 0
+    checks.append(
+        {
+            "name": "mean_crossings",
+            "hard": False,
+            "pass": bool(per_90d >= min_crossings_per_90d),
+            "value": round(per_90d, 1),
+            "threshold": min_crossings_per_90d,
+            "detail": "mean crossings per 90 days — trade opportunity frequency",
+        }
+    )
+
+    # 8) funding carry (advisory, never a REJECT trigger)
+    if (
+        funding is not None
+        and not funding.empty
+        and sym_a in funding
+        and sym_b in funding
+    ):
+        carry = net_funding_carry(funding[sym_a], funding[sym_b], hedge_ratio=ratio)
+        checks.append(
+            {
+                "name": "funding_carry",
+                "hard": False,
+                "pass": True,
+                "value": round(carry["annualized"], 4) if carry["available"] else None,
+                "detail": f"annualized net carry long {sym_a} / short {sym_b}"
+                if carry["available"]
+                else "funding history unavailable",
+            }
+        )
+
+    hard_fails = [c["name"] for c in checks if c["hard"] and not c["pass"]]
+    soft_fails = [c["name"] for c in checks if not c["hard"] and not c["pass"]]
+    verdict = "REJECT" if hard_fails else ("MARGINAL" if soft_fails else "PASS")
+
+    if verdict == "REJECT":
+        recommendation = (
+            f"REJECT — {sym_a} and {sym_b} do not form a tradeable spread on "
+            f"this data (failed: {', '.join(hard_fails)}). No parameter tuning "
+            "rescues a spread that does not mean-revert; consider a "
+            "funding-spread pair, a momentum/trend approach, or a different, "
+            "statistically related pair."
+        )
+    elif verdict == "MARGINAL":
+        recommendation = (
+            f"MARGINAL — hard checks pass but {', '.join(soft_fails)} are weak; "
+            "proceed only with reduced size and strict walk-forward validation."
+        )
+    else:
+        recommendation = (
+            "PASS — build with the suggested hedge ratio and half-life-derived "
+            "lookback/time-stop, then validate out-of-sample as usual."
+        )
+
+    suggested = {
+        "hedge_ratio": round(ratio, 4),
+        "lookback_bars": int(4 * hl_bars) if math.isfinite(hl_bars) else None,
+        "time_stop_bars": int(2.5 * hl_bars) if math.isfinite(hl_bars) else None,
+        "z_entry": z_entry,
+        "z_exit": z_exit,
+    }
+    return {
+        "pair": [sym_a, sym_b],
+        "n_bars": n_bars,
+        "days": round(days, 1),
+        "verdict": verdict,
+        "checks": checks,
+        "suggested": suggested,
+        "recommendation": recommendation,
+        "multiple_testing_note": (
+            "at the 5% level ~1 in 20 random pairs passes cointegration alone; "
+            "when scanning a universe require the stability check too and "
+            "prefer fewer, stronger pairs"
+        ),
+    }
+
+
+# ── I/O orchestrators (function-local imports; run via op_runner) ────────────
+
+
+def _job_context(job_id: str, store: Any) -> tuple[Any, dict, Any, list[str], int]:
+    from wayfinder_paths.jobs.execution.job import _load_job_yaml
+    from wayfinder_paths.jobs.execution.primitives import (
+        ExecutionSpec,
+        bar_interval_seconds,
+    )
+    from wayfinder_paths.jobs.execution.validation import resolve_execution_spec
+
+    root = store.job_dir(job_id)
+    job_data = _load_job_yaml(root)
+    spec_data, _ = resolve_execution_spec(root, job_data)
+    spec = ExecutionSpec.from_dict(spec_data)
+    params = dict(job_data.get("execution_params") or {})
+    symbols = [
+        str(s)
+        for s in (params.get("symbols") or spec.data_contract.get("symbols") or [])
+    ]
+    bar_seconds = bar_interval_seconds(spec.data_contract.get("bar_interval")) or 3600
+    return root, params, spec, symbols, bar_seconds
+
+
+def _pair_prices(
+    symbols: list[str],
+    *,
+    bar_interval: str,
+    days: int,
+    exchange: str,
+    feed: Any | None,
+) -> pd.DataFrame:
+    import asyncio
+
+    from wayfinder_paths.jobs.execution.ccxt_feed import fetch_ccxt_dataset_rows
+
+    rows, _meta = asyncio.run(
+        fetch_ccxt_dataset_rows(
+            symbols, bar_interval, days=days, exchange_id=exchange, exchange=feed
+        )
+    )
+    frame = pd.DataFrame(rows)
+    pivot = frame.pivot_table(index="timestamp", columns="symbol", values="close")
+    return pivot[symbols].dropna()
+
+
+def _job_funding(root: Any, symbols: list[str]) -> pd.DataFrame | None:
+    path = root / "state" / "features.jsonl"
+    if not path.exists():
+        return None
+    rows = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(row, dict) and row.get("name") == "funding":
+            rows.append(row)
+    if not rows:
+        return None
+    frame = pd.DataFrame(rows)
+    pivot = frame.pivot_table(index="timestamp", columns="symbol", values="value")
+    return pivot if all(s in pivot.columns for s in symbols) else None
+
+
+def pair_check_job(
+    job_id: str,
+    *,
+    symbols: list[str] | None = None,
+    days: int = 720,
+    bar_interval: str | None = None,
+    exchange: str = "binance",
+    fee_bps: float | None = None,
+    slippage_bps: float | None = None,
+    store: Any | None = None,
+    feed: Any | None = None,
+) -> dict[str, Any]:
+    """Run the pair admission gate for a job — fetches long history (default
+    2 years) and persists the report under results/research/pair_check/."""
+    from wayfinder_paths.jobs.store import JobStore
+
+    store = store or JobStore()
+    root, params, spec, job_symbols, bar_seconds = _job_context(job_id, store)
+    pair = [str(s) for s in (symbols or job_symbols)]
+    if len(pair) != 2:
+        raise ValueError(
+            f"pair_check needs exactly 2 symbols; got {pair} — pass symbols=[A, B]"
+        )
+    interval = bar_interval or spec.data_contract.get("bar_interval") or "1h"
+    from wayfinder_paths.jobs.execution.primitives import bar_interval_seconds
+
+    seconds = bar_interval_seconds(interval) or bar_seconds
+    prices = _pair_prices(
+        pair, bar_interval=interval, days=days, exchange=exchange, feed=feed
+    )
+    report = pair_admission_gate(
+        prices,
+        bar_seconds=seconds,
+        funding=_job_funding(root, pair),
+        fee_bps=fee_bps if fee_bps is not None else float(params.get("fee_bps") or 5.0),
+        slippage_bps=slippage_bps
+        if slippage_bps is not None
+        else float(params.get("slippage_bps") or 3.5),
+    )
+    report["bar_interval"] = interval
+    report["exchange"] = exchange
+    out_dir = root / "results" / "research" / "pair_check"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"{pair[0]}_{pair[1]}.json"
+    out_path.write_text(json.dumps(report, indent=2, default=str), encoding="utf-8")
+    report["artifact"] = str(out_path)
+    return report
+
+
+def signal_check_job(
+    job_id: str,
+    *,
+    column: str,
+    horizons: list[int] | None = None,
+    store: Any | None = None,
+) -> dict[str, Any]:
+    """Event-study a strategy's precomputed signal column against the job's
+    dataset — per symbol — WITHOUT running a backtest. The strategy's
+    `precompute()` materializes the column (the same one decide() reads)."""
+    from wayfinder_paths.jobs.execution.features import apply_precompute
+    from wayfinder_paths.jobs.execution.job import _load_dataset, _load_job_yaml
+    from wayfinder_paths.jobs.execution.primitives import ExecutionSpec
+    from wayfinder_paths.jobs.execution.simulator import _load_strategy
+    from wayfinder_paths.jobs.execution.validation import resolve_execution_spec
+    from wayfinder_paths.jobs.store import JobStore
+
+    store = store or JobStore()
+    root = store.job_dir(job_id)
+    job_data = _load_job_yaml(root)
+    spec_data, _ = resolve_execution_spec(root, job_data)
+    spec = ExecutionSpec.from_dict(spec_data)
+    params = dict(job_data.get("execution_params") or {})
+    script = store.resolve_script_entrypoint(job_id, job_data)
+    strategy = _load_strategy(script, params)
+    dataset = _load_dataset(root, spec, job_data)
+    view = apply_precompute(strategy, dataset.bars)
+    frame = view.to_frame()
+    results: dict[str, Any] = {}
+    for symbol in sorted(frame["symbol"].astype(str).unique()):
+        sub = frame[frame["symbol"] == symbol].reset_index(drop=True)
+        if column not in sub.columns:
+            raise KeyError(
+                f"column {column!r} not found after precompute; available "
+                f"non-bar columns: "
+                f"{sorted(set(sub.columns) - {'timestamp', 'symbol', 'open', 'high', 'low', 'close', 'volume'})}"
+            )
+        results[symbol] = event_study(sub, column, horizons=horizons)
+    overall = any(r["has_edge"] for r in results.values())
+    return {
+        "column": column,
+        "per_symbol": results,
+        "has_edge": overall,
+        "read": (
+            "the signal shows measurable predictive power on at least one "
+            "symbol — proceed to a quick backtest"
+            if overall
+            else "the signal has no measured predictive power on any symbol — "
+            "change the idea before building a strategy around it"
+        ),
+    }

--- a/wayfinder_paths/mcp/tools/jobs.py
+++ b/wayfinder_paths/mcp/tools/jobs.py
@@ -38,6 +38,8 @@ JobAction = Literal[
     "validate_job",
     "fetch_dataset",
     "fetch_funding",
+    "pair_check",
+    "signal_check",
     "backtest_job",
     "backtest_diagnose",
     "experiments",
@@ -145,6 +147,10 @@ async def core_jobs(
     grid_id: str | None = None,
     run_id: str | None = None,
     via_proposal: bool = False,
+    symbols: list[str] | None = None,
+    column: str | None = None,
+    horizons: list[int] | None = None,
+    bar_interval: str | None = None,
 ) -> dict[str, Any]:
     """Manage high-level Wayfinder jobs.
 
@@ -161,10 +167,14 @@ async def core_jobs(
       - `approve_proposal` / `reject_proposal` after the worker creates proposals.
       - `claim_application` / `validate_application` / `complete_application`
         from an apply worker.
-      - Strategy-development loop for execution-spec jobs: `fetch_dataset` (real
-        candles into the job; `dataset_source="ccxt"` + `exchange="binance"` for
-        long history), `fetch_funding` (historical funding rates into the job's
-        feature store — first-class carry data, as-of merged onto the bars as a
+      - Strategy-development loop for execution-spec jobs: `signal_check`
+        (event-study a precomputed entry column BEFORE building — no edge at
+        the signal level means no strategy will fix it) and `pair_check` (the
+        statistical admission gate for any pair/spread idea — run it FIRST; a
+        REJECT saves days of tuning), `fetch_dataset` (real candles into the
+        job; `dataset_source="ccxt"` + `exchange="binance"` for long history),
+        `fetch_funding` (historical funding rates into the job's feature
+        store — first-class carry data, as-of merged onto the bars as a
         `funding` column), `backtest_job` (use `quick_bars` while iterating),
         `backtest_diagnose` (ranked next steps), `experiments` (param grid via
         `grid` inline or `grid_path`; pass `wf_test_bars`/`wf_folds` for
@@ -257,6 +267,29 @@ async def core_jobs(
         return await _run_job_op(
             "fetch_funding",
             {"job_id": job_id, "days": days, "exchange": exchange, "quote": quote},
+        )
+
+    if action == "pair_check":
+        # Admission gate for any two-legged idea: run BEFORE building a pair/
+        # spread strategy. days defaults to 14 in this signature for dataset
+        # fetches; pair statistics need years, so widen unless caller set it.
+        return await _run_job_op(
+            "pair_check",
+            {
+                "job_id": job_id,
+                "symbols": symbols,
+                "days": days if days != 14 else 720,
+                "bar_interval": bar_interval,
+                "exchange": exchange,
+            },
+        )
+
+    if action == "signal_check":
+        if not column:
+            return err("invalid_request", "signal_check requires column")
+        return await _run_job_op(
+            "signal_check",
+            {"job_id": job_id, "column": column, "horizons": horizons},
         )
 
     if action == "experiments":

--- a/wayfinder_paths/tests/test_research_and_pair_check.py
+++ b/wayfinder_paths/tests/test_research_and_pair_check.py
@@ -1,0 +1,302 @@
+"""The pre-trade research toolkit: signal event-studies and the pair admission
+gate. These are the tools that stop the strategy agent from building six
+parameter variants of a signal with no predictive power, or pair-trading two
+correlated-but-not-cointegrated majors (the live ETH/SOL failure)."""
+
+from __future__ import annotations
+
+import json
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from wayfinder_paths.jobs.research import (
+    cost_hurdle,
+    engle_granger_both,
+    event_study,
+    hurst_exponent,
+    mean_crossings,
+    ou_half_life,
+    pair_admission_gate,
+    pair_check_job,
+)
+
+RNG = np.random.default_rng(7)
+HOUR = 3600
+
+
+def _ou_series(n: int, phi: float = 0.94, sigma: float = 1.0) -> np.ndarray:
+    x = np.zeros(n)
+    noise = RNG.normal(0, sigma, n)
+    for i in range(1, n):
+        x[i] = phi * x[i - 1] + noise[i]
+    return x
+
+
+def _cointegrated_pair(
+    n: int = 3000, hedge: float = 0.8
+) -> tuple[np.ndarray, np.ndarray]:
+    """x = random walk; log(y) = hedge * log(x) + OU noise -> textbook pair.
+    phi=0.97 -> half-life ~23 bars (~23h on hourly bars): inside the gate's
+    tradeable band."""
+    log_x = np.cumsum(RNG.normal(0, 0.01, n)) + 5.0
+    spread = _ou_series(n, phi=0.97, sigma=0.004)
+    log_y = hedge * log_x + spread + 1.0
+    return np.exp(log_y), np.exp(log_x)
+
+
+def _correlated_not_cointegrated(n: int = 3000) -> tuple[np.ndarray, np.ndarray]:
+    """The ETH/SOL case: a shared market factor (high return correlation) plus
+    INDEPENDENT random-walk idiosyncratic components (levels drift apart)."""
+    market = RNG.normal(0, 0.01, n)
+    a = np.exp(np.cumsum(market + RNG.normal(0.0002, 0.006, n)) + 5.0)
+    b = np.exp(np.cumsum(market + RNG.normal(-0.0002, 0.008, n)) + 3.0)
+    return a, b
+
+
+def test_ou_half_life_recovers_known_ar1() -> None:
+    phi = 0.94
+    series = _ou_series(20_000, phi=phi)
+    expected = math.log(2) / -math.log(phi)
+    got = ou_half_life(series)
+    assert abs(got - expected) / expected < 0.25
+
+
+def test_engle_granger_passes_cointegrated_pair() -> None:
+    y, x = _cointegrated_pair()
+    result = engle_granger_both(y, x)
+    assert result["pass"], result
+    assert abs(result["ab"]["hedge_ratio"] - 0.8) < 0.1
+
+
+def test_engle_granger_rejects_independent_walks() -> None:
+    a = np.exp(np.cumsum(RNG.normal(0, 0.01, 3000)) + 4.0)
+    b = np.exp(np.cumsum(RNG.normal(0, 0.01, 3000)) + 4.0)
+    result = engle_granger_both(a, b)
+    assert not result["pass"], result
+
+
+def test_hurst_low_for_ou_high_for_trend() -> None:
+    ou = _ou_series(5000, phi=0.9)
+    trend = np.cumsum(RNG.normal(0.05, 1.0, 5000))
+    assert hurst_exponent(ou) < 0.5
+    assert hurst_exponent(trend) > 0.5
+
+
+def test_mean_crossings_exact_on_sine() -> None:
+    x = np.sin(np.linspace(0, 10 * np.pi, 1000))  # 5 full periods
+    assert 9 <= mean_crossings(x) <= 11  # endpoint fencepost tolerance
+
+
+def test_cost_hurdle_arithmetic() -> None:
+    # capture (2.0 - 0.5) * 0.01 = 1.5%; cost 2 legs * 2 sides * 8.5bp = 34bp
+    result = cost_hurdle(0.01, z_entry=2.0, z_exit=0.5, fee_bps=5.0, slippage_bps=3.5)
+    assert abs(result["expected_capture"] - 0.015) < 1e-9
+    assert abs(result["round_trip_cost"] - 0.0034) < 1e-9
+    assert result["pass"] is True  # 4.4x >= 3x
+    tight = cost_hurdle(0.001, z_entry=2.0, z_exit=0.5, fee_bps=5.0, slippage_bps=3.5)
+    assert tight["pass"] is False
+
+
+def _prices_frame(a: np.ndarray, b: np.ndarray) -> pd.DataFrame:
+    return pd.DataFrame({"AAA": a, "BBB": b})
+
+
+def test_gate_rejects_correlated_but_not_cointegrated() -> None:
+    """THE load-bearing test — the live ETH/SOL failure, codified: high return
+    correlation, drifting levels. The gate must REJECT before anyone tunes a
+    single parameter."""
+    a, b = _correlated_not_cointegrated()
+    corr = np.corrcoef(np.diff(np.log(a)), np.diff(np.log(b)))[0, 1]
+    assert corr > 0.5  # genuinely correlated...
+    report = pair_admission_gate(_prices_frame(a, b), bar_seconds=HOUR)
+    assert report["verdict"] == "REJECT"  # ...but not tradeable
+    failed = {c["name"] for c in report["checks"] if c["hard"] and not c["pass"]}
+    assert "engle_granger_both_directions" in failed or "rolling_stability" in failed
+    assert "REJECT" in report["recommendation"]
+
+
+def test_gate_passes_synthetic_cointegrated_pair() -> None:
+    y, x = _cointegrated_pair(n=9000)  # ~ 375 days of hourly bars
+    report = pair_admission_gate(
+        _prices_frame(y, x),
+        bar_seconds=HOUR,
+        fee_bps=0.5,
+        slippage_bps=0.25,  # cheap costs so the hurdle reflects the synthetic sigma
+    )
+    assert report["verdict"] in ("PASS", "MARGINAL"), report["checks"]
+    hard_fails = [c for c in report["checks"] if c["hard"] and not c["pass"]]
+    assert not hard_fails, hard_fails
+    assert report["suggested"]["hedge_ratio"] == pytest.approx(0.8, abs=0.1)
+    assert report["suggested"]["lookback_bars"] is not None
+    assert report["suggested"]["time_stop_bars"] is not None
+
+
+def test_gate_half_life_band_unit_conversion() -> None:
+    """Half-life band is specified in HOURS; a 4h-bar series must convert via
+    bar_seconds (the classic off-by-4x)."""
+    y, x = _cointegrated_pair(n=4000)
+    hourly = pair_admission_gate(_prices_frame(y, x), bar_seconds=HOUR)
+    four_hourly = pair_admission_gate(_prices_frame(y, x), bar_seconds=4 * HOUR)
+    hl_1h = next(c for c in hourly["checks"] if c["name"] == "half_life")["value"]
+    hl_4h = next(c for c in four_hourly["checks"] if c["name"] == "half_life")["value"]
+    assert hl_1h is not None and hl_4h is not None
+    assert hl_4h == pytest.approx(hl_1h * 4, rel=0.01)
+
+
+def test_event_study_detects_planted_edge_and_rejects_random() -> None:
+    n = 6000
+    close = np.full(n, 100.0)
+    signal = np.zeros(n, dtype=bool)
+    rng = np.random.default_rng(11)
+    drift = rng.normal(0, 0.002, n)
+    # plant: after each signal bar, the next 24 bars drift up strongly
+    fire_at = rng.choice(np.arange(100, n - 100), size=120, replace=False)
+    signal[fire_at] = True
+    boost = np.zeros(n)
+    for i in fire_at:
+        boost[i + 1 : i + 25] += 0.004
+    log_close = np.cumsum(drift + boost) + np.log(100)
+    close = np.exp(log_close)
+    frame = pd.DataFrame({"close": close, "sig": signal, "rand": rng.random(n) < 0.02})
+
+    planted = event_study(frame, "sig", horizons=[24])
+    assert planted["has_edge"], planted
+    h24 = planted["horizons"][0]
+    assert h24["n"] >= 100 and h24["t_stat_vs_drift"] >= 2.0
+
+    random_sig = event_study(frame, "rand", horizons=[24])
+    assert not random_sig["has_edge"], random_sig
+
+
+def test_event_study_flags_insufficient_sample() -> None:
+    rng = np.random.default_rng(3)
+    close = np.exp(np.cumsum(rng.normal(0, 0.01, 500)) + 4)
+    sig = np.zeros(500, dtype=bool)
+    sig[[50, 100, 150]] = True
+    frame = pd.DataFrame({"close": close, "sig": sig})
+    result = event_study(frame, "sig", horizons=[10])
+    assert not result["has_edge"]
+    assert result["horizons"][0]["n"] == 3
+    assert "insufficient" in (result["horizons"][0]["note"] or "")
+
+
+def test_event_study_missing_column_lists_available() -> None:
+    frame = pd.DataFrame({"close": [1.0, 2.0], "z": [0, 1]})
+    with pytest.raises(KeyError, match="z"):
+        event_study(frame, "nope", horizons=[1])
+
+
+class _FakePairFeed:
+    """Injectable ccxt fake for pair_check_job: serves deterministic
+    cointegrated candles for any symbol pair."""
+
+    def __init__(self):
+        y, x = _cointegrated_pair(n=9000)
+        self._series = {"AAA": y, "BBB": x}
+        # Anchor so the LAST bar is ~now: the real feed requests now-anchored
+        # lookback windows.
+        now_ms = int(pd.Timestamp.now(tz="UTC").timestamp() * 1000)
+        self._base_ms = (now_ms // 3_600_000) * 3_600_000 - 9000 * 3_600_000
+
+    async def load_markets(self):
+        return {
+            "AAA/USDT:USDT": {"active": True},
+            "BBB/USDT:USDT": {"active": True},
+        }
+
+    async def fetch_ohlcv(self, pair, timeframe, since=None, limit=1000):
+        coin = pair.split("/")[0]
+        series = self._series[coin]
+        base_ms = self._base_ms
+        start_idx = max(0, int(((since or base_ms) - base_ms) // 3_600_000))
+        out = []
+        for i in range(start_idx, min(start_idx + limit, len(series))):
+            px = float(series[i])
+            out.append([base_ms + i * 3_600_000, px, px * 1.001, px * 0.999, px, 10.0])
+        return out
+
+    async def close(self):
+        return None
+
+
+def test_pair_check_job_end_to_end_writes_artifact(tmp_path) -> None:
+    from wayfinder_paths.jobs.store import JobStore
+
+    store = JobStore(repo_root=tmp_path)
+    root = store.job_dir("pair-job")
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "job.yaml").write_text("id: pair-job\n")
+    (root / "execution_spec.json").write_text(
+        json.dumps(
+            {
+                "market_kind": "perp",
+                "data_contract": {"bar_interval": "1h", "symbols": ["AAA", "BBB"]},
+            }
+        )
+    )
+    report = pair_check_job(
+        "pair-job",
+        days=370,
+        store=store,
+        feed=_FakePairFeed(),
+        fee_bps=0.5,
+        slippage_bps=0.25,
+    )
+    assert report["verdict"] in ("PASS", "MARGINAL")
+    assert report["pair"] == ["AAA", "BBB"]
+    assert {c["name"] for c in report["checks"]} >= {
+        "engle_granger_both_directions",
+        "rolling_stability",
+        "half_life",
+        "cost_hurdle",
+        "hurst",
+        "mean_crossings",
+        "data_sufficiency",
+    }
+    artifact = root / "results" / "research" / "pair_check" / "AAA_BBB.json"
+    assert artifact.exists()
+    persisted = json.loads(artifact.read_text())
+    assert persisted["verdict"] == report["verdict"]
+
+
+def test_pair_check_job_requires_two_symbols(tmp_path) -> None:
+    from wayfinder_paths.jobs.store import JobStore
+
+    store = JobStore(repo_root=tmp_path)
+    root = store.job_dir("solo-job")
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "job.yaml").write_text("id: solo-job\n")
+    (root / "execution_spec.json").write_text(
+        json.dumps(
+            {
+                "market_kind": "perp",
+                "data_contract": {"bar_interval": "1h", "symbols": ["ETH"]},
+            }
+        )
+    )
+    with pytest.raises(ValueError, match="exactly 2"):
+        pair_check_job("solo-job", store=store, feed=_FakePairFeed())
+
+
+def test_op_runner_routes_research_ops(monkeypatch) -> None:
+    import wayfinder_paths.jobs.research as research_mod
+    from wayfinder_paths.jobs.execution import op_runner
+
+    monkeypatch.setattr(
+        research_mod,
+        "pair_check_job",
+        lambda job_id, **kw: {"stub": "pair", "job": job_id},
+    )
+    monkeypatch.setattr(
+        research_mod,
+        "signal_check_job",
+        lambda job_id, **kw: {"stub": "signal", "column": kw.get("column")},
+    )
+    assert op_runner._run("pair_check", {"job_id": "j"}) == {"stub": "pair", "job": "j"}
+    assert op_runner._run("signal_check", {"job_id": "j", "column": "z"}) == {
+        "stub": "signal",
+        "column": "z",
+    }


### PR DESCRIPTION
PR A of the approved "set the agent up to find edges" plan (research: the ETH/SOL failure was predictable — correlated ≠ cointegrated, no admission test, 1:1 sizing, one regime).

## What

**`wayfinder_paths/jobs/research.py`** — pre-trade statistical research layer (pure numpy/pandas above, I/O below; pure helpers usable inside strategy `precompute()`):
- Stats adapted from the buried example libs with **corrected EG critical values** (MacKinnon case-2; the example mislabeled −3.34 as p=0.03 — it's the 5% level): `ou_half_life`, `engle_granger(_both)` (+hedge ratio, order-sensitive both directions), `rolling_hedge_ratio`, `rolling_stability` (sliding-window majority), `adf_stat`.
- New: `hurst_exponent`, `mean_crossings`, `cost_hurdle` (capture ≥ 3× both-leg round trip), `net_funding_carry`, `rolling_adf_kill` (live kill-switch column), **`event_study`** (signal forward returns vs the series' own drift — the random-entry baseline — t-stats, n≥30 floor).
- **`pair_admission_gate`**: 8 checks → PASS/MARGINAL/REJECT + suggested hedge ratio & half-life-derived lookback/time-stop + plain-language recommendation + multiple-testing note.
- **`pair_check_job`** (2y candles by default, job funding features, persisted artifact) and **`signal_check_job`** (event-studies a precompute column — no backtest needed).

Wired: `wayfinder job pair-check / signal-check` CLI + `core_jobs(action="pair_check"|"signal_check")` via the isolated op_runner.

## Tests (15 new, all suites green)
Load-bearing: **correlated-but-not-cointegrated pair (the live ETH/SOL case) → gate REJECT**; synthetic cointegrated pair → PASS with hedge ratio ≈ truth; planted signal edge detected, random signal rejected; half-life unit conversion pinned; end-to-end job orchestrator with injected feed.

PR B (diagnose hardening + plateau) and PR C (search-methodology playbook) follow.