### PR TITLE
Tokens - Recognize Solana base58 addresses

### DIFF
--- a/wayfinder_paths/core/utils/token_refs.py
+++ b/wayfinder_paths/core/utils/token_refs.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import re
+
 from eth_utils import is_address
 
 from wayfinder_paths.core.constants.chains import CHAIN_CODE_TO_ID
+
+# base58 (Bitcoin alphabet — no 0, O, I, l), 32–44 chars: a Solana mint/pubkey.
+_SOLANA_ADDRESS_RE = re.compile(r"^[1-9A-HJ-NP-Za-km-z]{32,44}$")
 
 
 def looks_like_evm_address(value: str | None) -> bool:
@@ -18,6 +23,18 @@ def looks_like_evm_address(value: str | None) -> bool:
         return False
 
     return bool(is_address(raw))
+
+
+def looks_like_solana_address(value: str | None) -> bool:
+    if value is None:
+        return False
+
+    raw = str(value).strip()
+    # 0x-prefixed strings are EVM; a bare base58 string of mint length is SVM.
+    if not raw or raw.startswith(("0x", "0X")):
+        return False
+
+    return bool(_SOLANA_ADDRESS_RE.match(raw))
 
 
 def _parse_chain_part(value: str) -> int | None:
@@ -56,11 +73,11 @@ def parse_token_id_to_chain_and_address(
 
     left, right = parts[0].strip(), parts[1].strip()
 
-    if looks_like_evm_address(right):
+    if looks_like_evm_address(right) or looks_like_solana_address(right):
         chain_id = _parse_chain_part(left)
         return (int(chain_id), right) if chain_id is not None else (None, None)
 
-    if looks_like_evm_address(left):
+    if looks_like_evm_address(left) or looks_like_solana_address(left):
         chain_id = _parse_chain_part(right)
         return (int(chain_id), left) if chain_id is not None else (None, None)
 

--- a/wayfinder_paths/core/utils/token_resolver.py
+++ b/wayfinder_paths/core/utils/token_resolver.py
@@ -9,6 +9,7 @@ from wayfinder_paths.core.constants.base import NATIVE_COINGECKO_IDS, NATIVE_GAS
 from wayfinder_paths.core.constants.chains import CHAIN_CODE_TO_ID, CHAIN_ID_TO_CODE
 from wayfinder_paths.core.utils.token_refs import (
     looks_like_evm_address,
+    looks_like_solana_address,
     parse_token_id_to_chain_and_address,
 )
 from wayfinder_paths.core.utils.tokens import get_token_decimals, is_native_token
@@ -213,6 +214,11 @@ class TokenResolver:
             if not addr:
                 raise ValueError(f"Cannot resolve token: {query}")
             return chain_id_i, addr
+
+        # A base58 mint is a Solana address — return it as-is (case-sensitive,
+        # never checksummed) with the caller-supplied chain hint.
+        if looks_like_solana_address(q_raw):
+            return cls._validate_chain_id_hint(chain_id, query=q_raw), q_raw
 
         q = _normalize_token_query(q_raw)
         meta: dict[str, Any] | None = None

--- a/wayfinder_paths/tests/test_solana_token_refs.py
+++ b/wayfinder_paths/tests/test_solana_token_refs.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pytest
+
+from wayfinder_paths.core.utils.token_refs import (
+    looks_like_evm_address,
+    looks_like_solana_address,
+    parse_token_id_to_chain_and_address,
+)
+from wayfinder_paths.core.utils.token_resolver import TokenResolver
+
+USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+EVM_USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+
+
+def test_looks_like_solana_address():
+    assert looks_like_solana_address(USDC_MINT)
+    assert looks_like_solana_address("So11111111111111111111111111111111111111112")
+    # EVM addresses and slugs are not solana
+    assert not looks_like_solana_address(EVM_USDC)
+    assert not looks_like_solana_address("usdc")
+    assert not looks_like_solana_address(None)
+    assert not looks_like_solana_address("")
+    # solana detection must not swallow EVM
+    assert looks_like_evm_address(EVM_USDC)
+    assert not looks_like_evm_address(USDC_MINT)
+
+
+def test_parse_solana_token_id():
+    # both orderings, mint case preserved
+    assert parse_token_id_to_chain_and_address(f"solana_{USDC_MINT}") == (
+        900,
+        USDC_MINT,
+    )
+    assert parse_token_id_to_chain_and_address(f"{USDC_MINT}_solana") == (
+        900,
+        USDC_MINT,
+    )
+    assert parse_token_id_to_chain_and_address(f"900_{USDC_MINT}") == (900, USDC_MINT)
+
+
+@pytest.mark.asyncio
+async def test_resolve_bare_mint_preserves_case():
+    chain_id, addr = await TokenResolver.resolve_token(USDC_MINT, chain_id=900)
+    assert chain_id == 900
+    assert addr == USDC_MINT  # base58, never lowercased/checksummed


### PR DESCRIPTION
### Summary

Token resolution only recognized `0x` EVM addresses, so a base58 Solana mint (passed directly or in a `solana_<mint>` token id) fell through to symbol search. Add `looks_like_solana_address` (base58, 32–44 chars) and use it in the token-id parser and `resolve_token`, returning the mint as-is — case-sensitive, never checksummed — with the caller-supplied chain hint. `resolve_token_meta` keeps routing base58 mints through the token detail lookup so decimals/metadata come from the backend.

The chain-scoped discovery tools already pass the chain through, so this closes the address-resolution gap for Solana tokens.