### PR TITLE
jobs data-quality: coverage warning, fetch shortfall, WF hints, rank-check

### DIFF
--- a/.claude/skills/developing-jobs-v1-strategies/SKILL.md
+++ b/.claude/skills/developing-jobs-v1-strategies/SKILL.md
@@ -20,6 +20,7 @@ wayfinder job fetch-dataset <id> --days 720 --source ccxt --exchange binance
 # STEP 0 — validate the IDEA before building on it (see rules/strategy-search.md):
 wayfinder job pair-check <id> --symbols ETH,SOL --days 720    # any pair/long-short idea: the admission gate
 wayfinder job signal-check <id> --column entry_signal        # any entry signal: does it beat drift?
+wayfinder job rank-check <id> --column mom_score             # any basket ranking: does it order forward returns?
 wayfinder job backtest <id> --quick 1000      # fast iteration: last 1000 bars, ~2 KB summary
 wayfinder job backtest-diagnose <id>          # READ next_step + recommendations — the framework tells you what to try
 # apply the ONE change next_step names, repeat backtest --quick / diagnose (see "the improve loop" below)

--- a/.claude/skills/developing-jobs-v1-strategies/rules/strategy-search.md
+++ b/.claude/skills/developing-jobs-v1-strategies/rules/strategy-search.md
@@ -26,7 +26,13 @@ with `n >= 30`. **If no horizon beats drift, the entry has no predictive power
 filter tuning rescues entries that carry no information. This 30-second check
 is what converts "six variants of a dead idea" into one honest sentence.
 
-For any pair / long-short / basket idea, the equivalent step 0 is the
+For basket / cross-sectional ideas the equivalent test is
+`wayfinder job rank-check <id> --column <ranking>` — the Spearman rank IC of
+the ranking column vs relative forward returns (|t| >= 2, n >= 30, sign
+stable across both halves). A ranking that does not order future returns
+cannot be rescued by rebalance cadence or weighting.
+
+For any pair / long-short idea, the equivalent step 0 is the
 admission gate — `wayfinder job pair-check <id> --symbols A,B --days 720`
 (see `rules/pairs-and-baskets.md`). A REJECT is the methodology working, not
 a failure: it just saved days of tuning a spread that does not mean-revert.

--- a/.opencode/agents/wayfinder-quant.md
+++ b/.opencode/agents/wayfinder-quant.md
@@ -2,7 +2,7 @@
 description: Hidden quant worker for backtests, Delta Lab time series, CCXT analysis, and long-running analytics scripts.
 mode: subagent
 hidden: true
-steps: 64
+steps: 96
 temperature: 0.1
 permission:
   task:

--- a/.opencode/agents/wayfinder-strategy-lab.md
+++ b/.opencode/agents/wayfinder-strategy-lab.md
@@ -2,7 +2,7 @@
 description: Strategy Lab — builds, backtests, diagnoses, and iterates jobs_v1 trading strategies with rigor, and only offers to deploy an edge that survives out-of-sample. Select this to develop or harden a trading strategy.
 mode: primary
 temperature: 0.1
-steps: 64
+steps: 96
 permission:
   task:
     explore: allow

--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -47,7 +47,11 @@ from wayfinder_paths.jobs.models import (
     normalize_agent_mode,
 )
 from wayfinder_paths.jobs.proposals import propose_change
-from wayfinder_paths.jobs.research import pair_check_job, signal_check_job
+from wayfinder_paths.jobs.research import (
+    pair_check_job,
+    rank_check_job,
+    signal_check_job,
+)
 from wayfinder_paths.jobs.runner_bridge import RunnerBridge
 from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.jobs.sync import snapshot_job, sync_all_jobs
@@ -612,6 +616,28 @@ def pair_check_cmd(
 def signal_check_cmd(job_id: str, column: str, horizons: str | None) -> None:
     store = JobStore()
     result = signal_check_job(
+        job_id,
+        column=column,
+        horizons=[int(h) for h in horizons.split(",")] if horizons else None,
+        store=store,
+    )
+    _echo_json({"ok": True, "result": result})
+
+
+@job_cli.command(
+    name="rank-check",
+    help="Rank-IC study of a precomputed cross-sectional ranking column vs "
+    "relative forward returns — run BEFORE building a long/short basket "
+    "on that ranking.",
+)
+@click.argument("job_id")
+@click.option("--column", required=True, help="Precomputed ranking column name.")
+@click.option(
+    "--horizons", default=None, help="Comma-separated forward horizons in bars."
+)
+def rank_check_cmd(job_id: str, column: str, horizons: str | None) -> None:
+    store = JobStore()
+    result = rank_check_job(
         job_id,
         column=column,
         horizons=[int(h) for h in horizons.split(",")] if horizons else None,

--- a/wayfinder_paths/jobs/execution/job.py
+++ b/wayfinder_paths/jobs/execution/job.py
@@ -47,6 +47,25 @@ def summarize_backtest_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
         for k in ("type", "artifacts", "stamp", "walk_forward", "validation")
         if k in payload
     }
+    coverage = ((payload.get("dataset") or {}).get("feature_coverage")) or {}
+    thin = {
+        name: info
+        for name, info in coverage.items()
+        if float(info.get("coverage_fraction") or 0.0) < 0.8
+    }
+    if coverage:
+        # summarize drops the raw dataset metadata; coverage is decision-grade.
+        summary["feature_coverage"] = coverage
+    if thin:
+        worst = min(thin, key=lambda k: float(thin[k].get("coverage_fraction") or 0.0))
+        frac = float(thin[worst].get("coverage_fraction") or 0.0)
+        summary["feature_coverage_note"] = (
+            f"feature '{worst}' covers only {frac:.0%} of the bars span "
+            f"(thin: {sorted(thin)}) — bars outside a feature's span carry "
+            "NaN, so any comparison against full-history signals is biased. "
+            "Re-fetch the feature to match the dataset window "
+            "(e.g. fetch_funding with the same days as the candles)."
+        )
     result = payload.get("result")
     if isinstance(result, Mapping):
         if "ranked" in result:  # grid / optuna result
@@ -217,9 +236,40 @@ def _load_dataset(
         frames = load_feature_rows(list(feature_roots or (root,)), specs)
         dataset = PreparedExecutionDataset(
             merge_features(dataset.bars, frames, specs),
-            {**dataset.metadata, "features": [item.name for item in specs]},
+            {
+                **dataset.metadata,
+                "features": [item.name for item in specs],
+                "feature_coverage": _feature_coverage(dataset.bars, frames),
+            },
         )
     return dataset
+
+
+def _feature_coverage(bars: Any, frames: Mapping[str, Any]) -> dict[str, Any]:
+    """Per-feature span vs the bars span. A feature that covers only the tail
+    of the dataset silently handicaps that signal in any comparison (a 1-year
+    funding file against 6 years of candles condemned a signal in a live
+    session); coverage_fraction < 1 means every earlier bar carries NaN."""
+    timestamps = bars.timestamps
+    if not timestamps:
+        return {}
+    bars_first, bars_last = timestamps[0], timestamps[-1]
+    bars_span = max((bars_last - bars_first).total_seconds(), 1.0)
+    coverage: dict[str, Any] = {}
+    for name, frame in frames.items():
+        if frame.empty:
+            coverage[name] = {"rows": 0, "coverage_fraction": 0.0}
+            continue
+        first = frame["timestamp"].iloc[0]
+        last = frame["timestamp"].iloc[-1]
+        overlap = (min(last, bars_last) - max(first, bars_first)).total_seconds()
+        coverage[name] = {
+            "first_ts": str(first),
+            "last_ts": str(last),
+            "rows": int(len(frame)),
+            "coverage_fraction": round(max(0.0, overlap) / bars_span, 3),
+        }
+    return coverage
 
 
 def _resolve_dataset(

--- a/wayfinder_paths/jobs/execution/op_runner.py
+++ b/wayfinder_paths/jobs/execution/op_runner.py
@@ -47,6 +47,10 @@ def _run(op: str, kwargs: dict[str, Any]) -> Any:
         from wayfinder_paths.jobs.research import signal_check_job
 
         return signal_check_job(kwargs.pop("job_id"), **kwargs)
+    if op == "rank_check":
+        from wayfinder_paths.jobs.research import rank_check_job
+
+        return rank_check_job(kwargs.pop("job_id"), **kwargs)
     if op == "backtest_job":
         from wayfinder_paths.jobs.execution.job import (
             backtest_execution_job,

--- a/wayfinder_paths/jobs/execution/preflight.py
+++ b/wayfinder_paths/jobs/execution/preflight.py
@@ -153,7 +153,29 @@ def build_live_dataset(
         json.dumps({"bars": rows, "metadata": metadata}, indent=2, default=str) + "\n",
         encoding="utf-8",
     )
-    return {"path": str(path), "bars": len(rows), "metadata": metadata}
+    result: dict[str, Any] = {
+        "path": str(path),
+        "bars": len(rows),
+        "metadata": metadata,
+    }
+    # Requested-vs-received: venue feeds cap history silently — an agent asked
+    # for 720 days, got 290, and analyzed away without noticing the shortfall.
+    stamps = sorted({str(row.get("timestamp")) for row in rows})
+    if stamps:
+        first = pd.Timestamp(stamps[0])
+        last = pd.Timestamp(stamps[-1])
+        days_received = round((last - first).total_seconds() / 86_400, 1)
+        result["first_ts"] = str(first)
+        result["last_ts"] = str(last)
+        result["days_requested"] = days
+        result["days_received"] = days_received
+        if days_received < 0.9 * float(days):
+            result["warning"] = (
+                f"received {days_received} days of {days} requested — the "
+                "venue caps history. For longer windows use "
+                "dataset_source='ccxt' (exchange='binance')."
+            )
+    return result
 
 
 class ReplayFeed:
@@ -671,7 +693,7 @@ def fetch_funding_features(
             target.write_text(json.dumps(spec_doc, indent=2) + "\n", encoding="utf-8")
             declared = True
 
-    return {
+    result: dict[str, Any] = {
         "rows_fetched": len(rows),
         "rows_appended": appended,
         "per_symbol": metadata.get("per_symbol", {}),
@@ -679,3 +701,20 @@ def fetch_funding_features(
         "feature_declared_now": declared,
         "metadata": metadata,
     }
+    stamps = sorted(str(row.get("timestamp")) for row in rows)
+    if stamps:
+        first = pd.Timestamp(stamps[0])
+        last = pd.Timestamp(stamps[-1])
+        days_received = round((last - first).total_seconds() / 86_400, 1)
+        result["first_ts"] = str(first)
+        result["last_ts"] = str(last)
+        result["days_requested"] = days
+        result["days_received"] = days_received
+        if days_received < 0.9 * float(days):
+            result["warning"] = (
+                f"funding history covers {days_received} days of {days} "
+                "requested — bars outside this span carry NaN funding, which "
+                "biases any funding-vs-price-signal comparison. Match the "
+                "candle window or note the shortfall in your analysis."
+            )
+    return result

--- a/wayfinder_paths/jobs/execution/walk_forward.py
+++ b/wayfinder_paths/jobs/execution/walk_forward.py
@@ -67,9 +67,23 @@ def run_walk_forward(
     min_train = max(train_bars or warmup_bars, warmup_bars)
     required = folds * test_bars + min_train
     if total < required:
+        # Say what WOULD fit — agents were burning retries guessing fold sizes.
+        max_test_bars = (total - min_train) // folds if total > min_train else 0
+        max_folds = (total - min_train) // test_bars if total > min_train else 0
+        if max_test_bars >= 1:
+            feasible = (
+                f" Feasible here: test_bars<={max_test_bars} at folds={folds}, "
+                f"or folds<={max_folds} at test_bars={test_bars}."
+            )
+        else:
+            feasible = (
+                f" Dataset too small for any walk-forward at train>={min_train}; "
+                "fetch more history or lower train_bars/warmup_bars."
+            )
         raise ValueError(
             f"dataset has {total} bars; walk-forward with folds={folds}, "
-            f"test_bars={test_bars}, train>= {min_train} needs at least {required}"
+            f"test_bars={test_bars}, train>= {min_train} needs at least "
+            f"{required}.{feasible}"
         )
 
     fold_rows: list[dict[str, Any]] = []

--- a/wayfinder_paths/jobs/research.py
+++ b/wayfinder_paths/jobs/research.py
@@ -372,6 +372,112 @@ def event_study(
     }
 
 
+def rank_ic(
+    frames: dict[str, pd.DataFrame],
+    column: str,
+    horizons: list[int] | None = None,
+) -> dict[str, Any]:
+    """Does a cross-sectional RANKING column predict relative forward returns?
+    The basket-strategy analogue of event_study: baskets trade the ranking
+    (long the top, short the bottom), so the right pre-build test is the rank
+    information coefficient, not per-symbol event returns.
+
+    For each horizon h and each timestamp with >= 4 ranked symbols: Spearman
+    rank correlation between the column's cross-sectional ranks and the
+    ranks of forward log-returns. Reports mean IC, a t-stat over the period
+    ICs, the period count, and sign stability across the two halves of the
+    sample. Edge bar: |t| >= 2, n >= 30 periods, and both halves agree on
+    sign — testing many columns inflates false positives, same as signals.
+    """
+    horizons = horizons or [1, 2, 5, 10]
+    aligned: dict[str, pd.DataFrame] = {}
+    for symbol, frame in frames.items():
+        if column not in frame.columns:
+            raise KeyError(
+                f"column {column!r} not in frame for {symbol}; available: "
+                f"{sorted(frame.columns)}"
+            )
+        sub = frame[["timestamp", column, "close"]].copy()
+        sub["close"] = sub["close"].astype(float)
+        aligned[symbol] = sub.set_index("timestamp")
+    per_horizon = []
+    any_edge = False
+    for h in sorted({int(h) for h in horizons}):
+        if h <= 0:
+            continue
+        ics: list[float] = []
+        # union of timestamps, evaluated cross-sectionally
+        index = sorted(set().union(*(set(f.index) for f in aligned.values())))
+        for i, ts in enumerate(index):
+            if i + h >= len(index):
+                break
+            fwd_ts = index[i + h]
+            scores: list[float] = []
+            fwd: list[float] = []
+            for frame in aligned.values():
+                if ts not in frame.index or fwd_ts not in frame.index:
+                    continue
+                value = frame.at[ts, column]
+                c_now = frame.at[ts, "close"]
+                c_fwd = frame.at[fwd_ts, "close"]
+                if pd.isna(value) or pd.isna(c_now) or pd.isna(c_fwd) or c_now <= 0:
+                    continue
+                scores.append(float(value))
+                fwd.append(math.log(float(c_fwd) / float(c_now)))
+            if len(scores) < 4:
+                continue
+            rank_scores = pd.Series(scores).rank()
+            rank_fwd = pd.Series(fwd).rank()
+            ic = float(rank_scores.corr(rank_fwd))
+            if math.isfinite(ic):
+                ics.append(ic)
+        n = len(ics)
+        if n == 0:
+            per_horizon.append({"horizon": h, "n": 0, "verdict": "no periods"})
+            continue
+        mean_ic = float(np.mean(ics))
+        std_ic = float(np.std(ics, ddof=1)) if n > 1 else 0.0
+        t = mean_ic / (std_ic / math.sqrt(n)) if n > 1 and std_ic > 0 else 0.0
+        half = n // 2
+        first_sign = float(np.mean(ics[:half])) if half else 0.0
+        second_sign = float(np.mean(ics[half:])) if half else 0.0
+        stable = bool(
+            half >= 5 and first_sign * second_sign > 0
+        )  # both halves agree on sign
+        edge = bool(abs(t) >= 2.0 and n >= 30 and stable)
+        any_edge = any_edge or edge
+        per_horizon.append(
+            {
+                "horizon": h,
+                "n": n,
+                "mean_ic": mean_ic,
+                "t_stat": float(t),
+                "ic_first_half": first_sign,
+                "ic_second_half": second_sign,
+                "sign_stable": stable,
+                "edge": edge,
+                "note": "insufficient sample (n<30)" if n < 30 else None,
+            }
+        )
+    return {
+        "column": column,
+        "horizons": per_horizon,
+        "has_edge": any_edge,
+        "read": (
+            "the ranking carries cross-sectional information at one or more "
+            "horizons — worth building the basket and validating"
+            if any_edge
+            else "no horizon shows a stable rank IC with |t|>=2 and n>=30 — "
+            "the ranking does not order future returns; change the ranking "
+            "signal, not the basket parameters"
+        ),
+        "multiple_testing_note": (
+            "testing many ranking columns inflates false positives — at "
+            "|t|>=2 roughly 1 in 20 random rankings looks good by chance"
+        ),
+    }
+
+
 # ── pair admission gate (pure: DataFrames in, dict out) ──────────────────────
 
 
@@ -776,3 +882,56 @@ def signal_check_job(
             "change the idea before building a strategy around it"
         ),
     }
+
+
+def rank_check_job(
+    job_id: str,
+    *,
+    column: str,
+    horizons: list[int] | None = None,
+    store: Any | None = None,
+) -> dict[str, Any]:
+    """Rank-IC study of a strategy's precomputed ranking column across the
+    job's symbols — the pre-build test for basket/cross-sectional ideas
+    (event_study covers per-symbol entry signals; this covers rankings)."""
+    from wayfinder_paths.jobs.execution.features import apply_precompute
+    from wayfinder_paths.jobs.execution.job import _load_dataset, _load_job_yaml
+    from wayfinder_paths.jobs.execution.primitives import ExecutionSpec
+    from wayfinder_paths.jobs.execution.simulator import _load_strategy
+    from wayfinder_paths.jobs.execution.validation import resolve_execution_spec
+    from wayfinder_paths.jobs.store import JobStore
+
+    store = store or JobStore()
+    root = store.job_dir(job_id)
+    job_data = _load_job_yaml(root)
+    spec_data, _ = resolve_execution_spec(root, job_data)
+    spec = ExecutionSpec.from_dict(spec_data)
+    params = dict(job_data.get("execution_params") or {})
+    script = store.resolve_script_entrypoint(job_id, job_data)
+    strategy = _load_strategy(script, params)
+    dataset = _load_dataset(root, spec, job_data)
+    view = apply_precompute(strategy, dataset.bars)
+    frame = view.to_frame()
+    symbols = sorted(frame["symbol"].astype(str).unique())
+    if len(symbols) < 4:
+        raise ValueError(
+            f"rank-check needs >=4 symbols for a cross-section; job has "
+            f"{symbols} — for 1-2 symbols use signal-check instead"
+        )
+    frames = {
+        symbol: frame[frame["symbol"] == symbol].reset_index(drop=True)
+        for symbol in symbols
+    }
+    missing = [s for s, f in frames.items() if column not in f.columns]
+    if missing:
+        non_bar = sorted(
+            set(frame.columns)
+            - {"timestamp", "symbol", "open", "high", "low", "close", "volume"}
+        )
+        raise KeyError(
+            f"column {column!r} not found after precompute (missing for "
+            f"{missing}); available non-bar columns: {non_bar}"
+        )
+    result = rank_ic(frames, column, horizons=horizons)
+    result["symbols"] = symbols
+    return result

--- a/wayfinder_paths/mcp/tools/jobs.py
+++ b/wayfinder_paths/mcp/tools/jobs.py
@@ -40,6 +40,7 @@ JobAction = Literal[
     "fetch_funding",
     "pair_check",
     "signal_check",
+    "rank_check",
     "backtest_job",
     "backtest_diagnose",
     "experiments",
@@ -173,7 +174,10 @@ async def core_jobs(
         from an apply worker.
       - Strategy-development loop for execution-spec jobs: `signal_check`
         (event-study a precomputed entry column BEFORE building — no edge at
-        the signal level means no strategy will fix it) and `pair_check` (the
+        the signal level means no strategy will fix it), `rank_check` (the
+        basket analogue: Spearman rank IC of a cross-sectional ranking column
+        vs relative forward returns — run BEFORE building any long/short
+        basket on that ranking) and `pair_check` (the
         statistical admission gate for any pair/spread idea — run it FIRST; a
         REJECT saves days of tuning), `fetch_dataset` (real candles into the
         job; `dataset_source="ccxt"` + `exchange="binance"` for long history),
@@ -242,6 +246,14 @@ async def core_jobs(
         )
         job_path = store.save(job)
         result: dict[str, Any] = {"job": job.to_dict(), "job_yaml": str(job_path)}
+        entrypoint = store.resolve_script_entrypoint(job.id, job.to_dict())
+        if entrypoint is not None:
+            result["script_entrypoint"] = str(entrypoint)
+            result["hint"] = (
+                "write your decide()/build_strategy strategy at "
+                "script_entrypoint — the tick driver and backtests resolve "
+                "the module from there; do not copy it elsewhere"
+            )
         if compile:
             result["compile"] = JobCompiler(store=store).compile(job)
             sync_all_jobs(store=store)
@@ -311,6 +323,14 @@ async def core_jobs(
             return err("invalid_request", "signal_check requires column")
         return await _run_job_op(
             "signal_check",
+            {"job_id": job_id, "column": column, "horizons": horizons},
+        )
+
+    if action == "rank_check":
+        if not column:
+            return err("invalid_request", "rank_check requires column")
+        return await _run_job_op(
+            "rank_check",
             {"job_id": job_id, "column": column, "horizons": horizons},
         )
 

--- a/wayfinder_paths/tests/test_execution_ccxt_feed.py
+++ b/wayfinder_paths/tests/test_execution_ccxt_feed.py
@@ -250,3 +250,58 @@ def test_cli_fetch_dataset_source_option(monkeypatch) -> None:
     assert captured["exchange"] == "bybit"
     assert captured["market_type"] == "spot"
     assert captured["days"] == 30
+
+
+def test_build_live_dataset_reports_requested_vs_received(tmp_path: Path) -> None:
+    """Venue/exchange history caps are silent — an agent asked for 720 days,
+    got 290, and analyzed on without noticing. The result must carry both
+    numbers and warn on a shortfall."""
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        "shortfall-demo",
+        script=".wayfinder/jobs/shortfall-demo/workspace/src/strategy.py",
+        interval_seconds=3600,
+        execution_contract="jobs_v1",
+    )
+    spec = ExecutionSpec()
+    spec.data_contract["bar_interval"] = "1h"
+    job.execution_spec = spec.to_dict()
+    job.execution_params = {"symbols": ["SNX"]}
+    store.save(job)
+    root = store.job_dir(job.id)
+    (root / "workspace" / "src").mkdir(parents=True, exist_ok=True)
+    (root / "workspace" / "src" / "strategy.py").write_text(
+        "def decide(ctx):\n    return []\n", encoding="utf-8"
+    )
+    end_ms = BASE_MS + 60 * HOUR_MS
+    feed = CcxtMarketFeed(
+        exchange=FakeCcxtExchange(candles={"SNX/USDT:USDT": _candles(60)})
+    )
+
+    class FrozenFeed:
+        symbol_map = feed.symbol_map
+
+        async def get_completed_bars(
+            self, symbols, interval, *, lookback_bars, as_of=None
+        ):
+            return await feed.get_completed_bars(
+                symbols,
+                interval,
+                lookback_bars=lookback_bars,
+                as_of=pd.Timestamp(end_ms, unit="ms", tz="UTC"),
+            )
+
+    # 60 hourly candles ≈ 2.5 days of data against a 30-day request.
+    result = build_live_dataset(
+        job.id, days=30, store=store, source="ccxt", feed=FrozenFeed()
+    )
+    assert result["days_requested"] == 30
+    assert result["days_received"] < 3
+    assert "warning" in result and "30" in result["warning"]
+
+    # A satisfied request carries the numbers but no warning.
+    ok = build_live_dataset(
+        job.id, days=2, store=store, source="ccxt", feed=FrozenFeed()
+    )
+    assert ok["days_received"] >= 0.9 * 2
+    assert "warning" not in ok

--- a/wayfinder_paths/tests/test_jobs_features.py
+++ b/wayfinder_paths/tests/test_jobs_features.py
@@ -300,3 +300,54 @@ def test_validation_flags_feature_schema_and_availability(tmp_path: Path) -> Non
     checks = _feature_checks(tmp_path, spec)
     assert checks[0]["name"] == "declared_features_valid"
     assert checks[0]["passed"] is False
+
+
+def test_feature_coverage_metadata_and_summary_note(tmp_path: Path) -> None:
+    """A feature spanning only the tail of the dataset must be measured
+    (metadata.feature_coverage) and called out in the backtest summary —
+    a 1-year funding file silently handicapped a signal against 6 years of
+    candles in a live comparison."""
+    from wayfinder_paths.jobs.execution.job import summarize_backtest_payload
+
+    store, job, root = _feature_job(tmp_path)
+    bars = _bars(40)  # 40 x 5min bars
+    (root / "results" / "backtest").mkdir(parents=True, exist_ok=True)
+    (root / "results" / "backtest" / "input_bars.json").write_text(
+        json.dumps(bars), encoding="utf-8"
+    )
+    # sentiment rows cover only the last ~10% of the bar span
+    tail_rows = [
+        {"timestamp": bars[-3]["timestamp"], "name": "sentiment", "value": 0.9},
+        {"timestamp": bars[-1]["timestamp"], "name": "sentiment", "value": 0.2},
+    ]
+    (root / "state" / "features.jsonl").write_text(
+        "\n".join(json.dumps(row) for row in tail_rows) + "\n", encoding="utf-8"
+    )
+    spec = ExecutionSpec.from_dict(job.execution_spec)
+    dataset = _load_dataset(root, spec, job.to_dict())
+    coverage = dataset.metadata["feature_coverage"]["sentiment"]
+    assert coverage["rows"] == 2
+    assert coverage["coverage_fraction"] < 0.2
+
+    payload = {
+        "type": "single",
+        "result": {"run_id": "r", "params": {}, "stats": {}, "validation": {}},
+        "dataset": dict(dataset.metadata),
+    }
+    summary = summarize_backtest_payload(payload)
+    note = summary.get("feature_coverage_note")
+    assert note and "sentiment" in note and "biased" in note
+    assert summary["feature_coverage"]["sentiment"]["rows"] == 2
+
+    # Full-coverage feature -> no note.
+    full_rows = [
+        {"timestamp": bars[0]["timestamp"], "name": "sentiment", "value": 0.1},
+        {"timestamp": bars[-1]["timestamp"], "name": "sentiment", "value": 0.2},
+    ]
+    (root / "state" / "features.jsonl").write_text(
+        "\n".join(json.dumps(row) for row in full_rows) + "\n", encoding="utf-8"
+    )
+    dataset = _load_dataset(root, spec, job.to_dict())
+    payload["dataset"] = dict(dataset.metadata)
+    summary = summarize_backtest_payload(payload)
+    assert "feature_coverage_note" not in summary

--- a/wayfinder_paths/tests/test_jobs_walk_forward.py
+++ b/wayfinder_paths/tests/test_jobs_walk_forward.py
@@ -228,3 +228,18 @@ def test_experiment_records_walk_forward_and_promotion_never_blocks(
     job = store.load(job_id)
     assert job.execution_params["direction"] == "long"
     assert outcome["backtest"]["walk_forward"]["summary"]["fold_count"] == 2
+
+
+def test_insufficient_bars_error_names_feasible_sizing(tmp_path: Path) -> None:
+    """The error must say what WOULD fit — agents burned five retries
+    guessing fold sizes against the bare 'needs at least N' message."""
+    with pytest.raises(ValueError, match=r"Feasible here: test_bars<=\d+"):
+        run_walk_forward(
+            _script(tmp_path),
+            PreparedExecutionDataset.from_rows(_bars(count=200)),
+            _spec(),
+            {"direction": ["long"]},
+            folds=4,
+            test_bars=100,
+            train_bars=80,
+        )

--- a/wayfinder_paths/tests/test_research_and_pair_check.py
+++ b/wayfinder_paths/tests/test_research_and_pair_check.py
@@ -300,3 +300,75 @@ def test_op_runner_routes_research_ops(monkeypatch) -> None:
         "stub": "signal",
         "column": "z",
     }
+
+
+def _cross_section(n_bars: int, n_symbols: int, *, informative: bool, seed: int = 5):
+    """Synthetic multi-symbol frames. When informative, the ranking column
+    equals each symbol's next-period relative performance rank plus noise —
+    a real cross-sectional edge. Otherwise the column is pure noise."""
+    from wayfinder_paths.jobs.research import rank_ic  # noqa: F401 (import check)
+
+    rng = np.random.default_rng(seed)
+    ts = pd.date_range("2024-01-01", periods=n_bars, freq="D", tz="UTC")
+    # per-symbol daily relative strengths, drawn fresh each bar
+    rel = rng.normal(0, 0.01, size=(n_bars, n_symbols))
+    frames: dict[str, pd.DataFrame] = {}
+    for j in range(n_symbols):
+        # forward return of symbol j at bar i is rel[i+1, j]
+        log_close = np.cumsum(np.concatenate([[0.0], rel[1:, j]])) + np.log(100)
+        close = np.exp(log_close)
+        if informative:
+            score = np.empty(n_bars)
+            score[:-1] = rel[1:, j] + rng.normal(0, 0.004, n_bars - 1)
+            score[-1] = 0.0
+        else:
+            score = rng.normal(0, 1, n_bars)
+        frames[f"S{j}"] = pd.DataFrame(
+            {"timestamp": ts, "close": close, "score": score}
+        )
+    return frames
+
+
+def test_rank_ic_detects_informative_ranking_and_rejects_noise() -> None:
+    from wayfinder_paths.jobs.research import rank_ic
+
+    informative = rank_ic(
+        _cross_section(400, 10, informative=True), "score", horizons=[1]
+    )
+    assert informative["has_edge"], informative
+    h1 = informative["horizons"][0]
+    assert h1["n"] >= 30 and h1["mean_ic"] > 0.2 and h1["sign_stable"]
+
+    noise = rank_ic(_cross_section(400, 10, informative=False), "score", horizons=[1])
+    assert not noise["has_edge"], noise
+
+
+def test_rank_ic_flags_insufficient_sample() -> None:
+    from wayfinder_paths.jobs.research import rank_ic
+
+    result = rank_ic(_cross_section(25, 6, informative=True), "score", horizons=[1])
+    h1 = result["horizons"][0]
+    assert h1["n"] < 30 and h1["note"] == "insufficient sample (n<30)"
+
+
+def test_rank_ic_missing_column_lists_available() -> None:
+    from wayfinder_paths.jobs.research import rank_ic
+
+    frames = _cross_section(50, 4, informative=False)
+    with pytest.raises(KeyError, match="score"):
+        rank_ic(frames, "nope", horizons=[1])
+
+
+def test_rank_check_op_routes(monkeypatch) -> None:
+    import wayfinder_paths.jobs.research as research_mod
+    from wayfinder_paths.jobs.execution import op_runner
+
+    monkeypatch.setattr(
+        research_mod,
+        "rank_check_job",
+        lambda job_id, **kw: {"stub": "rank", "column": kw.get("column")},
+    )
+    assert op_runner._run("rank_check", {"job_id": "j", "column": "mom"}) == {
+        "stub": "rank",
+        "column": "mom",
+    }

--- a/wayfinder_paths/tests/test_wayfinder_jobs.py
+++ b/wayfinder_paths/tests/test_wayfinder_jobs.py
@@ -951,6 +951,10 @@ def test_mcp_create_defaults_to_jobs_v1(tmp_path: Path, monkeypatch) -> None:
     assert job.execution_contract == "jobs_v1"
     wrapper = tmp_path / ".wayfinder_runs/jobs/fresh_strategy_script.py"
     assert "run_scheduled_tick" in wrapper.read_text(encoding="utf-8")
+    # Create tells the agent exactly where the strategy module lives —
+    # layout guessing cost real tool calls in live sessions.
+    assert result["result"]["script_entrypoint"].endswith("strategy.py")
+    assert "script_entrypoint" in result["result"]["hint"]
 
 
 def test_mcp_sync_heals_stale_wrapper_after_contract_flip(


### PR DESCRIPTION
jobs data-quality: coverage warning, fetch shortfall, WF hints, rank-check

Closes the data-quality and research-tooling backlog from four rounds of
live validation - each item is a silent gap that cost agent time or biased
a conclusion in a real session.

- Feature-coverage warning: _load_dataset now measures each feature's span
  vs the bars span (metadata.feature_coverage: first/last ts, rows,
  coverage_fraction) and summarize_backtest_payload surfaces both the
  numbers and a note when any feature covers < 80% of the dataset. A
  1-year funding file against 6 years of candles silently condemned the
  funding signal in a live A/B - bars outside a feature's span carry NaN.
- fetch_dataset / fetch_funding requested-vs-received: results now carry
  first_ts/last_ts/days_requested/days_received and warn when received
  < 90% of requested (venue history caps are silent - an agent asked for
  720 days, got 290, and analyzed on).
- Walk-forward sizing hint: the "needs at least N bars" error now states
  what WOULD fit (max test_bars at the requested folds, max folds at the
  requested test_bars) - kills the five-retry guessing loop observed live.
- rank_check: the basket analogue of signal_check. Pure rank_ic() -
  per-horizon Spearman rank IC between a cross-sectional ranking column
  and relative forward returns, t-stat over period ICs, n, and sign
  stability across sample halves (edge bar: |t|>=2, n>=30, stable) - plus
  rank_check_job() running the strategy's own precompute, wired through
  op_runner/MCP ("rank_check")/CLI (rank-check) exactly like signal_check.
  Basket strategies are where the documented edge lives and had no
  signal-first test.
- create echoes script_entrypoint + hint: agents were guessing the job
  layout (and appeasing wrong paths by copying files to the repo root).
- Agent step budgets: strategy-lab and quant 64 -> 96 (two live validation
  turns hit the cap mid-walk-forward).
- SKILL.md / strategy-search.md: rank-check joins step 0.

Tests: coverage metadata + note on tail-only feature and absence on full
coverage; fetch shortfall warning + satisfied-request silence; WF feasible-
sizing message; rank_ic planted-edge detection / noise rejection /
insufficient-sample flag / missing-column KeyError; op_runner routing;
create-echo assertions. 154 passing across the touched suites.
