### PR TITLE
jobs: forward open position survives skipped ticks; traded symbol charts first

### DIFF
--- a/wayfinder_paths/jobs/backtest_artifacts.py
+++ b/wayfinder_paths/jobs/backtest_artifacts.py
@@ -74,6 +74,30 @@ def summarize_backtest_artifacts(
     }
 
 
+def order_series_for_display(
+    series: list[dict[str, Any]], markers: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Marker-bearing price series first, then equity curves, then the rest.
+
+    The jobs UI renders only the first couple of series — with a multi-symbol
+    data contract the traded symbol's chart (the one with entry/exit markers)
+    must sort ahead of untraded siblings or the markers are never visible.
+    Stable within ranks, so single-symbol payloads are unchanged.
+    """
+    marked = {
+        str(marker["symbol"]) for marker in markers if marker.get("symbol") is not None
+    }
+
+    def rank(entry: dict[str, Any]) -> int:
+        if entry.get("symbol") is not None and str(entry["symbol"]) in marked:
+            return 0
+        if entry.get("kind") == "equity_curve":
+            return 1
+        return 2
+
+    return sorted(series, key=rank)
+
+
 def load_backtest_view(
     job_id: str,
     *,
@@ -146,7 +170,10 @@ def load_backtest_view(
             for key, value in visualization.items()
             if key not in {"series", "markers"}
         }
-        | {"series": selected_series, "markers": markers},
+        | {
+            "series": order_series_for_display(selected_series, markers),
+            "markers": markers,
+        },
         "trades": latest["trades"] if latest else [],
     }
 

--- a/wayfinder_paths/jobs/forward_artifacts.py
+++ b/wayfinder_paths/jobs/forward_artifacts.py
@@ -7,7 +7,12 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
-from wayfinder_paths.jobs.backtest_artifacts import VIEW_KINDS, _in_range, _parse_ts
+from wayfinder_paths.jobs.backtest_artifacts import (
+    VIEW_KINDS,
+    _in_range,
+    _parse_ts,
+    order_series_for_display,
+)
 from wayfinder_paths.jobs.forward import default_forward_summary
 from wayfinder_paths.jobs.models import (
     DEFAULT_FORWARD_FILLS,
@@ -195,7 +200,7 @@ def load_forward_view(
                     if entry.get("symbol") is not None
                 }
             ),
-            "series": selected_series,
+            "series": order_series_for_display(selected_series, selected_markers),
             "markers": selected_markers,
             "events": events,
         },

--- a/wayfinder_paths/jobs/forward_artifacts.py
+++ b/wayfinder_paths/jobs/forward_artifacts.py
@@ -55,7 +55,13 @@ def forward_open_position(
     if not ticks:
         return None
     tick = ticks[-1]
-    positions = (tick.get("ledger") or {}).get("positions") or {}
+    # Skipped ticks (no_new_bar) record an empty top-level ledger; the real
+    # unchanged state lives in engine_state_pre. Without this fallback the
+    # open position vanishes from the snapshot on every between-bar tick.
+    ledger = tick.get("ledger") or (
+        (tick.get("engine_state_pre") or {}).get("ledger") or {}
+    )
+    positions = ledger.get("positions") or {}
     for symbol, position in positions.items():
         side = str(position.get("side") or "")
         size = float(position.get("size") or 0.0)

--- a/wayfinder_paths/tests/test_jobs_forward_view.py
+++ b/wayfinder_paths/tests/test_jobs_forward_view.py
@@ -186,6 +186,43 @@ def test_open_position_reported(tmp_path: Path) -> None:
     assert position["mode"] == "live"
 
 
+def test_open_position_survives_skipped_tick(tmp_path: Path) -> None:
+    """Skipped ticks (no_new_bar) record an empty top-level ledger with the
+    unchanged state under engine_state_pre — the open position must not vanish
+    from the snapshot between bars."""
+    store = _seed_job(tmp_path)
+    forward = store.job_dir("carry") / "results" / "forward"
+    skipped = {
+        "kind": "tick",
+        "bar_ts": "2026-07-16T09:00:00+00:00",
+        "mode": "live",
+        "skipped": True,
+        "skip_reason": "no_new_bar",
+        "ledger": {},
+        "engine_state_pre": {
+            "ledger": {
+                "realized_pnl": 0.7,
+                "positions": {
+                    "IMX": {
+                        "side": "short",
+                        "size": 500.0,
+                        "avg_price": 0.124,
+                        "opened_at": "2026-07-16T12:00:00+00:00",
+                    }
+                },
+            }
+        },
+    }
+    with (forward / "ticks.jsonl").open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(skipped) + "\n")
+
+    result = load_forward_view("carry", store=store, include_prices=False)
+    position = result["summary"]["open_position"]
+    assert position["symbol"] == "IMX"
+    assert position["side"] == "short"
+    assert position["size"] == 500.0
+
+
 def test_downsampling_caps_points(tmp_path: Path) -> None:
     store = _seed_job(tmp_path)
     forward = store.job_dir("carry") / "results" / "forward"

--- a/wayfinder_paths/tests/test_jobs_forward_view.py
+++ b/wayfinder_paths/tests/test_jobs_forward_view.py
@@ -223,6 +223,28 @@ def test_open_position_survives_skipped_tick(tmp_path: Path) -> None:
     assert position["size"] == 500.0
 
 
+def test_series_order_puts_marked_symbol_first(tmp_path: Path) -> None:
+    """With a multi-symbol data contract only the traded symbol carries
+    markers; it must sort ahead of the equity curve and untraded siblings so
+    UIs that render the first couple of series show the markers."""
+    from wayfinder_paths.jobs.backtest_artifacts import order_series_for_display
+
+    series = [
+        {"name": "equity", "kind": "equity_curve", "symbol": None},
+        {"name": "CL_price", "kind": "market_price", "symbol": "xyz:CL"},
+        {"name": "MU_price", "kind": "market_price", "symbol": "xyz:MU"},
+        {"name": "SNDK_price", "kind": "market_price", "symbol": "xyz:SNDK"},
+    ]
+    markers = [{"symbol": "xyz:SNDK", "kind": "entry"}]
+    ordered = order_series_for_display(series, markers)
+    assert [entry["name"] for entry in ordered] == [
+        "SNDK_price",
+        "equity",
+        "CL_price",
+        "MU_price",
+    ]
+
+
 def test_downsampling_caps_points(tmp_path: Path) -> None:
     store = _seed_job(tmp_path)
     forward = store.job_dir("carry") / "results" / "forward"


### PR DESCRIPTION
Two fixes for "no entry markers on the graphs" (xyz-scalp-lab):

**1. Open position vanished on skipped ticks.** Skipped ticks (`no_new_bar`) write an empty top-level `ledger` with the real unchanged state under `engine_state_pre`. `forward_open_position` only read the last tick's top-level ledger, so `open_position` was null in the synced snapshot whenever the most recent tick was a skip — which is most of the time between bars. That made `hasForwardActivity` false in the jobs UI and hid the forward Price/PnL chart sources exactly while a trade was live. Fix: fall back to `engine_state_pre.ledger` when the top-level ledger is empty.

**2. Marker-bearing series sorted off-screen.** With a multi-symbol data contract (this job watches MU/SNDK/CL, trades SNDK) the view payloads listed series in symbol order and the hero renders only the first two — the SNDK chart (the only one with entry/exit markers) never made it on screen; users saw CL and MU with no markers. Fix: `order_series_for_display` puts marker-bearing price series first, then equity curves, then untraded siblings, applied in both `load_backtest_view` and `load_forward_view`. Stable sort — single-symbol jobs (imx-short) unchanged.

Tests: skipped-tick regression + ordering unit test; forward/backtest suites pass (46). Server-side ordering means the already-deployed FE benefits without another FE deploy.