### PR TITLE
jobs: forward-view lifecycle events — mode flips, version applications, halts

### DIFF
--- a/wayfinder_paths/jobs/forward_artifacts.py
+++ b/wayfinder_paths/jobs/forward_artifacts.py
@@ -170,6 +170,11 @@ def load_forward_view(
         if _in_range(_parse_ts(marker["timestamp"]), start, end)
         and (view != "legs" or not symbols or str(marker["symbol"]) in symbols)
     ]
+    events = [
+        event
+        for event in forward_events(ticks, proposals=store.proposals(job_id))
+        if _in_range(_parse_ts(event["timestamp"]), start, end)
+    ]
     return {
         "available": True,
         "view": view,
@@ -186,9 +191,84 @@ def load_forward_view(
             ),
             "series": selected_series,
             "markers": selected_markers,
+            "events": events,
         },
         "trades": _tail_jsonl(forward_dir / Path(DEFAULT_FORWARD_TRADES).name, 50),
     }
+
+
+def forward_events(
+    ticks: list[dict[str, Any]],
+    *,
+    proposals: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    """Lifecycle annotations for the forward chart, derived from the ticks.
+
+    Every tick records the mode and revision it executed under, so transitions
+    between consecutive ticks ARE the job's history: paper<->live flips, a new
+    strategy version taking effect (labeled with the applied proposal's summary
+    when one matches the revision), and halts engaging. The chart draws these
+    as vertical event lines.
+    """
+    summary_by_revision: dict[str, str] = {}
+    for proposal in proposals or []:
+        proposal_revision = str(
+            (proposal.get("candidate_report") or {}).get("revision")
+            or proposal.get("candidate_revision")
+            or ""
+        )
+        proposal_summary = str(proposal.get("summary") or "").strip()
+        if proposal_revision and proposal_summary:
+            summary_by_revision[proposal_revision] = proposal_summary
+
+    events: list[dict[str, Any]] = []
+    previous_mode: str | None = None
+    previous_revision: str | None = None
+    previous_halted = False
+    for tick in ticks:
+        timestamp = tick.get("bar_ts") or tick.get("ts")
+        if not timestamp:
+            continue
+        mode = str(tick.get("mode") or "") or None
+        revision = str(tick.get("revision") or "") or None
+        if previous_mode is not None and mode and mode != previous_mode:
+            events.append(
+                {
+                    "timestamp": str(timestamp),
+                    "kind": "mode_flip",
+                    "mode": mode,
+                    "label": f"→ {mode.upper()}",
+                }
+            )
+        if previous_revision is not None and revision and revision != previous_revision:
+            summary = summary_by_revision.get(revision)
+            events.append(
+                {
+                    "timestamp": str(timestamp),
+                    "kind": "revision",
+                    "revision": revision,
+                    "label": (summary[:60] if summary else f"update {revision[:8]}"),
+                }
+            )
+        guards = {str(guard.get("kind")) for guard in tick.get("guard_events") or []}
+        halted = bool(guards & {"risk_halt", "manual_halt"})
+        if halted and not previous_halted:
+            reasons = [
+                str(guard.get("reason") or "")
+                for guard in tick.get("guard_events") or []
+                if str(guard.get("kind")) in {"risk_halt", "manual_halt"}
+            ]
+            events.append(
+                {
+                    "timestamp": str(timestamp),
+                    "kind": "halt",
+                    "label": (reasons[0][:60] if reasons and reasons[0] else "halted"),
+                }
+            )
+        previous_mode = mode or previous_mode
+        previous_revision = revision or previous_revision
+        previous_halted = halted
+    return events
 
 
 def _fill_markers(fills: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/wayfinder_paths/tests/test_jobs_forward_view.py
+++ b/wayfinder_paths/tests/test_jobs_forward_view.py
@@ -11,7 +11,7 @@ import json
 from pathlib import Path
 
 from wayfinder_paths.jobs.forward import load_forward_snapshot
-from wayfinder_paths.jobs.forward_artifacts import load_forward_view
+from wayfinder_paths.jobs.forward_artifacts import forward_events, load_forward_view
 from wayfinder_paths.jobs.models import WayfinderJob
 from wayfinder_paths.jobs.store import JobStore
 
@@ -249,3 +249,68 @@ def test_snapshot_summary_includes_split_and_position(tmp_path: Path) -> None:
     assert summary["pnl_by_mode"] == {"paper": 1.4, "live": -0.7}
     assert summary["trades_by_mode"] == {"paper": 1, "live": 1}
     assert summary["open_position"]["symbol"] == "IMX"
+
+
+def test_forward_events_annotate_lifecycle(tmp_path: Path) -> None:
+    """Mode flips, revision changes (labeled from the matching proposal), and
+    halt engagements become chart events; steady-state ticks emit nothing."""
+    ticks = [
+        {"bar_ts": "2026-07-14T00:00:00+00:00", "mode": "paper", "revision": "aaa111"},
+        {"bar_ts": "2026-07-14T01:00:00+00:00", "mode": "paper", "revision": "aaa111"},
+        {"bar_ts": "2026-07-14T02:00:00+00:00", "mode": "live", "revision": "aaa111"},
+        {"bar_ts": "2026-07-14T03:00:00+00:00", "mode": "live", "revision": "bbb222"},
+        {
+            "bar_ts": "2026-07-14T04:00:00+00:00",
+            "mode": "live",
+            "revision": "bbb222",
+            "guard_events": [{"kind": "manual_halt", "reason": "fat finger"}],
+        },
+        {  # halt persists -> no second event
+            "bar_ts": "2026-07-14T05:00:00+00:00",
+            "mode": "live",
+            "revision": "bbb222",
+            "guard_events": [{"kind": "manual_halt", "reason": "fat finger"}],
+        },
+    ]
+    proposals = [
+        {
+            "summary": "Widen the stop to 9%",
+            "candidate_report": {"revision": "bbb222"},
+        }
+    ]
+    events = forward_events(ticks, proposals=proposals)
+    assert [(e["kind"], e["timestamp"][11:13]) for e in events] == [
+        ("mode_flip", "02"),
+        ("revision", "03"),
+        ("halt", "04"),
+    ]
+    assert events[0]["label"] == "\u2192 LIVE"
+    assert events[1]["label"] == "Widen the stop to 9%"
+    assert events[2]["label"] == "fat finger"
+
+
+def test_forward_view_includes_events(tmp_path: Path) -> None:
+    store = _seed_job(tmp_path)
+    forward = store.job_dir("carry") / "results" / "forward"
+    rows = [
+        {
+            "kind": "tick",
+            "bar_ts": "2026-07-14T00:00:00+00:00",
+            "mode": "paper",
+            "revision": "aaa111",
+            "ledger": {"realized_pnl": 0.0, "positions": {}},
+        },
+        {
+            "kind": "tick",
+            "bar_ts": "2026-07-14T01:00:00+00:00",
+            "mode": "live",
+            "revision": "aaa111",
+            "ledger": {"realized_pnl": 0.0, "positions": {}},
+        },
+    ]
+    (forward / "ticks.jsonl").write_text(
+        "".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8"
+    )
+    result = load_forward_view("carry", store=store, include_prices=False)
+    events = result["visualization"]["events"]
+    assert [(e["kind"], e["mode"]) for e in events] == [("mode_flip", "live")]


### PR DESCRIPTION
## Why

The jobs chart shows trades but not the job's *history*: when it flipped paper↔live, when a new strategy version took effect, when a halt engaged. Every forward tick already records `mode` + `revision` + guard events — the transitions between consecutive ticks ARE that history; nothing new needs recording.

## What

`forward_events(ticks, proposals=…)` in `jobs/forward_artifacts.py`:
- **mode_flip** — consecutive-tick mode change → `{kind, mode, label: "→ LIVE"}`
- **revision** — revision change → labeled with the applied proposal's `summary` when one matches the candidate revision (via `candidate_report.revision`/`candidate_revision`), else `update <rev8>`
- **halt** — `risk_halt`/`manual_halt` guard engaging (transitions only; a persisting halt emits once), labeled with the guard reason

Included as `visualization.events` in the forward-view payload, filtered by the same `--from/--to` range. Backend proxies it untouched; the FE (vault-frontend#1839 follow-up) renders them as colored vertical lines on the hero chart.

## Tests

`test_jobs_forward_view.py` +2: lifecycle sequence (flip → revision-with-proposal-label → halt-with-reason, steady-state silent, persisting halt deduped) and payload inclusion. 11 pass; ruff/format clean; no new mypy errors.