### PR TITLE
Wallets - read from the ring-centric wallets endpoint

### DIFF
--- a/wayfinder_paths/core/clients/WalletClient.py
+++ b/wayfinder_paths/core/clients/WalletClient.py
@@ -14,15 +14,6 @@ class WalletClient(WayfinderClient):
         resp = await self._authed_request("GET", url)
         return resp.json()
 
-    async def list_wallets(
-        self, instance_id: str | None = None
-    ) -> list[dict[str, Any]]:
-        url = f"{get_api_base_url()}/wallets/"
-        if instance_id:
-            url += f"?instance_id={instance_id}"
-        resp = await self._authed_request("GET", url)
-        return resp.json()
-
     async def list_wallet_rings(
         self, instance_id: str | None = None
     ) -> list[dict[str, Any]]:

--- a/wayfinder_paths/core/clients/WalletClient.py
+++ b/wayfinder_paths/core/clients/WalletClient.py
@@ -23,6 +23,15 @@ class WalletClient(WayfinderClient):
         resp = await self._authed_request("GET", url)
         return resp.json()
 
+    async def list_wallet_rings(
+        self, instance_id: str | None = None
+    ) -> list[dict[str, Any]]:
+        url = f"{get_api_base_url()}/wallets/rings/"
+        if instance_id:
+            url += f"?instance_id={instance_id}"
+        resp = await self._authed_request("GET", url)
+        return resp.json()
+
     async def create_wallet(
         self,
         policies: list[dict],

--- a/wayfinder_paths/core/utils/wallets.py
+++ b/wayfinder_paths/core/utils/wallets.py
@@ -44,22 +44,24 @@ async def load_remote_wallets() -> list[dict[str, Any]]:
         )
         wallets = []
         for i, ring in enumerate(rings):
-            evm = ring["evm"]
-            addr = evm["wallet_address"]
-            svm = ring.get("svm")
-            entry = {
-                # Ring label is the source of truth; identity/binding stays the EVM wallet.
-                "address": addr,
-                "label": ring.get("label") or f"remote-{i}",
-                "type": "remote",
-                "chain_type": evm["chain_type"],
-                "wallet_type": evm["wallet_type"],
-                # TTL fields live at the ring level, present only for session/strategy wallets.
-                "session_expires_at": ring.get("session_expires_at"),
-                "session_expires_in": ring.get("session_expires_in"),
-                "svm_address": svm["wallet_address"] if svm else None,
-            }
-            wallets.append(entry)
+            label = ring["label"] or f"remote-{i}"
+            # One entry per ring leg — the EVM and SVM wallets share the ring
+            # label and are distinguished by chain_type; each leg carries its own
+            # session expiry (session/strategy wallets only).
+            for leg in (ring["evm"], ring.get("svm")):
+                if not leg:
+                    continue
+                wallets.append(
+                    {
+                        "address": leg["wallet_address"],
+                        "label": label,
+                        "type": "remote",
+                        "chain_type": leg["chain_type"],
+                        "wallet_type": leg["wallet_type"],
+                        "session_expires_at": leg.get("session_expires_at"),
+                        "session_expires_in": leg.get("session_expires_in"),
+                    }
+                )
         return wallets
     except Exception as exc:
         logger.debug(f"Failed to fetch remote wallets: {exc}")

--- a/wayfinder_paths/core/utils/wallets.py
+++ b/wayfinder_paths/core/utils/wallets.py
@@ -39,18 +39,22 @@ async def load_remote_wallets() -> list[dict[str, Any]]:
     if not get_api_key() or not is_opencode_instance():
         return []
     try:
+        features = await WALLET_CLIENT.get_features()
+        solana_enabled = "solana_enabled" in features["enabledSwitches"]
         rings = await WALLET_CLIENT.list_wallet_rings(
             instance_id=get_opencode_instance_id()
         )
         wallets = []
         for i, ring in enumerate(rings):
             label = ring["label"] or f"remote-{i}"
-            # One entry per ring leg — the EVM and SVM wallets share the ring
-            # label and are distinguished by chain_type; each leg carries its own
-            # session expiry (session/strategy wallets only).
-            for leg in (ring["evm"], ring.get("svm")):
-                if not leg:
-                    continue
+            # One entry per ring leg — the EVM leg always, the SVM leg only when
+            # Solana is enabled. Same ring label, distinguished by chain_type; each
+            # leg carries its own session expiry (session/strategy wallets only).
+            legs = [ring["evm"]]
+            svm = ring.get("svm")
+            if svm and solana_enabled:
+                legs.append(svm)
+            for leg in legs:
                 wallets.append(
                     {
                         "address": leg["wallet_address"],

--- a/wayfinder_paths/core/utils/wallets.py
+++ b/wayfinder_paths/core/utils/wallets.py
@@ -39,20 +39,25 @@ async def load_remote_wallets() -> list[dict[str, Any]]:
     if not get_api_key() or not is_opencode_instance():
         return []
     try:
-        raw = await WALLET_CLIENT.list_wallets(instance_id=get_opencode_instance_id())
+        rings = await WALLET_CLIENT.list_wallet_rings(
+            instance_id=get_opencode_instance_id()
+        )
         wallets = []
-        for i, w in enumerate(raw):
-            addr = w.get("wallet_address")
-            if not addr:
-                continue
+        for i, ring in enumerate(rings):
+            evm = ring["evm"]
+            addr = evm["wallet_address"]
+            svm = ring.get("svm")
             entry = {
+                # Ring label is the source of truth; identity/binding stays the EVM wallet.
                 "address": addr,
-                "label": w.get("label") or f"remote-{i}",
+                "label": ring.get("label") or f"remote-{i}",
                 "type": "remote",
-                "chain_type": w.get("chain_type", "ethereum"),
-                "wallet_type": w.get("wallet_type", "session"),
-                "session_expires_at": w.get("session_expires_at"),
-                "session_expires_in": w.get("session_expires_in"),
+                "chain_type": evm["chain_type"],
+                "wallet_type": evm["wallet_type"],
+                # TTL fields live at the ring level, present only for session/strategy wallets.
+                "session_expires_at": ring.get("session_expires_at"),
+                "session_expires_in": ring.get("session_expires_in"),
+                "svm_address": svm["wallet_address"] if svm else None,
             }
             wallets.append(entry)
         return wallets

--- a/wayfinder_paths/mcp/utils.py
+++ b/wayfinder_paths/mcp/utils.py
@@ -207,19 +207,16 @@ def read_text_excerpt(path: Path, *, max_chars: int = 1200) -> str | None:
 
 
 def public_wallet_view(w: dict[str, Any]) -> dict[str, Any]:
-    view = {
-        # Ring label + the EVM (primary) address; both surfaced to the agent.
+    # Each ring leg (EVM / SVM) is its own entry — chain_type tells them apart,
+    # the shared label ties them to the same ring.
+    return {
         "label": w.get("label"),
         "address": w.get("address"),
+        "chain_type": w.get("chain_type"),
         "wallet_type": w.get("wallet_type"),
         "session_expires_at": w.get("session_expires_at"),
         "session_expires_in": w.get("session_expires_in"),
     }
-    # Surface the paired Solana address only once the ring has an SVM side.
-    svm_address = w.get("svm_address")
-    if svm_address:
-        view["svm_address"] = svm_address
-    return view
 
 
 def normalize_address(addr: str | None) -> str | None:

--- a/wayfinder_paths/mcp/utils.py
+++ b/wayfinder_paths/mcp/utils.py
@@ -207,13 +207,19 @@ def read_text_excerpt(path: Path, *, max_chars: int = 1200) -> str | None:
 
 
 def public_wallet_view(w: dict[str, Any]) -> dict[str, Any]:
-    return {
+    view = {
+        # Ring label + the EVM (primary) address; both surfaced to the agent.
         "label": w.get("label"),
         "address": w.get("address"),
         "wallet_type": w.get("wallet_type"),
         "session_expires_at": w.get("session_expires_at"),
         "session_expires_in": w.get("session_expires_in"),
     }
+    # Surface the paired Solana address only once the ring has an SVM side.
+    svm_address = w.get("svm_address")
+    if svm_address:
+        view["svm_address"] = svm_address
+    return view
 
 
 def normalize_address(addr: str | None) -> str | None:

--- a/wayfinder_paths/tests/test_svm_wallet_reads.py
+++ b/wayfinder_paths/tests/test_svm_wallet_reads.py
@@ -8,8 +8,10 @@ from wayfinder_paths.core.utils import wallets as wallets_mod
 from wayfinder_paths.mcp.utils import public_wallet_view
 
 
-def _ring_side(*, chain_type: str, address: str) -> dict[str, object]:
-    return {
+def _ring_side(
+    *, chain_type: str, address: str, expires_at: int | None = None
+) -> dict[str, object]:
+    side = {
         "wallet_address": address,
         "chain_type": chain_type,
         "label": "side",
@@ -18,10 +20,14 @@ def _ring_side(*, chain_type: str, address: str) -> dict[str, object]:
         "policy_id": "pol-1",
         "created": "2026-01-01T00:00:00Z",
     }
+    if expires_at is not None:
+        side["session_expires_at"] = expires_at
+        side["session_expires_in"] = expires_at - 1000
+    return side
 
 
 @pytest.mark.asyncio
-async def test_load_remote_wallets_reads_rings(monkeypatch):
+async def test_load_remote_wallets_one_entry_per_leg(monkeypatch):
     monkeypatch.setattr(wallets_mod, "get_api_key", lambda: "wk_test")
     monkeypatch.setattr(wallets_mod, "is_opencode_instance", lambda: True)
     monkeypatch.setattr(wallets_mod, "get_opencode_instance_id", lambda: "app-123")
@@ -31,20 +37,20 @@ async def test_load_remote_wallets_reads_rings(monkeypatch):
         AsyncMock(
             return_value=[
                 {
-                    "label": "Session 1",
+                    "label": "solar-wind",
                     "evm": _ring_side(
                         chain_type="ethereum",
                         address="0x000000000000000000000000000000000000dEaD",
+                        expires_at=1784224019,
                     ),
                     "svm": _ring_side(
                         chain_type="solana",
                         address="So11111111111111111111111111111111111111112",
+                        expires_at=1784224999,
                     ),
-                    "session_expires_at": 1784224019,
-                    "session_expires_in": 3421,
                 },
                 {
-                    "label": "Session 2",
+                    "label": "lone-oak",
                     "evm": _ring_side(
                         chain_type="ethereum",
                         address="0x000000000000000000000000000000000000bEEF",
@@ -57,36 +63,38 @@ async def test_load_remote_wallets_reads_rings(monkeypatch):
 
     result = await wallets_mod.load_remote_wallets()
 
-    # Ring label is the source of truth; EVM address is the primary identity.
-    assert result[0]["label"] == "Session 1"
-    assert result[0]["address"] == "0x000000000000000000000000000000000000dEaD"
-    assert result[0]["svm_address"] == "So11111111111111111111111111111111111111112"
-    assert result[0]["session_expires_at"] == 1784224019
-    assert result[0]["session_expires_in"] == 3421
+    # Ring 1 -> two entries (EVM + SVM) sharing the ring label, told apart by
+    # chain_type, each with its own session expiry. Ring 2 -> one entry.
+    assert len(result) == 3
+    evm1, svm1, evm2 = result
 
-    assert result[1]["label"] == "Session 2"
-    assert result[1]["svm_address"] is None
-    assert result[1]["session_expires_at"] is None
+    assert evm1["label"] == svm1["label"] == "solar-wind"
+    assert evm1["address"] == "0x000000000000000000000000000000000000dEaD"
+    assert evm1["chain_type"] == "ethereum"
+    assert evm1["session_expires_at"] == 1784224019
+
+    assert svm1["address"] == "So11111111111111111111111111111111111111112"
+    assert svm1["chain_type"] == "solana"
+    assert svm1["session_expires_at"] == 1784224999
+
+    assert evm2["label"] == "lone-oak"
+    assert evm2["chain_type"] == "ethereum"
+    assert evm2["session_expires_at"] is None
 
 
-def test_public_wallet_view_surfaces_svm_when_present():
+def test_public_wallet_view_shape():
     view = public_wallet_view(
         {
-            "label": "Session 1",
-            "address": "0x000000000000000000000000000000000000dEaD",
-            "svm_address": "So11111111111111111111111111111111111111112",
+            "label": "solar-wind",
+            "address": "So11111111111111111111111111111111111111112",
+            "chain_type": "solana",
+            "wallet_type": "session",
+            "session_expires_at": 1784224999,
+            "session_expires_in": 3421,
         }
     )
-    assert view["label"] == "Session 1"
-    assert view["svm_address"] == "So11111111111111111111111111111111111111112"
-
-
-def test_public_wallet_view_omits_svm_when_absent():
-    view = public_wallet_view(
-        {
-            "label": "Session 2",
-            "address": "0x000000000000000000000000000000000000bEEF",
-            "svm_address": None,
-        }
-    )
+    assert view["label"] == "solar-wind"
+    assert view["address"] == "So11111111111111111111111111111111111111112"
+    assert view["chain_type"] == "solana"
+    assert view["session_expires_at"] == 1784224999
     assert "svm_address" not in view

--- a/wayfinder_paths/tests/test_svm_wallet_reads.py
+++ b/wayfinder_paths/tests/test_svm_wallet_reads.py
@@ -26,40 +26,52 @@ def _ring_side(
     return side
 
 
-@pytest.mark.asyncio
-async def test_load_remote_wallets_one_entry_per_leg(monkeypatch):
+def _rings() -> list[dict[str, object]]:
+    return [
+        {
+            "label": "solar-wind",
+            "evm": _ring_side(
+                chain_type="ethereum",
+                address="0x000000000000000000000000000000000000dEaD",
+                expires_at=1784224019,
+            ),
+            "svm": _ring_side(
+                chain_type="solana",
+                address="So11111111111111111111111111111111111111112",
+                expires_at=1784224999,
+            ),
+        },
+        {
+            "label": "lone-oak",
+            "evm": _ring_side(
+                chain_type="ethereum",
+                address="0x000000000000000000000000000000000000bEEF",
+            ),
+            "svm": None,
+        },
+    ]
+
+
+def _setup(monkeypatch, *, solana_enabled: bool) -> None:
     monkeypatch.setattr(wallets_mod, "get_api_key", lambda: "wk_test")
     monkeypatch.setattr(wallets_mod, "is_opencode_instance", lambda: True)
     monkeypatch.setattr(wallets_mod, "get_opencode_instance_id", lambda: "app-123")
+    switches = ["solana_enabled"] if solana_enabled else []
+    monkeypatch.setattr(
+        wallets_mod.WALLET_CLIENT,
+        "get_features",
+        AsyncMock(return_value={"enabledSwitches": switches, "enabledFlags": []}),
+    )
     monkeypatch.setattr(
         wallets_mod.WALLET_CLIENT,
         "list_wallet_rings",
-        AsyncMock(
-            return_value=[
-                {
-                    "label": "solar-wind",
-                    "evm": _ring_side(
-                        chain_type="ethereum",
-                        address="0x000000000000000000000000000000000000dEaD",
-                        expires_at=1784224019,
-                    ),
-                    "svm": _ring_side(
-                        chain_type="solana",
-                        address="So11111111111111111111111111111111111111112",
-                        expires_at=1784224999,
-                    ),
-                },
-                {
-                    "label": "lone-oak",
-                    "evm": _ring_side(
-                        chain_type="ethereum",
-                        address="0x000000000000000000000000000000000000bEEF",
-                    ),
-                    "svm": None,
-                },
-            ]
-        ),
+        AsyncMock(return_value=_rings()),
     )
+
+
+@pytest.mark.asyncio
+async def test_load_remote_wallets_one_entry_per_leg(monkeypatch):
+    _setup(monkeypatch, solana_enabled=True)
 
     result = await wallets_mod.load_remote_wallets()
 
@@ -80,6 +92,16 @@ async def test_load_remote_wallets_one_entry_per_leg(monkeypatch):
     assert evm2["label"] == "lone-oak"
     assert evm2["chain_type"] == "ethereum"
     assert evm2["session_expires_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_load_remote_wallets_omits_svm_when_solana_disabled(monkeypatch):
+    _setup(monkeypatch, solana_enabled=False)
+
+    result = await wallets_mod.load_remote_wallets()
+
+    # SVM legs are dropped — only the two EVM legs remain.
+    assert [w["chain_type"] for w in result] == ["ethereum", "ethereum"]
 
 
 def test_public_wallet_view_shape():

--- a/wayfinder_paths/tests/test_svm_wallet_reads.py
+++ b/wayfinder_paths/tests/test_svm_wallet_reads.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from wayfinder_paths.core.utils import wallets as wallets_mod
+from wayfinder_paths.mcp.utils import public_wallet_view
+
+
+def _ring_side(*, chain_type: str, address: str) -> dict[str, object]:
+    return {
+        "wallet_address": address,
+        "chain_type": chain_type,
+        "label": "side",
+        "is_active": True,
+        "wallet_type": "session",
+        "policy_id": "pol-1",
+        "created": "2026-01-01T00:00:00Z",
+    }
+
+
+@pytest.mark.asyncio
+async def test_load_remote_wallets_reads_rings(monkeypatch):
+    monkeypatch.setattr(wallets_mod, "get_api_key", lambda: "wk_test")
+    monkeypatch.setattr(wallets_mod, "is_opencode_instance", lambda: True)
+    monkeypatch.setattr(wallets_mod, "get_opencode_instance_id", lambda: "app-123")
+    monkeypatch.setattr(
+        wallets_mod.WALLET_CLIENT,
+        "list_wallet_rings",
+        AsyncMock(
+            return_value=[
+                {
+                    "label": "Session 1",
+                    "evm": _ring_side(
+                        chain_type="ethereum",
+                        address="0x000000000000000000000000000000000000dEaD",
+                    ),
+                    "svm": _ring_side(
+                        chain_type="solana",
+                        address="So11111111111111111111111111111111111111112",
+                    ),
+                    "session_expires_at": 1784224019,
+                    "session_expires_in": 3421,
+                },
+                {
+                    "label": "Session 2",
+                    "evm": _ring_side(
+                        chain_type="ethereum",
+                        address="0x000000000000000000000000000000000000bEEF",
+                    ),
+                    "svm": None,
+                },
+            ]
+        ),
+    )
+
+    result = await wallets_mod.load_remote_wallets()
+
+    # Ring label is the source of truth; EVM address is the primary identity.
+    assert result[0]["label"] == "Session 1"
+    assert result[0]["address"] == "0x000000000000000000000000000000000000dEaD"
+    assert result[0]["svm_address"] == "So11111111111111111111111111111111111111112"
+    assert result[0]["session_expires_at"] == 1784224019
+    assert result[0]["session_expires_in"] == 3421
+
+    assert result[1]["label"] == "Session 2"
+    assert result[1]["svm_address"] is None
+    assert result[1]["session_expires_at"] is None
+
+
+def test_public_wallet_view_surfaces_svm_when_present():
+    view = public_wallet_view(
+        {
+            "label": "Session 1",
+            "address": "0x000000000000000000000000000000000000dEaD",
+            "svm_address": "So11111111111111111111111111111111111111112",
+        }
+    )
+    assert view["label"] == "Session 1"
+    assert view["svm_address"] == "So11111111111111111111111111111111111111112"
+
+
+def test_public_wallet_view_omits_svm_when_absent():
+    view = public_wallet_view(
+        {
+            "label": "Session 2",
+            "address": "0x000000000000000000000000000000000000bEEF",
+            "svm_address": None,
+        }
+    )
+    assert "svm_address" not in view


### PR DESCRIPTION
### Summary

Wallet reads now consume the paired-wallet ("ring") listing instead of the flat wallet list. Each ring exposes a shared label plus an EVM side and an optional Solana side; the SDK loads the ring label as the wallet's label (source of truth), keeps the EVM address as the primary identity used for instance binding and signing, and carries the paired Solana address when the ring has one. Session/strategy expiry fields are read from the ring level. The public wallet view surfaces the ring label and both addresses to the agent, gating the Solana address on presence so EVM-only rings are unchanged. Adds a client method for the rings listing and updates coverage to the ring shape.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>