### PR TITLE
jobs: every_n_bars gains offset — pin a validated rebalance phase

### DIFF
--- a/wayfinder_paths/jobs/execution/primitives.py
+++ b/wayfinder_paths/jobs/execution/primitives.py
@@ -634,13 +634,16 @@ class ExecutionContext:
         (or always) fires. Use `ctx.every_n_bars(n)` for cadence."""
         return len(self.view._ensure_timestamps())
 
-    def every_n_bars(self, n: int) -> bool:
+    def every_n_bars(self, n: int, *, offset: int = 0) -> bool:
         """Epoch-aligned cadence gate: True when the latest completed bar's
-        position in the GLOBAL bar sequence (timestamp // bar_interval) is a
-        multiple of n. Identical in backtest and live, and restart-proof —
-        never count ticks in `strategy_state` for warmup or cadence (a state
-        reset re-warms the counter and the job goes dark for a full warmup
-        period)."""
+        position in the GLOBAL bar sequence (timestamp // bar_interval) is
+        congruent to `offset` mod n. Identical in backtest and live, and
+        restart-proof — never count ticks in `strategy_state` for warmup or
+        cadence (a state reset re-warms the counter and the job goes dark
+        for a full warmup period). `offset` pins WHICH bars fire: a strategy
+        validated on a particular rebalance phase keeps that exact schedule
+        (phase can matter — a one-day shift materially changed a break-even
+        daily basket's 4-year path)."""
         if n <= 1:
             return True
         timestamps = self.view._ensure_timestamps()
@@ -651,7 +654,7 @@ class ExecutionContext:
         )
         if not interval:
             return True
-        return int(timestamps[-1].timestamp() // interval) % n == 0
+        return int(timestamps[-1].timestamp() // interval) % n == offset % n
 
 
 def mark_to_market_equity(ctx: ExecutionContext) -> float:

--- a/wayfinder_paths/tests/test_view_symbol_fastpath.py
+++ b/wayfinder_paths/tests/test_view_symbol_fastpath.py
@@ -132,6 +132,10 @@ def test_every_n_bars_is_epoch_aligned_not_window_relative() -> None:
     assert fired in ([True, False, True, False, True, False],
                      [False, True, False, True, False, True])
     assert all(ctx_at(i).bar_index == 10 for i in range(20, 26))
+    # offset pins the phase: complementary offsets partition the bars.
+    for i in range(20, 26):
+        a, b = ctx_at(i).every_n_bars(2), ctx_at(i).every_n_bars(2, offset=1)
+        assert a != b
     # n<=1 is always live; a missing interval never blocks.
     assert ctx_at(20).every_n_bars(1) is True
     bare = ctx_at(20)


### PR DESCRIPTION
jobs: every_n_bars gains offset — pin a validated rebalance phase

Replacing the funding-carry basket's tick counter with every_n_bars(2)
surfaced real phase sensitivity: the gate fires the identical 736 times
over the 4-year dataset, but on even epoch-days instead of the baseline's
odd days — and that one-day shift turned a break-even backtest into -81%
(trade count -75%, peak notional +$524). The strategy is noise-dominated;
the migration must preserve the validated schedule exactly.

offset pins which bars fire (epoch_index % n == offset % n), so a strategy
validated on a particular phase keeps that exact calendar when moving off
boot-relative counters. Complementary offsets partition the bars (tested).
