### PR TITLE
jobs: capture the initializer opencode session on job create

### DIFF
--- a/wayfinder_paths/jobs/models.py
+++ b/wayfinder_paths/jobs/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any, Literal
@@ -244,11 +245,28 @@ class WayfinderJob:
             ],
             auto_limits=auto_limits_payload if normalized_mode == "auto" else {},
         )
+        # The creating agent's opencode session — the "initializer" the UI
+        # re-enters from a strategy's Conversations list. Rides the whole-spec
+        # sync, so no backend change is needed.
+        initializer_session = (
+            os.environ.get("OPENCODE_SESSION_ID")
+            or os.environ.get("OPENCODE_SESSIONID")
+            or ""
+        ).strip()
+        controller: dict[str, Any] = (
+            {
+                "initializer_session_id": initializer_session,
+                "created_at": utc_now_iso(),
+            }
+            if initializer_session
+            else {}
+        )
         return cls(
             id=jid,
             name=name or jid.replace("-", " ").title(),
             job_kind=infer_job_kind(script_enabled, normalized_mode),
             execution_contract=execution_contract,
+            controller=controller,
             goal=goal,
             versioning={
                 "active_revision": None,

--- a/wayfinder_paths/tests/test_jobs_initializer_session.py
+++ b/wayfinder_paths/tests/test_jobs_initializer_session.py
@@ -1,0 +1,73 @@
+"""The creating agent's opencode session is captured on the job spec.
+
+The Strategies UI re-enters "the conversation that built this strategy" from
+spec.controller.initializer_session_id — synced to the backend as part of the
+whole spec, so this is the single place the linkage is born.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.store import JobStore
+
+
+def test_new_captures_initializer_session_from_env(monkeypatch) -> None:
+    monkeypatch.setenv("OPENCODE_SESSION_ID", "ses_abc123")
+    job = WayfinderJob.new("init-capture", interval_seconds=3600)
+    assert job.controller["initializer_session_id"] == "ses_abc123"
+    assert job.controller["created_at"]
+
+
+def test_new_accepts_legacy_env_spelling(monkeypatch) -> None:
+    monkeypatch.delenv("OPENCODE_SESSION_ID", raising=False)
+    monkeypatch.setenv("OPENCODE_SESSIONID", "ses_legacy9")
+    job = WayfinderJob.new("init-legacy", interval_seconds=3600)
+    assert job.controller["initializer_session_id"] == "ses_legacy9"
+
+
+def test_new_leaves_controller_empty_without_env(monkeypatch) -> None:
+    monkeypatch.delenv("OPENCODE_SESSION_ID", raising=False)
+    monkeypatch.delenv("OPENCODE_SESSIONID", raising=False)
+    job = WayfinderJob.new("init-none", interval_seconds=3600)
+    assert job.controller == {}
+
+
+def test_controller_round_trips_through_yaml(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("OPENCODE_SESSION_ID", "ses_roundtrip")
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("init-roundtrip", script="strategy.py")
+    store.create_job(job)
+
+    loaded = store.load("init-roundtrip")
+
+    assert loaded.controller["initializer_session_id"] == "ses_roundtrip"
+    assert loaded.to_dict()["controller"]["initializer_session_id"] == (
+        "ses_roundtrip"
+    )
+
+
+def test_mcp_create_result_carries_initializer(tmp_path: Path, monkeypatch) -> None:
+    import asyncio
+
+    from wayfinder_paths.mcp.tools import jobs as jobs_tools
+    from wayfinder_paths.tests.test_wayfinder_jobs import _FakeBridge
+
+    monkeypatch.setenv("OPENCODE_SESSION_ID", "ses_mcp42")
+    monkeypatch.setattr("wayfinder_paths.jobs.compiler.RunnerBridge", _FakeBridge)
+    monkeypatch.setattr(jobs_tools, "JobStore", lambda: JobStore(repo_root=tmp_path))
+    monkeypatch.setattr(jobs_tools, "sync_all_jobs", lambda store=None: None)
+
+    result = asyncio.run(
+        jobs_tools.core_jobs(
+            action="create",
+            job_id="init-mcp",
+            script="strategy.py",
+            interval_seconds=3600,
+        )
+    )
+
+    assert result["ok"], result
+    controller = result["result"]["job"]["controller"]
+    assert controller["initializer_session_id"] == "ses_mcp42"


### PR DESCRIPTION
jobs: capture the initializer opencode session on job create

The Strategies UI needs "re-enter the conversation that built this
strategy". Wake sessions are already synced per mode
(reports.{mode}.session_id) but the CREATING session was never recorded.

WayfinderJob.new — the single funnel for both MCP core_jobs(create) and
the CLI create — now reads OPENCODE_SESSION_ID (or the legacy
OPENCODE_SESSIONID spelling) and, when present, sets
controller = {initializer_session_id, created_at}. Empty env leaves the
controller untouched. The controller field already round-trips
to_dict/from_dict and the backend stores the spec whole, so the linkage
rides the existing sync with no backend migration.
