### PR TITLE
Wallets - Fetch Solana balances in core_get_wallets

### DIFF
--- a/wayfinder_paths/core/clients/BalanceClient.py
+++ b/wayfinder_paths/core/clients/BalanceClient.py
@@ -8,14 +8,16 @@ class BalanceClient(WayfinderClient):
     async def get_enriched_wallet_balances(
         self,
         *,
-        wallet_address: str,
+        wallet_address: str | None = None,
+        svm_address: str | None = None,
         exclude_spam_tokens: bool = True,
     ) -> dict:
         url = f"{get_api_base_url()}/blockchain/balances/enriched/"
-        params = {
-            "address": wallet_address,
-            "exclude_spam_tokens": str(exclude_spam_tokens).lower(),
-        }
+        params = {"exclude_spam_tokens": str(exclude_spam_tokens).lower()}
+        if wallet_address:
+            params["address"] = wallet_address
+        if svm_address:
+            params["svm_address"] = svm_address
         response = await self._authed_request("GET", url, params=params)
         return response.json()
 

--- a/wayfinder_paths/mcp/tools/wallets.py
+++ b/wayfinder_paths/mcp/tools/wallets.py
@@ -417,42 +417,17 @@ async def core_wallets(
             return err("invalid_request", f"Unknown action: {action}")
 
 
-def _balance_usd(entry: dict[str, Any]) -> float:
-    val = entry.get("balanceUSD", 0)
+async def _fetch_balances(address: str, chain_type: str) -> dict[str, Any] | None:
+    # Solana wallets are base58 and must go to the svm_address param — the
+    # default address param is the EVM path and returns nothing for them.
     try:
-        return float(val or 0)
-    except (TypeError, ValueError):
-        return 0.0
-
-
-def _strip_solana(data: Any) -> Any:
-    """Drop Solana entries from an enriched-balances response (EVM-only view)."""
-    if not isinstance(data, dict) or not isinstance(data.get("balances"), list):
-        return data
-    balances_list = [b for b in data["balances"] if isinstance(b, dict)]
-    filtered = [
-        b for b in balances_list if str(b.get("network", "")).lower() != "solana"
-    ]
-    if len(filtered) == len(balances_list):
-        return data
-    out = dict(data)
-    out["balances"] = filtered
-    out["total_balance_usd"] = sum(_balance_usd(b) for b in filtered)
-    breakdown: dict[str, float] = {}
-    for b in filtered:
-        net = str(b.get("network") or "").strip()
-        if net:
-            breakdown[net] = breakdown.get(net, 0.0) + _balance_usd(b)
-    out["chain_breakdown"] = breakdown
-    return out
-
-
-async def _fetch_balances(address: str) -> dict[str, Any] | None:
-    try:
-        data = await BALANCE_CLIENT.get_enriched_wallet_balances(
+        if chain_type == "solana":
+            return await BALANCE_CLIENT.get_enriched_wallet_balances(
+                svm_address=address, exclude_spam_tokens=True
+            )
+        return await BALANCE_CLIENT.get_enriched_wallet_balances(
             wallet_address=address, exclude_spam_tokens=True
         )
-        return _strip_solana(data)
     except Exception as exc:  # noqa: BLE001
         return {"error": str(exc)}
 
@@ -482,7 +457,7 @@ async def core_get_wallets(
         existing = await load_wallets()
 
     views: list[dict[str, Any]] = []
-    addresses: list[str | None] = []
+    addr_chains: list[tuple[str | None, str]] = []
     for w in existing:
         view = public_wallet_view(w)
         addr = normalize_address(w.get("address"))
@@ -494,10 +469,13 @@ async def core_get_wallets(
         else:
             view["protocols"] = []
         views.append(view)
-        addresses.append(addr)
+        addr_chains.append((addr, w.get("chain_type") or "ethereum"))
 
     balances = await asyncio.gather(
-        *(_fetch_balances(a) if a else asyncio.sleep(0, result=None) for a in addresses)
+        *(
+            _fetch_balances(a, ct) if a else asyncio.sleep(0, result=None)
+            for a, ct in addr_chains
+        )
     )
     for view, bal in zip(views, balances, strict=True):
         view["balances"] = bal

--- a/wayfinder_paths/tests/test_mcp_balances.py
+++ b/wayfinder_paths/tests/test_mcp_balances.py
@@ -45,7 +45,9 @@ async def test_get_wallets_solana_uses_svm_address_param():
     }
     fake_client = AsyncMock()
     fake_client.get_enriched_wallet_balances = AsyncMock(
-        return_value={"balances": [{"chain": "solana", "symbol": "SOL", "value_usd": 8.0}]}
+        return_value={
+            "balances": [{"chain": "solana", "symbol": "SOL", "value_usd": 8.0}]
+        }
     )
 
     with (

--- a/wayfinder_paths/tests/test_mcp_balances.py
+++ b/wayfinder_paths/tests/test_mcp_balances.py
@@ -9,22 +9,17 @@ from wayfinder_paths.mcp.tools.wallets import core_get_wallets
 
 @pytest.fixture
 def mock_wallet():
-    return {"label": "test", "address": "0x000000000000000000000000000000000000dEaD"}
+    return {
+        "label": "test",
+        "address": "0x000000000000000000000000000000000000dEaD",
+        "chain_type": "ethereum",
+    }
 
 
 @pytest.mark.asyncio
-async def test_get_wallets_filters_solana(mock_wallet):
+async def test_get_wallets_evm_uses_address_param(mock_wallet):
     fake_client = AsyncMock()
-    fake_client.get_enriched_wallet_balances = AsyncMock(
-        return_value={
-            "balances": [
-                {"network": "base", "balanceUSD": 1.5},
-                {"network": "solana", "balanceUSD": 999.0},
-                {"network": "arbitrum", "balanceUSD": 2.0},
-            ],
-            "total_balance_usd": 1002.5,
-        }
-    )
+    fake_client.get_enriched_wallet_balances = AsyncMock(return_value={"balances": []})
 
     with (
         patch("wayfinder_paths.mcp.tools.wallets.BALANCE_CLIENT", fake_client),
@@ -36,13 +31,38 @@ async def test_get_wallets_filters_solana(mock_wallet):
         out = await core_get_wallets(label="test")
 
     assert out["ok"] is True
-    data = out["result"]
-    assert len(data["wallets"]) == 1
-    balances_data = data["wallets"][0]["balances"]
-    assert balances_data["total_balance_usd"] == pytest.approx(3.5)
-    assert balances_data["chain_breakdown"]["base"] == pytest.approx(1.5)
-    assert balances_data["chain_breakdown"]["arbitrum"] == pytest.approx(2.0)
-    assert all(b["network"].lower() != "solana" for b in balances_data["balances"])
+    kwargs = fake_client.get_enriched_wallet_balances.await_args.kwargs
+    assert kwargs["wallet_address"] == mock_wallet["address"]
+    assert "svm_address" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_get_wallets_solana_uses_svm_address_param():
+    svm_wallet = {
+        "label": "test",
+        "address": "BTXGZD6APaEPLUnELUT3Q1HWUYaWatu42WXT3YCU1vxY",
+        "chain_type": "solana",
+    }
+    fake_client = AsyncMock()
+    fake_client.get_enriched_wallet_balances = AsyncMock(
+        return_value={"balances": [{"chain": "solana", "symbol": "SOL", "value_usd": 8.0}]}
+    )
+
+    with (
+        patch("wayfinder_paths.mcp.tools.wallets.BALANCE_CLIENT", fake_client),
+        patch(
+            "wayfinder_paths.mcp.tools.wallets.find_wallet_by_label",
+            new=AsyncMock(return_value=svm_wallet),
+        ),
+    ):
+        out = await core_get_wallets(label="test")
+
+    assert out["ok"] is True
+    kwargs = fake_client.get_enriched_wallet_balances.await_args.kwargs
+    assert kwargs["svm_address"] == svm_wallet["address"]
+    assert "wallet_address" not in kwargs
+    balances = out["result"]["wallets"][0]["balances"]["balances"]
+    assert balances[0]["symbol"] == "SOL"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

Solana wallet entries returned empty balances from `core_get_wallets`: their base58 address was passed to the enriched-balances endpoint's EVM address param (which returns nothing for non-EVM addresses). Route by `chain_type` — Solana wallets use the `svm_address` param, EVM wallets keep `address` — so agent wallet reads include native SOL + SPL tokens. Drops the now-unnecessary Solana-stripping helper (each wallet fetches only its own chain).

Depends on the backend enriched endpoint accepting `svm_address`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>