### PR TITLE
jobs: sanitize the captured initializer session id charset

### DIFF
--- a/wayfinder_paths/jobs/models.py
+++ b/wayfinder_paths/jobs/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any, Literal
@@ -247,12 +248,16 @@ class WayfinderJob:
         )
         # The creating agent's opencode session — the "initializer" the UI
         # re-enters from a strategy's Conversations list. Rides the whole-spec
-        # sync, so no backend change is needed.
-        initializer_session = (
+        # sync, so no backend change is needed. opencode ids are `ses_<alnum>`;
+        # strip to that charset so a hostile parent-process env can't smuggle
+        # newlines/quotes/control chars downstream into frontend URLs or text.
+        initializer_session = re.sub(
+            r"[^A-Za-z0-9_-]",
+            "",
             os.environ.get("OPENCODE_SESSION_ID")
             or os.environ.get("OPENCODE_SESSIONID")
-            or ""
-        ).strip()
+            or "",
+        )
         controller: dict[str, Any] = (
             {
                 "initializer_session_id": initializer_session,

--- a/wayfinder_paths/tests/test_jobs_initializer_session.py
+++ b/wayfinder_paths/tests/test_jobs_initializer_session.py
@@ -34,6 +34,20 @@ def test_new_leaves_controller_empty_without_env(monkeypatch) -> None:
     assert job.controller == {}
 
 
+def test_new_sanitizes_session_id_charset(monkeypatch) -> None:
+    # A hostile parent-process env can't smuggle newlines/quotes/spaces into
+    # the spec that syncs downstream — only [A-Za-z0-9_-] survives.
+    monkeypatch.setenv("OPENCODE_SESSION_ID", 'ses_abc\ninjected: "x" /../')
+    job = WayfinderJob.new("init-dirty", interval_seconds=3600)
+    assert job.controller["initializer_session_id"] == "ses_abcinjectedx"
+
+
+def test_new_drops_all_junk_session_id(monkeypatch) -> None:
+    monkeypatch.setenv("OPENCODE_SESSION_ID", "\n  \t !@#")
+    job = WayfinderJob.new("init-junk", interval_seconds=3600)
+    assert job.controller == {}
+
+
 def test_controller_round_trips_through_yaml(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("OPENCODE_SESSION_ID", "ses_roundtrip")
     store = JobStore(repo_root=tmp_path)
@@ -43,9 +57,7 @@ def test_controller_round_trips_through_yaml(tmp_path: Path, monkeypatch) -> Non
     loaded = store.load("init-roundtrip")
 
     assert loaded.controller["initializer_session_id"] == "ses_roundtrip"
-    assert loaded.to_dict()["controller"]["initializer_session_id"] == (
-        "ses_roundtrip"
-    )
+    assert loaded.to_dict()["controller"]["initializer_session_id"] == ("ses_roundtrip")
 
 
 def test_mcp_create_result_carries_initializer(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
jobs: sanitize the captured initializer session id charset

Defense-in-depth from the jobs_v1 security pass. WayfinderJob.new captures
OPENCODE_SESSION_ID into the job spec, which syncs to the backend and
frontend. It was only .strip()'d — a hostile parent-process env could ride
newlines/quotes/control chars downstream into frontend URLs/text. opencode
ids are `ses_<alnum>`, so keep only [A-Za-z0-9_-]; an all-junk value yields
no capture (controller stays empty). Normal ses_ ids are unchanged.
