### PR TITLE
jobs: sync reflects RUNTIME state (runner/engine), not declared job.yaml

### DIFF
--- a/wayfinder_paths/jobs/execution/driver.py
+++ b/wayfinder_paths/jobs/execution/driver.py
@@ -55,12 +55,29 @@ def run_scheduled_tick(job_dir: str | Path | None = None) -> dict[str, Any]:
     mode = os.environ.get("WAYFINDER_JOB_MODE") or "paper"
     store = None
     job = None
+    divergence: dict[str, Any] | None = None
     try:
         store = JobStore()
         job = WayfinderJob.from_dict(_load_job_yaml(root))
+        # Fail-safe: never trade LIVE while the approved config (job.yaml) says
+        # paper. The runner env WAYFINDER_JOB_MODE can be flipped to live
+        # without updating job.yaml or recompiling — that split-brain once left
+        # a job live-trading real funds under a paper gate. Downgrade to paper
+        # and surface the divergence loudly so it can't happen silently.
+        declared_mode = str(job.script_loop.mode or "paper")
+        if mode == "live" and declared_mode != "live":
+            divergence = {
+                "kind": "mode_divergence",
+                "runner_mode": "live",
+                "declared_mode": declared_mode,
+                "action": "downgraded_to_paper",
+            }
+            mode = "paper"
         payload = asyncio.run(tick_job(job, root, mode, store=store))
     except Exception as exc:
         payload = {"ok": False, "error": str(exc)}
+    if divergence is not None:
+        payload.setdefault("guard_events", []).append(divergence)
     # Event-driven agent wakes fire ONLY from the scheduled entrypoint —
     # never from tick_job itself, so preflight sandbox ticks and manual
     # `wayfinder job tick` runs cannot wake the advisor.
@@ -84,6 +101,10 @@ def _tick_trigger_events(payload: dict[str, Any]) -> list[str]:
     }
     if guard_kinds & {"risk_halt", "manual_halt"}:
         events.append("risk_halt")
+    if "mode_divergence" in guard_kinds:
+        # Declared vs executed mode disagree — wake the advisor to reconcile
+        # job.yaml (reuses the reconcile_mismatch trigger).
+        events.append("reconcile_mismatch")
     return events
 
 

--- a/wayfinder_paths/jobs/runner_bridge.py
+++ b/wayfinder_paths/jobs/runner_bridge.py
@@ -84,19 +84,26 @@ class RunnerBridge:
         update_params.update(schedule)
         return self.client.call("update_job", update_params)
 
-    def job_statuses(self) -> dict[str, str]:
-        """Live runner status per job name, e.g. {"foo-script": "PAUSED"}.
-        Empty when the daemon is unreachable — callers degrade to "not paused"
-        rather than raise, so a down runner never breaks a sync."""
+    def job_states(self) -> dict[str, dict[str, Any]]:
+        """Full live runner state per job name — status, next_run_at,
+        last_run_at, last_ok_at, consecutive_failures, last_error, and the
+        baked `payload.env` (WAYFINDER_JOB_MODE / WAYFINDER_JOB_AGENT_MODE /
+        WAYFINDER_JOB_REVISION). This is the runtime source of truth: the
+        driver executes the mode in the env, not job.yaml. Empty when the
+        daemon is unreachable — callers degrade to the declared config rather
+        than raise, so a down runner never breaks a sync."""
         try:
             resp = self.client.call("status")
         except Exception:
             return {}
         jobs = ((resp or {}).get("result") or {}).get("jobs") or []
+        return {str(job.get("name")): job for job in jobs if job.get("name")}
+
+    def job_statuses(self) -> dict[str, str]:
+        """Live runner status per job name, e.g. {"foo-script": "PAUSED"}."""
         return {
-            str(job.get("name")): str(job.get("status") or "")
-            for job in jobs
-            if job.get("name")
+            name: str(state.get("status") or "")
+            for name, state in self.job_states().items()
         }
 
     def pause(self, name: str) -> dict[str, Any]:

--- a/wayfinder_paths/jobs/sync.py
+++ b/wayfinder_paths/jobs/sync.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Any
 
 import httpx
@@ -88,27 +89,88 @@ def _report_with_session(
     return None
 
 
+def _unix_to_iso(value: Any) -> str | None:
+    try:
+        return datetime.fromtimestamp(float(value), tz=UTC).isoformat()
+    except (TypeError, ValueError, OSError):
+        return None
+
+
+def _engine_mode(store: JobStore, job_id: str) -> str | None:
+    state = store.read_json(job_id, "state/engine_state.json", default=None)
+    if isinstance(state, dict) and state.get("mode"):
+        return str(state["mode"])
+    return None
+
+
+def _runtime_reconciliation(job: Any, store: JobStore) -> dict[str, Any]:
+    """Overlay the live runner/engine truth onto the scorecard so the UI shows
+    what's ACTUALLY running, not the declared job.yaml. The driver executes the
+    mode baked into the runner env (WAYFINDER_JOB_MODE), which an agent can flip
+    without touching job.yaml — that split-brain once left a job live-trading
+    while the UI read "paper". This extends the original paused reconciliation
+    to mode, agent_mode, active_revision, and the runner's scheduling/health
+    metrics. Degrades to {} (keep declared values) when the runner is down."""
+    script = job.script_loop
+    agent = job.agent_loop
+    loop_names = [
+        loop.runner_job_name
+        for loop in (script, agent)
+        if loop.enabled and loop.runner_job_name
+    ]
+    if not loop_names:
+        return {}
+    states = RunnerBridge(repo_root=store.repo_root).job_states()
+    if not states:
+        return {}
+    out: dict[str, Any] = {
+        "paused": any(states.get(n, {}).get("status") == "PAUSED" for n in loop_names)
+    }
+    script_state = states.get(script.runner_job_name or "") if script.enabled else None
+    if script_state:
+        env = (script_state.get("payload") or {}).get("env") or {}
+        declared_mode = str(script.mode or "paper")
+        runtime_mode = str(
+            env.get("WAYFINDER_JOB_MODE")
+            or _engine_mode(store, job.id)
+            or declared_mode
+        )
+        out["mode"] = runtime_mode
+        out["mode_mismatch"] = runtime_mode != declared_mode
+        if env.get("WAYFINDER_JOB_REVISION"):
+            out["active_revision"] = str(env["WAYFINDER_JOB_REVISION"])
+        out["runner_status"] = str(script_state.get("status") or "")
+        for src, iso in (
+            ("last_run_at", True),
+            ("last_ok_at", True),
+            ("next_run_at", True),
+        ):
+            value = script_state.get(src)
+            if value is not None:
+                out[src] = _unix_to_iso(value) if iso else value
+        out["consecutive_failures"] = int(script_state.get("consecutive_failures") or 0)
+        if script_state.get("last_error"):
+            out["last_error"] = str(script_state["last_error"])
+    agent_state = states.get(agent.runner_job_name or "") if agent.enabled else None
+    if agent_state:
+        aenv = (agent_state.get("payload") or {}).get("env") or {}
+        if aenv.get("WAYFINDER_JOB_AGENT_MODE"):
+            out["agent_mode"] = str(aenv["WAYFINDER_JOB_AGENT_MODE"])
+    return out
+
+
 def snapshot_job(job_id: str, *, store: JobStore | None = None) -> dict[str, Any]:
     store = store or JobStore()
     job = store.load(job_id)
     scorecard = store.read_json(job_id, "scorecard.json", default={}) or {}
-    # Reconcile runtime pause from the runner: a job's script_loop.mode stays
-    # "live" while paused, so without this the UI can't tell a paused live job
-    # from one that is actively trading. Self-healing (reflects true runner
-    # state regardless of how the pause was triggered); degrades to unchanged
-    # on a down runner.
-    loop_names = [
-        loop.runner_job_name
-        for loop in (job.script_loop, job.agent_loop)
-        if loop.enabled and loop.runner_job_name
-    ]
-    if loop_names:
-        statuses = RunnerBridge(repo_root=store.repo_root).job_statuses()
-        if statuses:
-            scorecard = {
-                **scorecard,
-                "paused": any(statuses.get(n) == "PAUSED" for n in loop_names),
-            }
+    # Reflect the live runner/engine state, not the declared job.yaml: mode
+    # (paper/live), agent_mode, active_revision, paused, and scheduling/health
+    # metrics all come from the runner where it is the source of truth. See
+    # _runtime_reconciliation. Degrades to the declared scorecard on a down
+    # runner, so a sync never breaks.
+    runtime = _runtime_reconciliation(job, store)
+    if runtime:
+        scorecard = {**scorecard, **runtime}
     runner_links = store.read_json(job_id, "runner_links.json", default={}) or {}
     latest_monitor = _report_with_session(store, job_id, "monitor")
     latest_intervene = _report_with_session(store, job_id, "intervene", "improve")

--- a/wayfinder_paths/tests/test_jobs_conversation_link.py
+++ b/wayfinder_paths/tests/test_jobs_conversation_link.py
@@ -29,6 +29,9 @@ class _FakeBridge:
     def __call__(self, *, repo_root=None):
         return self
 
+    def job_states(self) -> dict:
+        return {}
+
     def job_statuses(self) -> dict[str, str]:
         return {}
 

--- a/wayfinder_paths/tests/test_jobs_paused_sync.py
+++ b/wayfinder_paths/tests/test_jobs_paused_sync.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from wayfinder_paths.jobs import sync as sync_mod
 from wayfinder_paths.jobs.models import WayfinderJob
 from wayfinder_paths.jobs.store import JobStore
-from wayfinder_paths.jobs import sync as sync_mod
 from wayfinder_paths.jobs.sync import snapshot_job
 
 
@@ -24,14 +24,20 @@ def _job(tmp_path: Path) -> tuple[JobStore, WayfinderJob]:
 
 
 class _FakeBridge:
-    def __init__(self, statuses: dict[str, str]) -> None:
-        self._statuses = statuses
+    def __init__(self, states: dict) -> None:
+        # Accepts either {name: status_str} or {name: full_state_dict}.
+        self._states = {
+            n: (s if isinstance(s, dict) else {"status": s}) for n, s in states.items()
+        }
 
     def __call__(self, *, repo_root=None):  # constructed as RunnerBridge(repo_root=…)
         return self
 
+    def job_states(self) -> dict:
+        return self._states
+
     def job_statuses(self) -> dict[str, str]:
-        return self._statuses
+        return {n: str(s.get("status") or "") for n, s in self._states.items()}
 
 
 def test_paused_script_loop_sets_scorecard_paused(tmp_path, monkeypatch) -> None:

--- a/wayfinder_paths/tests/test_jobs_runtime_status.py
+++ b/wayfinder_paths/tests/test_jobs_runtime_status.py
@@ -1,0 +1,177 @@
+"""Job status/stats must reflect RUNTIME truth (the runner env + engine),
+not the declared job.yaml. The driver executes the mode baked into the runner
+env WAYFINDER_JOB_MODE, which an agent can flip without touching job.yaml —
+that split-brain once left a job live-trading while the UI read "paper".
+snapshot_job reconciles the runner state into the scorecard; the driver
+fail-safes to paper when the two diverge.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from wayfinder_paths.jobs import sync as sync_mod
+from wayfinder_paths.jobs.execution import driver as driver_mod
+from wayfinder_paths.jobs.execution.driver import (
+    _tick_trigger_events,
+    run_scheduled_tick,
+)
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.jobs.sync import snapshot_job
+
+
+def _job(tmp_path: Path, mode: str = "paper") -> tuple[JobStore, WayfinderJob]:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        "carry", script="strategy.py", interval_seconds=3600, agent_mode="monitor"
+    )
+    job.script_loop.mode = mode
+    store.create_job(job)
+    return store, job
+
+
+class _FakeBridge:
+    """Fake RunnerBridge exposing job_states — {name: full_runner_dict}."""
+
+    def __init__(self, states: dict) -> None:
+        self._states = states
+
+    def __call__(self, *, repo_root=None):
+        return self
+
+    def job_states(self) -> dict:
+        return self._states
+
+
+def _script_state(**env) -> dict:
+    return {
+        "status": "ACTIVE",
+        "payload": {"env": {"WAYFINDER_JOB_MODE": "live", **env}},
+        "last_run_at": 1784045000,
+        "last_ok_at": 1784045014,
+        "next_run_at": 1784047289,
+        "consecutive_failures": 0,
+        "last_error": None,
+    }
+
+
+def test_snapshot_reconciles_runtime_mode_and_flags_mismatch(tmp_path, monkeypatch):
+    # Declared paper, but the runner env runs live — the exact imx-short bug.
+    store, job = _job(tmp_path, mode="paper")
+    monkeypatch.setattr(
+        sync_mod, "RunnerBridge", _FakeBridge({"carry-script": _script_state()})
+    )
+    sc = snapshot_job(job.id, store=store)["scorecard"]
+    assert sc["mode"] == "live"  # runtime truth, not declared "paper"
+    assert sc["mode_mismatch"] is True
+    assert sc["runner_status"] == "ACTIVE"
+
+
+def test_snapshot_mode_matches_no_mismatch(tmp_path, monkeypatch):
+    store, job = _job(tmp_path, mode="live")
+    monkeypatch.setattr(
+        sync_mod, "RunnerBridge", _FakeBridge({"carry-script": _script_state()})
+    )
+    sc = snapshot_job(job.id, store=store)["scorecard"]
+    assert sc["mode"] == "live"
+    assert sc["mode_mismatch"] is False
+
+
+def test_snapshot_surfaces_runner_metrics_as_iso(tmp_path, monkeypatch):
+    store, job = _job(tmp_path, mode="live")
+    state = _script_state()
+    state["consecutive_failures"] = 3
+    state["last_error"] = "reconcile_fetch_failed"
+    monkeypatch.setattr(sync_mod, "RunnerBridge", _FakeBridge({"carry-script": state}))
+    sc = snapshot_job(job.id, store=store)["scorecard"]
+    assert sc["last_run_at"].startswith("2026-")  # unix -> ISO
+    assert sc["next_run_at"].startswith("2026-")
+    assert sc["consecutive_failures"] == 3
+    assert sc["last_error"] == "reconcile_fetch_failed"
+
+
+def test_snapshot_reconciles_agent_mode_and_revision(tmp_path, monkeypatch):
+    store, job = _job(tmp_path, mode="live")
+    monkeypatch.setattr(
+        sync_mod,
+        "RunnerBridge",
+        _FakeBridge(
+            {
+                "carry-script": _script_state(WAYFINDER_JOB_REVISION="rev123"),
+                "carry-agent": {
+                    "status": "ACTIVE",
+                    "payload": {"env": {"WAYFINDER_JOB_AGENT_MODE": "intervene"}},
+                },
+            }
+        ),
+    )
+    sc = snapshot_job(job.id, store=store)["scorecard"]
+    assert sc["agent_mode"] == "intervene"
+    assert sc["active_revision"] == "rev123"
+
+
+def test_snapshot_falls_back_to_engine_mode(tmp_path, monkeypatch):
+    # Runner env lacks WAYFINDER_JOB_MODE -> use engine_state.json (last ran as).
+    store, job = _job(tmp_path, mode="paper")
+    store.write_json(job.id, "state/engine_state.json", {"mode": "live"})
+    state = {"status": "ACTIVE", "payload": {"env": {}}}
+    monkeypatch.setattr(sync_mod, "RunnerBridge", _FakeBridge({"carry-script": state}))
+    sc = snapshot_job(job.id, store=store)["scorecard"]
+    assert sc["mode"] == "live"
+    assert sc["mode_mismatch"] is True
+
+
+def test_snapshot_degrades_when_runner_down(tmp_path, monkeypatch):
+    # Empty states == unreachable daemon -> no runtime overlay at all.
+    store, job = _job(tmp_path, mode="paper")
+    monkeypatch.setattr(sync_mod, "RunnerBridge", _FakeBridge({}))
+    sc = snapshot_job(job.id, store=store)["scorecard"]
+    assert "mode" not in sc
+    assert "paused" not in sc
+
+
+def test_paused_still_reconciled(tmp_path, monkeypatch):
+    store, job = _job(tmp_path, mode="live")
+    state = _script_state()
+    state["status"] = "PAUSED"
+    monkeypatch.setattr(sync_mod, "RunnerBridge", _FakeBridge({"carry-script": state}))
+    assert snapshot_job(job.id, store=store)["scorecard"]["paused"] is True
+
+
+def test_driver_downgrades_live_under_paper(tmp_path, monkeypatch):
+    # The fail-safe: env says live, job.yaml says paper -> execute paper +
+    # emit a mode_divergence guard that wakes the advisor.
+    store, job = _job(tmp_path, mode="paper")
+    captured: dict = {}
+
+    def _fake_tick(job_arg, root, mode, **kw):
+        captured["mode"] = mode
+        return {"ok": True, "snapshot": {"status": "ok"}}
+
+    monkeypatch.setattr(driver_mod, "tick_job", _fake_tick)
+    monkeypatch.setattr(driver_mod, "fire_triggers", lambda *a, **k: None)
+    monkeypatch.setenv("WAYFINDER_JOB_DIR", str(store.job_dir(job.id)))
+    monkeypatch.setenv("WAYFINDER_JOB_MODE", "live")
+
+    payload = run_scheduled_tick()
+    assert captured["mode"] == "paper"  # downgraded, no live orders
+    kinds = {g["kind"] for g in payload["guard_events"]}
+    assert "mode_divergence" in kinds
+    assert "reconcile_mismatch" in _tick_trigger_events(payload)
+
+
+def test_driver_runs_live_when_declared_live(tmp_path, monkeypatch):
+    store, job = _job(tmp_path, mode="live")
+    captured: dict = {}
+    monkeypatch.setattr(
+        driver_mod,
+        "tick_job",
+        lambda job_arg, root, mode, **kw: captured.update(mode=mode) or {"ok": True},
+    )
+    monkeypatch.setattr(driver_mod, "fire_triggers", lambda *a, **k: None)
+    monkeypatch.setenv("WAYFINDER_JOB_DIR", str(store.job_dir(job.id)))
+    monkeypatch.setenv("WAYFINDER_JOB_MODE", "live")
+    payload = run_scheduled_tick()
+    assert captured["mode"] == "live"
+    assert not payload.get("guard_events")


### PR DESCRIPTION
### Summary

imx-short exposed a split-brain: the driver executes the mode baked into the runner env `WAYFINDER_JOB_MODE`, but the backend/UI read the mode from `job.yaml script_loop.mode`. An agent flipped the runner env to `live` without updating job.yaml, so the job was **live-trading real funds while the UI showed "Paper."** `snapshot_job` already reconciled the `paused` flag from the live runner for exactly this reason (a paused live job would otherwise read as actively trading); this generalizes that pattern to every field where declared ≠ runtime, and adds a driver fail-safe.

- **`RunnerBridge.job_states()`** — returns the full per-job runner dict (status, next_run_at, last_run_at, last_ok_at, consecutive_failures, last_error, `payload.env`). `job_statuses()` now derives from it. One socket round-trip.
- **`snapshot_job` / `_runtime_reconciliation`** — overlays onto the `scorecard` the *actual* mode (runner env, fallback `engine_state.mode`), `agent_mode`, `active_revision`, `paused`, a `mode_mismatch` flag, and the runner's scheduling/health metrics (last/next run as ISO, consecutive_failures, last_error, runner_status). Degrades to the declared scorecard when the runner is unreachable, so a sync never breaks. The backend stores `scorecard` verbatim as jsonb — **no backend change**; the frontend reads `scorecard.*` preferentially (frontend PR follows).
- **Driver `run_scheduled_tick` fail-safe** — if the runner env says `live` but the approved config (job.yaml) says `paper`, downgrade the tick to paper (no live orders) and emit a `mode_divergence` guard that wakes the advisor via the `reconcile_mismatch` trigger. Real funds can never trade under a paper gate, even if an env flip bypassed the approval flow.

### Testing
10 new tests (runtime mode + mismatch, declared-live match, ISO metrics, agent_mode/revision reconcile, engine_state fallback, degrade on down runner, paused still reconciled, driver downgrades live-under-paper + guard, runs live when declared live); 78 in the sync/worker/driver/forward suites pass; ruff + format clean; no new mypy errors.