### PR TITLE
jobs diagnose: sample-size gates, artifact detector, pair rules, grid plateau

### DIFF
--- a/wayfinder_paths/jobs/backtest_artifacts.py
+++ b/wayfinder_paths/jobs/backtest_artifacts.py
@@ -190,6 +190,24 @@ def diagnose_backtest(
         ts = _parse_ts(trade.get("timestamp"))
         return ts.hour if ts else -1
 
+    def _same_bar_close_fraction() -> float | None:
+        # Fraction of closes that fill on the SAME timestamp as the position's
+        # most recent opening fill — the signature of same-bar bracket fills,
+        # which produce fantasy win rates the live engine cannot reproduce.
+        opens: dict[str, str | None] = {}
+        paired = 0
+        same = 0
+        for trade in trades:
+            symbol = str(trade.get("symbol") or "?")
+            if abs(float(trade.get("realized_pnl_delta") or 0.0)) > 0:
+                open_ts = opens.get(symbol)
+                if open_ts is not None:
+                    paired += 1
+                    same += 1 if trade.get("timestamp") == open_ts else 0
+            else:
+                opens[symbol] = trade.get("timestamp")
+        return same / paired if paired else None
+
     def _bucket(key_fn: Any) -> dict[Any, dict[str, Any]]:
         agg: dict[Any, dict[str, float]] = {}
         for trade in closes:
@@ -237,20 +255,35 @@ def diagnose_backtest(
     by_exit_reason = _bucket(_reason)
     by_close_hour = dict(sorted(_bucket(_hour).items()))
     by_side = _bucket(lambda t: t.get("side") or "?")
+    by_symbol = _bucket(lambda t: str(t.get("symbol") or "?"))
     recommendations = _recommendations(
-        stats, by_exit_reason, by_side, by_close_hour, len(closes)
+        stats,
+        by_exit_reason,
+        by_side,
+        by_close_hour,
+        by_symbol,
+        len(closes),
+        same_bar_close_fraction=_same_bar_close_fraction(),
     )
     return {
         "available": True,
         "run_id": latest.get("run_id"),
         "headline": {k: stats[k] for k in headline_keys if k in stats},
         "closed_trades_analyzed": len(closes),
+        "how_to_use": (
+            "Recommendations are hypotheses ranked by evidence, not edicts — "
+            "verify any change on the full dataset AND out-of-sample "
+            "(walk-forward) before keeping it. Never remove a risk control "
+            "(stop / time-stop) to lift a backtest; retune it via a grid + "
+            "walk-forward instead."
+        ),
         # The single most important thing to do next — read this first.
         "next_step": recommendations[0]["suggest"] if recommendations else None,
         "recommendations": recommendations,
         "by_exit_reason": by_exit_reason,
         "by_close_hour_utc": by_close_hour,
         "by_side": by_side,
+        "by_symbol": by_symbol,
         "worst_trades": [_trade_view(t) for t in ranked[:top_trades]],
         "best_trades": [_trade_view(t) for t in reversed(ranked[-top_trades:])],
     }
@@ -265,14 +298,31 @@ def _recommendations(
     by_reason: dict[Any, dict[str, Any]],
     by_side: dict[Any, dict[str, Any]],
     by_hour: dict[Any, dict[str, Any]],
+    by_symbol: dict[Any, dict[str, Any]],
     n_closes: int,
+    *,
+    same_bar_close_fraction: float | None = None,
 ) -> list[dict[str, Any]]:
     """Turn the run's own stats + trade buckets into ranked, evidence-backed
     next actions — so a bad backtest yields concrete things to try instead of a
     hand-rolled recompute. Every recommendation quotes the numbers that triggered
     it (never invented); the top one is echoed as `next_step`. This is what makes
     the diagnose→improve loop good: read `recommendations`, change ONE thing, and
-    re-run `--quick` rather than thrashing across many full backtests."""
+    re-run `--quick` rather than thrashing across many full backtests.
+
+    INVARIANT (risk-control preservation): no recommendation text may suggest
+    REMOVING a risk control — stop, time-stop, trailing stop, liquidation
+    buffer. Suggestions may retune (widen/tighten via grid + walk-forward),
+    never delete. A string-level test in test_backtest_profile_and_summary.py
+    enforces this across crafted payloads.
+
+    Bucket-driven rules (exit-reason / side / hour / symbol concentration) only
+    fire when the bucket has n >= 8 trades AND >= 25% of all closes — below
+    that a bucket is a hypothesis, not evidence (n=12 bucket inferences drove a
+    live exit-rule change that didn't survive validation)."""
+
+    def gated(bucket_n: int) -> bool:
+        return bucket_n >= 8 and bucket_n >= 0.25 * n_closes
 
     def pct(value: Any) -> str:
         return (
@@ -326,16 +376,55 @@ def _recommendations(
             "Reduce leverage and/or widen the stop — the position is force-closed "
             "before the thesis can play out. Fix this before tuning entries.",
         )
-    # High: negative base — params rarely rescue a signal with no edge.
-    if tc >= 10 and net is not None and net <= 0:
+    # High: results too good to be real are usually simulation artifacts —
+    # same-bar bracket fills, look-ahead in precompute, or fantasy fill prices.
+    # This codifies what a live session had to catch by hand.
+    same_bar_hot = (
+        same_bar_close_fraction is not None and same_bar_close_fraction >= 0.5
+    )
+    if tc >= 10 and ((wr is not None and wr > 0.90) or same_bar_hot):
+        evidence = f"win_rate={pct(wr)} over {tc} trades"
+        if same_bar_close_fraction is not None:
+            evidence += (
+                f"; {same_bar_close_fraction:.0%} of closes fill on the entry bar"
+            )
         add(
             "high",
-            "No edge on this data (net loss)",
-            f"net_return={pct(net)}, sharpe={num(sharpe)}, profit_factor={num(pf)}",
-            "Change the entry/exit idea or add a regime filter — a negative base "
-            "rarely turns positive from parameter tuning alone. Re-think the trigger "
-            "before sweeping params.",
+            "Result looks like an execution artifact, not edge",
+            evidence,
+            "Win rates this high (or entries that close on their own bar) are "
+            "usually a simulation artifact — same-bar bracket fills, look-ahead "
+            "in precompute, or unrealistic fill prices. Check same_bar_policy / "
+            "ohlc_rules in the execution spec and validate before believing any "
+            "of these numbers.",
         )
+    multi_symbol = len([k for k in by_symbol if str(k) != "?"]) >= 2
+    # High: negative base — params rarely rescue a signal with no edge. For a
+    # multi-symbol (pair/basket) strategy the first question is statistical:
+    # correlated is not cointegrated, and no parameter rescues a spread that
+    # does not mean-revert — so pair-check outranks generic re-thinking.
+    if tc >= 10 and net is not None and net <= 0:
+        if multi_symbol:
+            add(
+                "high",
+                "Losing multi-symbol strategy — test the relationship first",
+                f"net_return={pct(net)}, profit_factor={num(pf)}, "
+                f"symbols={sorted(str(k) for k in by_symbol)}",
+                "Run `job pair-check <id> --symbols A,B` before tuning anything: "
+                "correlated is not cointegrated, and no parameter rescues a "
+                "spread that does not mean-revert. If the gate REJECTs, change "
+                "the pair or the idea (funding-spread pair, momentum, carry) — "
+                "not the thresholds.",
+            )
+        else:
+            add(
+                "high",
+                "No edge on this data (net loss)",
+                f"net_return={pct(net)}, sharpe={num(sharpe)}, profit_factor={num(pf)}",
+                "Change the entry/exit idea or add a regime filter — a negative "
+                "base rarely turns positive from parameter tuning alone. "
+                "Re-think the trigger before sweeping params.",
+            )
     # High: wins often but the losers are bigger — a payoff problem, not an entry one.
     if wr is not None and wr > 0.55 and pf is not None and pf < 1.1:
         add(
@@ -377,48 +466,83 @@ def _recommendations(
         gross_loss = sum(abs(v["pnl"]) for v in losing.values())
         worst_key = min(losing, key=lambda k: losing[k]["pnl"])
         worst = losing[worst_key]
-        if gross_loss > 0 and abs(worst["pnl"]) >= 0.5 * gross_loss:
+        if (
+            gross_loss > 0
+            and abs(worst["pnl"]) >= 0.5 * gross_loss
+            and gated(worst["trades"])
+        ):
             is_stop = "stop" in str(worst_key).lower()
             add(
                 "medium",
                 f"Losses concentrate in one exit: {worst_key}",
-                f"{worst_key}: {worst['trades']} trades, pnl={num(worst['pnl'])} "
+                f"{worst_key}: n={worst['trades']} of {n_closes} closes, "
+                f"pnl={num(worst['pnl'])} "
                 f"({worst['pnl'] / -gross_loss * -1:.0%} of gross loss)",
-                "You're getting stopped out — widen the stop or add an entry filter "
-                "so you're not stopped on entry noise."
+                "You're getting stopped out — widen the stop (via grid + "
+                "walk-forward) or add an entry filter so you're not stopped on "
+                "entry noise. Keep the stop — never trade without one."
                 if is_stop
-                else f"Revisit the {worst_key} exit rule — that's where the losses are.",
+                else f"Revisit the {worst_key} exit rule — that's where the "
+                "losses are. Retune it through the validation ladder, don't "
+                "delete it.",
             )
+    # Medium: one leg of a multi-symbol strategy carries the losses — a sizing
+    # problem (1:1 notional is almost never neutral), not an entry problem.
+    if multi_symbol and losses_hurt:
+        losing_symbols = {k: v for k, v in by_symbol.items() if v.get("pnl", 0) < 0}
+        if losing_symbols:
+            sym_gross_loss = sum(abs(v["pnl"]) for v in losing_symbols.values())
+            worst_sym = min(losing_symbols, key=lambda k: losing_symbols[k]["pnl"])
+            leg = losing_symbols[worst_sym]
+            if (
+                sym_gross_loss > 0
+                and abs(leg["pnl"]) >= 0.8 * sym_gross_loss
+                and gated(leg["trades"])
+            ):
+                add(
+                    "medium",
+                    f"One leg carries the losses: {worst_sym}",
+                    f"{worst_sym}: n={leg['trades']} of {n_closes} closes, "
+                    f"pnl={num(leg['pnl'])} "
+                    f"({abs(leg['pnl']) / sym_gross_loss:.0%} of symbol gross loss)",
+                    "Size the legs by the regression hedge ratio, not 1:1 — "
+                    "`job pair-check` reports `suggested.hedge_ratio`. A 1:1 "
+                    "notional pair carries directional exposure on the more "
+                    "volatile leg.",
+                )
     # Low: the edge is one-directional.
     losing_sides = {k: v for k, v in by_side.items() if v.get("pnl", 0) < 0}
     winning_sides = {k: v for k, v in by_side.items() if v.get("pnl", 0) > 0}
     if losing_sides and winning_sides:
         side_key = min(losing_sides, key=lambda k: losing_sides[k]["pnl"])
-        add(
-            "low",
-            f"One direction loses money: {side_key}",
-            f"{side_key}: {losing_sides[side_key]['trades']} trades, "
-            f"pnl={num(losing_sides[side_key]['pnl'])}",
-            f"The edge is one-directional — consider trading only the profitable "
-            f"side or filtering {side_key} entries.",
-        )
+        if gated(losing_sides[side_key]["trades"]):
+            add(
+                "low",
+                f"One direction loses money: {side_key}",
+                f"{side_key}: n={losing_sides[side_key]['trades']} of "
+                f"{n_closes} closes, pnl={num(losing_sides[side_key]['pnl'])}",
+                f"The edge is one-directional — consider trading only the "
+                f"profitable side or filtering {side_key} entries. Verify on the "
+                f"full dataset first; a one-sided split can be a regime artifact.",
+            )
     # Low: P&L concentrates in a few hours — a session filter may help.
     net_hour = sum(v.get("pnl", 0) for v in by_hour.values())
     if net_hour > 0 and len(by_hour) >= 6:
-        top3 = sorted((v.get("pnl", 0) for v in by_hour.values()), reverse=True)[:3]
-        if sum(top3) >= 0.7 * net_hour:
-            hot = [
-                str(k)
-                for k, v in sorted(
-                    by_hour.items(), key=lambda kv: kv[1].get("pnl", 0), reverse=True
-                )[:3]
-            ]
+        hot_rows = sorted(
+            by_hour.items(), key=lambda kv: kv[1].get("pnl", 0), reverse=True
+        )[:3]
+        top3_pnl = sum(v.get("pnl", 0) for _, v in hot_rows)
+        top3_n = sum(int(v.get("trades", 0)) for _, v in hot_rows)
+        if top3_pnl >= 0.7 * net_hour and gated(top3_n):
+            hot = [str(k) for k, _ in hot_rows]
             add(
                 "low",
                 "P&L concentrates in a few hours (UTC)",
-                f"hours {', '.join(hot)} hold ≥70% of net P&L",
+                f"hours {', '.join(hot)} hold ≥70% of net P&L "
+                f"(n={top3_n} of {n_closes} closes)",
                 "A session / time-of-day entry filter may cut the flat or negative "
-                "hours and lift risk-adjusted return.",
+                "hours and lift risk-adjusted return. Treat as a hypothesis — "
+                "verify on the full dataset and out-of-sample before keeping it.",
             )
     # Validate: promising in-sample → the ONLY next step is out-of-sample proof.
     if (

--- a/wayfinder_paths/jobs/execution/job.py
+++ b/wayfinder_paths/jobs/execution/job.py
@@ -52,7 +52,7 @@ def summarize_backtest_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
         if "ranked" in result:  # grid / optuna result
             summary["result"] = {
                 k: result[k]
-                for k in ("grid_id", "rank_by", "optimizer", "search")
+                for k in ("grid_id", "rank_by", "optimizer", "search", "plateau")
                 if k in result
             }
             summary["result"]["run_count"] = len(result.get("runs") or [])

--- a/wayfinder_paths/jobs/execution/simulator.py
+++ b/wayfinder_paths/jobs/execution/simulator.py
@@ -90,6 +90,9 @@ class ExecutionGridResult:
     # the search settings when not an exhaustive grid.
     optimizer: str = "grid"
     search: dict[str, Any] | None = None
+    # Additive: neighbor-robustness of the top cell (grid_plateau) — only for
+    # exhaustive dict-of-lists grids; None for optuna and list-of-dicts.
+    plateau: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -531,6 +534,70 @@ def rank_and_partition(
     return ranked[:top_n], invalid
 
 
+def grid_plateau(
+    run_rows: list[dict[str, Any]],
+    param_grid: Mapping[str, list[Any]],
+    *,
+    rank_by: str,
+) -> dict[str, Any] | None:
+    """Neighbor-robustness of the top grid cell: neighbors differ in exactly
+    one parameter by one step along that parameter's grid list, and
+    plateau_score = mean(neighbor metric) / top metric. Near 1.0 means the
+    optimum sits on a plateau; < 0.5 means a lone spike that is likely noise —
+    the walk_forward docstring's failure mode (a top cell whose neighbors all
+    lose), now measured instead of discovered out-of-sample. Returns None when
+    nothing is swept (no axis with >1 value), the top metric is <= 0 (a ratio
+    against a loss is meaningless), or the top cell has no valid neighbors."""
+    valid = [row for row in run_rows if row["validation"]["execution_valid"]]
+    axes = {key: list(values) for key, values in param_grid.items() if len(values) > 1}
+    if not valid or not axes:
+        return None
+    top = max(valid, key=lambda row: float(row[rank_by] or 0))
+    top_metric = float(top[rank_by] or 0)
+    if top_metric <= 0:
+        return None
+
+    def is_neighbor(row: dict[str, Any]) -> bool:
+        diffs = [
+            key
+            for key in param_grid
+            if row["params"].get(key) != top["params"].get(key)
+        ]
+        if len(diffs) != 1 or diffs[0] not in axes:
+            return False
+        axis = axes[diffs[0]]
+        try:
+            step = abs(
+                axis.index(row["params"][diffs[0]])
+                - axis.index(top["params"][diffs[0]])
+            )
+        except ValueError:
+            return False
+        return step == 1
+
+    neighbors = [row for row in valid if is_neighbor(row)]
+    if not neighbors:
+        return None
+    neighbor_mean = sum(float(row[rank_by] or 0) for row in neighbors) / len(neighbors)
+    score = neighbor_mean / top_metric
+    result: dict[str, Any] = {
+        "rank_by": rank_by,
+        "top_params": top["params"],
+        "top_metric": round(top_metric, 6),
+        "neighbor_count": len(neighbors),
+        "neighbor_mean": round(neighbor_mean, 6),
+        "plateau_score": round(score, 3),
+    }
+    if score < 0.5:
+        result["note"] = (
+            f"top cell is a lone spike — its one-step neighbors average "
+            f"{score:.0%} of its {rank_by}, which is likely noise. Prefer a "
+            "parameter region where the neighbors also perform (the best "
+            "plateau), and confirm with walk-forward before trusting it."
+        )
+    return result
+
+
 def available_cpu_count() -> int:
     """Usable CPUs for backtest fan-out. Respects a cgroup CPU quota (Fly
     machines are quota-limited, and os.cpu_count() reports the host's cores,
@@ -647,6 +714,11 @@ def run_execution_grid(
             "cpu_count": available_cpu_count(),
             "param_count": len(params_list),
         },
+        plateau=(
+            grid_plateau(run_rows, param_grid, rank_by=rank_by)
+            if isinstance(param_grid, Mapping)
+            else None
+        ),
     )
 
 

--- a/wayfinder_paths/tests/test_backtest_profile_and_summary.py
+++ b/wayfinder_paths/tests/test_backtest_profile_and_summary.py
@@ -286,10 +286,12 @@ def _write_latest(store, job_id: str, stats: dict, trades: list) -> None:
     )
 
 
-def _closes(pnls_reasons_sides: list) -> list:
-    """Build closing fills (reduce_only, non-zero pnl) from (pnl, reason, side)."""
+def _closes(rows: list) -> list:
+    """Build closing fills (reduce_only, non-zero pnl) from (pnl, reason, side)
+    or (pnl, reason, side, symbol) tuples."""
     out = []
-    for i, (pnl, reason, side) in enumerate(pnls_reasons_sides):
+    for i, row in enumerate(rows):
+        pnl, reason, side, *rest = row
         out.append(
             {
                 "timestamp": f"2026-01-01T{i % 24:02d}:00:00+00:00",
@@ -297,6 +299,7 @@ def _closes(pnls_reasons_sides: list) -> list:
                 "reduce_only": True,
                 "realized_pnl_delta": pnl,
                 "raw": {"metadata": {"exit_reason": reason}},
+                **({"symbol": rest[0]} if rest else {}),
             }
         )
     return out
@@ -309,19 +312,20 @@ def test_recommendations_flag_poor_payoff_high_winrate(tmp_path) -> None:
     from wayfinder_paths.jobs.store import JobStore
 
     store = JobStore(repo_root=tmp_path)
-    # 24 trades, 70% winners but a poor profit factor.
+    # 25 trades, 68% winners but a poor profit factor; 8 stop-outs clear the
+    # bucket sample gate (n>=8 and >=25% of closes) so the stop rec fires.
     trades = _closes(
-        [(1.0, "take_profit", "buy")] * 17 + [(-3.0, "stop_loss", "buy")] * 7
+        [(1.0, "take_profit", "buy")] * 17 + [(-3.0, "stop_loss", "buy")] * 8
     )
     _write_latest(
         store,
         "payoff",
         {
-            "net_return": -0.04,
-            "trade_count": 24,
-            "win_rate": 17 / 24,
-            "profit_factor": 17.0 / 21.0,
-            "avg_trade_pnl": (17 - 21) / 24,
+            "net_return": -0.07,
+            "trade_count": 25,
+            "win_rate": 17 / 25,
+            "profit_factor": 17.0 / 24.0,
+            "avg_trade_pnl": (17 - 24) / 25,
             "sharpe": -0.3,
         },
         trades,
@@ -365,6 +369,282 @@ def test_recommendations_validate_path_points_to_walk_forward(tmp_path) -> None:
     assert "decay_ratio" in validate[0]["suggest"]
     # No blocking/high issue on a clean promising run.
     assert diag["recommendations"][0]["severity"] == "validate"
+
+
+def test_bucket_rules_gate_on_sample_size(tmp_path) -> None:
+    """A bucket below n>=8 or <25% of closes is a hypothesis, not evidence —
+    concentration rules must NOT fire on it (n=12 bucket inferences drove a
+    live exit change that didn't survive validation). The same fixture with
+    the bucket at n=8 fires."""
+    from wayfinder_paths.jobs.backtest_artifacts import diagnose_backtest
+    from wayfinder_paths.jobs.store import JobStore
+
+    store = JobStore(repo_root=tmp_path)
+    stats = {
+        "net_return": -0.06,
+        "trade_count": 24,
+        "win_rate": 19 / 24,
+        "profit_factor": 0.8,
+        "avg_trade_pnl": -0.25,
+        "sharpe": -0.4,
+    }
+    # 5 stop-outs hold ALL the gross loss but n=5 < 8 → gated out.
+    _write_latest(
+        store,
+        "gated",
+        stats,
+        _closes([(1.0, "take_profit", "buy")] * 19 + [(-5.0, "stop_loss", "buy")] * 5),
+    )
+    diag = diagnose_backtest("gated", store=store)
+    assert not any(
+        "concentrate in one exit" in r["issue"].lower() for r in diag["recommendations"]
+    ), diag["recommendations"]
+    # Same shape with 8 stop-outs (8 >= 25% of 24 closes... 8/24 = 33%) → fires.
+    _write_latest(
+        store,
+        "ungated",
+        stats,
+        _closes([(1.0, "take_profit", "buy")] * 16 + [(-5.0, "stop_loss", "buy")] * 8),
+    )
+    diag = diagnose_backtest("ungated", store=store)
+    fired = [
+        r
+        for r in diag["recommendations"]
+        if "concentrate in one exit" in r["issue"].lower()
+    ]
+    assert fired and "n=8" in fired[0]["evidence"]
+
+
+def test_no_recommendation_removes_risk_controls(tmp_path) -> None:
+    """String-level invariant: across payloads engineered to fire every rule,
+    no suggestion may contain removal language for stops/time-stops. Retune,
+    widen, filter — never remove."""
+    import re
+
+    from wayfinder_paths.jobs.backtest_artifacts import diagnose_backtest
+    from wayfinder_paths.jobs.store import JobStore
+
+    store = JobStore(repo_root=tmp_path)
+    payloads = {
+        # poor payoff + stop concentration + one-sided losses
+        "a": (
+            {
+                "net_return": -0.08,
+                "trade_count": 32,
+                "win_rate": 0.6,
+                "profit_factor": 0.7,
+                "avg_trade_pnl": -0.1,
+                "sharpe": -0.5,
+                "liquidation_count": 1,
+                "total_fees": 50.0,
+                "buy_hold_return": 0.4,
+            },
+            _closes(
+                [(1.0, "take_profit", "buy")] * 19
+                + [(-4.0, "stop_loss", "buy")] * 9
+                + [(-2.0, "stop_loss", "sell")] * 4
+            ),
+        ),
+        # multi-symbol losing pair, one leg carrying the losses
+        "b": (
+            {
+                "net_return": -0.12,
+                "trade_count": 30,
+                "win_rate": 0.4,
+                "profit_factor": 0.6,
+                "avg_trade_pnl": -0.2,
+                "sharpe": -0.9,
+            },
+            _closes(
+                [(1.0, "signal", "buy", "ETH")] * 10
+                + [(-0.5, "signal", "buy", "ETH")] * 5
+                + [(-4.0, "signal", "sell", "SOL")] * 15
+            ),
+        ),
+        # artifact-grade win rate
+        "c": (
+            {
+                "net_return": 0.5,
+                "trade_count": 12,
+                "win_rate": 0.95,
+                "profit_factor": 9.0,
+                "avg_trade_pnl": 1.0,
+                "sharpe": 3.0,
+            },
+            _closes([(1.0, "take_profit", "buy")] * 12),
+        ),
+    }
+    forbidden = re.compile(
+        r"(remove|delete|disable|drop|get rid of|no longer need|trade without)"
+        r"[^.]{0,40}(stop|time[- ]?stop|risk control)",
+        re.IGNORECASE,
+    )
+    for job_id, (stats, trades) in payloads.items():
+        _write_latest(store, job_id, stats, trades)
+        diag = diagnose_backtest(job_id, store=store)
+        for rec in diag["recommendations"]:
+            text = f"{rec['issue']} {rec['suggest']}"
+            assert not forbidden.search(text), (job_id, text)
+        assert "Never remove a risk control" in diag["how_to_use"]
+
+
+def test_simulation_artifact_detector(tmp_path) -> None:
+    """>90% win rate on n>=10, or entries that close on their own bar, is
+    flagged as a likely execution artifact — the same-bar bracket-fill case a
+    live session had to catch by hand."""
+    from wayfinder_paths.jobs.backtest_artifacts import diagnose_backtest
+    from wayfinder_paths.jobs.store import JobStore
+
+    store = JobStore(repo_root=tmp_path)
+    # Interleave open fills (pnl=0) at the SAME timestamp as their close —
+    # same-bar bracket fills.
+    trades = []
+    for i in range(12):
+        ts = f"2026-01-01T{i % 24:02d}:00:00+00:00"
+        trades.append(
+            {
+                "timestamp": ts,
+                "side": "buy",
+                "symbol": "ETH",
+                "realized_pnl_delta": 0.0,
+            }
+        )
+        trades.append(
+            {
+                "timestamp": ts,
+                "side": "sell",
+                "symbol": "ETH",
+                "reduce_only": True,
+                "realized_pnl_delta": 1.0,
+                "raw": {"metadata": {"exit_reason": "take_profit"}},
+            }
+        )
+    _write_latest(
+        store,
+        "artifact",
+        {
+            "net_return": 0.4,
+            "trade_count": 12,
+            "win_rate": 1.0,
+            "profit_factor": 99.0,
+            "avg_trade_pnl": 1.0,
+            "sharpe": 4.0,
+        },
+        trades,
+    )
+    diag = diagnose_backtest("artifact", store=store)
+    fired = [r for r in diag["recommendations"] if "artifact" in r["issue"].lower()]
+    assert fired, diag["recommendations"]
+    assert fired[0]["severity"] == "high"
+    assert "100% of closes fill on the entry bar" in fired[0]["evidence"]
+    assert "same_bar_policy" in fired[0]["suggest"]
+
+
+def test_multi_symbol_losing_recommends_pair_check(tmp_path) -> None:
+    """A losing multi-symbol strategy gets 'run pair-check' ranked ABOVE the
+    generic no-edge advice (which it replaces), plus the hedge-ratio sizing rec
+    when one leg carries >=80% of the symbol gross loss."""
+    from wayfinder_paths.jobs.backtest_artifacts import diagnose_backtest
+    from wayfinder_paths.jobs.store import JobStore
+
+    store = JobStore(repo_root=tmp_path)
+    trades = _closes(
+        [(1.0, "signal", "buy", "ETH")] * 10
+        + [(-0.5, "signal", "buy", "ETH")] * 5
+        + [(-4.0, "signal", "sell", "SOL")] * 15
+    )
+    _write_latest(
+        store,
+        "pair",
+        {
+            "net_return": -0.12,
+            "trade_count": 30,
+            "win_rate": 10 / 30,
+            "profit_factor": 10.0 / 62.5,
+            "avg_trade_pnl": -1.75,
+            "sharpe": -1.1,
+        },
+        trades,
+    )
+    diag = diagnose_backtest("pair", store=store)
+    assert diag["by_symbol"]["SOL"]["trades"] == 15
+    top = diag["recommendations"][0]
+    assert top["severity"] == "high"
+    assert "pair-check" in top["suggest"]
+    assert "correlated is not cointegrated" in top["suggest"]
+    # The generic single-symbol no-edge text is replaced, not duplicated.
+    assert not any(
+        r["issue"].startswith("No edge on this data") for r in diag["recommendations"]
+    )
+    hedge = [r for r in diag["recommendations"] if "hedge ratio" in r["suggest"]]
+    assert hedge, diag["recommendations"]
+    assert "SOL" in hedge[0]["issue"]
+
+
+def test_grid_plateau_lone_spike_vs_plateau() -> None:
+    """plateau_score = mean(one-step neighbors) / top cell. A lone spike
+    (<0.5) carries the noise note; a genuine plateau does not. Nothing swept
+    or a non-positive top metric → None."""
+    from wayfinder_paths.jobs.execution.simulator import grid_plateau
+
+    grid = {"a": [1, 2, 3], "b": [10, 20]}
+
+    def row(a, b, metric):
+        return {
+            "params": {"a": a, "b": b},
+            "validation": {"execution_valid": True},
+            "net_return": metric,
+        }
+
+    spike = [
+        row(1, 10, 0.05),
+        row(2, 10, 1.0),  # top
+        row(3, 10, 0.05),
+        row(1, 20, 0.05),
+        row(2, 20, 0.05),  # neighbor (b: 10→20)
+        row(3, 20, 0.05),
+    ]
+    result = grid_plateau(spike, grid, rank_by="net_return")
+    assert result["top_params"] == {"a": 2, "b": 10}
+    assert result["neighbor_count"] == 3  # (1,10), (3,10), (2,20)
+    assert result["plateau_score"] == 0.05
+    assert "lone spike" in result["note"]
+
+    plateau = (
+        [r | {"net_return": 0.9} for r in spike[:1]]
+        + spike[1:2]
+        + [r | {"net_return": 0.9} for r in spike[2:]]
+    )
+    result = grid_plateau(plateau, grid, rank_by="net_return")
+    assert result["plateau_score"] == 0.9
+    assert "note" not in result
+
+    # Non-positive top metric → ratio is meaningless → None.
+    losing = [row(1, 10, -0.2), row(2, 10, -0.1), row(3, 10, -0.3)]
+    assert grid_plateau(losing, grid, rank_by="net_return") is None
+    # Nothing swept → None.
+    assert grid_plateau(spike, {"a": [2]}, rank_by="net_return") is None
+
+
+def test_grid_summary_carries_plateau() -> None:
+    """summarize_backtest_payload keeps the plateau block so the agent sees
+    the robustness read without loading the full grid payload."""
+    from wayfinder_paths.jobs.execution.job import summarize_backtest_payload
+
+    payload = {
+        "type": "grid",
+        "result": {
+            "grid_id": "g1",
+            "rank_by": "net_return",
+            "runs": [],
+            "ranked": [],
+            "invalid": [],
+            "plateau": {"plateau_score": 0.3, "note": "top cell is a lone spike"},
+        },
+        "stamp": {},
+    }
+    summary = summarize_backtest_payload(payload)
+    assert summary["result"]["plateau"]["plateau_score"] == 0.3
 
 
 def test_walk_forward_default_is_bounded_rolling_not_anchored() -> None:

--- a/wayfinder_paths/tests/test_jobs_walk_forward.py
+++ b/wayfinder_paths/tests/test_jobs_walk_forward.py
@@ -163,15 +163,18 @@ def test_insufficient_bars_raises(tmp_path: Path) -> None:
             test_bars=50,
             anchored=True,
         )
-    with pytest.raises(ValueError, match="train_bars or anchored"):
-        run_walk_forward(
-            _script(tmp_path),
-            PreparedExecutionDataset.from_rows(_bars()),
-            _spec(),
-            {"direction": ["long"]},
-            folds=1,
-            test_bars=50,
-        )
+    # Omitting train_bars/anchored no longer raises — it defaults to a bounded
+    # rolling window (see test_walk_forward_default_is_bounded_rolling_not_anchored).
+    result = run_walk_forward(
+        _script(tmp_path),
+        PreparedExecutionDataset.from_rows(_bars()),
+        _spec(),
+        {"direction": ["long"]},
+        folds=1,
+        test_bars=50,
+    )
+    assert result["spec"]["anchored"] is False
+    assert result["spec"]["train_bars"] is not None  # bounded rolling default
 
 
 def _make_bundle(tmp_path: Path) -> tuple[JobStore, str]:


### PR DESCRIPTION
jobs diagnose: sample-size gates, artifact detector, pair rules, grid plateau

Hardens the backtest-diagnose recommendation engine so its advice is
statistically sound, and adds a neighbor-robustness read to grid ranking.
Live sessions showed the agent changing exit behavior on n=12 bucket
evidence and trusting a lone-spike grid cell that was a window artifact.

backtest_artifacts.py:
- Bucket sample gate: concentration rules (exit reason / side / hour /
  symbol) only fire when the bucket has n >= 8 AND >= 25% of closes;
  evidence strings carry n. Below that a bucket is a hypothesis, not
  evidence.
- Risk-control preservation INVARIANT: no recommendation may suggest
  removing a stop/time-stop - retune via grid + walk-forward instead.
  Documented in the engine and enforced by a string-level test that runs
  every rule against crafted payloads.
- how_to_use in the diagnose payload: recommendations are hypotheses
  ranked by evidence; verify on full data AND out-of-sample; never delete
  risk controls to lift a backtest.
- Simulation-artifact detector (high): win_rate > 90% on n >= 10, or
  >= 50% of closes filling on their entry bar (same-bar bracket fills),
  points at same_bar_policy/ohlc_rules - codifies what a live session
  had to catch by hand.
- by_symbol bucket + pair rules: a losing multi-symbol strategy gets
  "run pair-check first - correlated is not cointegrated" (high, replaces
  the generic no-edge text); one leg carrying >= 80% of symbol gross loss
  gets "size legs by the regression hedge ratio, not 1:1" (medium).

simulator.py / job.py:
- grid_plateau: neighbor-robustness of the top grid cell (one-step
  neighbors along each swept axis; score = mean(neighbor)/top). < 0.5
  carries a lone-spike note. Attached to ExecutionGridResult (exhaustive
  dict-of-lists grids only) and kept by summarize_backtest_payload so the
  agent sees it without loading the grid payload.

Tests: gate on/off at the n=8 boundary, removal-language invariant across
rule-firing payloads, artifact detector with same-bar fills, pair rules,
plateau spike-vs-plateau + non-positive-top None. Also updates the stale
half of test_insufficient_bars_raises to the bounded-rolling-default
behavior (covered since the warmup-window change; it asserted the old
error).
