### PR TITLE
jobs live: venue-equity sizing, mode-flip state reset, bridge env guard

### DIFF
--- a/.claude/skills/developing-jobs-v1-strategies/rules/going-live.md
+++ b/.claude/skills/developing-jobs-v1-strategies/rules/going-live.md
@@ -24,6 +24,13 @@ native gas.)
    platform; scripts get a signer via
    `wayfinder_paths.core.utils.wallets.get_remote_sign_callback(address)`.
 4. **Fund it** (§2).
+4b. **Schedule at the bar close, not "24h from now"**: set
+   `script_loop.cron_expr` in `job.yaml` (e.g. `"10 0 * * *"` UTC for daily
+   bars — close +10min) instead of an interval anchored at resume time,
+   which acts on each bar ~a day late. Schedule/mode/contract changes are
+   ALWAYS made by editing `job.yaml` and running `wayfinder job compile
+   <id>` (or `core_jobs(action="sync")`) — never by updating the runner
+   job directly (a direct update drops the env that carries live mode).
 5. **Point the job at its wallet**: set `wallet_label: <job-id>` under
    `execution_params` in `job.yaml` — the live driver defaults to the "main"
    wallet and will trade the wrong account without it.
@@ -79,6 +86,15 @@ Rules: quote first and show the user output/fee; check each step's success
 tuple before the next (a bridge takes minutes — poll the destination balance,
 don't fire the deposit blind); a receipt with `status=0` is a FAILURE.
 
+## 2b. Sizing capital: live is reconciled from the venue
+
+Live order sizing now uses the venue's marked account value automatically
+(reconciled every tick — the engine puts it on the tick snapshot). You still
+SET `execution_params.initial_capital` to the actual deposit because it
+feeds (a) paper-mode parity (paper has no venue account) and (b) the risk
+circuit breaker's drawdown math. Just know a stale value can no longer
+mis-size live orders.
+
 ## 3. Sizing minimums (do this math out loud)
 
 `per_leg = capital × leverage / n_legs` must clear **$10**. A $30 deposit on
@@ -94,6 +110,11 @@ remember the $5 bridge-deposit minimum on top.
   the SDK tick driver and need no standalone file.
 - **Orders not appearing live**: check per-leg notional ≥ $10, and that the
   runner job is resumed (`core_runner_status(action="status")`).
+- **Switching paper→live**: the engine now archives and resets its state
+  on a mode flip (paper test ticks no longer pollute live), adopting your
+  real venue positions on the first live tick. Jobs whose state predates
+  this fix need a one-time manual reset: delete `state/engine_state.json`
+  before the first live tick.
 - **New jobs**: `core_jobs(action="create")` defaults to
   `execution_contract="jobs_v1"` — never hand-edit job.yaml for this on new
   jobs; only legacy standalone scripts need `execution_contract="legacy"`.

--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -17,7 +17,7 @@ from wayfinder_paths.jobs.backtest_artifacts import (
     diagnose_backtest,
     load_backtest_view,
 )
-from wayfinder_paths.jobs.compiler import JobCompiler
+from wayfinder_paths.jobs.compiler import JobCompiler, compile_job
 from wayfinder_paths.jobs.execution.driver import tick_job
 from wayfinder_paths.jobs.execution.experiments import (
     list_experiments,
@@ -194,6 +194,16 @@ def list_cmd() -> None:
             "result": [snapshot_job(job.id, store=store) for job in store.list_jobs()],
         }
     )
+
+
+@job_cli.command(
+    name="compile",
+    help="Recompile runner wrappers/links from job.yaml (source of truth). "
+    "Run after editing script_loop schedule, mode, or execution_contract.",
+)
+@click.argument("job_id")
+def compile_cmd(job_id: str) -> None:
+    _echo_json({"ok": True, "result": compile_job(job_id)})
 
 
 @job_cli.command(name="status", help="Show a high-level job snapshot.")

--- a/wayfinder_paths/jobs/execution/driver.py
+++ b/wayfinder_paths/jobs/execution/driver.py
@@ -135,9 +135,30 @@ async def tick_job(
         or (job.versioning or {}).get("active_revision")
         or ""
     )
+    now = now if now is not None else pd.Timestamp.now(tz="UTC")
     state_path = root / ENGINE_STATE_PATH
     state_file_existed = state_path.exists()
     state = EngineState.load(state_path)
+    mode_notes: list[dict[str, Any]] = []
+    if state_file_existed and state.mode and state.mode != mode:
+        # A paper test tick otherwise pollutes live (consumed bars, stale
+        # bar_count, paper positions). Archive and start fresh; clearing
+        # state_file_existed re-arms first-run venue adoption in _reconcile.
+        archive_path = state_path.with_name(
+            f"engine_state.{state.mode}.{now.strftime('%Y%m%dT%H%M%SZ')}.json"
+        )
+        state_path.rename(archive_path)
+        mode_notes.append(
+            {
+                "kind": "mode_flip_state_reset",
+                "from_mode": state.mode,
+                "to_mode": mode,
+                "archived": str(archive_path),
+            }
+        )
+        state = EngineState()
+        state_file_existed = False
+    state.mode = mode
     state.revision = revision or state.revision
 
     if adapters is None:
@@ -146,7 +167,6 @@ async def tick_job(
             for venue in (spec.venues or ["hyperliquid"])
         }
     brokers = {name: adapter.broker for name, adapter in adapters.items()}
-    now = now if now is not None else pd.Timestamp.now(tz="UTC")
 
     lookback_bars = int(params.get("lookback_bars") or 200)
     rows: list[dict[str, Any]] = []
@@ -183,7 +203,9 @@ async def tick_job(
             {"kind": "risk_halt", "reason": halt_reason, "snapshot": risk_snapshot}
         )
         if snapshot.status == "valid":
-            snapshot = StateSnapshot(status="risk_halt", reason=halt_reason)
+            snapshot = StateSnapshot(
+                status="risk_halt", reason=halt_reason, data=snapshot.data
+            )
 
     # Manual kill switch: outranks every other status (including ambiguous)
     # — reduce-only regardless, and cancel queued OPENs before they can
@@ -192,7 +214,9 @@ async def tick_job(
     if manual_halt is not None:
         halt_note = f"manual halt: {manual_halt.get('reason') or 'unspecified'}"
         risk_notes.append({"kind": "manual_halt", "reason": halt_note})
-        snapshot = StateSnapshot(status="risk_halt", reason=halt_note)
+        snapshot = StateSnapshot(
+            status="risk_halt", reason=halt_note, data=snapshot.data
+        )
         kept_intents = []
         for intent in state.pending_intents:
             if intent.reduce_only:
@@ -262,6 +286,7 @@ async def tick_job(
             auto_limits=dict(job.agent_loop.auto_limits or {}) or None,
             client_order_prefix=job.id,
         )
+    tick.guard_events.extend(mode_notes)
     tick.guard_events.extend(reconcile_notes)
     tick.guard_events.extend(risk_notes)
     tick.guard_events.extend(feature_guards)
@@ -318,6 +343,16 @@ async def tick_job(
         now=now,
         engine_state_pre=engine_state_pre,
     )
+    for note in mode_notes:
+        store.append_journal(
+            job.id,
+            {
+                "type": "mode_flip_state_reset",
+                "from_mode": note["from_mode"],
+                "to_mode": note["to_mode"],
+                "archived": note["archived"],
+            },
+        )
     if snapshot.status == "ambiguous":
         store.append_journal(
             job.id,
@@ -365,6 +400,7 @@ async def _reconcile(
         return StateSnapshot(status="valid"), []
     notes: list[dict[str, Any]] = []
     venue_positions: dict[str, Any] = {}
+    account_values: dict[str, float] = {}
     for name, broker in brokers.items():
         try:
             venue_state = await broker.fetch_state(symbols)
@@ -382,6 +418,22 @@ async def _reconcile(
                 ],
             )
         venue_positions.update(venue_state.positions)
+        account_value = (venue_state.balances or {}).get("accountValue")
+        if account_value is not None:
+            account_values[name] = float(account_value)
+
+    # Venue-marked equity rides the snapshot (NOT params): the drift
+    # reconciler replays ticks with raw job.yaml params, so params-borne
+    # equity would replay wrong and flag false drift. mark_to_market_equity
+    # treats snapshot.data["account_value"] as authoritative in live mode.
+    data: dict[str, Any] = (
+        {
+            "account_value": sum(account_values.values()),
+            "account_value_by_venue": dict(account_values),
+        }
+        if account_values
+        else {}
+    )
 
     if not state_file_existed and venue_positions:
         for symbol, record in venue_positions.items():
@@ -394,7 +446,10 @@ async def _reconcile(
                     "reason": "no engine state on disk; adopted venue position",
                 }
             )
-        return StateSnapshot(status="valid", reason="adopted_from_venue"), notes
+        return (
+            StateSnapshot(status="valid", reason="adopted_from_venue", data=data),
+            notes,
+        )
 
     reasons: list[str] = []
     for symbol, venue_record in venue_positions.items():
@@ -419,8 +474,11 @@ async def _reconcile(
         notes.extend(
             {"kind": "reconcile_mismatch", "reason": reason} for reason in reasons
         )
-        return StateSnapshot(status="ambiguous", reason="; ".join(reasons)), notes
-    return StateSnapshot(status="valid"), notes
+        return (
+            StateSnapshot(status="ambiguous", reason="; ".join(reasons), data=data),
+            notes,
+        )
+    return StateSnapshot(status="valid", data=data), notes
 
 
 def _record(

--- a/wayfinder_paths/jobs/execution/engine.py
+++ b/wayfinder_paths/jobs/execution/engine.py
@@ -99,6 +99,9 @@ class EngineState:
     revision: str | None = None
     strategy_state: dict[str, Any] = field(default_factory=dict)
     liquidated_at: str | None = None
+    # Mode that produced this state ("paper" | "live"); the driver archives
+    # and resets state on a mode flip so paper test ticks can't pollute live.
+    mode: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -110,6 +113,7 @@ class EngineState:
             "revision": self.revision,
             "strategy_state": dict(self.strategy_state),
             "liquidated_at": self.liquidated_at,
+            "mode": self.mode,
         }
 
     @classmethod
@@ -130,6 +134,7 @@ class EngineState:
             revision=payload.get("revision"),
             strategy_state=dict(payload.get("strategy_state") or {}),
             liquidated_at=payload.get("liquidated_at"),
+            mode=payload.get("mode"),
         )
 
     @classmethod

--- a/wayfinder_paths/jobs/execution/primitives.py
+++ b/wayfinder_paths/jobs/execution/primitives.py
@@ -632,10 +632,16 @@ class ExecutionContext:
 
 
 def mark_to_market_equity(ctx: ExecutionContext) -> float:
-    """Current equity as decide() can see it: initial capital + realized PnL +
-    unrealized mark-to-market at the latest completed close. Pure (ctx data
-    only — purity-sandbox safe) and bar-identical to the simulator's equity
-    curve, so compound sizing in backtest and live use the same number."""
+    """Current equity as decide() can see it. In LIVE mode the reconcile step
+    puts the venue's marked account value on `state_snapshot.data` and that is
+    authoritative (it already embeds realized + unrealized PnL) — sizing from
+    config capital nearly fired ~$8k orders on a $29.50 account. Backtests
+    never populate snapshot data, so they keep the config-capital arithmetic:
+    initial capital + realized PnL + unrealized mark-to-market at the latest
+    completed close. Pure (ctx data only — purity-sandbox safe)."""
+    live_account_value = (ctx.state_snapshot.data or {}).get("account_value")
+    if live_account_value is not None and float(live_account_value) > 0:
+        return float(live_account_value)
     equity = (
         float(ctx.params.get("initial_capital") or DEFAULT_INITIAL_CAPITAL)
         + ctx.ledger.realized_pnl

--- a/wayfinder_paths/jobs/execution/reconcile.py
+++ b/wayfinder_paths/jobs/execution/reconcile.py
@@ -173,6 +173,10 @@ async def _replay_rows(
             snapshot=StateSnapshot(
                 status=str(snapshot_data.get("status") or "valid"),
                 reason=snapshot_data.get("reason"),
+                # data carries venue-reconciled account equity; dropping it
+                # here would replay live equity-sized intents at config
+                # capital and flag false drift.
+                data=dict(snapshot_data.get("data") or {}),
             ),
         )
         recorded = [

--- a/wayfinder_paths/jobs/runner_bridge.py
+++ b/wayfinder_paths/jobs/runner_bridge.py
@@ -41,8 +41,16 @@ class RunnerBridge:
         cron_expr: str | None = None,
         timezone: str = "UTC",
         timeout_seconds: int | None = None,
-        env: dict[str, str] | None = None,
+        env: dict[str, str],
     ) -> dict[str, Any]:
+        if not env:
+            raise ValueError(
+                "add_or_update_script_job requires the full job env: update_job "
+                "replaces the runner payload wholesale, and a missing env "
+                "silently reverts WAYFINDER_JOB_MODE to paper (this flipped a "
+                "live job in production). Regenerate via JobCompiler.compile — "
+                "job.yaml is the source of truth for schedules and env."
+            )
         schedule = schedule_request_params(
             interval_seconds=interval_seconds,
             cron_expr=cron_expr,
@@ -52,11 +60,10 @@ class RunnerBridge:
             "script_path": script_path,
             "args": [],
             "debug": False,
+            "env": {str(k): str(v) for k, v in env.items()},
         }
         if timeout_seconds is not None:
             payload["timeout_seconds"] = int(timeout_seconds)
-        if env:
-            payload["env"] = {str(k): str(v) for k, v in env.items()}
 
         params: dict[str, Any] = {
             "name": name,

--- a/wayfinder_paths/tests/test_jobs_live_driver.py
+++ b/wayfinder_paths/tests/test_jobs_live_driver.py
@@ -89,10 +89,12 @@ class FakeLiveBroker:
         *,
         venue_positions: dict[str, PositionRecord] | None = None,
         fetch_error: Exception | None = None,
+        account_value: float | None = None,
     ) -> None:
         self.placed: list[OrderIntent] = []
         self.venue_positions = venue_positions or {}
         self.fetch_error = fetch_error
+        self.account_value = account_value
         self.snapshot: Any = None
 
     async def place(
@@ -115,7 +117,16 @@ class FakeLiveBroker:
     async def fetch_state(self, symbols: Any = ()) -> VenueState:
         if self.fetch_error is not None:
             raise self.fetch_error
-        return VenueState(positions=dict(self.venue_positions), source="fake")
+        balances = (
+            {"accountValue": self.account_value}
+            if self.account_value is not None
+            else {}
+        )
+        return VenueState(
+            positions=dict(self.venue_positions),
+            balances=balances,
+            source="fake",
+        )
 
     async def get_capacity(self, symbol: str, side: str) -> TradeCapacity:
         return TradeCapacity(safe=True, source="fake")
@@ -487,3 +498,170 @@ def test_compiler_wrapper_branches_on_contract(tmp_path: Path) -> None:
     legacy_wrapper = (tmp_path / legacy_wrappers["script"]).read_text(encoding="utf-8")
     assert 'runpy.run_path(str(ENTRYPOINT), run_name="__main__")' in legacy_wrapper
     assert "run_scheduled_tick" not in legacy_wrapper
+
+
+EQUITY_STRATEGY = """
+from wayfinder_paths.jobs.execution import OrderIntent
+from wayfinder_paths.jobs.execution.primitives import mark_to_market_equity
+
+
+class Strategy:
+    def __init__(self, params):
+        self.params = params
+
+    def decide(self, ctx):
+        if "SNX" in ctx.ledger.positions:
+            return []
+        equity = mark_to_market_equity(ctx)
+        return [
+            OrderIntent(
+                action="OPEN",
+                venue="hyperliquid",
+                symbol="SNX",
+                side="long",
+                notional=equity * 0.5,
+            )
+        ]
+
+
+def build_strategy(params):
+    return Strategy(params)
+"""
+
+
+def _equity_job(tmp_path: Path, *, params: dict[str, Any] | None = None):
+    store, job, root = _make_job(tmp_path, mode="live", params=params)
+    script = root / "workspace" / "src" / "strategy.py"
+    script.write_text(EQUITY_STRATEGY.lstrip(), encoding="utf-8")
+    return store, job, root
+
+
+async def test_live_sizing_uses_venue_account_value(tmp_path: Path) -> None:
+    """The $8k-orders-on-a-$29.50-account bug: live equity must come from the
+    venue's marked account value on snapshot.data, not config initial_capital."""
+    store, job, root = _equity_job(tmp_path, params={"initial_capital": 10_000.0})
+    broker = FakeLiveBroker(account_value=29.50)
+    view = _view(2)
+    result = await tick_job(
+        job,
+        root,
+        "live",
+        store=store,
+        adapters={"hyperliquid": FakeAdapter(view, broker)},
+        now=_now(view),
+    )
+    assert result["snapshot"]["data"]["account_value"] == 29.50
+    intents = result["intents"]
+    assert intents, result
+    assert abs(float(intents[0]["notional"]) - 29.50 * 0.5) < 1e-9
+    # The recorded tick row carries the same snapshot data (replay parity).
+    ticks_file = root / "results" / "forward" / "ticks.jsonl"
+    row = json.loads(ticks_file.read_text().strip().splitlines()[-1])
+    assert row["snapshot"]["data"]["account_value"] == 29.50
+
+
+async def test_live_sizing_falls_back_to_config_without_balances(
+    tmp_path: Path,
+) -> None:
+    store, job, root = _equity_job(tmp_path, params={"initial_capital": 500.0})
+    broker = FakeLiveBroker()  # no account_value reported
+    view = _view(2)
+    result = await tick_job(
+        job,
+        root,
+        "live",
+        store=store,
+        adapters={"hyperliquid": FakeAdapter(view, broker)},
+        now=_now(view),
+    )
+    assert "account_value" not in (result["snapshot"].get("data") or {})
+    intents = result["intents"]
+    assert intents and abs(float(intents[0]["notional"]) - 250.0) < 1e-9
+
+
+async def test_mode_flip_archives_state_and_adopts_venue(tmp_path: Path) -> None:
+    """Paper test ticks must not pollute live: on paper->live the state file is
+    archived, strategy_state resets, and venue positions are adopted."""
+    store, job, root = _make_job(tmp_path, mode="live")
+    view = _view(2)
+    # Paper tick writes state stamped mode=paper (and consumes the bar).
+    await tick_job(
+        job,
+        root,
+        "paper",
+        store=store,
+        adapters={
+            "hyperliquid": FakeAdapter(view, PaperBroker(capabilities=PERP_CAPS))
+        },
+        now=_now(view),
+    )
+    state_path = root / "state" / "engine_state.json"
+    assert EngineState.load(state_path).mode == "paper"
+
+    venue_positions = {
+        "SNX": PositionRecord(symbol="SNX", side="long", size=2.0, avg_price=9.5)
+    }
+    broker = FakeLiveBroker(venue_positions=venue_positions, account_value=100.0)
+    result = await tick_job(
+        job,
+        root,
+        "live",
+        store=store,
+        adapters={"hyperliquid": FakeAdapter(view, broker)},
+        now=_now(view),
+    )
+    archives = list((root / "state").glob("engine_state.paper.*.json"))
+    assert archives, "paper state should be archived on flip"
+    flip_events = [
+        e for e in result["guard_events"] if e.get("kind") == "mode_flip_state_reset"
+    ]
+    assert flip_events and flip_events[0]["from_mode"] == "paper"
+    restored = EngineState.load(state_path)
+    assert restored.mode == "live"
+    assert restored.ledger.positions["SNX"].metadata.get("adopted_from_venue")
+    assert restored.strategy_state == {}
+
+
+async def test_legacy_state_without_mode_is_stamped_not_archived(
+    tmp_path: Path,
+) -> None:
+    store, job, root = _make_job(tmp_path, mode="live")
+    state_path = root / "state" / "engine_state.json"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    legacy = EngineState().to_dict()
+    legacy.pop("mode")
+    state_path.write_text(json.dumps(legacy), encoding="utf-8")
+
+    view = _view(2)
+    await tick_job(
+        job,
+        root,
+        "live",
+        store=store,
+        adapters={"hyperliquid": FakeAdapter(view, FakeLiveBroker())},
+        now=_now(view),
+    )
+    assert not list((root / "state").glob("engine_state.*.*.json"))
+    assert EngineState.load(state_path).mode == "live"
+
+
+async def test_risk_halt_downgrade_preserves_snapshot_data(tmp_path: Path) -> None:
+    store, job, root = _make_job(
+        tmp_path, mode="live", params={"initial_capital": 100.0}
+    )
+    (root / "workspace").mkdir(parents=True, exist_ok=True)
+    (root / "workspace" / "risk_limits.json").write_text(
+        json.dumps({"max_drawdown_pct": -0.0000001}), encoding="utf-8"
+    )
+    broker = FakeLiveBroker(account_value=42.0)
+    view = _view(2)
+    result = await tick_job(
+        job,
+        root,
+        "live",
+        store=store,
+        adapters={"hyperliquid": FakeAdapter(view, broker)},
+        now=_now(view),
+    )
+    # Whatever the halt outcome, the venue equity must not be dropped.
+    assert result["snapshot"]["data"]["account_value"] == 42.0

--- a/wayfinder_paths/tests/test_jobs_reconcile.py
+++ b/wayfinder_paths/tests/test_jobs_reconcile.py
@@ -149,3 +149,44 @@ def test_reconcile_reports_data_drift_on_view_hash_mismatch(tmp_path: Path) -> N
 
     assert report["data_drift_ticks"] > 0
     assert report["ticks_compared"] == 0 or report["intent_match_rate"] is not None
+
+
+def test_live_equity_sized_intents_survive_replay(tmp_path: Path) -> None:
+    """REGRESSION for the params trap: venue account equity rides on
+    snapshot.data (recorded per tick and reconstructed at replay), NOT on
+    params — params-borne equity would replay at config capital and flag
+    false drift on every live equity-sized job."""
+    from wayfinder_paths.tests.test_jobs_live_driver import (
+        EQUITY_STRATEGY,
+        FakeLiveBroker,
+    )
+
+    store, job, root = _make_job(tmp_path, mode="live")
+    script = root / "workspace" / "src" / "strategy.py"
+    script.write_text(EQUITY_STRATEGY.lstrip(), encoding="utf-8")
+    job.execution_params = {"symbols": ["SNX"], "initial_capital": 10_000.0}
+    store.save(job)
+    bars = _bars(6)
+    (root / "results" / "backtest").mkdir(parents=True, exist_ok=True)
+    (root / "results" / "backtest" / "input_bars.json").write_text(
+        json.dumps(bars), encoding="utf-8"
+    )
+
+    async def _run() -> None:
+        broker = FakeLiveBroker(account_value=29.50)
+        for count in range(1, len(bars) + 1):
+            view = CompletedBarsView.from_rows(bars[:count])
+            await tick_job(
+                job,
+                root,
+                "live",
+                store=store,
+                adapters={"hyperliquid": FakeAdapter(view, broker)},
+                now=view.timestamps[-1],
+            )
+
+    asyncio.run(_run())
+
+    report = reconcile_job(job.id, store=store)
+    assert report["ticks_compared"] > 0
+    assert report["intent_match_rate"] == 1.0, report

--- a/wayfinder_paths/tests/test_jobs_sizing.py
+++ b/wayfinder_paths/tests/test_jobs_sizing.py
@@ -180,3 +180,49 @@ def test_grid_accepts_return_on_margin_and_leverage_dimension(tmp_path) -> None:
     assert all(row["stats"]["return_on_margin"] is not None for row in result.runs)
     leverages = {row["params"]["leverage"] for row in result.runs}
     assert leverages == {1.0, 2.0, 3.0}
+
+
+def test_mark_to_market_equity_prefers_live_account_value() -> None:
+    """Live ticks carry the venue's marked account value on snapshot.data —
+    it already embeds realized+unrealized PnL, so it wins outright."""
+    from wayfinder_paths.jobs.execution import CompletedBarsView, ExecutionSpec
+    from wayfinder_paths.jobs.execution.primitives import (
+        ExecutionContext,
+        PositionLedger,
+        StateSnapshot,
+        mark_to_market_equity,
+    )
+
+    view = CompletedBarsView.from_rows(
+        [
+            {
+                "timestamp": "2026-01-01T00:00:00Z",
+                "symbol": "SNX",
+                "open": 10.0,
+                "high": 10.5,
+                "low": 9.5,
+                "close": 10.0,
+                "volume": 1.0,
+            }
+        ]
+    )
+
+    def ctx_with(snapshot: StateSnapshot) -> ExecutionContext:
+        return ExecutionContext(
+            view=view,
+            ledger=PositionLedger(),
+            state_snapshot=snapshot,
+            capacity=None,
+            params={"initial_capital": 10_000.0},
+            timestamp="2026-01-01T00:00:00Z",
+            execution_spec=ExecutionSpec(),
+        )
+
+    live = ctx_with(StateSnapshot(status="valid", data={"account_value": 29.5}))
+    assert mark_to_market_equity(live) == 29.5
+    # No snapshot data (every backtest) -> config-capital arithmetic unchanged.
+    backtest = ctx_with(StateSnapshot(status="valid"))
+    assert mark_to_market_equity(backtest) == 10_000.0
+    # Zero/negative account value is not a sane override -> fall back.
+    broke = ctx_with(StateSnapshot(status="valid", data={"account_value": 0.0}))
+    assert mark_to_market_equity(broke) == 10_000.0

--- a/wayfinder_paths/tests/test_wayfinder_jobs.py
+++ b/wayfinder_paths/tests/test_wayfinder_jobs.py
@@ -993,3 +993,45 @@ def test_mcp_sync_heals_stale_wrapper_after_contract_flip(
     text = wrapper.read_text(encoding="utf-8")
     assert "run_scheduled_tick" in text
     assert "runpy" not in text
+
+
+def test_bridge_requires_env() -> None:
+    """update_job replaces the runner payload wholesale — a schedule-only
+    update without env silently reverted WAYFINDER_JOB_MODE to paper on a
+    LIVE job in production. env is now mandatory."""
+    import pytest
+
+    from wayfinder_paths.jobs.runner_bridge import RunnerBridge
+
+    bridge = RunnerBridge.__new__(RunnerBridge)  # skip daemon paths
+    with pytest.raises(ValueError, match="JobCompiler.compile"):
+        bridge.add_or_update_script_job(
+            name="x-script", script_path="x.py", interval_seconds=60, env={}
+        )
+
+
+def test_bridge_update_path_carries_env(monkeypatch) -> None:
+    from wayfinder_paths.jobs import runner_bridge as rb
+
+    calls: list[tuple[str, dict]] = []
+
+    class FakeClient:
+        def call(self, method, params):
+            calls.append((method, params))
+            if method == "add_job":
+                return {"ok": False, "error": "UNIQUE constraint failed: jobs.name"}
+            return {"ok": True}
+
+    bridge = rb.RunnerBridge.__new__(rb.RunnerBridge)
+    bridge.client = FakeClient()
+    resp = bridge.add_or_update_script_job(
+        name="x-script",
+        script_path="x.py",
+        interval_seconds=60,
+        env={"WAYFINDER_JOB_MODE": "live"},
+    )
+    assert resp["ok"]
+    update_calls = [p for m, p in calls if m == "update_job"]
+    assert update_calls and update_calls[0]["payload"]["env"] == {
+        "WAYFINDER_JOB_MODE": "live"
+    }


### PR DESCRIPTION
jobs live: venue-equity sizing, mode-flip state reset, bridge env guard

The first real live deployment surfaced three money-path defects. Design
reviewed; the key constraint is the drift reconciler, which replays recorded
ticks with the RAW job.yaml execution_params - so live equity must ride the
per-tick SNAPSHOT, never params.

1. Live sizing from venue equity (snapshot.data). _reconcile already fetched
   the venue's marked account value (Hyperliquid crossMarginSummary
   .accountValue) and discarded it; sizing used execution_params
   .initial_capital - a stale backtest value nearly fired ~$8k orders per
   leg on a $29.50 account. Now: _reconcile attaches {"account_value",
   "account_value_by_venue"} to every post-fetch StateSnapshot (adoption,
   mismatch-ambiguous, clean); tick_job's risk-halt/manual-halt downgrades
   preserve snapshot.data; mark_to_market_equity returns the venue value
   when present (>0) - it already embeds realized+unrealized, no double
   counting. Backtests never populate snapshot data: byte-identical
   backtest behavior (existing simulator-curve parity test unchanged).
   reconcile_job's replay now reconstructs snapshot.data, so equity-sized
   live intents replay exactly (new regression test asserts
   intent_match_rate == 1.0 - the params trap).
   Fallbacks: fetch failure keeps the ambiguous/reduce-only path (opens
   blocked, so config capital can never mis-size a live open); venues
   without balances fall back to config capital.

2. Mode-flip state reset. Engine state persisted across paper->live: a
   paper test tick consumed the day's bar and left strategy_state behind
   (observed live). EngineState gains an additive `mode` field; on a flip
   the driver archives state to engine_state.<oldmode>.<utc>.json, starts
   fresh, and clears state_file_existed so the existing venue-adoption
   path repopulates real positions - which, with (1), also carries the
   account value, so the first post-flip tick sizes correctly. Guard event
   + journal entry (`mode_flip_state_reset`). Legacy files without `mode`
   are stamped, never archived.

3. RunnerBridge env guard. update_job replaces the runner payload
   wholesale; a schedule-only add_or_update_script_job call without env
   silently reverted WAYFINDER_JOB_MODE to paper on a live job in
   production. env is now a required kwarg (loud ValueError pointing at
   JobCompiler.compile / job.yaml as the source of truth) and is always
   included in both add and update payloads.

4. CLI parity: new `wayfinder job compile <id>` (recompiles wrappers/links
   from job.yaml after schedule/mode/contract edits; MCP sync has done
   this since #501 but the CLI had no equivalent).

Runbook (going-live.md): live sizing reconciles from the venue (keep
initial_capital for paper parity + risk circuit breaker); schedule at bar
close via script_loop.cron_expr + `job compile`, never direct runner
updates; pre-fix jobs need a one-time engine-state reset when flipping
modes.

Tests: venue-equity sizing end-to-end (intent notional + recorded tick row),
config fallback, replay-parity regression, mode-flip archive/adopt/reset,
legacy stamp-only, risk-halt data preservation, equity-override unit trio
(live/backtest/zero), bridge env guard + update-path env carriage. 133
passing across the touched suites.
