### PR TITLE
jobs: forward-view — paper/live chart payload with mode-tagged markers + PnL split

### DIFF
--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -37,6 +37,7 @@ from wayfinder_paths.jobs.execution.reconcile import reconcile_job
 from wayfinder_paths.jobs.execution.validation import validate_execution_job
 from wayfinder_paths.jobs.execution.walk_forward import format_fold_table
 from wayfinder_paths.jobs.features import append_feature, list_features
+from wayfinder_paths.jobs.forward_artifacts import load_forward_view
 from wayfinder_paths.jobs.gating import evaluate_live_gate
 from wayfinder_paths.jobs.halt import clear_halt, request_halt
 from wayfinder_paths.jobs.ledger import append_ledger_row, tail_ledger
@@ -843,6 +844,51 @@ def backtest_view_cmd(
         to_ts=to_ts,
         max_points=max_points,
         proposal_id=proposal_id,
+    )
+    _echo_json({"ok": True, "result": result})
+
+
+@job_cli.command(
+    name="forward-view",
+    help="Bounded forward (paper/live) visualization payload: price series, "
+    "PnL curve, and entry/exit markers tagged with the mode they executed in.",
+)
+@click.argument("job_id")
+@click.option(
+    "--view",
+    type=click.Choice(["all", "legs", "spread", "equity", "drawdown", "performance"]),
+    default="all",
+    show_default=True,
+)
+@click.option("--series", "series_names", multiple=True)
+@click.option("--from", "from_ts", default=None)
+@click.option("--to", "to_ts", default=None)
+@click.option("--max-points", type=int, default=1500, show_default=True)
+@click.option(
+    "--no-prices",
+    is_flag=True,
+    default=False,
+    help="Skip the on-demand candle fetch (markers + PnL curve only).",
+)
+def forward_view_cmd(
+    job_id: str,
+    view: str,
+    series_names: tuple[str, ...],
+    from_ts: str | None,
+    to_ts: str | None,
+    max_points: int,
+    no_prices: bool,
+) -> None:
+    store = JobStore()
+    result = load_forward_view(
+        job_id,
+        store=store,
+        view=view,
+        series_names=list(series_names),
+        from_ts=from_ts,
+        to_ts=to_ts,
+        max_points=max_points,
+        include_prices=not no_prices,
     )
     _echo_json({"ok": True, "result": result})
 

--- a/wayfinder_paths/jobs/forward.py
+++ b/wayfinder_paths/jobs/forward.py
@@ -340,12 +340,26 @@ def load_forward_snapshot(
     store: Any | None = None,
     limit: int = 25,
 ) -> dict[str, Any]:
+    # Local import: forward_artifacts imports this module for summary defaults.
+    from wayfinder_paths.jobs.forward_artifacts import (
+        forward_open_position,
+        forward_pnl_breakdown,
+    )
+
     root = job_dir or (store.job_dir(job_id) if store is not None else None)
     if root is None:
         root = Path.cwd() / ".wayfinder" / "jobs" / safe_job_id(job_id)
     forward_dir = root / "results" / "forward"
     summary_path = forward_dir / Path(DEFAULT_FORWARD_SUMMARY).name
     summary = _read_json(summary_path, default_forward_summary(job_id))
+    # Enrich the snapshot copy (never the recorder-owned summary.json) with the
+    # paper-vs-live split and any open position — the jobs UI reads these from
+    # the synced snapshot for its PnL headline.
+    summary = {
+        **summary,
+        **forward_pnl_breakdown(forward_dir),
+        "open_position": forward_open_position(forward_dir),
+    }
     return {
         "summary": summary,
         # System-owned forward-performance line (from live transactions) that the

--- a/wayfinder_paths/jobs/forward_artifacts.py
+++ b/wayfinder_paths/jobs/forward_artifacts.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import math
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from wayfinder_paths.jobs.backtest_artifacts import VIEW_KINDS, _in_range, _parse_ts
+from wayfinder_paths.jobs.forward import default_forward_summary
+from wayfinder_paths.jobs.models import (
+    DEFAULT_FORWARD_FILLS,
+    DEFAULT_FORWARD_SUMMARY,
+    DEFAULT_FORWARD_TICKS,
+    DEFAULT_FORWARD_TRADES,
+)
+from wayfinder_paths.jobs.store import JobStore
+
+# Chart context beyond the first forward tick, and a hard fetch cap — the
+# forward window grows unboundedly, the chart payload must not.
+_WARMUP_BARS = 24
+_MAX_PRICE_BARS = 2000
+
+
+def forward_pnl_breakdown(forward_dir: Path) -> dict[str, Any]:
+    """Paper-vs-live split of closed forward trades, from trades.jsonl.
+
+    Every forward record carries the mode it executed under (ForwardRecorder
+    bakes it in), so the split is a group-by — no separate ledgers exist.
+    Returns {"pnl_by_mode": {...}, "trades_by_mode": {...}} with both modes
+    always present so consumers can tell "no live trades" (count 0) from
+    "live is flat" (pnl 0.0).
+    """
+    pnl = {"paper": 0.0, "live": 0.0}
+    counts = {"paper": 0, "live": 0}
+    for row in _read_jsonl(forward_dir / Path(DEFAULT_FORWARD_TRADES).name):
+        mode = str(row.get("mode") or "paper")
+        if mode not in pnl:
+            continue
+        raw_pnl = row.get("net_pnl")
+        if raw_pnl is None:
+            continue
+        pnl[mode] += float(raw_pnl)
+        counts[mode] += 1
+    return {"pnl_by_mode": pnl, "trades_by_mode": counts}
+
+
+def forward_open_position(
+    forward_dir: Path, *, last_closes: dict[str, float] | None = None
+) -> dict[str, Any] | None:
+    """The currently-open position (if any) from the latest tick's ledger,
+    with unrealized PnL marked at the last known close when available."""
+    ticks = _tail_jsonl(forward_dir / Path(DEFAULT_FORWARD_TICKS).name, 1)
+    if not ticks:
+        return None
+    tick = ticks[-1]
+    positions = (tick.get("ledger") or {}).get("positions") or {}
+    for symbol, position in positions.items():
+        side = str(position.get("side") or "")
+        size = float(position.get("size") or 0.0)
+        avg_price = float(position.get("avg_price") or 0.0)
+        if not size:
+            continue
+        result: dict[str, Any] = {
+            "symbol": str(symbol),
+            "side": side,
+            "size": size,
+            "avg_price": avg_price,
+            "opened_at": position.get("opened_at"),
+            "mode": tick.get("mode"),
+        }
+        last_close = (last_closes or {}).get(str(symbol))
+        if last_close is not None and avg_price:
+            direction = -1.0 if side == "short" else 1.0
+            result["unrealized_pnl"] = direction * (last_close - avg_price) * size
+            result["marked_at_price"] = last_close
+        return result  # engine holds at most one position per strategy today
+    return None
+
+
+def load_forward_view(
+    job_id: str,
+    *,
+    store: JobStore | None = None,
+    view: str = "all",
+    series_names: list[str] | None = None,
+    from_ts: str | None = None,
+    to_ts: str | None = None,
+    max_points: int = 1500,
+    include_prices: bool = True,
+) -> dict[str, Any]:
+    """Bounded forward (paper/live) visualization payload for the jobs UI.
+
+    Mirrors `load_backtest_view`'s response shape so the whole chart pipeline
+    (backend proxy + FE renderer) is reused, but is built on demand from the
+    forward artifacts instead of a pre-written visualization.json:
+    - markers from fills.jsonl, each tagged with the MODE it executed under
+    - a PnL curve from the tick ledger's realized_pnl progression
+    - market_price OHLC series fetched through the same venue feed the driver
+      uses (forward ticks don't persist bars); on fetch failure the payload
+      degrades to markers + PnL with a `price_note` instead of failing.
+    """
+    store = store or JobStore()
+    forward_dir = store.job_dir(job_id) / "results" / "forward"
+    fills = _read_jsonl(forward_dir / Path(DEFAULT_FORWARD_FILLS).name)
+    ticks = _read_jsonl(forward_dir / Path(DEFAULT_FORWARD_TICKS).name)
+    if not fills and not ticks:
+        return {"available": False}
+
+    markers = _fill_markers(fills)
+    series: list[dict[str, Any]] = [_pnl_series(job_id, ticks, store=store)]
+
+    price_note: str | None = None
+    last_closes: dict[str, float] = {}
+    if include_prices:
+        try:
+            price_series = _fetch_price_series(job_id, ticks, store=store)
+            series.extend(price_series)
+            for entry in price_series:
+                if entry["points"]:
+                    last_closes[str(entry["symbol"])] = float(
+                        entry["points"][-1]["close"]
+                    )
+        except Exception as exc:  # degrade: chart still shows PnL + markers
+            price_note = f"price series unavailable: {exc}"
+
+    summary_path = forward_dir / Path(DEFAULT_FORWARD_SUMMARY).name
+    summary = _read_json(summary_path) or default_forward_summary(job_id)
+    summary = {
+        **summary,
+        **forward_pnl_breakdown(forward_dir),
+        "open_position": forward_open_position(forward_dir, last_closes=last_closes),
+    }
+    if price_note:
+        summary["price_note"] = price_note
+
+    requested = {item.strip() for item in series_names or [] if item.strip()}
+    bounded_max = min(max(max_points, 100), 10_000)
+    start = _parse_ts(from_ts)
+    end = _parse_ts(to_ts)
+    kinds = VIEW_KINDS.get(view)
+    selected_series = []
+    for entry in series:
+        if requested and entry["name"] not in requested:
+            continue
+        if kinds is not None and entry["kind"] not in kinds:
+            continue
+        points = [
+            point
+            for point in entry["points"]
+            if _in_range(_parse_ts(point["timestamp"]), start, end)
+        ]
+        if len(points) > bounded_max:
+            # Even-stride downsample keeping first/last (same as backtest view).
+            last_index = len(points) - 1
+            points = [
+                points[math.floor(index * last_index / (bounded_max - 1))]
+                for index in range(bounded_max)
+            ]
+        selected_series.append({**entry, "points": points})
+    symbols = {
+        str(entry["symbol"])
+        for entry in selected_series
+        if entry.get("symbol") is not None
+    }
+    selected_markers = [
+        marker
+        for marker in markers
+        if _in_range(_parse_ts(marker["timestamp"]), start, end)
+        and (view != "legs" or not symbols or str(marker["symbol"]) in symbols)
+    ]
+    return {
+        "available": True,
+        "view": view,
+        "summary": summary,
+        "visualization": {
+            "schema_version": "1.0",
+            "source": "forward",
+            "symbols": sorted(
+                {
+                    str(entry["symbol"])
+                    for entry in series
+                    if entry.get("symbol") is not None
+                }
+            ),
+            "series": selected_series,
+            "markers": selected_markers,
+        },
+        "trades": _tail_jsonl(forward_dir / Path(DEFAULT_FORWARD_TRADES).name, 50),
+    }
+
+
+def _fill_markers(fills: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    markers = []
+    for fill in fills:
+        if str(fill.get("status") or "filled") != "filled":
+            continue
+        timestamp = fill.get("timestamp") or fill.get("ts")
+        if not timestamp:
+            continue
+        kind = "exit" if fill.get("reduce_only") else "entry"
+        mode = str(fill.get("mode") or "paper")
+        raw = fill.get("raw") or {}
+        meta = raw.get("intent_metadata") or {}
+        reason = meta.get("entry_reason") or meta.get("exit_reason")
+        markers.append(
+            {
+                "timestamp": str(timestamp),
+                "symbol": str(fill.get("symbol") or ""),
+                "side": fill.get("side"),
+                "price": fill.get("avg_price"),
+                "kind": kind,
+                "mode": mode,
+                "label": f"{mode} {kind}" + (f": {reason}" if reason else ""),
+            }
+        )
+    markers.sort(key=lambda marker: str(marker["timestamp"]))
+    return markers
+
+
+def _pnl_series(
+    job_id: str, ticks: list[dict[str, Any]], *, store: JobStore
+) -> dict[str, Any]:
+    """Equity curve from the tick ledger: initial_capital + realized_pnl.
+
+    Uses each tick's POST-tick ledger (the top-level `ledger` field), so a
+    close's PnL lands on the bar it happened, and carries the tick's mode so
+    the FE could shade paper vs live segments later.
+    """
+    job = store.load(job_id)
+    initial_capital = float(job.execution_params.get("initial_capital") or 10_000)
+    points = []
+    for tick in ticks:
+        timestamp = tick.get("bar_ts") or tick.get("ts")
+        ledger = tick.get("ledger") or {}
+        if not timestamp or "realized_pnl" not in ledger:
+            continue
+        realized = float(ledger.get("realized_pnl") or 0.0)
+        points.append(
+            {
+                "timestamp": str(timestamp),
+                "value": initial_capital + realized,
+                "equity": initial_capital + realized,
+                "realized_pnl": realized,
+                "mode": tick.get("mode"),
+            }
+        )
+    return {
+        "name": "forward_equity",
+        "kind": "equity_curve",
+        "symbol": None,
+        "points": points,
+    }
+
+
+def _fetch_price_series(
+    job_id: str, ticks: list[dict[str, Any]], *, store: JobStore
+) -> list[dict[str, Any]]:
+    """OHLC market_price series covering the forward window, fetched through
+    the same venue feed the live driver uses (imported lazily — the execution
+    stack pulls pandas et al., which a markers-only caller never needs)."""
+    import pandas as pd
+
+    from wayfinder_paths.jobs.execution.primitives import (
+        CompletedBarsView,
+        ExecutionSpec,
+        bar_interval_seconds,
+    )
+    from wayfinder_paths.jobs.execution.validation import resolve_execution_spec
+    from wayfinder_paths.jobs.execution.venues import build_adapter
+
+    job = store.load(job_id)
+    root = store.job_dir(job_id)
+    spec_data, _ = resolve_execution_spec(root, job.to_dict())
+    if not spec_data:
+        raise RuntimeError("execution_spec missing")
+    spec = ExecutionSpec.from_dict(spec_data)
+    params = dict(job.execution_params)
+    bar_interval = spec.data_contract.get("bar_interval")
+    interval_seconds = bar_interval_seconds(bar_interval)
+    if not interval_seconds:
+        raise RuntimeError("execution_spec.data_contract.bar_interval missing")
+    symbols = [
+        str(symbol)
+        for symbol in (params.get("symbols") or spec.data_contract.get("symbols") or [])
+    ]
+    if not symbols:
+        raise RuntimeError("no symbols configured")
+
+    now = pd.Timestamp.now(tz="UTC")
+    first_ts = _parse_ts(
+        str(ticks[0].get("bar_ts") or ticks[0].get("ts")) if ticks else None
+    )
+    if first_ts is not None:
+        window_bars = math.ceil(
+            (now - pd.Timestamp(first_ts)).total_seconds() / interval_seconds
+        )
+    else:
+        window_bars = _MAX_PRICE_BARS
+    lookback_bars = min(max(window_bars + _WARMUP_BARS, _WARMUP_BARS), _MAX_PRICE_BARS)
+
+    async def _fetch() -> CompletedBarsView:
+        rows: list[Mapping[str, Any]] = []
+        # mode="paper" builds the read-only market-data side; no signing/keys.
+        for venue in spec.venues or ["hyperliquid"]:
+            adapter = build_adapter(venue, mode="paper", spec=spec, params=params)
+            view = await adapter.feed.get_completed_bars(
+                symbols, str(bar_interval), lookback_bars=lookback_bars, as_of=now
+            )
+            rows.extend(view.to_rows())
+        if not rows:
+            raise RuntimeError("no completed bars returned by any venue feed")
+        return CompletedBarsView.from_rows(rows)
+
+    frame = asyncio.run(_fetch()).to_frame()
+    series = []
+    for symbol in symbols:
+        symbol_frame = frame[frame["symbol"] == symbol]
+        points = [
+            {
+                "timestamp": row.timestamp.isoformat(),
+                "value": float(row.close),
+                "open": float(row.open),
+                "high": float(row.high),
+                "low": float(row.low),
+                "close": float(row.close),
+                "volume": float(row.volume)
+                if "volume" in symbol_frame.columns and pd.notna(row.volume)
+                else None,
+            }
+            for row in symbol_frame.itertuples()
+        ]
+        series.append(
+            {
+                "name": f"{symbol}_price",
+                "kind": "market_price",
+                "symbol": symbol,
+                "points": points,
+            }
+        )
+    return series
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        if line.strip():
+            rows.append(json.loads(line))
+    return rows
+
+
+def _tail_jsonl(path: Path, limit: int) -> list[dict[str, Any]]:
+    if not path.exists() or limit <= 0:
+        return []
+    lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    return [json.loads(line) for line in lines[-limit:] if line.strip()]
+
+
+def _read_json(path: Path) -> Any:
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None

--- a/wayfinder_paths/tests/test_jobs_forward_view.py
+++ b/wayfinder_paths/tests/test_jobs_forward_view.py
@@ -1,0 +1,251 @@
+"""`load_forward_view` mirrors the backtest view for FORWARD (paper/live) data:
+entry/exit markers tagged with the mode they executed in, a PnL curve from the
+tick ledger, and a paper-vs-live PnL split — so the jobs UI can show what a
+paper strategy actually did (the week imx-short traded invisibly is the bug
+this exists to fix).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from wayfinder_paths.jobs.forward import load_forward_snapshot
+from wayfinder_paths.jobs.forward_artifacts import load_forward_view
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.store import JobStore
+
+
+def _seed_job(tmp_path: Path) -> JobStore:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("carry", script="strategy.py", interval_seconds=3600)
+    job.execution_params["initial_capital"] = 100.0
+    store.create_job(job)
+    forward = store.job_dir("carry") / "results" / "forward"
+    forward.mkdir(parents=True, exist_ok=True)
+
+    def write_jsonl(name: str, rows: list[dict]) -> None:
+        (forward / name).write_text(
+            "".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8"
+        )
+
+    write_jsonl(
+        "fills.jsonl",
+        [
+            {
+                "kind": "fill",
+                "timestamp": "2026-07-14T05:00:00+00:00",
+                "symbol": "IMX",
+                "side": "sell",
+                "avg_price": 0.130,
+                "filled_size": 700.0,
+                "reduce_only": False,
+                "status": "filled",
+                "mode": "paper",
+                "raw": {"intent_metadata": {"entry_reason": "new_low_5"}},
+            },
+            {
+                "kind": "fill",
+                "timestamp": "2026-07-15T10:00:00+00:00",
+                "symbol": "IMX",
+                "side": "buy",
+                "avg_price": 0.128,
+                "filled_size": 700.0,
+                "reduce_only": True,
+                "status": "filled",
+                "mode": "paper",
+                "raw": {"intent_metadata": {"exit_reason": "sma50_floor"}},
+            },
+            {
+                "kind": "fill",
+                "timestamp": "2026-07-16T02:00:00+00:00",
+                "symbol": "IMX",
+                "side": "sell",
+                "avg_price": 0.125,
+                "filled_size": 700.0,
+                "reduce_only": False,
+                "status": "filled",
+                "mode": "live",
+            },
+            {
+                "kind": "fill",
+                "timestamp": "2026-07-16T09:00:00+00:00",
+                "symbol": "IMX",
+                "side": "buy",
+                "avg_price": 0.126,
+                "filled_size": 700.0,
+                "reduce_only": True,
+                "status": "filled",
+                "mode": "live",
+            },
+        ],
+    )
+    write_jsonl(
+        "trades.jsonl",
+        [
+            {
+                "kind": "trade",
+                "symbol": "IMX",
+                "side": "buy",
+                "net_pnl": 1.4,
+                "closed_at": "2026-07-15T10:00:00+00:00",
+                "mode": "paper",
+            },
+            {
+                "kind": "trade",
+                "symbol": "IMX",
+                "side": "buy",
+                "net_pnl": -0.7,
+                "closed_at": "2026-07-16T09:00:00+00:00",
+                "mode": "live",
+            },
+        ],
+    )
+    write_jsonl(
+        "ticks.jsonl",
+        [
+            {
+                "kind": "tick",
+                "bar_ts": f"2026-07-14T{hour:02d}:00:00+00:00",
+                "mode": "paper",
+                "ledger": {"realized_pnl": 0.0, "positions": {}},
+            }
+            for hour in range(4)
+        ]
+        + [
+            {
+                "kind": "tick",
+                "bar_ts": "2026-07-15T10:00:00+00:00",
+                "mode": "paper",
+                "ledger": {"realized_pnl": 1.4, "positions": {}},
+            },
+            {
+                "kind": "tick",
+                "bar_ts": "2026-07-16T09:00:00+00:00",
+                "mode": "live",
+                "ledger": {
+                    "realized_pnl": 0.7,
+                    "positions": {
+                        "IMX": {
+                            "side": "short",
+                            "size": 500.0,
+                            "avg_price": 0.124,
+                            "opened_at": "2026-07-16T12:00:00+00:00",
+                        }
+                    },
+                },
+            },
+        ],
+    )
+    return store
+
+
+def test_markers_carry_mode_and_kind(tmp_path: Path) -> None:
+    store = _seed_job(tmp_path)
+    result = load_forward_view("carry", store=store, include_prices=False)
+    assert result["available"] is True
+    markers = result["visualization"]["markers"]
+    assert [(m["kind"], m["mode"]) for m in markers] == [
+        ("entry", "paper"),
+        ("exit", "paper"),
+        ("entry", "live"),
+        ("exit", "live"),
+    ]
+    assert markers[0]["label"] == "paper entry: new_low_5"
+    assert markers[1]["label"] == "paper exit: sma50_floor"
+
+
+def test_pnl_by_mode_splits_paper_and_live(tmp_path: Path) -> None:
+    store = _seed_job(tmp_path)
+    result = load_forward_view("carry", store=store, include_prices=False)
+    summary = result["summary"]
+    assert summary["pnl_by_mode"] == {"paper": 1.4, "live": -0.7}
+    assert summary["trades_by_mode"] == {"paper": 1, "live": 1}
+
+
+def test_pnl_curve_uses_initial_capital(tmp_path: Path) -> None:
+    store = _seed_job(tmp_path)
+    result = load_forward_view("carry", store=store, include_prices=False)
+    equity = next(
+        s for s in result["visualization"]["series"] if s["kind"] == "equity_curve"
+    )
+    assert equity["points"][0]["value"] == 100.0
+    assert equity["points"][-1]["value"] == 100.7
+    # Points carry the mode of the tick they came from.
+    assert equity["points"][0]["mode"] == "paper"
+    assert equity["points"][-1]["mode"] == "live"
+
+
+def test_open_position_reported(tmp_path: Path) -> None:
+    store = _seed_job(tmp_path)
+    result = load_forward_view("carry", store=store, include_prices=False)
+    position = result["summary"]["open_position"]
+    assert position["symbol"] == "IMX"
+    assert position["side"] == "short"
+    assert position["size"] == 500.0
+    assert position["mode"] == "live"
+
+
+def test_downsampling_caps_points(tmp_path: Path) -> None:
+    store = _seed_job(tmp_path)
+    forward = store.job_dir("carry") / "results" / "forward"
+    rows = [
+        json.dumps(
+            {
+                "kind": "tick",
+                "bar_ts": f"2026-07-{1 + hour // 24:02d}T{hour % 24:02d}:00:00+00:00",
+                "mode": "paper",
+                "ledger": {"realized_pnl": float(hour), "positions": {}},
+            }
+        )
+        for hour in range(600)
+    ]
+    (forward / "ticks.jsonl").write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+    result = load_forward_view(
+        "carry", store=store, include_prices=False, max_points=200
+    )
+    equity = next(
+        s for s in result["visualization"]["series"] if s["kind"] == "equity_curve"
+    )
+    assert len(equity["points"]) == 200
+    # First and last points survive the stride.
+    assert equity["points"][0]["realized_pnl"] == 0.0
+    assert equity["points"][-1]["realized_pnl"] == 599.0
+
+
+def test_price_fetch_failure_degrades_with_note(tmp_path: Path) -> None:
+    store = _seed_job(tmp_path)
+    # No execution_spec exists in the seeded job -> the price fetch raises and
+    # the view degrades to markers + PnL with a note instead of failing.
+    result = load_forward_view("carry", store=store, include_prices=True)
+    assert result["available"] is True
+    assert "price_note" in result["summary"]
+    kinds = {s["kind"] for s in result["visualization"]["series"]}
+    assert kinds == {"equity_curve"}
+    assert len(result["visualization"]["markers"]) == 4
+
+
+def test_view_filter_selects_kinds(tmp_path: Path) -> None:
+    store = _seed_job(tmp_path)
+    result = load_forward_view(
+        "carry", store=store, include_prices=False, view="equity"
+    )
+    kinds = {s["kind"] for s in result["visualization"]["series"]}
+    assert kinds == {"equity_curve"}
+
+
+def test_unavailable_when_no_forward_data(tmp_path: Path) -> None:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("empty", script="strategy.py", interval_seconds=3600)
+    store.create_job(job)
+    assert load_forward_view("empty", store=store) == {"available": False}
+
+
+def test_snapshot_summary_includes_split_and_position(tmp_path: Path) -> None:
+    store = _seed_job(tmp_path)
+    snapshot = load_forward_snapshot("carry", store=store)
+    summary = snapshot["summary"]
+    assert summary["pnl_by_mode"] == {"paper": 1.4, "live": -0.7}
+    assert summary["trades_by_mode"] == {"paper": 1, "live": 1}
+    assert summary["open_position"]["symbol"] == "IMX"


### PR DESCRIPTION
## Why

imx-short paper-traded for a week (3 closed trades +$0.57, an open short right now) and the Strategies UI showed none of it — no trade markers, no PnL, only a muted "Paper · …" status line. Every forward record already carries the `mode` it executed under (ForwardRecorder bakes it in) and `trades.jsonl` carries per-trade `net_pnl` — the missing piece was a view that serves it.

## What

- **`jobs/forward_artifacts.py` (new)** — `load_forward_view()` mirrors `load_backtest_view`'s response shape so the entire chart pipeline (backend machine-exec proxy + FE TradingView renderer) is reused as-is, built on demand from `results/forward/`:
  - **markers** from `fills.jsonl` — `entry`/`exit`, each tagged **`mode: paper|live`** with a label like `paper entry: new_low_5`
  - **PnL curve** (`equity_curve`) from the tick ledger's `realized_pnl` over `execution_params.initial_capital`; points carry the tick's mode
  - **`market_price` OHLC series** fetched through the same venue feed the driver uses (forward ticks don't persist bars) — one bounded fetch per chart load (≤2000 bars); on failure the payload degrades to markers + PnL with a `price_note`
  - **summary** adds `pnl_by_mode` / `trades_by_mode` (group-by of `trades.jsonl`; both modes always present so "no live trades" ≠ "live is flat") and `open_position` marked at the last close
  - same view/series/time filters + even-stride downsampling as the backtest view
- **`load_forward_snapshot()`** summary now carries `pnl_by_mode` / `trades_by_mode` / `open_position` — the synced snapshot already includes the `forward` block, so the UI's PnL headline rides the existing sync (refreshed every tick since #520).
- **CLI `wayfinder job forward-view <id>`** mirroring `backtest-view` (`--view/--series/--from/--to/--max-points`, plus `--no-prices`) for the backend proxy.

## Tests

`test_jobs_forward_view.py` (9): markers carry mode+kind+labels, pnl_by_mode splits paper/live, PnL curve uses initial_capital and carries mode, open position reported, downsampling caps points keeping first/last, price-fetch failure degrades with a note, view filtering, unavailable-when-empty, and the snapshot summary enrichment. Broader jobs subset green; ruff + format clean; mypy adds only the pandas-stub note identical to `driver.py` baseline.

## Companion changes

Backend: store/serve the snapshot's `forward` block + a `/forward/` proxy route (mirror of `/backtest/`). Frontend: Trading tab + paper/live-tagged markers + PnL headline + Paper badge. SDK reaches the box after merge + bake/roll.