### PR TITLE
Wallets - adapt create to the EVM+SVM pair response

### DIFF
--- a/scripts/make_wallets.py
+++ b/scripts/make_wallets.py
@@ -170,8 +170,10 @@ async def main():
             result = await create_remote_wallet(
                 label=label, wallet_type=args.wallet_type, policies=policies
             )
+            evm, svm = result["evm"], result["svm"]
             print(
-                f"[remote] {result['wallet_address']}  (label: {result.get('label', label)})"
+                f"[remote] evm={evm['wallet_address']} svm={svm['wallet_address']}  "
+                f"(label: {evm['label']})"
             )
         return
 

--- a/wayfinder_paths/core/utils/wallets.py
+++ b/wayfinder_paths/core/utils/wallets.py
@@ -336,9 +336,11 @@ async def create_remote_wallet(
         label=label,
         wallet_type=wallet_type,
     )
+    # A create provisions an EVM + SVM wallet pair ({"evm": ..., "svm": ...});
+    # the instance binds to the EVM wallet.
     if is_opencode_instance():
         await WALLET_CLIENT.bind_to_instance(
-            result["wallet_address"], get_opencode_instance_id()
+            result["evm"]["wallet_address"], get_opencode_instance_id()
         )
     return result
 

--- a/wayfinder_paths/mcp/tools/wallets.py
+++ b/wayfinder_paths/mcp/tools/wallets.py
@@ -252,8 +252,9 @@ async def core_wallets(
                     {
                         "wallets": [public_wallet_view(x) for x in refreshed],
                         "created": {
-                            "label": result.get("label", want),
-                            "address": result["wallet_address"],
+                            "label": result["evm"]["label"],
+                            "evm_address": result["evm"]["wallet_address"],
+                            "svm_address": result["svm"]["wallet_address"],
                         },
                     }
                 )


### PR DESCRIPTION
### Summary

The wallet-create endpoint now returns an EVM + SVM wallet pair (`{"evm": ..., "svm": ...}`) instead of a single flat wallet. `create_remote_wallet` binds the instance to the EVM wallet, and the `core_wallets` create tool + `make_wallets.py` surface both the EVM and SVM addresses.