### PR TITLE
jobs: sync a paused flag so a paused job stops showing Live

### DIFF
--- a/wayfinder_paths/jobs/runner_bridge.py
+++ b/wayfinder_paths/jobs/runner_bridge.py
@@ -84,6 +84,21 @@ class RunnerBridge:
         update_params.update(schedule)
         return self.client.call("update_job", update_params)
 
+    def job_statuses(self) -> dict[str, str]:
+        """Live runner status per job name, e.g. {"foo-script": "PAUSED"}.
+        Empty when the daemon is unreachable — callers degrade to "not paused"
+        rather than raise, so a down runner never breaks a sync."""
+        try:
+            resp = self.client.call("status")
+        except Exception:
+            return {}
+        jobs = ((resp or {}).get("result") or {}).get("jobs") or []
+        return {
+            str(job.get("name")): str(job.get("status") or "")
+            for job in jobs
+            if job.get("name")
+        }
+
     def pause(self, name: str) -> dict[str, Any]:
         return self.client.call("pause_job", {"name": name})
 

--- a/wayfinder_paths/jobs/sync.py
+++ b/wayfinder_paths/jobs/sync.py
@@ -17,6 +17,7 @@ from wayfinder_paths.jobs.execution.primitives import ExecutionSpec
 from wayfinder_paths.jobs.forward import load_forward_snapshot
 from wayfinder_paths.jobs.gating import evaluate_live_gate
 from wayfinder_paths.jobs.halt import read_halt
+from wayfinder_paths.jobs.runner_bridge import RunnerBridge
 from wayfinder_paths.jobs.store import JobStore
 
 
@@ -63,6 +64,23 @@ def snapshot_job(job_id: str, *, store: JobStore | None = None) -> dict[str, Any
     store = store or JobStore()
     job = store.load(job_id)
     scorecard = store.read_json(job_id, "scorecard.json", default={}) or {}
+    # Reconcile runtime pause from the runner: a job's script_loop.mode stays
+    # "live" while paused, so without this the UI can't tell a paused live job
+    # from one that is actively trading. Self-healing (reflects true runner
+    # state regardless of how the pause was triggered); degrades to unchanged
+    # on a down runner.
+    loop_names = [
+        loop.runner_job_name
+        for loop in (job.script_loop, job.agent_loop)
+        if loop.enabled and loop.runner_job_name
+    ]
+    if loop_names:
+        statuses = RunnerBridge(repo_root=store.repo_root).job_statuses()
+        if statuses:
+            scorecard = {
+                **scorecard,
+                "paused": any(statuses.get(n) == "PAUSED" for n in loop_names),
+            }
     runner_links = store.read_json(job_id, "runner_links.json", default={}) or {}
     latest_monitor = store.read_json(
         job_id, "reports/monitor/latest.json", default=None

--- a/wayfinder_paths/tests/test_jobs_paused_sync.py
+++ b/wayfinder_paths/tests/test_jobs_paused_sync.py
@@ -1,0 +1,59 @@
+"""A paused job must sync a `paused` flag so the UI stops showing "Live".
+
+The runner keeps a job's `script_loop.mode` at "live" while it's paused, so the
+synced snapshot reconciles the real runner status into scorecard.paused.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.jobs import sync as sync_mod
+from wayfinder_paths.jobs.sync import snapshot_job
+
+
+def _job(tmp_path: Path) -> tuple[JobStore, WayfinderJob]:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        "carry", script="strategy.py", interval_seconds=3600, agent_mode="monitor"
+    )
+    store.create_job(job)
+    return store, job
+
+
+class _FakeBridge:
+    def __init__(self, statuses: dict[str, str]) -> None:
+        self._statuses = statuses
+
+    def __call__(self, *, repo_root=None):  # constructed as RunnerBridge(repo_root=…)
+        return self
+
+    def job_statuses(self) -> dict[str, str]:
+        return self._statuses
+
+
+def test_paused_script_loop_sets_scorecard_paused(tmp_path, monkeypatch) -> None:
+    store, job = _job(tmp_path)
+    monkeypatch.setattr(
+        sync_mod, "RunnerBridge", _FakeBridge({"carry-script": "PAUSED"})
+    )
+    assert snapshot_job(job.id, store=store)["scorecard"]["paused"] is True
+
+
+def test_running_loops_report_not_paused(tmp_path, monkeypatch) -> None:
+    store, job = _job(tmp_path)
+    monkeypatch.setattr(
+        sync_mod,
+        "RunnerBridge",
+        _FakeBridge({"carry-script": "OK", "carry-agent": "OK"}),
+    )
+    assert snapshot_job(job.id, store=store)["scorecard"]["paused"] is False
+
+
+def test_down_runner_leaves_scorecard_untouched(tmp_path, monkeypatch) -> None:
+    # Empty status map == unreachable daemon → don't assert paused either way.
+    store, job = _job(tmp_path)
+    monkeypatch.setattr(sync_mod, "RunnerBridge", _FakeBridge({}))
+    assert "paused" not in snapshot_job(job.id, store=store)["scorecard"]


### PR DESCRIPTION
jobs: sync a paused flag so a paused job stops showing "Live"

A job's script_loop.mode stays "live" while its runner loops are paused, so
the synced snapshot carried no signal that the job wasn't trading — the UI
kept showing "Live". Reconcile the real runner status into the snapshot:

- RunnerBridge.job_statuses() queries the daemon's status RPC and returns
  {job_name: status}; empty when the daemon is unreachable (never raises).
- snapshot_job sets scorecard.paused = any enabled loop reports PAUSED. It's
  self-healing (reflects true runner state regardless of how the pause was
  triggered — CLI, MCP, or the runner directly) and degrades to unchanged
  when the runner is down.

scorecard rides the sync + backend serialization whole, so no backend
change; the frontend reads scorecard.paused to render "Paused".

Tests: paused script loop → scorecard.paused true; running loops → false;
down runner → scorecard left untouched.
