### PR TITLE
Wallets - Fan out Solana priority-fee estimation across RPCs

### DIFF
--- a/wayfinder_paths/core/utils/svm.py
+++ b/wayfinder_paths/core/utils/svm.py
@@ -19,24 +19,48 @@ from wayfinder_paths.core.constants.chains import CHAIN_ID_SOLANA
 from wayfinder_paths.core.utils.web3 import _get_rpcs_for_chain_id, _is_wayfinder_rpc
 
 
+def _get_solana_client(rpc: str, commitment: Commitment | None) -> AsyncClient:
+    api_key = get_api_key() if _is_wayfinder_rpc(rpc) else None
+    headers = {"X-API-KEY": api_key} if api_key else None
+    return AsyncClient(rpc, commitment=commitment or Confirmed, extra_headers=headers)
+
+
 @asynccontextmanager
 async def solana_client_from_chain_id(
     chain_id: int = CHAIN_ID_SOLANA,
     commitment: Commitment | None = None,
 ):
-    """Async context manager yielding an ``AsyncClient`` for ``chain_id``.
+    """Async context manager yielding a single ``AsyncClient`` for ``chain_id``.
 
     RPC resolution mirrors ``web3_from_chain_id``: explicit ``rpc_urls``
     config overrides win, otherwise the Wayfinder RPC proxy is used
     (authenticated with the configured API key). Only the first resolved
     RPC gets a client — constructing one per RPC would leak the unused
-    httpx sessions.
+    httpx sessions. Use ``solana_clients_from_chain_id`` for fan-out reads.
     """
-    rpc = _get_rpcs_for_chain_id(chain_id)[0]
-    api_key = get_api_key() if _is_wayfinder_rpc(rpc) else None
-    headers = {"X-API-KEY": api_key} if api_key else None
-    client = AsyncClient(rpc, commitment=commitment or Confirmed, extra_headers=headers)
+    client = _get_solana_client(_get_rpcs_for_chain_id(chain_id)[0], commitment)
     try:
         yield client
     finally:
         await client.close()
+
+
+@asynccontextmanager
+async def solana_clients_from_chain_id(
+    chain_id: int = CHAIN_ID_SOLANA,
+    commitment: Commitment | None = None,
+):
+    """Async context manager yielding one ``AsyncClient`` per resolved RPC.
+
+    Mirrors the EVM ``web3s_from_chain_id`` fan-out: the Wayfinder RPC proxy
+    exposes N indexed endpoints, so reads that must defeat divergent per-node
+    views (e.g. recent priority fees) can query every node in parallel.
+    """
+    clients = [
+        _get_solana_client(rpc, commitment) for rpc in _get_rpcs_for_chain_id(chain_id)
+    ]
+    try:
+        yield clients
+    finally:
+        for client in clients:
+            await client.close()

--- a/wayfinder_paths/core/utils/svm_transaction.py
+++ b/wayfinder_paths/core/utils/svm_transaction.py
@@ -18,6 +18,7 @@ from typing import Any
 
 import httpx
 from loguru import logger
+from solana.rpc.async_api import AsyncClient
 from solana.rpc.commitment import Confirmed
 from solana.rpc.models import TxOpts
 from solders.compute_budget import set_compute_unit_limit, set_compute_unit_price
@@ -30,7 +31,10 @@ from solders.transaction_status import TransactionConfirmationStatus
 
 from wayfinder_paths.core.clients.WalletClient import WALLET_CLIENT
 from wayfinder_paths.core.constants.chains import CHAIN_ID_SOLANA
-from wayfinder_paths.core.utils.svm import solana_client_from_chain_id
+from wayfinder_paths.core.utils.svm import (
+    solana_client_from_chain_id,
+    solana_clients_from_chain_id,
+)
 from wayfinder_paths.core.utils.transaction import (
     SponsorshipUnavailableError,
     TransactionRevertedError,
@@ -140,19 +144,31 @@ async def get_recent_priority_fee(
 ) -> int:
     """Recent priority fee in micro-lamports per compute unit.
 
-    Uses ``getRecentPrioritizationFees`` and takes the given percentile of
-    the NONZERO samples, clamped to ``[floor, ceiling]``. Zero-fee samples
-    dominate the response on quiet slots and would peg the estimate to zero,
-    so they are dropped; when every sample is zero the floor is returned.
+    Fanned out across every resolved RPC and reduced with ``max`` — mirroring
+    the EVM nonce fan-out — so a node lagging on recent-fee data can't drag the
+    estimate down and leave the transaction stuck behind higher-paying ones.
+
+    Per node: ``getRecentPrioritizationFees`` and the given percentile of the
+    NONZERO samples. Zero-fee samples dominate quiet slots and would peg the
+    estimate to zero, so they are dropped; a node seeing only zeros contributes
+    the floor. The max across nodes is clamped to ``[floor, ceiling]``.
     """
-    async with solana_client_from_chain_id(chain_id) as client:
+
+    async def _get_priority_fee(client: AsyncClient) -> int:
         resp = await client.get_recent_prioritization_fees()
-    fees = sorted(f.prioritization_fee for f in resp.value if f.prioritization_fee > 0)
-    if not fees:
-        return floor
-    # Nearest-rank percentile over the nonzero samples.
-    fee = fees[max(0, math.ceil(percentile / 100 * len(fees)) - 1)]
-    return max(floor, min(ceiling, fee))
+        fees = sorted(
+            f.prioritization_fee for f in resp.value if f.prioritization_fee > 0
+        )
+        if not fees:
+            return floor
+        # Nearest-rank percentile over the nonzero samples.
+        return fees[max(0, math.ceil(percentile / 100 * len(fees)) - 1)]
+
+    async with solana_clients_from_chain_id(chain_id) as clients:
+        priority_fees = await asyncio.gather(
+            *[_get_priority_fee(client) for client in clients]
+        )
+    return max(floor, min(ceiling, max(priority_fees)))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Summary

`get_recent_priority_fee` queried only the first resolved RPC. Fan it out across every node — mirroring the EVM nonce fan-out (`web3s_from_chain_id` + `gather` + `max`):

- Add `solana_clients_from_chain_id` to `svm` (an `AsyncClient` per resolved RPC), alongside the existing single-client context manager.
- `get_recent_priority_fee` now queries every node’s `getRecentPrioritizationFees` in parallel and takes the max of the per-node percentile estimates, clamped to `[floor, ceiling]`. A node lagging on recent-fee data can no longer underprice a send and leave it stuck behind higher-paying transactions.
- Single-RPC configs collapse to one client (unchanged behavior).