### PR TITLE
Tokens - Solana swap + send execution in onchain tools

### DIFF
--- a/wayfinder_paths/core/utils/svm.py
+++ b/wayfinder_paths/core/utils/svm.py
@@ -15,8 +15,15 @@ from solana.rpc.async_api import AsyncClient
 from solana.rpc.commitment import Commitment, Confirmed
 
 from wayfinder_paths.core.config import get_api_key
-from wayfinder_paths.core.constants.chains import CHAIN_ID_SOLANA
+from wayfinder_paths.core.constants.chains import CHAIN_ID_SOLANA, SVM_CHAIN_IDS
 from wayfinder_paths.core.utils.web3 import _get_rpcs_for_chain_id, _is_wayfinder_rpc
+
+
+def is_solana_chain(chain_id: int | str | None) -> bool:
+    try:
+        return int(chain_id) in SVM_CHAIN_IDS  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return False
 
 
 def _get_solana_client(rpc: str, commitment: Commitment | None) -> AsyncClient:

--- a/wayfinder_paths/core/utils/svm.py
+++ b/wayfinder_paths/core/utils/svm.py
@@ -23,6 +23,10 @@ def is_solana_chain(chain_id: int | str) -> bool:
     return int(chain_id) in SVM_CHAIN_IDS
 
 
+def get_solana_explorer_link(signature: str) -> str:
+    return f"https://solscan.io/tx/{signature}"
+
+
 def _get_solana_client(rpc: str, commitment: Commitment | None) -> AsyncClient:
     api_key = get_api_key() if _is_wayfinder_rpc(rpc) else None
     headers = {"X-API-KEY": api_key} if api_key else None

--- a/wayfinder_paths/core/utils/svm.py
+++ b/wayfinder_paths/core/utils/svm.py
@@ -19,11 +19,8 @@ from wayfinder_paths.core.constants.chains import CHAIN_ID_SOLANA, SVM_CHAIN_IDS
 from wayfinder_paths.core.utils.web3 import _get_rpcs_for_chain_id, _is_wayfinder_rpc
 
 
-def is_solana_chain(chain_id: int | str | None) -> bool:
-    try:
-        return int(chain_id) in SVM_CHAIN_IDS  # type: ignore[arg-type]
-    except (TypeError, ValueError):
-        return False
+def is_solana_chain(chain_id: int | str) -> bool:
+    return int(chain_id) in SVM_CHAIN_IDS
 
 
 def _get_solana_client(rpc: str, commitment: Commitment | None) -> AsyncClient:

--- a/wayfinder_paths/core/utils/svm_tokens.py
+++ b/wayfinder_paths/core/utils/svm_tokens.py
@@ -35,23 +35,6 @@ WRAPPED_SOL_MINT = "So11111111111111111111111111111111111111112"
 SOL_DECIMALS = 9
 
 
-def get_associated_token_address(
-    owner: Pubkey, mint: Pubkey, program_id: Pubkey | None = None
-) -> Pubkey:
-    """Derive the associated token account address for ``owner``/``mint``.
-
-    ``program_id`` selects the owning token program (classic SPL Token by
-    default, pass ``TOKEN_2022_PROGRAM_ID`` for Token-2022 mints).
-    """
-    if program_id is None:
-        program_id = TOKEN_PROGRAM_ID
-    key, _ = Pubkey.find_program_address(
-        seeds=[bytes(owner), bytes(program_id), bytes(mint)],
-        program_id=ASSOCIATED_TOKEN_PROGRAM_ID,
-    )
-    return key
-
-
 async def _get_mint_account(client: AsyncClient, mint: Pubkey):
     info = (await client.get_account_info(mint)).value
     if info is None:
@@ -66,6 +49,56 @@ async def _resolve_token_program_id(client: AsyncClient, mint: Pubkey) -> Pubkey
         if info.owner == TOKEN_2022_PROGRAM_ID
         else TOKEN_PROGRAM_ID
     )
+
+
+async def _get_mint_decimals(client: AsyncClient, mint: Pubkey) -> int:
+    info = await _get_mint_account(client, mint)
+    data = bytes(info.data)
+    if len(data) < MINT_LAYOUT.sizeof():
+        raise ValueError(f"Account {mint} does not look like an SPL mint")
+    return int(MINT_LAYOUT.parse(data).decimals)
+
+
+def get_associated_token_address(
+    owner: Pubkey, mint: Pubkey, program_id: Pubkey
+) -> Pubkey:
+    """Derive the associated token account address for ``owner``/``mint``.
+
+    ``program_id`` is the owning token program (``TOKEN_PROGRAM_ID`` or
+    ``TOKEN_2022_PROGRAM_ID``), resolved from the mint account's owner.
+    """
+    key, _ = Pubkey.find_program_address(
+        seeds=[bytes(owner), bytes(program_id), bytes(mint)],
+        program_id=ASSOCIATED_TOKEN_PROGRAM_ID,
+    )
+    return key
+
+
+def _create_ata_idempotent_instruction(
+    payer: Pubkey, owner: Pubkey, mint: Pubkey, token_program_id: Pubkey
+) -> Instruction:
+    """CreateIdempotent variant of the associated-token-account instruction.
+
+    The installed spl helper only emits plain Create (empty instruction data),
+    which fails if the account already exists. CreateIdempotent (discriminator
+    ``1``) is a no-op in that case, so a transfer built while the recipient's
+    ATA was missing cannot be raced by a concurrent ATA creation.
+    """
+    base = create_associated_token_account(
+        payer=payer, owner=owner, mint=mint, token_program_id=token_program_id
+    )
+    return Instruction(
+        program_id=base.program_id, data=bytes([1]), accounts=base.accounts
+    )
+
+
+def _serialize_unsigned(message: MessageV0) -> str:
+    """Serialize a compiled message as an unsigned VersionedTransaction (base64)."""
+    placeholder_signatures = [
+        Signature.default() for _ in range(message.header.num_required_signatures)
+    ]
+    tx = VersionedTransaction.populate(message, placeholder_signatures)
+    return base64.b64encode(bytes(tx)).decode("ascii")
 
 
 async def get_sol_balance(wallet_address: str, chain_id: int = CHAIN_ID_SOLANA) -> int:
@@ -104,14 +137,6 @@ async def get_solana_token_balance(
     return await get_spl_token_balance(wallet_address, token_address, chain_id)
 
 
-async def _get_mint_decimals(client: AsyncClient, mint: Pubkey) -> int:
-    info = await _get_mint_account(client, mint)
-    data = bytes(info.data)
-    if len(data) < MINT_LAYOUT.sizeof():
-        raise ValueError(f"Account {mint} does not look like an SPL mint")
-    return int(MINT_LAYOUT.parse(data).decimals)
-
-
 async def get_spl_mint_decimals(
     mint: str | None, chain_id: int = CHAIN_ID_SOLANA
 ) -> int:
@@ -121,33 +146,6 @@ async def get_spl_mint_decimals(
     assert mint is not None  # is_native_token(None) is True
     async with solana_client_from_chain_id(chain_id) as client:
         return await _get_mint_decimals(client, Pubkey.from_string(mint))
-
-
-def _serialize_unsigned(message: MessageV0) -> str:
-    """Serialize a compiled message as an unsigned VersionedTransaction (base64)."""
-    placeholder_signatures = [
-        Signature.default() for _ in range(message.header.num_required_signatures)
-    ]
-    tx = VersionedTransaction.populate(message, placeholder_signatures)
-    return base64.b64encode(bytes(tx)).decode("ascii")
-
-
-def _create_ata_idempotent_instruction(
-    payer: Pubkey, owner: Pubkey, mint: Pubkey, token_program_id: Pubkey
-) -> Instruction:
-    """CreateIdempotent variant of the associated-token-account instruction.
-
-    The installed spl helper only emits plain Create (empty instruction data),
-    which fails if the account already exists. CreateIdempotent (discriminator
-    ``1``) is a no-op in that case, so a transfer built while the recipient's
-    ATA was missing cannot be raced by a concurrent ATA creation.
-    """
-    base = create_associated_token_account(
-        payer=payer, owner=owner, mint=mint, token_program_id=token_program_id
-    )
-    return Instruction(
-        program_id=base.program_id, data=bytes([1]), accounts=base.accounts
-    )
 
 
 async def build_solana_send_transaction(

--- a/wayfinder_paths/core/utils/svm_tokens.py
+++ b/wayfinder_paths/core/utils/svm_tokens.py
@@ -1,0 +1,254 @@
+"""Solana (SVM) token balances, mint metadata, and transfer envelopes.
+
+Mirrors the EVM token layer in ``core/utils/tokens.py`` for chain id 900:
+native SOL + SPL balances, mint decimals, and the unsigned transfer envelope
+builder, built on the ``AsyncClient`` context manager in ``svm.py``.
+Token-2022 aware.
+"""
+
+from __future__ import annotations
+
+import base64
+
+from solana.rpc.async_api import AsyncClient
+from solders.instruction import Instruction
+from solders.message import MessageV0
+from solders.pubkey import Pubkey
+from solders.signature import Signature
+from solders.system_program import TransferParams, transfer
+from solders.transaction import VersionedTransaction
+from spl.token._layouts import MINT_LAYOUT
+from spl.token.constants import (
+    ASSOCIATED_TOKEN_PROGRAM_ID,
+    TOKEN_2022_PROGRAM_ID,
+    TOKEN_PROGRAM_ID,
+)
+from spl.token.instructions import create_associated_token_account, transfer_checked
+from spl.token.models import TransferCheckedParams
+
+from wayfinder_paths.core.constants.chains import CHAIN_ID_SOLANA
+from wayfinder_paths.core.utils.svm import solana_client_from_chain_id
+from wayfinder_paths.core.utils.tokens import is_native_token
+
+SOL_NATIVE_SENTINEL = "11111111111111111111111111111111"
+WRAPPED_SOL_MINT = "So11111111111111111111111111111111111111112"
+SOL_DECIMALS = 9
+
+
+def get_associated_token_address(
+    owner: Pubkey, mint: Pubkey, program_id: Pubkey | None = None
+) -> Pubkey:
+    """Derive the associated token account address for ``owner``/``mint``.
+
+    ``program_id`` selects the owning token program (classic SPL Token by
+    default, pass ``TOKEN_2022_PROGRAM_ID`` for Token-2022 mints).
+    """
+    if program_id is None:
+        program_id = TOKEN_PROGRAM_ID
+    key, _ = Pubkey.find_program_address(
+        seeds=[bytes(owner), bytes(program_id), bytes(mint)],
+        program_id=ASSOCIATED_TOKEN_PROGRAM_ID,
+    )
+    return key
+
+
+async def _get_mint_account(client: AsyncClient, mint: Pubkey):
+    info = (await client.get_account_info(mint)).value
+    if info is None:
+        raise ValueError(f"Token mint account not found: {mint}")
+    return info
+
+
+async def _resolve_token_program_id(client: AsyncClient, mint: Pubkey) -> Pubkey:
+    info = await _get_mint_account(client, mint)
+    return (
+        TOKEN_2022_PROGRAM_ID
+        if info.owner == TOKEN_2022_PROGRAM_ID
+        else TOKEN_PROGRAM_ID
+    )
+
+
+async def get_sol_balance(wallet_address: str, chain_id: int = CHAIN_ID_SOLANA) -> int:
+    """Native SOL balance in lamports."""
+    async with solana_client_from_chain_id(chain_id) as client:
+        resp = await client.get_balance(Pubkey.from_string(wallet_address))
+        return int(resp.value)
+
+
+async def get_spl_token_balance(
+    wallet_address: str, mint: str, chain_id: int = CHAIN_ID_SOLANA
+) -> int:
+    """SPL token balance (raw base units) held in the owner's ATA.
+
+    Token-2022 aware: the token program is resolved from the mint account's
+    owner. Returns 0 when the associated token account does not exist.
+    """
+    async with solana_client_from_chain_id(chain_id) as client:
+        owner = Pubkey.from_string(wallet_address)
+        mint_pubkey = Pubkey.from_string(mint)
+        program_id = await _resolve_token_program_id(client, mint_pubkey)
+        ata = get_associated_token_address(owner, mint_pubkey, program_id)
+        ata_info = (await client.get_account_info(ata)).value
+        if ata_info is None:
+            return 0
+        resp = await client.get_token_account_balance(ata)
+        return int(resp.value.amount)
+
+
+async def get_solana_token_balance(
+    wallet_address: str, token_address: str | None, chain_id: int = CHAIN_ID_SOLANA
+) -> int:
+    if is_native_token(token_address):
+        return await get_sol_balance(wallet_address, chain_id)
+    assert token_address is not None  # is_native_token(None) is True
+    return await get_spl_token_balance(wallet_address, token_address, chain_id)
+
+
+async def _get_mint_decimals(client: AsyncClient, mint: Pubkey) -> int:
+    info = await _get_mint_account(client, mint)
+    data = bytes(info.data)
+    if len(data) < MINT_LAYOUT.sizeof():
+        raise ValueError(f"Account {mint} does not look like an SPL mint")
+    return int(MINT_LAYOUT.parse(data).decimals)
+
+
+async def get_spl_mint_decimals(
+    mint: str | None, chain_id: int = CHAIN_ID_SOLANA
+) -> int:
+    """Decimals for an SPL mint (native SOL sentinel returns 9)."""
+    if is_native_token(mint):
+        return SOL_DECIMALS
+    assert mint is not None  # is_native_token(None) is True
+    async with solana_client_from_chain_id(chain_id) as client:
+        return await _get_mint_decimals(client, Pubkey.from_string(mint))
+
+
+def _serialize_unsigned(message: MessageV0) -> str:
+    """Serialize a compiled message as an unsigned VersionedTransaction (base64)."""
+    placeholder_signatures = [
+        Signature.default() for _ in range(message.header.num_required_signatures)
+    ]
+    tx = VersionedTransaction.populate(message, placeholder_signatures)
+    return base64.b64encode(bytes(tx)).decode("ascii")
+
+
+def _create_ata_idempotent_instruction(
+    payer: Pubkey, owner: Pubkey, mint: Pubkey, token_program_id: Pubkey
+) -> Instruction:
+    """CreateIdempotent variant of the associated-token-account instruction.
+
+    The installed spl helper only emits plain Create (empty instruction data),
+    which fails if the account already exists. CreateIdempotent (discriminator
+    ``1``) is a no-op in that case, so a transfer built while the recipient's
+    ATA was missing cannot be raced by a concurrent ATA creation.
+    """
+    base = create_associated_token_account(
+        payer=payer, owner=owner, mint=mint, token_program_id=token_program_id
+    )
+    return Instruction(
+        program_id=base.program_id, data=bytes([1]), accounts=base.accounts
+    )
+
+
+async def build_solana_send_transaction(
+    from_address: str,
+    to_address: str,
+    token_address: str | None,
+    amount: int,
+    chain_id: int = CHAIN_ID_SOLANA,
+) -> dict:
+    """Build an unsigned SOL/SPL transfer and return the Solana tx envelope.
+
+    Returns the shared Solana transaction envelope used across the stack:
+
+        {
+            "chainType": "solana",
+            "chainId": 900,
+            "serializedTransaction": "<base64>",
+            "lastValidBlockHeight": <int>,
+        }
+
+    The transaction is serialized UNSIGNED (placeholder signatures) with the
+    sender as fee payer. Native SOL uses a system transfer; SPL tokens use
+    ``transfer_checked``, prepended with an idempotent ATA-create for the
+    recipient when their associated token account does not exist yet (rent
+    paid by the sender). Token-2022 aware via the mint account's owner.
+
+    Args:
+        from_address: Sender (and fee payer) base58 address.
+        to_address: Recipient base58 address.
+        token_address: SPL mint address, or a native sentinel/None for SOL.
+        amount: Amount in raw base units (lamports for SOL).
+        chain_id: Internal Solana chain id (900).
+    """
+    if amount <= 0:
+        raise ValueError("Transfer amount must be positive")
+
+    from_pubkey = Pubkey.from_string(from_address)
+    to_pubkey = Pubkey.from_string(to_address)
+
+    async with solana_client_from_chain_id(chain_id) as client:
+        instructions: list[Instruction] = []
+
+        if is_native_token(token_address):
+            instructions.append(
+                transfer(
+                    TransferParams(
+                        from_pubkey=from_pubkey,
+                        to_pubkey=to_pubkey,
+                        lamports=amount,
+                    )
+                )
+            )
+        else:
+            assert token_address is not None  # is_native_token(None) is True
+            mint = Pubkey.from_string(token_address)
+            program_id = await _resolve_token_program_id(client, mint)
+            source_ata = get_associated_token_address(from_pubkey, mint, program_id)
+            dest_ata = get_associated_token_address(to_pubkey, mint, program_id)
+
+            dest_info = (await client.get_account_info(dest_ata)).value
+            if dest_info is None:
+                # Recipient has no associated token account yet — the sender
+                # pays rent to create it as part of the same transaction.
+                instructions.append(
+                    _create_ata_idempotent_instruction(
+                        payer=from_pubkey,
+                        owner=to_pubkey,
+                        mint=mint,
+                        token_program_id=program_id,
+                    )
+                )
+
+            decimals = await _get_mint_decimals(client, mint)
+            instructions.append(
+                transfer_checked(
+                    TransferCheckedParams(
+                        program_id=program_id,
+                        source=source_ata,
+                        mint=mint,
+                        dest=dest_ata,
+                        owner=from_pubkey,
+                        amount=amount,
+                        decimals=decimals,
+                    )
+                )
+            )
+
+        blockhash_resp = await client.get_latest_blockhash()
+        recent_blockhash = blockhash_resp.value.blockhash
+        last_valid_block_height = int(blockhash_resp.value.last_valid_block_height)
+
+    message = MessageV0.try_compile(
+        payer=from_pubkey,
+        instructions=instructions,
+        address_lookup_table_accounts=[],
+        recent_blockhash=recent_blockhash,
+    )
+
+    return {
+        "chainType": "solana",
+        "chainId": int(chain_id),
+        "serializedTransaction": _serialize_unsigned(message),
+        "lastValidBlockHeight": last_valid_block_height,
+    }

--- a/wayfinder_paths/core/utils/wallets.py
+++ b/wayfinder_paths/core/utils/wallets.py
@@ -82,6 +82,18 @@ async def load_remote_wallets() -> list[dict[str, Any]]:
         return []
 
 
+async def is_solana_enabled() -> bool:
+    """Whether the solana_enabled switch is on for this instance's account.
+
+    Solana agent wallets are remote-only, so off-instance callers are never
+    Solana-enabled and skip the features fetch.
+    """
+    if not get_api_key() or not is_opencode_instance():
+        return False
+    features = await WALLET_CLIENT.get_features()
+    return "solana_enabled" in features["enabledSwitches"]
+
+
 async def load_wallets() -> list[dict[str, Any]]:
     """Load local + remote wallets."""
     local = _load_local_wallets()

--- a/wayfinder_paths/mcp/tools/execute.py
+++ b/wayfinder_paths/mcp/tools/execute.py
@@ -142,16 +142,9 @@ async def _broadcast_svm(
     chain_id: int,
     wait_for_confirmation: bool,
 ) -> tuple[bool, dict[str, Any]]:
-    """Decode an unsigned base64 v0 tx envelope and broadcast it on Solana.
-
-    Mirrors ``_broadcast``'s (ok, result) contract so the tools stay
-    branch-symmetric. No allowance, no checksum — SPL transfers are
-    authorized by the transaction signature itself and addresses are base58.
-    """
     try:
-        vt = VersionedTransaction.from_bytes(base64.b64decode(serialized_transaction))
         signature = await send_svm_versioned_transaction(
-            vt,
+            VersionedTransaction.from_bytes(base64.b64decode(serialized_transaction)),
             sign_callback,
             chain_id=chain_id,
             wait_for_confirmation=wait_for_confirmation,
@@ -166,11 +159,7 @@ async def _broadcast_svm(
 
 
 async def _token_balance(token_address: str, chain_id: int, wallet_address: str) -> int:
-    """Raw token balance, dispatched to the SVM reader on Solana chains.
-
-    ``tokens.get_token_balance`` is EVM-only (checksums the address); Solana
-    balances go through the base58-native SPL/SOL reader.
-    """
+    # get_token_balance is EVM-only (checksums the address); Solana is base58.
     if is_solana_chain(chain_id):
         return await get_solana_token_balance(wallet_address, token_address, chain_id)
     return await get_token_balance(token_address, chain_id, wallet_address)
@@ -357,14 +346,9 @@ async def onchain_swap(
             "quote_error", "best_quote missing calldata", {"best_quote": best_quote}
         )
 
-    # Solana routes carry a pre-built, unsigned v0 tx envelope (base58 addresses,
-    # no approvals) instead of EVM calldata — decode + broadcast via the SVM path
-    # and skip the checksum/allowance/bridge-tracking EVM flow entirely.
-    is_solana_route = calldata.get("chainType") == "solana" or is_solana_chain(
-        from_chain_id
-    )
-
-    if is_solana_route:
+    # Solana routes carry a pre-built, unsigned v0 tx envelope instead of EVM
+    # calldata — broadcast via SVM and skip checksum/allowance/bridge-tracking.
+    if calldata.get("chainType") == "solana" or is_solana_chain(from_chain_id):
         serialized = calldata.get("serializedTransaction")
         if not serialized:
             return err(
@@ -564,8 +548,7 @@ async def onchain_send(
         )
 
     if is_solana_chain(int(resolved_chain_id)):
-        # Solana transfer envelope: base58 recipient/mint (never checksummed),
-        # decode + broadcast through the SVM path.
+        # Solana transfer envelope: base58 recipient/mint (never checksummed).
         envelope = await build_solana_send_transaction(
             from_address=sender,
             to_address=rcpt,
@@ -573,7 +556,6 @@ async def onchain_send(
             amount=int(amount_raw),
             chain_id=int(resolved_chain_id),
         )
-        transaction = envelope
         sent_ok, sent = await _broadcast_svm(
             sign_callback,
             envelope["serializedTransaction"],
@@ -586,7 +568,7 @@ async def onchain_send(
         if not sent_ok:
             status = "failed"
         response["status"] = status
-        response["raw"] = {"transaction": transaction, "token": token_meta}
+        response["raw"] = {"transaction": envelope, "token": token_meta}
         _annotate_profile(
             address=sender,
             label=wallet_label,

--- a/wayfinder_paths/mcp/tools/execute.py
+++ b/wayfinder_paths/mcp/tools/execute.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
+import base64
 from typing import Any
 
 from eth_utils import to_checksum_address
+from solders.transaction import VersionedTransaction
 
 from wayfinder_paths.core.clients.BRAPClient import BRAP_CLIENT
 from wayfinder_paths.core.constants import ZERO_ADDRESS
 from wayfinder_paths.core.utils.etherscan import get_etherscan_transaction_link
+from wayfinder_paths.core.utils.svm import is_solana_chain
+from wayfinder_paths.core.utils.svm_tokens import (
+    build_solana_send_transaction,
+    get_solana_token_balance,
+)
+from wayfinder_paths.core.utils.svm_transaction import send_svm_versioned_transaction
 from wayfinder_paths.core.utils.token_resolver import TokenResolver
 from wayfinder_paths.core.utils.tokens import (
     build_send_transaction,
@@ -125,6 +133,47 @@ async def _broadcast(
         return True, result
     except Exception as e:
         return False, {"error": sanitize_for_json(str(e)), "chain_id": chain_id}
+
+
+async def _broadcast_svm(
+    sign_callback,
+    serialized_transaction: str,
+    *,
+    chain_id: int,
+    wait_for_confirmation: bool,
+) -> tuple[bool, dict[str, Any]]:
+    """Decode an unsigned base64 v0 tx envelope and broadcast it on Solana.
+
+    Mirrors ``_broadcast``'s (ok, result) contract so the tools stay
+    branch-symmetric. No allowance, no checksum — SPL transfers are
+    authorized by the transaction signature itself and addresses are base58.
+    """
+    try:
+        vt = VersionedTransaction.from_bytes(base64.b64decode(serialized_transaction))
+        signature = await send_svm_versioned_transaction(
+            vt,
+            sign_callback,
+            chain_id=chain_id,
+            wait_for_confirmation=wait_for_confirmation,
+        )
+        return True, {
+            "txn_hash": signature,
+            "chain_id": chain_id,
+            "confirmation_waited": wait_for_confirmation,
+        }
+    except Exception as e:
+        return False, {"error": sanitize_for_json(str(e)), "chain_id": chain_id}
+
+
+async def _token_balance(token_address: str, chain_id: int, wallet_address: str) -> int:
+    """Raw token balance, dispatched to the SVM reader on Solana chains.
+
+    ``tokens.get_token_balance`` is EVM-only (checksums the address); Solana
+    balances go through the base58-native SPL/SOL reader.
+    """
+    if is_solana_chain(chain_id):
+        return await get_solana_token_balance(wallet_address, token_address, chain_id)
+    return await get_token_balance(token_address, chain_id, wallet_address)
 
 
 async def _ensure_allowance(
@@ -258,7 +307,7 @@ async def onchain_swap(
     except ValueError as exc:
         return err("invalid_amount", str(exc))
 
-    balance = await get_token_balance(from_token_addr, int(from_chain_id), sender)
+    balance = await _token_balance(from_token_addr, int(from_chain_id), sender)
     if balance < amount_raw:
         symbol = from_meta["symbol"] or "tokens"
         return err(
@@ -308,77 +357,103 @@ async def onchain_swap(
             "quote_error", "best_quote missing calldata", {"best_quote": best_quote}
         )
 
-    swap_tx = dict(calldata)
-    swap_tx["chainId"] = int(from_chain_id)
-    swap_tx["from"] = to_checksum_address(sender)
-    if "value" in swap_tx:
-        swap_tx["value"] = int(swap_tx["value"])
-
-    spender = (
-        best_quote.get("approvalAddress")
-        or best_quote.get("approval_address")
-        or swap_tx.get("to")
-    )
-    approve_amount = (
-        best_quote.get("input_amount")
-        or best_quote.get("inputAmount")
-        or best_quote.get("amount1")
-        or best_quote.get("amount")
+    # Solana routes carry a pre-built, unsigned v0 tx envelope (base58 addresses,
+    # no approvals) instead of EVM calldata — decode + broadcast via the SVM path
+    # and skip the checksum/allowance/bridge-tracking EVM flow entirely.
+    is_solana_route = calldata.get("chainType") == "solana" or is_solana_chain(
+        from_chain_id
     )
 
-    if (
-        from_token_addr.lower() != ZERO_ADDRESS.lower()
-        and spender
-        and approve_amount is not None
-    ):
-        try:
-            need = int(approve_amount)
-        except Exception:
-            need = int(amount_raw)
-        ok_allow, approval_tx = await _ensure_allowance(
-            sign_callback=sign_callback,
-            chain_id=int(from_chain_id),
-            token_address=from_token_addr,
-            owner=to_checksum_address(sender),
-            spender=to_checksum_address(str(spender)),
-            amount=need,
-        )
-        if approval_tx:
-            response["effects"]["approval"] = approval_tx
-        if not ok_allow:
-            response["status"] = "failed"
-            response["raw"] = _compact_quote(quote_data, None)
-            return ok(response)
-
-    sent_ok, sent = await _broadcast(
-        sign_callback,
-        swap_tx,
-        chain_id=int(from_chain_id),
-        wait_for_receipt=wait_for_receipt,
-        confirmations=receipt_confirmations,
-    )
-    response["effects"]["swap"] = sent
-
-    status = "confirmed" if sent_ok and wait_for_receipt else "submitted"
-    if not sent_ok:
-        status = "failed"
-
-    bridge_tracking = best_quote.get("bridge_tracking")
-    if sent_ok and wait_for_receipt and bridge_tracking:
-        try:
-            bridge_result = await BRAP_CLIENT.wait_for_bridge_execution(
-                bridge_tracking=bridge_tracking,
-                tx_hash=sent["txn_hash"],
+    if is_solana_route:
+        serialized = calldata.get("serializedTransaction")
+        if not serialized:
+            return err(
+                "quote_error",
+                "solana best_quote missing serializedTransaction",
+                {"best_quote": best_quote},
             )
-            response["effects"]["bridge"] = bridge_result
-            if not bridge_result.get("is_success"):
-                status = "failed"
-        except Exception as exc:  # noqa: BLE001
-            response["effects"]["bridge"] = {
-                "state": "pending",
-                "error": sanitize_for_json(str(exc)),
-            }
-            status = "submitted"
+        sent_ok, sent = await _broadcast_svm(
+            sign_callback,
+            serialized,
+            chain_id=int(from_chain_id),
+            wait_for_confirmation=wait_for_receipt,
+        )
+        response["effects"]["swap"] = sent
+        status = "confirmed" if sent_ok and wait_for_receipt else "submitted"
+        if not sent_ok:
+            status = "failed"
+    else:
+        swap_tx = dict(calldata)
+        swap_tx["chainId"] = int(from_chain_id)
+        swap_tx["from"] = to_checksum_address(sender)
+        if "value" in swap_tx:
+            swap_tx["value"] = int(swap_tx["value"])
+
+        spender = (
+            best_quote.get("approvalAddress")
+            or best_quote.get("approval_address")
+            or swap_tx.get("to")
+        )
+        approve_amount = (
+            best_quote.get("input_amount")
+            or best_quote.get("inputAmount")
+            or best_quote.get("amount1")
+            or best_quote.get("amount")
+        )
+
+        if (
+            from_token_addr.lower() != ZERO_ADDRESS.lower()
+            and spender
+            and approve_amount is not None
+        ):
+            try:
+                need = int(approve_amount)
+            except Exception:
+                need = int(amount_raw)
+            ok_allow, approval_tx = await _ensure_allowance(
+                sign_callback=sign_callback,
+                chain_id=int(from_chain_id),
+                token_address=from_token_addr,
+                owner=to_checksum_address(sender),
+                spender=to_checksum_address(str(spender)),
+                amount=need,
+            )
+            if approval_tx:
+                response["effects"]["approval"] = approval_tx
+            if not ok_allow:
+                response["status"] = "failed"
+                response["raw"] = _compact_quote(quote_data, None)
+                return ok(response)
+
+        sent_ok, sent = await _broadcast(
+            sign_callback,
+            swap_tx,
+            chain_id=int(from_chain_id),
+            wait_for_receipt=wait_for_receipt,
+            confirmations=receipt_confirmations,
+        )
+        response["effects"]["swap"] = sent
+
+        status = "confirmed" if sent_ok and wait_for_receipt else "submitted"
+        if not sent_ok:
+            status = "failed"
+
+        bridge_tracking = best_quote.get("bridge_tracking")
+        if sent_ok and wait_for_receipt and bridge_tracking:
+            try:
+                bridge_result = await BRAP_CLIENT.wait_for_bridge_execution(
+                    bridge_tracking=bridge_tracking,
+                    tx_hash=sent["txn_hash"],
+                )
+                response["effects"]["bridge"] = bridge_result
+                if not bridge_result.get("is_success"):
+                    status = "failed"
+            except Exception as exc:  # noqa: BLE001
+                response["effects"]["bridge"] = {
+                    "state": "pending",
+                    "error": sanitize_for_json(str(exc)),
+                }
+                status = "submitted"
 
     response["status"] = status
     response["raw"] = _compact_quote(quote_data, best_quote)
@@ -472,7 +547,7 @@ async def onchain_send(
     except ValueError as exc:
         return err("invalid_amount", str(exc))
 
-    balance = await get_token_balance(token_address, int(resolved_chain_id), sender)
+    balance = await _token_balance(token_address, int(resolved_chain_id), sender)
     if balance < amount_raw:
         symbol = token_meta["symbol"] or "tokens"
         return err(
@@ -487,6 +562,42 @@ async def onchain_send(
                 "need_raw": amount_raw,
             },
         )
+
+    if is_solana_chain(int(resolved_chain_id)):
+        # Solana transfer envelope: base58 recipient/mint (never checksummed),
+        # decode + broadcast through the SVM path.
+        envelope = await build_solana_send_transaction(
+            from_address=sender,
+            to_address=rcpt,
+            token_address=token_address,
+            amount=int(amount_raw),
+            chain_id=int(resolved_chain_id),
+        )
+        transaction = envelope
+        sent_ok, sent = await _broadcast_svm(
+            sign_callback,
+            envelope["serializedTransaction"],
+            chain_id=int(resolved_chain_id),
+            wait_for_confirmation=wait_for_receipt,
+        )
+        label = "send_native" if is_native else "send_erc20"
+        response["effects"][label] = sent
+        status = "confirmed" if sent_ok and wait_for_receipt else "submitted"
+        if not sent_ok:
+            status = "failed"
+        response["status"] = status
+        response["raw"] = {"transaction": transaction, "token": token_meta}
+        _annotate_profile(
+            address=sender,
+            label=wallet_label,
+            protocol="balance",
+            action=label,
+            tool="onchain_send",
+            status=status,
+            chain_id=int(resolved_chain_id),
+            details={"recipient": rcpt, "amount": amount, "token": token_q},
+        )
+        return ok(response)
 
     transaction = await build_send_transaction(
         from_address=sender,

--- a/wayfinder_paths/mcp/tools/execute.py
+++ b/wayfinder_paths/mcp/tools/execute.py
@@ -9,7 +9,10 @@ from solders.transaction import VersionedTransaction
 from wayfinder_paths.core.clients.BRAPClient import BRAP_CLIENT
 from wayfinder_paths.core.constants import ZERO_ADDRESS
 from wayfinder_paths.core.utils.etherscan import get_etherscan_transaction_link
-from wayfinder_paths.core.utils.svm import is_solana_chain
+from wayfinder_paths.core.utils.svm import (
+    get_solana_explorer_link,
+    is_solana_chain,
+)
 from wayfinder_paths.core.utils.svm_tokens import (
     build_solana_send_transaction,
     get_solana_token_balance,
@@ -154,9 +157,16 @@ async def _broadcast_svm(
             "txn_hash": signature,
             "chain_id": chain_id,
             "confirmation_waited": wait_for_confirmation,
+            "explorer_url": get_solana_explorer_link(signature),
         }
     except Exception as e:
         return False, {"error": sanitize_for_json(str(e)), "chain_id": chain_id}
+
+
+def _tx_status(sent_ok: bool, waited: bool) -> str:
+    if not sent_ok:
+        return "failed"
+    return "confirmed" if waited else "submitted"
 
 
 async def _token_balance(token_address: str, chain_id: int, wallet_address: str) -> int:
@@ -351,7 +361,7 @@ async def onchain_swap(
 
     # Solana routes carry a pre-built, unsigned v0 tx envelope instead of EVM
     # calldata — broadcast via SVM and skip checksum/allowance/bridge-tracking.
-    if calldata.get("chainType") == "solana" or is_solana_chain(from_chain_id):
+    if is_solana_chain(from_chain_id):
         serialized = calldata.get("serializedTransaction")
         if not serialized:
             return err(
@@ -366,9 +376,7 @@ async def onchain_swap(
             wait_for_confirmation=wait_for_receipt,
         )
         response["effects"]["swap"] = sent
-        status = "confirmed" if sent_ok and wait_for_receipt else "submitted"
-        if not sent_ok:
-            status = "failed"
+        status = _tx_status(sent_ok, wait_for_receipt)
         response["status"] = status
         response["raw"] = compact_quote
         _annotate_profile(
@@ -438,9 +446,7 @@ async def onchain_swap(
     )
     response["effects"]["swap"] = sent
 
-    status = "confirmed" if sent_ok and wait_for_receipt else "submitted"
-    if not sent_ok:
-        status = "failed"
+    status = _tx_status(sent_ok, wait_for_receipt)
 
     bridge_tracking = best_quote.get("bridge_tracking")
     if sent_ok and wait_for_receipt and bridge_tracking:
@@ -567,6 +573,8 @@ async def onchain_send(
             },
         )
 
+    label = "send_native" if is_native else "send_erc20"
+
     if is_solana_chain(int(resolved_chain_id)):
         # Solana transfer envelope: base58 recipient/mint (never checksummed).
         envelope = await build_solana_send_transaction(
@@ -582,11 +590,8 @@ async def onchain_send(
             chain_id=int(resolved_chain_id),
             wait_for_confirmation=wait_for_receipt,
         )
-        label = "send_native" if is_native else "send_erc20"
         response["effects"][label] = sent
-        status = "confirmed" if sent_ok and wait_for_receipt else "submitted"
-        if not sent_ok:
-            status = "failed"
+        status = _tx_status(sent_ok, wait_for_receipt)
         response["status"] = status
         response["raw"] = {"transaction": envelope, "token": token_meta}
         _annotate_profile(
@@ -616,12 +621,9 @@ async def onchain_send(
         wait_for_receipt=wait_for_receipt,
         confirmations=receipt_confirmations,
     )
-    label = "send_native" if is_native else "send_erc20"
     response["effects"][label] = sent
 
-    status = "confirmed" if sent_ok and wait_for_receipt else "submitted"
-    if not sent_ok:
-        status = "failed"
+    status = _tx_status(sent_ok, wait_for_receipt)
     response["status"] = status
     response["raw"] = {"transaction": transaction, "token": token_meta}
 

--- a/wayfinder_paths/mcp/tools/execute.py
+++ b/wayfinder_paths/mcp/tools/execute.py
@@ -143,8 +143,9 @@ async def _broadcast_svm(
     wait_for_confirmation: bool,
 ) -> tuple[bool, dict[str, Any]]:
     try:
+        tx = VersionedTransaction.from_bytes(base64.b64decode(serialized_transaction))
         signature = await send_svm_versioned_transaction(
-            VersionedTransaction.from_bytes(base64.b64decode(serialized_transaction)),
+            tx,
             sign_callback,
             chain_id=chain_id,
             wait_for_confirmation=wait_for_confirmation,
@@ -346,6 +347,8 @@ async def onchain_swap(
             "quote_error", "best_quote missing calldata", {"best_quote": best_quote}
         )
 
+    compact_quote = _compact_quote(quote_data, best_quote)
+
     # Solana routes carry a pre-built, unsigned v0 tx envelope instead of EVM
     # calldata — broadcast via SVM and skip checksum/allowance/bridge-tracking.
     if calldata.get("chainType") == "solana" or is_solana_chain(from_chain_id):
@@ -366,81 +369,98 @@ async def onchain_swap(
         status = "confirmed" if sent_ok and wait_for_receipt else "submitted"
         if not sent_ok:
             status = "failed"
-    else:
-        swap_tx = dict(calldata)
-        swap_tx["chainId"] = int(from_chain_id)
-        swap_tx["from"] = to_checksum_address(sender)
-        if "value" in swap_tx:
-            swap_tx["value"] = int(swap_tx["value"])
-
-        spender = (
-            best_quote.get("approvalAddress")
-            or best_quote.get("approval_address")
-            or swap_tx.get("to")
-        )
-        approve_amount = (
-            best_quote.get("input_amount")
-            or best_quote.get("inputAmount")
-            or best_quote.get("amount1")
-            or best_quote.get("amount")
-        )
-
-        if (
-            from_token_addr.lower() != ZERO_ADDRESS.lower()
-            and spender
-            and approve_amount is not None
-        ):
-            try:
-                need = int(approve_amount)
-            except Exception:
-                need = int(amount_raw)
-            ok_allow, approval_tx = await _ensure_allowance(
-                sign_callback=sign_callback,
-                chain_id=int(from_chain_id),
-                token_address=from_token_addr,
-                owner=to_checksum_address(sender),
-                spender=to_checksum_address(str(spender)),
-                amount=need,
-            )
-            if approval_tx:
-                response["effects"]["approval"] = approval_tx
-            if not ok_allow:
-                response["status"] = "failed"
-                response["raw"] = _compact_quote(quote_data, None)
-                return ok(response)
-
-        sent_ok, sent = await _broadcast(
-            sign_callback,
-            swap_tx,
+        response["status"] = status
+        response["raw"] = compact_quote
+        _annotate_profile(
+            address=sender,
+            label=wallet_label,
+            protocol="brap",
+            action="swap",
+            tool="onchain_swap",
+            status=status,
             chain_id=int(from_chain_id),
-            wait_for_receipt=wait_for_receipt,
-            confirmations=receipt_confirmations,
+            details={
+                "from_token": from_token,
+                "to_token": to_token,
+                "amount": amount,
+            },
         )
-        response["effects"]["swap"] = sent
+        return ok(response)
 
-        status = "confirmed" if sent_ok and wait_for_receipt else "submitted"
-        if not sent_ok:
-            status = "failed"
+    swap_tx = dict(calldata)
+    swap_tx["chainId"] = int(from_chain_id)
+    swap_tx["from"] = to_checksum_address(sender)
+    if "value" in swap_tx:
+        swap_tx["value"] = int(swap_tx["value"])
 
-        bridge_tracking = best_quote.get("bridge_tracking")
-        if sent_ok and wait_for_receipt and bridge_tracking:
-            try:
-                bridge_result = await BRAP_CLIENT.wait_for_bridge_execution(
-                    bridge_tracking=bridge_tracking,
-                    tx_hash=sent["txn_hash"],
-                )
-                response["effects"]["bridge"] = bridge_result
-                if not bridge_result.get("is_success"):
-                    status = "failed"
-            except Exception as exc:  # noqa: BLE001
-                response["effects"]["bridge"] = {
-                    "state": "pending",
-                    "error": sanitize_for_json(str(exc)),
-                }
-                status = "submitted"
+    spender = (
+        best_quote.get("approvalAddress")
+        or best_quote.get("approval_address")
+        or swap_tx.get("to")
+    )
+    approve_amount = (
+        best_quote.get("input_amount")
+        or best_quote.get("inputAmount")
+        or best_quote.get("amount1")
+        or best_quote.get("amount")
+    )
+
+    if (
+        from_token_addr.lower() != ZERO_ADDRESS.lower()
+        and spender
+        and approve_amount is not None
+    ):
+        try:
+            need = int(approve_amount)
+        except Exception:
+            need = int(amount_raw)
+        ok_allow, approval_tx = await _ensure_allowance(
+            sign_callback=sign_callback,
+            chain_id=int(from_chain_id),
+            token_address=from_token_addr,
+            owner=to_checksum_address(sender),
+            spender=to_checksum_address(str(spender)),
+            amount=need,
+        )
+        if approval_tx:
+            response["effects"]["approval"] = approval_tx
+        if not ok_allow:
+            response["status"] = "failed"
+            response["raw"] = _compact_quote(quote_data, None)
+            return ok(response)
+
+    sent_ok, sent = await _broadcast(
+        sign_callback,
+        swap_tx,
+        chain_id=int(from_chain_id),
+        wait_for_receipt=wait_for_receipt,
+        confirmations=receipt_confirmations,
+    )
+    response["effects"]["swap"] = sent
+
+    status = "confirmed" if sent_ok and wait_for_receipt else "submitted"
+    if not sent_ok:
+        status = "failed"
+
+    bridge_tracking = best_quote.get("bridge_tracking")
+    if sent_ok and wait_for_receipt and bridge_tracking:
+        try:
+            bridge_result = await BRAP_CLIENT.wait_for_bridge_execution(
+                bridge_tracking=bridge_tracking,
+                tx_hash=sent["txn_hash"],
+            )
+            response["effects"]["bridge"] = bridge_result
+            if not bridge_result.get("is_success"):
+                status = "failed"
+        except Exception as exc:  # noqa: BLE001
+            response["effects"]["bridge"] = {
+                "state": "pending",
+                "error": sanitize_for_json(str(exc)),
+            }
+            status = "submitted"
 
     response["status"] = status
-    response["raw"] = _compact_quote(quote_data, best_quote)
+    response["raw"] = compact_quote
 
     _annotate_profile(
         address=sender,

--- a/wayfinder_paths/mcp/tools/execute.py
+++ b/wayfinder_paths/mcp/tools/execute.py
@@ -26,7 +26,10 @@ from wayfinder_paths.core.utils.tokens import (
 )
 from wayfinder_paths.core.utils.transaction import send_transaction
 from wayfinder_paths.core.utils.units import from_erc20_raw
-from wayfinder_paths.core.utils.wallets import get_wallet_signing_callback
+from wayfinder_paths.core.utils.wallets import (
+    get_wallet_signing_callback,
+    is_solana_enabled,
+)
 from wayfinder_paths.mcp.state.profile_store import WalletProfileStore
 from wayfinder_paths.mcp.utils import (
     catch_errors,
@@ -291,6 +294,8 @@ async def onchain_swap(
             "Could not resolve chain_id for one or more tokens",
             {"from_chain_id": from_chain_id, "to_chain_id": to_chain_id},
         )
+    if is_solana_chain(from_chain_id) and not await is_solana_enabled():
+        return err("solana_disabled", "Solana is not enabled for this account.")
     if not from_token_addr or not to_token_addr:
         return err(
             "invalid_token",
@@ -551,6 +556,9 @@ async def onchain_send(
         )
     decimals = int(token_meta.get("decimals") or 18)
     is_native = token_address.lower() == ZERO_ADDRESS.lower()
+
+    if is_solana_chain(int(resolved_chain_id)) and not await is_solana_enabled():
+        return err("solana_disabled", "Solana is not enabled for this account.")
 
     try:
         amount_raw = parse_amount_to_raw(amount, decimals)

--- a/wayfinder_paths/tests/test_solana_swap_send.py
+++ b/wayfinder_paths/tests/test_solana_swap_send.py
@@ -142,6 +142,10 @@ async def test_swap_solana_route_broadcasts_via_svm_and_skips_allowance():
     assert out["ok"] is True
     assert out["result"]["status"] == "confirmed"
     assert out["result"]["effects"]["swap"]["txn_hash"] == SOL_SIG
+    assert (
+        out["result"]["effects"]["swap"]["explorer_url"]
+        == f"https://solscan.io/tx/{SOL_SIG}"
+    )
     # No approval on Solana, and the EVM broadcast must never fire.
     assert "approval" not in out["result"]["effects"]
     evm_send.assert_not_awaited()

--- a/wayfinder_paths/tests/test_solana_swap_send.py
+++ b/wayfinder_paths/tests/test_solana_swap_send.py
@@ -70,7 +70,6 @@ def _unsigned_v0_b64(payer: str, to: str, lamports: int = 1_000) -> str:
 
 @pytest.mark.asyncio
 async def test_swap_solana_route_broadcasts_via_svm_and_skips_allowance():
-    """A solana-route quote is decoded + broadcast via SVM, not the EVM path."""
     from_meta = {
         "symbol": "USDC",
         "decimals": 6,
@@ -86,7 +85,6 @@ async def test_swap_solana_route_broadcasts_via_svm_and_skips_allowance():
     serialized = _unsigned_v0_b64(SENDER, RECIPIENT)
 
     async def fake_resolve(query: str, *, chain_id: int | None = None):
-        _ = chain_id
         return from_meta if query == "from" else to_meta
 
     fake_brap = AsyncMock()
@@ -159,7 +157,6 @@ async def test_swap_solana_route_broadcasts_via_svm_and_skips_allowance():
 
 @pytest.mark.asyncio
 async def test_swap_solana_route_detected_by_chain_id_without_chaintype():
-    """Falls back to chain-id detection when calldata omits chainType."""
     meta = {
         "symbol": "USDC",
         "decimals": 6,
@@ -345,7 +342,6 @@ async def test_send_solana_spl_builds_envelope_and_broadcasts_via_svm():
 
 @pytest.mark.asyncio
 async def test_send_solana_native_sol_uses_native_label():
-    """Native SOL resolves to ZERO_ADDRESS → send_native label + native envelope."""
     token_meta = {
         "symbol": "SOL",
         "decimals": 9,

--- a/wayfinder_paths/tests/test_solana_swap_send.py
+++ b/wayfinder_paths/tests/test_solana_swap_send.py
@@ -36,6 +36,17 @@ def _tmp_state(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("WAYFINDER_RUNS_DIR", str(tmp_path / "runs"))
 
 
+@pytest.fixture(autouse=True)
+def _solana_enabled():
+    # Default the flag on; the flag-off tests re-patch it to False.
+    with patch(
+        "wayfinder_paths.mcp.tools.execute.is_solana_enabled",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        yield
+
+
 def _svm_callback():
     cb = AsyncMock()
     cb.wallet_address = SENDER
@@ -440,5 +451,89 @@ async def test_send_solana_insufficient_balance_short_circuits_before_build():
 
     assert out["ok"] is False
     assert out["error"]["code"] == "insufficient_balance"
+    build_svm.assert_not_awaited()
+    svm_send.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# solana_enabled guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_swap_solana_blocked_when_flag_disabled():
+    meta = {
+        "symbol": "USDC",
+        "decimals": 6,
+        "chain_id": CHAIN_ID_SOLANA,
+        "address": USDC_MINT,
+    }
+    with (
+        patch(
+            "wayfinder_paths.mcp.tools.execute.is_solana_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.get_wallet_signing_callback",
+            new=AsyncMock(return_value=(_svm_callback(), SENDER)),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.TokenResolver.resolve_token_meta",
+            new_callable=AsyncMock,
+            return_value=meta,
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.send_svm_versioned_transaction",
+            new_callable=AsyncMock,
+        ) as svm_send,
+    ):
+        out = await onchain_swap(
+            wallet_label="main", from_token="from", to_token="to", amount="1.0"
+        )
+
+    assert out["ok"] is False
+    assert out["error"]["code"] == "solana_disabled"
+    svm_send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_solana_blocked_when_flag_disabled():
+    token_meta = {
+        "symbol": "USDC",
+        "decimals": 6,
+        "chain_id": CHAIN_ID_SOLANA,
+        "address": USDC_MINT,
+    }
+    with (
+        patch(
+            "wayfinder_paths.mcp.tools.execute.is_solana_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.get_wallet_signing_callback",
+            new=AsyncMock(return_value=(_svm_callback(), SENDER)),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.TokenResolver.resolve_token_meta",
+            new_callable=AsyncMock,
+            return_value=token_meta,
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.build_solana_send_transaction",
+            new_callable=AsyncMock,
+        ) as build_svm,
+        patch(
+            "wayfinder_paths.mcp.tools.execute.send_svm_versioned_transaction",
+            new_callable=AsyncMock,
+        ) as svm_send,
+    ):
+        out = await onchain_send(
+            wallet_label="main", token="usdc", recipient=RECIPIENT, amount="1.0"
+        )
+
+    assert out["ok"] is False
+    assert out["error"]["code"] == "solana_disabled"
     build_svm.assert_not_awaited()
     svm_send.assert_not_awaited()

--- a/wayfinder_paths/tests/test_solana_swap_send.py
+++ b/wayfinder_paths/tests/test_solana_swap_send.py
@@ -1,0 +1,444 @@
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from solders.hash import Hash
+from solders.message import MessageV0
+from solders.pubkey import Pubkey
+from solders.signature import Signature
+from solders.system_program import TransferParams, transfer
+from solders.transaction import VersionedTransaction
+
+from wayfinder_paths.core.constants import ZERO_ADDRESS
+from wayfinder_paths.core.constants.chains import CHAIN_ID_SOLANA
+from wayfinder_paths.core.utils.token_resolver import TokenResolver
+from wayfinder_paths.mcp.tools.execute import onchain_send, onchain_swap
+
+SENDER = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM"
+# Mixed-case base58 (case-sensitive) — lets us assert it is never checksummed/lowered.
+RECIPIENT = "8uqKmV5bMcoGw2AxoEMkseHF78ZDrAWpACvfUhxwmqqT"
+USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+SOL_SIG = "5" + "j" * 87  # base58-ish placeholder signature the SVM path returns
+
+
+@pytest.fixture(autouse=True)
+def _clear_token_resolver_cache():
+    TokenResolver._token_details_cache.clear()
+    TokenResolver._gas_token_cache.clear()
+
+
+@pytest.fixture(autouse=True)
+def _tmp_state(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("WAYFINDER_MCP_STATE_PATH", str(tmp_path / "mcp.sqlite3"))
+    monkeypatch.setenv("WAYFINDER_RUNS_DIR", str(tmp_path / "runs"))
+
+
+def _svm_callback():
+    cb = AsyncMock()
+    cb.wallet_address = SENDER
+    cb.chain_type = "solana"
+    return cb
+
+
+def _unsigned_v0_b64(payer: str, to: str, lamports: int = 1_000) -> str:
+    """A real, decodable unsigned v0 transaction, base64-encoded."""
+    payer_pk = Pubkey.from_string(payer)
+    ix = transfer(
+        TransferParams(
+            from_pubkey=payer_pk,
+            to_pubkey=Pubkey.from_string(to),
+            lamports=lamports,
+        )
+    )
+    msg = MessageV0.try_compile(
+        payer=payer_pk,
+        instructions=[ix],
+        address_lookup_table_accounts=[],
+        recent_blockhash=Hash.default(),
+    )
+    sigs = [Signature.default() for _ in range(msg.header.num_required_signatures)]
+    return base64.b64encode(bytes(VersionedTransaction.populate(msg, sigs))).decode()
+
+
+# ---------------------------------------------------------------------------
+# onchain_swap — Solana route
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_swap_solana_route_broadcasts_via_svm_and_skips_allowance():
+    """A solana-route quote is decoded + broadcast via SVM, not the EVM path."""
+    from_meta = {
+        "symbol": "USDC",
+        "decimals": 6,
+        "chain_id": CHAIN_ID_SOLANA,
+        "address": USDC_MINT,
+    }
+    to_meta = {
+        "symbol": "SOL",
+        "decimals": 9,
+        "chain_id": CHAIN_ID_SOLANA,
+        "address": ZERO_ADDRESS,
+    }
+    serialized = _unsigned_v0_b64(SENDER, RECIPIENT)
+
+    async def fake_resolve(query: str, *, chain_id: int | None = None):
+        _ = chain_id
+        return from_meta if query == "from" else to_meta
+
+    fake_brap = AsyncMock()
+    fake_brap.get_quote = AsyncMock(
+        return_value={
+            "quotes": [{"provider": "jupiter"}],
+            "best_quote": {
+                "provider": "jupiter",
+                "input_amount": "1000000",
+                "calldata": {
+                    "chainType": "solana",
+                    "chainId": CHAIN_ID_SOLANA,
+                    "serializedTransaction": serialized,
+                },
+            },
+        }
+    )
+
+    with (
+        patch(
+            "wayfinder_paths.mcp.tools.execute.get_wallet_signing_callback",
+            new=AsyncMock(return_value=(_svm_callback(), SENDER)),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.TokenResolver.resolve_token_meta",
+            new_callable=AsyncMock,
+            side_effect=fake_resolve,
+        ),
+        patch("wayfinder_paths.mcp.tools.execute.BRAP_CLIENT", fake_brap),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.get_solana_token_balance",
+            new=AsyncMock(return_value=10**9),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.send_svm_versioned_transaction",
+            new_callable=AsyncMock,
+            return_value=SOL_SIG,
+        ) as svm_send,
+        patch(
+            "wayfinder_paths.mcp.tools.execute.send_transaction",
+            new_callable=AsyncMock,
+        ) as evm_send,
+        patch(
+            "wayfinder_paths.mcp.tools.execute.ensure_allowance",
+            new_callable=AsyncMock,
+        ) as ensure,
+    ):
+        out = await onchain_swap(
+            wallet_label="main",
+            from_token="from",
+            to_token="to",
+            amount="1.0",
+        )
+
+    assert out["ok"] is True
+    assert out["result"]["status"] == "confirmed"
+    assert out["result"]["effects"]["swap"]["txn_hash"] == SOL_SIG
+    # No approval on Solana, and the EVM broadcast must never fire.
+    assert "approval" not in out["result"]["effects"]
+    evm_send.assert_not_awaited()
+    ensure.assert_not_awaited()
+
+    # The SVM broadcaster received the decoded VersionedTransaction (not a str/dict).
+    svm_send.assert_awaited_once()
+    vt_arg = svm_send.await_args.args[0]
+    assert isinstance(vt_arg, VersionedTransaction)
+    assert svm_send.await_args.kwargs["chain_id"] == CHAIN_ID_SOLANA
+    assert svm_send.await_args.kwargs["wait_for_confirmation"] is True
+
+
+@pytest.mark.asyncio
+async def test_swap_solana_route_detected_by_chain_id_without_chaintype():
+    """Falls back to chain-id detection when calldata omits chainType."""
+    meta = {
+        "symbol": "USDC",
+        "decimals": 6,
+        "chain_id": CHAIN_ID_SOLANA,
+        "address": USDC_MINT,
+    }
+    serialized = _unsigned_v0_b64(SENDER, RECIPIENT)
+
+    fake_brap = AsyncMock()
+    fake_brap.get_quote = AsyncMock(
+        return_value={
+            "quotes": [{"provider": "jupiter"}],
+            "best_quote": {
+                "provider": "jupiter",
+                "input_amount": "1000000",
+                "calldata": {"serializedTransaction": serialized},
+            },
+        }
+    )
+
+    with (
+        patch(
+            "wayfinder_paths.mcp.tools.execute.get_wallet_signing_callback",
+            new=AsyncMock(return_value=(_svm_callback(), SENDER)),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.TokenResolver.resolve_token_meta",
+            new_callable=AsyncMock,
+            return_value=meta,
+        ),
+        patch("wayfinder_paths.mcp.tools.execute.BRAP_CLIENT", fake_brap),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.get_solana_token_balance",
+            new=AsyncMock(return_value=10**9),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.send_svm_versioned_transaction",
+            new_callable=AsyncMock,
+            return_value=SOL_SIG,
+        ) as svm_send,
+        patch(
+            "wayfinder_paths.mcp.tools.execute.send_transaction",
+            new_callable=AsyncMock,
+        ) as evm_send,
+    ):
+        out = await onchain_swap(
+            wallet_label="main", from_token="from", to_token="to", amount="1.0"
+        )
+
+    assert out["ok"] is True
+    svm_send.assert_awaited_once()
+    evm_send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_swap_solana_route_missing_serialized_tx_errors():
+    meta = {
+        "symbol": "USDC",
+        "decimals": 6,
+        "chain_id": CHAIN_ID_SOLANA,
+        "address": USDC_MINT,
+    }
+    fake_brap = AsyncMock()
+    fake_brap.get_quote = AsyncMock(
+        return_value={
+            "quotes": [{"provider": "jupiter"}],
+            "best_quote": {
+                "provider": "jupiter",
+                "input_amount": "1000000",
+                "calldata": {"chainType": "solana"},
+            },
+        }
+    )
+
+    with (
+        patch(
+            "wayfinder_paths.mcp.tools.execute.get_wallet_signing_callback",
+            new=AsyncMock(return_value=(_svm_callback(), SENDER)),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.TokenResolver.resolve_token_meta",
+            new_callable=AsyncMock,
+            return_value=meta,
+        ),
+        patch("wayfinder_paths.mcp.tools.execute.BRAP_CLIENT", fake_brap),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.get_solana_token_balance",
+            new=AsyncMock(return_value=10**9),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.send_svm_versioned_transaction",
+            new_callable=AsyncMock,
+        ) as svm_send,
+    ):
+        out = await onchain_swap(
+            wallet_label="main", from_token="from", to_token="to", amount="1.0"
+        )
+
+    assert out["ok"] is False
+    assert out["error"]["code"] == "quote_error"
+    svm_send.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# onchain_send — chain 900
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_solana_spl_builds_envelope_and_broadcasts_via_svm():
+    token_meta = {
+        "symbol": "USDC",
+        "decimals": 6,
+        "chain_id": CHAIN_ID_SOLANA,
+        "address": USDC_MINT,
+    }
+    serialized = _unsigned_v0_b64(SENDER, RECIPIENT)
+    envelope = {
+        "chainType": "solana",
+        "chainId": CHAIN_ID_SOLANA,
+        "serializedTransaction": serialized,
+        "lastValidBlockHeight": 250_000_000,
+    }
+
+    with (
+        patch(
+            "wayfinder_paths.mcp.tools.execute.get_wallet_signing_callback",
+            new=AsyncMock(return_value=(_svm_callback(), SENDER)),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.TokenResolver.resolve_token_meta",
+            new_callable=AsyncMock,
+            return_value=token_meta,
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.get_solana_token_balance",
+            new=AsyncMock(return_value=5_000_000),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.build_solana_send_transaction",
+            new_callable=AsyncMock,
+            return_value=envelope,
+        ) as build_svm,
+        patch(
+            "wayfinder_paths.mcp.tools.execute.build_send_transaction",
+            new_callable=AsyncMock,
+        ) as build_evm,
+        patch(
+            "wayfinder_paths.mcp.tools.execute.send_svm_versioned_transaction",
+            new_callable=AsyncMock,
+            return_value=SOL_SIG,
+        ) as svm_send,
+        patch(
+            "wayfinder_paths.mcp.tools.execute.send_transaction",
+            new_callable=AsyncMock,
+        ) as evm_send,
+    ):
+        out = await onchain_send(
+            wallet_label="main",
+            token="usdc",
+            recipient=RECIPIENT,
+            amount="1.0",
+        )
+
+    assert out["ok"] is True
+    assert out["result"]["status"] == "confirmed"
+    assert out["result"]["effects"]["send_erc20"]["txn_hash"] == SOL_SIG
+    # Recipient passed through un-checksummed (base58 is case-sensitive).
+    assert out["result"]["recipient"] == RECIPIENT
+
+    # Solana build + SVM broadcast fired; the EVM equivalents did not.
+    build_svm.assert_awaited_once()
+    assert build_svm.await_args.kwargs["to_address"] == RECIPIENT
+    assert build_svm.await_args.kwargs["token_address"] == USDC_MINT
+    assert build_svm.await_args.kwargs["chain_id"] == CHAIN_ID_SOLANA
+    build_evm.assert_not_awaited()
+    evm_send.assert_not_awaited()
+
+    svm_send.assert_awaited_once()
+    vt_arg = svm_send.await_args.args[0]
+    assert isinstance(vt_arg, VersionedTransaction)
+
+
+@pytest.mark.asyncio
+async def test_send_solana_native_sol_uses_native_label():
+    """Native SOL resolves to ZERO_ADDRESS → send_native label + native envelope."""
+    token_meta = {
+        "symbol": "SOL",
+        "decimals": 9,
+        "chain_id": CHAIN_ID_SOLANA,
+        "address": ZERO_ADDRESS,
+    }
+    envelope = {
+        "chainType": "solana",
+        "chainId": CHAIN_ID_SOLANA,
+        "serializedTransaction": _unsigned_v0_b64(SENDER, RECIPIENT),
+        "lastValidBlockHeight": 250_000_000,
+    }
+
+    with (
+        patch(
+            "wayfinder_paths.mcp.tools.execute.get_wallet_signing_callback",
+            new=AsyncMock(return_value=(_svm_callback(), SENDER)),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.TokenResolver.resolve_token_meta",
+            new_callable=AsyncMock,
+            return_value=token_meta,
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.get_solana_token_balance",
+            new=AsyncMock(return_value=10**9),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.build_solana_send_transaction",
+            new_callable=AsyncMock,
+            return_value=envelope,
+        ) as build_svm,
+        patch(
+            "wayfinder_paths.mcp.tools.execute.send_svm_versioned_transaction",
+            new_callable=AsyncMock,
+            return_value=SOL_SIG,
+        ) as svm_send,
+    ):
+        out = await onchain_send(
+            wallet_label="main",
+            token="native",
+            recipient=RECIPIENT,
+            amount="0.5",
+            chain_id=CHAIN_ID_SOLANA,
+        )
+
+    assert out["ok"] is True
+    assert "send_native" in out["result"]["effects"]
+    assert out["result"]["effects"]["send_native"]["txn_hash"] == SOL_SIG
+    build_svm.assert_awaited_once()
+    assert build_svm.await_args.kwargs["token_address"] == ZERO_ADDRESS
+    svm_send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_send_solana_insufficient_balance_short_circuits_before_build():
+    token_meta = {
+        "symbol": "USDC",
+        "decimals": 6,
+        "chain_id": CHAIN_ID_SOLANA,
+        "address": USDC_MINT,
+    }
+    with (
+        patch(
+            "wayfinder_paths.mcp.tools.execute.get_wallet_signing_callback",
+            new=AsyncMock(return_value=(_svm_callback(), SENDER)),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.TokenResolver.resolve_token_meta",
+            new_callable=AsyncMock,
+            return_value=token_meta,
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.get_solana_token_balance",
+            new=AsyncMock(return_value=0),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.build_solana_send_transaction",
+            new_callable=AsyncMock,
+        ) as build_svm,
+        patch(
+            "wayfinder_paths.mcp.tools.execute.send_svm_versioned_transaction",
+            new_callable=AsyncMock,
+        ) as svm_send,
+    ):
+        out = await onchain_send(
+            wallet_label="main",
+            token="usdc",
+            recipient=RECIPIENT,
+            amount="1.0",
+        )
+
+    assert out["ok"] is False
+    assert out["error"]["code"] == "insufficient_balance"
+    build_svm.assert_not_awaited()
+    svm_send.assert_not_awaited()


### PR DESCRIPTION
### Summary

`onchain_swap` and `onchain_send` were EVM-only (checksum + allowance + EVM broadcast). Add a Solana (chain 900) branch to each:

- **swap**: when the BRAP quote is a Solana route (`chainType == "solana"`), decode the base64 `serializedTransaction` envelope and broadcast via `send_svm_versioned_transaction` — no allowance, no checksum (SPL transfers are authorized by the tx signature; addresses are base58).
- **send**: on chain 900, build the transfer envelope via `build_solana_send_transaction` (native SOL + SPL + Token-2022, idempotent ATA) and broadcast the same way.

EVM paths kept byte-identical. Adds `is_solana_chain` + the `svm_tokens` transfer builder (mirrors the EVM token layer). Wallet-label→SVM-signer and base58 token resolution already work on main.

Tests: 6 new mocked tests (envelope decode + SVM dispatch, allowance skipped, base58 un-checksummed, native/SPL send); EVM regression suites unchanged.