### PR TITLE
jobs diagnose: no-edge recommendation points at signal-check

### DIFF
--- a/wayfinder_paths/jobs/backtest_artifacts.py
+++ b/wayfinder_paths/jobs/backtest_artifacts.py
@@ -421,9 +421,11 @@ def _recommendations(
                 "high",
                 "No edge on this data (net loss)",
                 f"net_return={pct(net)}, sharpe={num(sharpe)}, profit_factor={num(pf)}",
-                "Change the entry/exit idea or add a regime filter — a negative "
-                "base rarely turns positive from parameter tuning alone. "
-                "Re-think the trigger before sweeping params.",
+                "Test the SIGNAL before touching parameters: run `job "
+                "signal-check <id> --column <entry_column>` — if no horizon "
+                "beats the series' own drift (t >= 2, n >= 30), the entry has "
+                "no predictive power and no exit/stop/sizing change will save "
+                "it; change the idea or add a regime filter instead.",
             )
     # High: wins often but the losers are bigger — a payoff problem, not an entry one.
     if wr is not None and wr > 0.55 and pf is not None and pf < 1.1:


### PR DESCRIPTION
jobs diagnose: no-edge recommendation points at signal-check

Live validation of the search playbook (#496) showed the pair path works
end-to-end (the agent now runs pair-check FIRST on "long ETH short SOL" and
returns a plain-language REJECT with the gate numbers), but on "buy ETH when
RSI is oversold - build it" the agent skipped the signal-check step and went
straight to build -> backtest -> 3 parameter iterations before honestly
concluding "the signal itself lacks predictive power".

Per the recommendation-engine principle (mechanical tools over prompt
exhortations), put the pointer where the agent actually looks at that
moment: the single-symbol "No edge on this data" high recommendation now
names `job signal-check --column <entry_column>` and the beats-drift
criterion (t >= 2, n >= 30) as the FIRST action, mirroring how the
multi-symbol branch already names pair-check. Two-sentence text change,
no logic change; suite green (25).
