### PR TITLE
Hyperliquid - Index spot tokens by id

### DIFF
--- a/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
+++ b/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
@@ -59,6 +59,13 @@ MAINNET = "Mainnet"
 # Collateral: outcomes settle in USDC.
 
 
+def _spot_token_by_index(tokens: list[dict[str, Any]]) -> dict[int, dict[str, Any]]:
+    # Spot universe pairs reference tokens by their `index` field, which stops
+    # matching array position once tokens are delisted and gaps appear. Indexing
+    # positionally silently drops every high-index token, so map by `index`.
+    return {t["index"]: t for t in tokens if "index" in t}
+
+
 def outcome_encoding(outcome_id: int, side: int) -> int:
     return 10 * outcome_id + side
 
@@ -417,6 +424,7 @@ class HyperliquidAdapter(BaseAdapter):
             response = {}
             tokens = spot_meta.get("tokens", [])
             universe = spot_meta.get("universe", [])
+            token_by_index = _spot_token_by_index(tokens)
 
             for pair in universe:
                 pair_tokens = pair.get("tokens", [])
@@ -425,8 +433,8 @@ class HyperliquidAdapter(BaseAdapter):
 
                 base_idx, quote_idx = pair_tokens[0], pair_tokens[1]
 
-                base_info = tokens[base_idx] if base_idx < len(tokens) else {}
-                quote_info = tokens[quote_idx] if quote_idx < len(tokens) else {}
+                base_info = token_by_index.get(base_idx, {})
+                quote_info = token_by_index.get(quote_idx, {})
 
                 base_name = base_info.get("name", f"TOKEN{base_idx}")
                 quote_name = quote_info.get("name", f"TOKEN{quote_idx}")

--- a/wayfinder_paths/adapters/hyperliquid_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/hyperliquid_adapter/test_adapter.py
@@ -3,7 +3,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from wayfinder_paths.adapters.hyperliquid_adapter.adapter import HyperliquidAdapter
+from wayfinder_paths.adapters.hyperliquid_adapter.adapter import (
+    HyperliquidAdapter,
+    _spot_token_by_index,
+)
 
 
 class TestHyperliquidAdapter:
@@ -119,6 +122,44 @@ class TestHyperliquidAdapter:
         with _patch_adapter():
             success, data = await adapter.get_spot_meta()
             assert success
+
+    def test_spot_token_by_index_maps_by_index_field(self):
+        # position 1 holds a token whose `index` is 844 — the real HL shape once
+        # earlier tokens delist. A positional list lookup can't reach index 844.
+        tokens = [
+            {"index": 0, "name": "USDC"},
+            {"index": 844, "name": "UANSEM"},
+        ]
+        by_index = _spot_token_by_index(tokens)
+        assert by_index[844]["name"] == "UANSEM"
+        assert by_index[0]["name"] == "USDC"
+        assert 844 >= len(tokens)  # positional access would be out of range
+
+    @pytest.mark.asyncio
+    async def test_get_spot_assets_resolves_high_index_tokens(
+        self, adapter, mock_info, _patch_adapter
+    ):
+        # tokens list is 3 long, but UANSEM sits at index 844. Positional
+        # `tokens[844]` fell back to the placeholder "TOKEN844"; the index map
+        # resolves it to the real name so the agent can trade the pair.
+        mock_info.spot_meta = {
+            "tokens": [
+                {"index": 0, "name": "USDC"},
+                {"index": 19, "name": "ANSEM"},
+                {"index": 844, "name": "UANSEM"},
+            ],
+            "universe": [
+                {"tokens": [19, 0], "name": "@18", "index": 18},
+                {"tokens": [844, 0], "name": "@699", "index": 699},
+            ],
+        }
+        with _patch_adapter():
+            success, assets = await adapter.get_spot_assets()
+
+        assert success
+        assert assets["UANSEM/USDC"] == 10699
+        assert assets["ANSEM/USDC"] == 10018
+        assert not any(name.startswith("TOKEN") for name in assets)
 
     @pytest.mark.asyncio
     async def test_get_l2_book(self, adapter, mock_info, _patch_adapter):


### PR DESCRIPTION
### Summary
Spot universe pairs reference tokens by their `index` field, which stops matching array position once tokens are delisted and gaps appear. `get_spot_assets` indexed positionally, so high-index tokens resolved to a placeholder name (e.g. `TOKEN844/USDC`) — a liquid pair could be shadowed by a stale same-name pair, and the resolvable name pointed at a dead market. Map tokens by their `index` field instead of array position.

**Strictly a superset — nothing lost, only recovered.** Diffing the old (positional) vs new (index-field) resolution over all 312 spot pairs: real-named pairs go **301 → 312**, with **0 removed, 0 repointed to a different asset, and no name collisions**. The 11 that change were all `TOKEN<idx>` placeholders (unreachable) → now their real name:

| 24h vol | Was (unreachable) | Now resolves to |
| --: | --- | --- |
| $1,112,933 | `TOKEN844/USDC` | **UANSEM/USDC** |
| $162,327 | `TOKEN843/USDC` | **DRV/USDC** |
| $48,810 | `TOKEN610/USDC` | **SPCXD/USDC** |
| $4,446 | `TOKEN641/USDC` | **MGW/USDC** |
| $1,572 | `TOKEN480/USDC` | **SPCX/USDC** |
| $421 | `TOKEN734/USDC` | **MAX/USDC** |
| $36 | `TOKEN479/USDC` | **WARS/USDC** |
| $0 | `TOKEN845/USDC` | **NVDAX/USDC** |
| $0 | `TOKEN842/USDC` | **HNIL/USDC** |
| $0 | `TOKEN513/USDC` | **ONEAR/USDC** |
| $0 | `TOKEN481/USDC` | **WBRL/USDC** |

<sub>Live snapshot; volumes drift and the affected set grows as more tokens delist. Volume/dead-market filtering stays on the FE — the agent gains all 11 as resolvable. Unit tests cover the index resolution.</sub>