### PR TITLE
runner: daemon refreshes the wayfinder-jobs backend (fix stale Strategies UI)

### DIFF
--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -337,6 +337,11 @@ class RunnerDaemon:
                 ),
             )
 
+        # Refresh the wayfinder-jobs backend after every run so the Strategies
+        # UI (conversations, proposals, reconciled mode) tracks activity instead
+        # of only updating on ~hourly/4-hourly agent wakes.
+        self._sync_to_backend_async()
+
     def _run_side_effect(self, label: str, callback: Callable[[], None]) -> None:
         def _target() -> None:
             try:
@@ -404,27 +409,20 @@ class RunnerDaemon:
             return
 
         def _sync() -> None:
-            jobs = []
-            for j in self._db.list_jobs():
-                result = self._db.get_job(name=j["name"])
-                if not result:
-                    continue
-                job, state = result
-                jobs.append(
-                    {
-                        "job_name": job.name,
-                        "job_type": job.type,
-                        "status": state.status,
-                        "interval_seconds": job.interval_seconds,
-                        "schedule_kind": job.schedule_kind,
-                        "cron_expr": job.cron_expr,
-                        "timezone": job.timezone,
-                        "payload": job.payload,
-                    }
-                )
-            SCHEDULED_JOBS_CLIENT.bulk_sync(jobs)
+            # Push the wayfinder-jobs snapshot (per-mode session ids for the
+            # Conversations panel, proposals, and the reconciled scorecard/mode)
+            # so the Strategies UI reflects runtime state. This is the daemon's
+            # periodic refresh: the event-driven paths (agent wakes, propose,
+            # MCP core_jobs) already call sync_all_jobs, but between them the UI
+            # went stale — the daemon's push had been left on the removed legacy
+            # `/jobs/sync/` endpoint (404). Lazy-imported to avoid any import
+            # cycle with the jobs package at daemon startup.
+            from wayfinder_paths.jobs.store import JobStore
+            from wayfinder_paths.jobs.sync import sync_all_jobs
 
-        self._run_side_effect("bulk-sync", _sync)
+            sync_all_jobs(store=JobStore(repo_root=self._paths.repo_root))
+
+        self._run_side_effect("wayfinder-sync", _sync)
 
     def _notify_session(
         self,

--- a/wayfinder_paths/tests/test_runner_reconcile.py
+++ b/wayfinder_paths/tests/test_runner_reconcile.py
@@ -1,12 +1,20 @@
+"""The runner daemon keeps the wayfinder-jobs backend fresh.
+
+The event-driven paths (agent wakes, propose, MCP core_jobs) already call
+sync_all_jobs; the daemon adds the periodic/after-run push so the Strategies UI
+(conversations, proposals, reconciled mode) doesn't go stale between wakes. This
+replaced the daemon's dead legacy `/jobs/sync/` push (ScheduledJobsClient).
+"""
+
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
-from wayfinder_paths.core.clients.ScheduledJobsClient import SCHEDULED_JOBS_CLIENT
-from wayfinder_paths.runner.constants import JOB_TYPE_SCRIPT, JobStatus
-from wayfinder_paths.runner.daemon import RunnerDaemon
+from wayfinder_paths.runner.constants import JOB_TYPE_SCRIPT, JobStatus, RunStatus
+from wayfinder_paths.runner.daemon import RunnerDaemon, RunningProcess
 from wayfinder_paths.runner.paths import RunnerPaths
 
 
@@ -34,85 +42,74 @@ def _add_local(daemon: RunnerDaemon, name: str) -> None:
     )
 
 
-def test_bulk_sync_sends_all_local_jobs(
+def test_sync_pushes_wayfinder_snapshot(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("OPENCODE_INSTANCE_ID", "inst-xyz")
-
     daemon = RunnerDaemon(paths=_paths(tmp_path))
-    _add_local(daemon, "job-a")
-    _add_local(daemon, "job-b")
 
-    synced: list[list[dict]] = []
+    stores: list[object] = []
     monkeypatch.setattr(
-        SCHEDULED_JOBS_CLIENT, "bulk_sync", lambda jobs: synced.append(jobs)
+        "wayfinder_paths.jobs.sync.sync_all_jobs",
+        lambda *, store: stores.append(store),
     )
-
-    jobs = []
-    for j in daemon._db.list_jobs():
-        job, state = daemon._db.get_job(name=j["name"])
-        jobs.append(
-            {
-                "job_name": job.name,
-                "job_type": job.type,
-                "status": state.status,
-                "interval_seconds": job.interval_seconds,
-                "payload": job.payload,
-            }
-        )
-    SCHEDULED_JOBS_CLIENT.bulk_sync(jobs)
-
-    assert len(synced) == 1
-    names = {j["job_name"] for j in synced[0]}
-    assert names == {"job-a", "job-b"}
-
-
-def test_bulk_sync_noop_when_not_opencode(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.delenv("OPENCODE_INSTANCE_ID", raising=False)
-
-    daemon = RunnerDaemon(paths=_paths(tmp_path))
-    _add_local(daemon, "job-a")
-
-    called = False
-
-    def _fail(jobs):
-        nonlocal called
-        called = True
-
-    monkeypatch.setattr(SCHEDULED_JOBS_CLIENT, "bulk_sync", _fail)
+    # Run the side-effect callback inline so the assertion is deterministic.
+    monkeypatch.setattr(daemon, "_run_side_effect", lambda _label, cb: cb())
 
     daemon._sync_to_backend_async()
 
-    assert not called
+    assert len(stores) == 1
+    # The store is rooted at the daemon's repo_root so it resolves the job dirs.
+    assert stores[0].repo_root == tmp_path.resolve()
 
 
-def test_bulk_sync_empty_when_no_jobs(
+def test_sync_noop_when_not_opencode(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setenv("OPENCODE_INSTANCE_ID", "inst-xyz")
-
+    monkeypatch.delenv("OPENCODE_INSTANCE_ID", raising=False)
     daemon = RunnerDaemon(paths=_paths(tmp_path))
 
-    synced: list[list[dict]] = []
+    stores: list[object] = []
     monkeypatch.setattr(
-        SCHEDULED_JOBS_CLIENT, "bulk_sync", lambda jobs: synced.append(jobs)
+        "wayfinder_paths.jobs.sync.sync_all_jobs",
+        lambda *, store: stores.append(store),
+    )
+    monkeypatch.setattr(daemon, "_run_side_effect", lambda _label, cb: cb())
+
+    daemon._sync_to_backend_async()
+
+    assert stores == []
+
+
+def test_finish_run_triggers_backend_sync(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    daemon = RunnerDaemon(paths=_paths(tmp_path))
+    _add_local(daemon, "job-a")
+    job, _ = daemon._db.get_job(name="job-a")
+    run_id = daemon._db.reserve_run(
+        job_id=job.id, started_at=0, next_run_at=60, reason="schedule", scheduled_for=0
+    )
+    rp = RunningProcess(
+        run_id=run_id,
+        job_id=job.id,
+        job_name="job-a",
+        started_at=0,
+        reason="schedule",
+        scheduled_for=0,
+        timeout_seconds=None,
+        popen=Mock(),
+        log_path=tmp_path / "x.log",
+    )
+    daemon._running[run_id] = rp
+
+    synced = Mock()
+    monkeypatch.setattr(daemon, "_sync_to_backend_async", synced)
+    # Neutralize the notify/report side-effect threads for a focused assertion.
+    monkeypatch.setattr(daemon, "_run_side_effect", lambda _label, _cb: None)
+
+    daemon._finish_run(
+        rp, finished_at=100, status=RunStatus.OK, exit_code=0, error_text=None
     )
 
-    jobs = []
-    for j in daemon._db.list_jobs():
-        job, state = daemon._db.get_job(name=j["name"])
-        jobs.append(
-            {
-                "job_name": job.name,
-                "job_type": job.type,
-                "status": state.status,
-                "interval_seconds": job.interval_seconds,
-                "payload": job.payload,
-            }
-        )
-    SCHEDULED_JOBS_CLIENT.bulk_sync(jobs)
-
-    assert len(synced) == 1
-    assert synced[0] == []
+    synced.assert_called_once()


### PR DESCRIPTION
## Why

On `strategies-dev.wayfinder.ai/app/jobs?job=imx-short` the Conversations panel and proposals showed empty. Investigation on the live box (and across SDK/backend/frontend) found the SDK, backend, and frontend are all **correct** — the data is present and the page renders it when fresh (verified: `snapshot_job("imx-short")` emits both wake session ids + both proposals; the backend GET returns them; the live page renders the Conversations list, the chat transcript, and both proposals in the Proposals tab).

The panels were **stale**. The wayfinder-jobs backend is fed by `sync_all_jobs()` → `/wayfinder-jobs/sync/`, which only runs on **event-driven** paths (agent wakes at `worker.py:537`, `propose/approve/reject`, MCP `core_jobs`). imx-short's agent wakes only every ~4h and script ticks don't sync the snapshot, so the UI drifts stale between wakes (same class as the earlier "still says paper").

There was supposed to be a periodic refresh, but the runner daemon's `_sync_to_backend_async` was left on the **removed legacy** `SCHEDULED_JOBS_CLIENT.bulk_sync` → `POST …/jobs/sync/` → **404** (confirmed spamming `runnerd.log`), sending legacy scheduled-job dicts, never a wayfinder snapshot — an incomplete migration. It also only fired at startup + control actions, never after a run.

## What

- **`_sync_to_backend_async`** now pushes the wayfinder snapshot via `sync_all_jobs(store=JobStore(repo_root=self._paths.repo_root))` instead of the dead legacy `bulk_sync` (also stops the constant 404 log spam). Lazy-imported to avoid any import cycle with the jobs package at daemon startup. On the box `self._paths.repo_root` is `/wf/sdk` (verified: `JobStore(repo_root="/wf/sdk").list_jobs()` returns all jobs; `/wf/sdk/.wayfinder` symlinks to the persistent volume).
- **`_finish_run`** triggers a backend sync after every run completion, so UI freshness tracks activity (hourly script ticks) rather than agent-wake cadence.

## Tests

Rewrote `test_runner_reconcile.py`: asserts the wayfinder push happens on-instance, no-ops off-instance, and fires on run completion. Broader runner suite green; ruff+format clean; no new mypy errors (the 3 reported are identical on the `wayfinder-jobs-v1` baseline — pre-existing `_control` typing).

## Delivery

SDK-only → reaches the box after bake + image roll. **Frontend needs no change/deploy** — the live page already renders conversations + proposals correctly from the current API. Out of scope (noted): `report_run` → `/jobs/{name}/runs/` (500) is a related legacy-endpoint breakage; `controller.initializer_session_id` is only captured at create-time (future-only — the "Built this strategy" row).