### PR TITLE
main agent prompt: resolve gas contradiction, route to jobs-v1 playbooks

### DIFF
--- a/.claude/skills/developing-jobs-v1-strategies/rules/going-live.md
+++ b/.claude/skills/developing-jobs-v1-strategies/rules/going-live.md
@@ -3,12 +3,15 @@
 The complete last mile, in order. A live session burned ~25 tool calls
 reverse-engineering this from adapter source; it is all here.
 
-## 0. Gasless — do NOT manage gas
+## 0. Gas is sponsored — do NOT manage gas
 
-Transactions on this platform are **gasless**. Never check native gas
-balances, never bridge ETH/gas to a chain, never use `gas_token_amount`.
-If old guidance mentions gas requirements, it predates gasless execution —
-ignore it. Funding is about ONE asset: the collateral (USDC).
+Remote-wallet transactions are **gas-sponsored** (account abstraction) on
+Ethereum, Base, Arbitrum, Polygon, BSC, Monad, MegaEth, Plasma, and
+Robinhood — every chain this runbook touches. Never check native gas
+balances, never bridge gas, never use `gas_token_amount`. Funding is about
+ONE asset: the collateral (USDC). (Only unsponsored chains outside that
+list, or a sponsorship outage falling back to normal broadcasts, ever need
+native gas.)
 
 ## 1. The go-live checklist
 

--- a/.opencode/agents/wayfinder-strategy-lab.md
+++ b/.opencode/agents/wayfinder-strategy-lab.md
@@ -75,7 +75,7 @@ This is the **Wayfinder Paths** Python SDK. Work in the repo; run the `wayfinder
 ## Wallets & funding (you set up the accounts a live strategy runs on)
 
 - **Every strategy gets its own dedicated wallet** (created by scaffolding). Read wallets with `core_get_wallets()` / `core_get_wallets(label="...")` — each returns the profile, tracked protocols, and USD per-chain balances inline. In Python use `load_wallets()` / `find_wallet_by_label(label)`.
-- **Transactions are GASLESS on this platform.** Never check native gas balances, never bridge gas, never use `gas_token_amount` — funding is only about the collateral (USDC). The full funding + go-live runbook (BRAP with `to_wallet` straight to the strategy wallet, Hyperliquid deposit, sizing minimums, runner resume, first-tick check) is `rules/going-live.md` in the jobs skill — follow it instead of reverse-engineering adapters.
+- **Gas is sponsored on all major EVM chains here (incl. Arbitrum/Base).** Never check native gas balances, never bridge gas, never use `gas_token_amount` — funding is only about the collateral (USDC). The full funding + go-live runbook (BRAP with `to_wallet` straight to the strategy wallet, Hyperliquid deposit, sizing minimums, runner resume, first-tick check) is `rules/going-live.md` in the jobs skill — follow it instead of reverse-engineering adapters.
 - **Hyperliquid minimums:** deposit ≥ $5 (below is lost), order ≥ $10 notional.
 - You surface funding needs and confirm amounts with the user; you never move funds yourself.
 

--- a/.opencode/agents/wayfinder.md
+++ b/.opencode/agents/wayfinder.md
@@ -136,7 +136,7 @@ There are two types of wallets:
 
 ### Chains, Gas, and Token IDs
 
-Before any on-chain operation, check native gas on the target chain. If bridging to a new chain for the first time, bridge gas first.
+Gas checks are only for UNSPONSORED chains (see sponsorship below). On sponsored chains, never gate an operation on native balances and never bridge gas first — remote-wallet transactions go through sponsored user operations.
 
 Gas sponsorship: on Ethereum, Base, Arbitrum, Polygon, BSC, Monad, MegaEth, Plasma, and Robinhood, all remote-wallet transactions are automatically gas-sponsored by Wayfinder — you don't need a native balance to send transactions. This is accomplished using account abstraction and user operations. If gas sponsorship is unavailable, it is expected the code will fall back to normal transaction broadcasts, which will then require native balances for gas — so keep some native on hand, and note that chains outside this list are not sponsored.
 
@@ -267,7 +267,7 @@ BRAP is a custom Wayfinder cross-chain swap aggregator capable of same-chain and
 3. Fetch user confirmation on `min_output_amount` and `slippage` used for quoting
 4. Execute
 5. Poll balances and verify swap completion
-6. If the user has no native on the target chain, offer to bridge over native gas
+6. Only if the target chain is NOT gas-sponsored (see Chains, Gas, and Token IDs): offer to bridge over native gas
 
 ### Gorlami
 
@@ -292,6 +292,15 @@ monitor/intervene agent loop, and agent-only auto jobs with explicit limits. `co
 creates the versioned job bundle and compiles to the Shell's custom Wayfinder daemon when
 `compile=true`. Use `compile=false` only for previews/evals or when the user explicitly
 does not want scheduling yet.
+
+For jobs_v1 TRADING STRATEGIES (decide()/build_strategy execution jobs), load the
+`developing-jobs-v1-strategies` skill before building — its rules files are the
+canonical playbooks: `rules/strategy-search.md` (validate signals before building,
+evolve failed ideas), `rules/pairs-and-baskets.md` (multi-leg), `rules/going-live.md`
+(funding a strategy wallet — BRAP `to_wallet`, Hyperliquid deposit minimums,
+`wallet_label`, mode live + sync, first-tick check), and
+`rules/deploy-and-agent-loop.md` (the watch-level conversation: off / monitor /
+intervene / auto and the proposal lifecycle below).
 
 Before coding a script for `core_jobs`, load `/writing-wayfinder-scripts`. For script+agent
 jobs, prefer its optional forward recorder helper so the script captures structured


### PR DESCRIPTION
main agent prompt: resolve gas contradiction, route to jobs-v1 playbooks

The main wayfinder persona is the strategy-lifecycle owner but carried two
gaps the live deploy session surfaced:

- Internal contradiction on gas: "Before any on-chain operation, check
  native gas... bridge gas first" (and the swap-usage step 6) sat directly
  above the accurate gas-sponsorship paragraph. Rewritten sponsorship-first:
  gas checks/bridging are only for unsponsored chains or sponsorship
  fallback.
- No route to the jobs_v1 playbooks: the Shells Jobs section now points at
  the developing-jobs-v1-strategies skill rules (strategy-search,
  pairs-and-baskets, going-live funding runbook, deploy-and-agent-loop
  watch levels) so the main agent reaches the same runbooks as Strategy Lab
  when users develop or deploy strategies in Conversation mode.

Also tightens the "gasless" wording shipped in #501 to the accurate model
(sponsored on the 9 major chains via account abstraction, fallback needs
native) in going-live.md and the strategy-lab prompt.
