### PR TITLE
Contract execution - guard raw transfers to contracts

### DIFF
--- a/wayfinder_paths/core/utils/web3.py
+++ b/wayfinder_paths/core/utils/web3.py
@@ -169,3 +169,9 @@ async def web3_from_chain_id(chain_id: int):
         yield web3s[0]
     finally:
         await web3s[0].provider.disconnect()
+
+
+async def is_contract(chain_id: int, address: str) -> bool:
+    async with web3_from_chain_id(int(chain_id)) as w3:
+        code = await w3.eth.get_code(AsyncWeb3.to_checksum_address(address))
+    return len(code) > 0

--- a/wayfinder_paths/mcp/tools/evm_contract.py
+++ b/wayfinder_paths/mcp/tools/evm_contract.py
@@ -504,6 +504,7 @@ async def contracts_execute(
     abi: list[dict[str, Any]] | str | None = None,
     abi_path: str | None = None,
     wait_for_receipt: bool = True,
+    override: bool = False,
 ) -> dict[str, Any]:
     """Execute a contract function by encoding calldata and broadcasting a tx.
 
@@ -557,6 +558,23 @@ async def contracts_execute(
         )
     except Exception as exc:
         return err("invalid_args", str(exc))
+
+    if (
+        not override
+        and str(fn_abi.get("name") or "").strip() == "transfer"
+        and casted_args
+        and await web3_utils.is_contract(int(chain_id), casted_args[0])
+    ):
+        return err(
+            "raw_transfer_to_contract",
+            "Raw transfers to contracts are discouraged. There may be a loss of funds "
+            "if you accidentally execute the transaction, but you must verify with the "
+            "user that this is actually their intention. In particular, never send "
+            "tokens directly to a Uniswap V2 (or fork) pool: the pool absorbs them on "
+            "the next reserve sync without paying out. Use a router or an atomic swap "
+            "contract instead. Otherwise, you need to review the contract source code "
+            "or public documentation that sending funds to this contract is expected.",
+        )
 
     try:
         tx = await encode_call(

--- a/wayfinder_paths/tests/test_mcp_evm_contract.py
+++ b/wayfinder_paths/tests/test_mcp_evm_contract.py
@@ -510,3 +510,138 @@ async def test_contracts_get_falls_back_to_proxy_abi_when_impl_fetch_fails():
     result = out["result"]
     assert result["source"] == "etherscan_v2"
     assert result["abi"] == proxy_abi
+
+
+_TRANSFER_ABI = [
+    {
+        "type": "function",
+        "name": "transfer",
+        "stateMutability": "nonpayable",
+        "inputs": [
+            {"name": "to", "type": "address"},
+            {"name": "amount", "type": "uint256"},
+        ],
+        "outputs": [{"name": "", "type": "bool"}],
+    }
+]
+_WALLET = {"address": "0x" + "aa" * 20, "private_key_hex": "0x" + "11" * 32}
+
+
+@pytest.mark.asyncio
+async def test_contract_execute_refuses_transfer_to_contract():
+    token = "0x" + "12" * 20
+    pool = "0x" + "cc" * 20
+    fake_encode = AsyncMock()
+    fake_send = AsyncMock()
+
+    with (
+        patch(
+            "wayfinder_paths.core.utils.wallets.find_wallet_by_label",
+            return_value=_WALLET,
+        ),
+        patch(
+            "wayfinder_paths.core.utils.web3.is_contract",
+            AsyncMock(return_value=True),
+        ),
+        patch("wayfinder_paths.mcp.tools.evm_contract.encode_call", fake_encode),
+        patch("wayfinder_paths.mcp.tools.evm_contract.send_transaction", fake_send),
+    ):
+        out = await contracts_execute(
+            wallet_label="main",
+            chain_id=1,
+            contract_address=token,
+            function_name="transfer",
+            args=f'["{pool}", "1000"]',
+            abi=_TRANSFER_ABI,
+        )
+
+    assert out["ok"] is False, out
+    assert out["error"]["code"] == "raw_transfer_to_contract"
+    fake_encode.assert_not_awaited()
+    fake_send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_contract_execute_allows_transfer_to_eoa():
+    token = "0x" + "12" * 20
+    recipient = "0x" + "bb" * 20
+    fake_send = AsyncMock(return_value="0x" + "99" * 32)
+
+    with (
+        patch(
+            "wayfinder_paths.core.utils.wallets.find_wallet_by_label",
+            return_value=_WALLET,
+        ),
+        patch(
+            "wayfinder_paths.core.utils.web3.is_contract",
+            AsyncMock(return_value=False),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.evm_contract.WalletProfileStore.default",
+            return_value=Mock(annotate_safe=Mock()),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.evm_contract.encode_call",
+            AsyncMock(return_value={"to": token, "data": "0xdeadbeef"}),
+        ),
+        patch("wayfinder_paths.mcp.tools.evm_contract.send_transaction", fake_send),
+        patch(
+            "wayfinder_paths.mcp.tools.evm_contract.get_etherscan_transaction_link",
+            return_value="https://example.invalid/tx",
+        ),
+    ):
+        out = await contracts_execute(
+            wallet_label="main",
+            chain_id=1,
+            contract_address=token,
+            function_name="transfer",
+            args=f'["{recipient}", "1000"]',
+            abi=_TRANSFER_ABI,
+            wait_for_receipt=False,
+        )
+
+    assert out["ok"] is True, out
+    fake_send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_contract_execute_transfer_to_contract_override_bypasses():
+    token = "0x" + "12" * 20
+    pool = "0x" + "cc" * 20
+    fake_is_contract = AsyncMock(return_value=True)
+    fake_send = AsyncMock(return_value="0x" + "99" * 32)
+
+    with (
+        patch(
+            "wayfinder_paths.core.utils.wallets.find_wallet_by_label",
+            return_value=_WALLET,
+        ),
+        patch("wayfinder_paths.core.utils.web3.is_contract", fake_is_contract),
+        patch(
+            "wayfinder_paths.mcp.tools.evm_contract.WalletProfileStore.default",
+            return_value=Mock(annotate_safe=Mock()),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.evm_contract.encode_call",
+            AsyncMock(return_value={"to": token, "data": "0xdeadbeef"}),
+        ),
+        patch("wayfinder_paths.mcp.tools.evm_contract.send_transaction", fake_send),
+        patch(
+            "wayfinder_paths.mcp.tools.evm_contract.get_etherscan_transaction_link",
+            return_value="https://example.invalid/tx",
+        ),
+    ):
+        out = await contracts_execute(
+            wallet_label="main",
+            chain_id=1,
+            contract_address=token,
+            function_name="transfer",
+            args=f'["{pool}", "1000"]',
+            abi=_TRANSFER_ABI,
+            wait_for_receipt=False,
+            override=True,
+        )
+
+    assert out["ok"] is True, out
+    fake_send.assert_awaited_once()
+    fake_is_contract.assert_not_awaited()


### PR DESCRIPTION
### Summary

`contracts_execute` refuses an ERC20 `transfer` whose recipient is a contract unless `override=True` is passed. On refusal it returns a `raw_transfer_to_contract` error telling the caller to confirm intent with the user, warning specifically against sending tokens directly into a Uniswap V2 (or fork) pool, and directing them to verify via the contract source or public docs that sending funds there is expected. Transfers to EOAs, non-transfer calls, and any call with `override=True` are unaffected. The reusable `is_contract(chain_id, address)` check lives in `core/utils/web3.py` alongside `web3_from_chain_id`.