### PR TITLE
jobs: keep the wake session id linkable in per-job Conversations

### DIFF
--- a/wayfinder_paths/jobs/sync.py
+++ b/wayfinder_paths/jobs/sync.py
@@ -60,6 +60,34 @@ class WayfinderJobsClient:
 WAYFINDER_JOBS_CLIENT = WayfinderJobsClient()
 
 
+def _report_with_session(
+    store: JobStore, job_id: str, *dir_names: str
+) -> dict[str, Any] | None:
+    """Latest report for a mode, with session_id/created_at backfilled from
+    the durable sidecar. The wake agent overwrites latest.json with its own
+    finding and drops those keys; without the backfill the frontend's per-job
+    Conversations list can't link the wake session. `dir_names` allows the
+    legacy fallback (intervene->improve, auto->decide)."""
+    for dir_name in dir_names:
+        report = store.read_json(
+            job_id, f"reports/{dir_name}/latest.json", default=None
+        )
+        if not isinstance(report, dict):
+            continue
+        if not report.get("session_id") or not report.get("created_at"):
+            sidecar = store.read_json(
+                job_id, f"reports/{dir_name}/session.json", default=None
+            )
+            if isinstance(sidecar, dict):
+                report = {
+                    **report,
+                    "session_id": report.get("session_id") or sidecar.get("session_id"),
+                    "created_at": report.get("created_at") or sidecar.get("created_at"),
+                }
+        return report
+    return None
+
+
 def snapshot_job(job_id: str, *, store: JobStore | None = None) -> dict[str, Any]:
     store = store or JobStore()
     job = store.load(job_id)
@@ -82,19 +110,10 @@ def snapshot_job(job_id: str, *, store: JobStore | None = None) -> dict[str, Any
                 "paused": any(statuses.get(n) == "PAUSED" for n in loop_names),
             }
     runner_links = store.read_json(job_id, "runner_links.json", default={}) or {}
-    latest_monitor = store.read_json(
-        job_id, "reports/monitor/latest.json", default=None
-    )
-    latest_intervene = store.read_json(
-        job_id,
-        "reports/intervene/latest.json",
-        default=store.read_json(job_id, "reports/improve/latest.json", default=None),
-    )
-    latest_auto = store.read_json(
-        job_id,
-        "reports/auto/latest.json",
-        default=store.read_json(job_id, "reports/decide/latest.json", default=None),
-    )
+    latest_monitor = _report_with_session(store, job_id, "monitor")
+    latest_intervene = _report_with_session(store, job_id, "intervene", "improve")
+    latest_auto = _report_with_session(store, job_id, "auto", "decide")
+    latest_apply = _report_with_session(store, job_id, "apply")
     validation = (
         store.read_json(job_id, "reports/validation/latest.json", default={}) or {}
     )
@@ -117,6 +136,7 @@ def snapshot_job(job_id: str, *, store: JobStore | None = None) -> dict[str, Any
             "monitor": latest_monitor,
             "intervene": latest_intervene,
             "auto": latest_auto,
+            "apply": latest_apply,
             "reconcile": store.read_json(
                 job_id, "reports/reconcile/latest.json", default=None
             ),

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -491,6 +491,25 @@ def _write_report(
     (report_dir / "latest.json").write_text(
         json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
     )
+    # Durable session pointer. The wake agent overwrites latest.json with its
+    # own structured finding, which drops session_id/created_at — so the
+    # frontend's per-job Conversations list loses the link (observed: a job
+    # whose agent wrote rich findings showed "No linked conversations yet"
+    # while one whose envelope survived linked fine). This sidecar is never
+    # touched by the agent; snapshot_job backfills from it. The session per
+    # (job, mode) is stable (reused by title), so a stale sidecar stays
+    # correct. Only overwrite on a real session so a failed wake can't blank
+    # a good pointer.
+    if session_id:
+        (report_dir / "session.json").write_text(
+            json.dumps(
+                {"session_id": session_id, "created_at": report["created_at"]},
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
     scorecard_updates: dict[str, Any] = {
         "health": status,
         "last_agent_check_at": report["created_at"],

--- a/wayfinder_paths/tests/test_jobs_conversation_link.py
+++ b/wayfinder_paths/tests/test_jobs_conversation_link.py
@@ -1,0 +1,144 @@
+"""The frontend's per-job Conversations list links wake sessions via
+`reports.{mode}.session_id`. The wake agent overwrites reports/{mode}/latest.json
+with its own structured finding, dropping session_id/created_at — so the SDK
+keeps a durable sidecar and snapshot_job backfills from it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from wayfinder_paths.jobs import sync as sync_mod
+from wayfinder_paths.jobs import worker as worker_mod
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.jobs.sync import _report_with_session, snapshot_job
+from wayfinder_paths.jobs.worker import _write_report
+
+
+def _job(tmp_path: Path) -> tuple[JobStore, WayfinderJob]:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        "carry", script="strategy.py", interval_seconds=3600, agent_mode="monitor"
+    )
+    store.create_job(job)
+    return store, job
+
+
+class _FakeBridge:
+    def __call__(self, *, repo_root=None):
+        return self
+
+    def job_statuses(self) -> dict[str, str]:
+        return {}
+
+
+def _clobber(store: JobStore, job_id: str, mode: str) -> None:
+    """Simulate the wake agent overwriting latest.json with its own finding —
+    no session_id, timestamp under a different key."""
+    store.write_json(
+        job_id,
+        f"reports/{mode}/latest.json",
+        {"mode": mode, "health": "green", "checked_at": "2026-07-13T23:08:45Z"},
+    )
+
+
+def test_write_report_persists_session_sidecar(tmp_path, monkeypatch) -> None:
+    store, job = _job(tmp_path)
+    monkeypatch.setattr(worker_mod, "sync_all_jobs", lambda *a, **k: None)
+    _write_report(
+        store=store,
+        job_id=job.id,
+        mode="monitor",
+        status="green",
+        summary="queued",
+        session_id="ses_abc",
+        queued=True,
+        error=None,
+    )
+    sidecar = store.read_json(job.id, "reports/monitor/session.json", default=None)
+    assert sidecar["session_id"] == "ses_abc"
+    assert sidecar["created_at"]
+
+
+def test_write_report_keeps_sidecar_when_session_missing(tmp_path, monkeypatch) -> None:
+    store, job = _job(tmp_path)
+    monkeypatch.setattr(worker_mod, "sync_all_jobs", lambda *a, **k: None)
+    _write_report(
+        store=store,
+        job_id=job.id,
+        mode="monitor",
+        status="green",
+        summary="ok",
+        session_id="ses_good",
+        queued=True,
+        error=None,
+    )
+    # A later wake that fails to get a session must NOT blank the good pointer.
+    _write_report(
+        store=store,
+        job_id=job.id,
+        mode="monitor",
+        status="yellow",
+        summary="no session",
+        session_id=None,
+        queued=False,
+        error="down",
+    )
+    sidecar = store.read_json(job.id, "reports/monitor/session.json", default=None)
+    assert sidecar["session_id"] == "ses_good"
+
+
+def test_snapshot_backfills_session_from_sidecar(tmp_path, monkeypatch) -> None:
+    store, job = _job(tmp_path)
+    monkeypatch.setattr(sync_mod, "RunnerBridge", _FakeBridge())
+    store.write_json(
+        job.id,
+        "reports/monitor/session.json",
+        {"session_id": "ses_wake", "created_at": "2026-07-13T23:08:45Z"},
+    )
+    _clobber(store, job.id, "monitor")  # agent finding, no session_id
+    report = snapshot_job(job.id, store=store)["reports"]["monitor"]
+    assert report["session_id"] == "ses_wake"
+    assert report["created_at"] == "2026-07-13T23:08:45Z"
+    assert report["health"] == "green"  # the agent's finding is preserved
+
+
+def test_snapshot_prefers_report_session_over_sidecar(tmp_path, monkeypatch) -> None:
+    store, job = _job(tmp_path)
+    monkeypatch.setattr(sync_mod, "RunnerBridge", _FakeBridge())
+    store.write_json(
+        job.id,
+        "reports/monitor/session.json",
+        {"session_id": "ses_stale", "created_at": "2026-07-01T00:00:00Z"},
+    )
+    store.write_json(
+        job.id,
+        "reports/monitor/latest.json",
+        {
+            "mode": "monitor",
+            "session_id": "ses_fresh",
+            "created_at": "2026-07-14T00:00:00Z",
+        },
+    )
+    report = snapshot_job(job.id, store=store)["reports"]["monitor"]
+    assert report["session_id"] == "ses_fresh"
+
+
+def test_snapshot_includes_apply_report(tmp_path, monkeypatch) -> None:
+    store, job = _job(tmp_path)
+    monkeypatch.setattr(sync_mod, "RunnerBridge", _FakeBridge())
+    store.write_json(
+        job.id,
+        "reports/apply/session.json",
+        {"session_id": "ses_apply", "created_at": "2026-07-13T15:06:34Z"},
+    )
+    _clobber(store, job.id, "apply")
+    reports = snapshot_job(job.id, store=store)["reports"]
+    assert "apply" in reports
+    assert reports["apply"]["session_id"] == "ses_apply"
+
+
+def test_report_with_session_missing_returns_none(tmp_path) -> None:
+    store, job = _job(tmp_path)
+    assert _report_with_session(store, job.id, "monitor") is None


### PR DESCRIPTION
### Summary

The per-job **Conversations** list on the jobs page links each agent wake via `reports.{mode}.session_id` (+ `created_at`). The SDK's `_write_report` writes an envelope carrying both at wake-queue time, but the wake **agent** then overwrites `reports/{mode}/latest.json` with its own structured finding (`health`/`findings`/`checked_at`, no `session_id`) — so by sync time the link is gone. Diagnosed live: `funding-carry-basket` showed *"No linked conversations yet"* despite ~10 wake sessions on the instance, while `imx-short` (whose minimal envelope happened to survive) linked fine.

**Fix**
- `_write_report` also writes a durable `reports/{mode}/session.json` sidecar (`session_id` + `created_at`) the agent never touches. Only overwritten on a real session, so a failed wake can't blank a good pointer; the session per (job, mode) is stable (reused by title) so a stale sidecar stays correct.
- `snapshot_job` backfills `session_id`/`created_at` into each report from the sidecar when the agent's finding dropped them, and now also carries the `apply` report (the frontend's "Applied a change" row reads `reports.apply`, which `snapshot_job` never sent).

Forward-looking: every future wake writes the sidecar, so the link survives whatever the agent writes to `latest.json`. Retired jobs that won't wake again (e.g. `funding-carry-basket`) need a one-time sidecar backfill from their journal — not done here.

6 new tests (sidecar persisted / not blanked by a sessionless wake / snapshot backfills a clobbered report / report's own session_id wins / apply linked); 48 in the sync+worker suite pass; ruff + format clean; no new mypy errors.