### PR TITLE
jobs: bracket delegation is a valid stop pattern, not a close-only stop

### DIFF
--- a/wayfinder_paths/jobs/execution/validation.py
+++ b/wayfinder_paths/jobs/execution/validation.py
@@ -572,12 +572,19 @@ def _script_static_checks(
     close_stop_pattern = re.search(
         r"(stop|take_profit|tp).*close", code_text, re.IGNORECASE
     )
+    # Intent bracket dicts ({"bracket": {"stop_loss": ...}}) delegate stop
+    # evaluation to the engine, which honors ohlc_rules (intrabar highs/lows)
+    # — pricing the level off a close is then correct, not a close-only stop.
+    # Without this escape hatch `"stop_loss": current_close * 0.98` inside a
+    # bracket trips the regex and agents contort strategy code to appease it.
+    bracket_delegation = re.search(r"[\"']bracket[\"']\s*:", code_text)
     checks.append(
         {
             "name": "no_close_only_stop_tp",
             "passed": close_stop_pattern is None
             or "BracketEngine" in code_text
-            or "ohlc_" in code_text,
+            or "ohlc_" in code_text
+            or bracket_delegation is not None,
         }
     )
     return checks

--- a/wayfinder_paths/tests/test_execution_timing_validation.py
+++ b/wayfinder_paths/tests/test_execution_timing_validation.py
@@ -344,6 +344,24 @@ def test_close_stop_check_still_fires_in_code(tmp_path: Path) -> None:
     assert _check(report, "no_close_only_stop_tp")["passed"] is False
 
 
+def test_close_stop_check_allows_bracket_delegation(tmp_path: Path) -> None:
+    """An intent bracket ({"bracket": {"stop_loss": ...}}) delegates stop
+    evaluation to the engine's ohlc_rules path — pricing the level off a close
+    is correct there, not a close-only stop (the xyz-scalp-lab false positive
+    that made the worker propose a cosmetic line split)."""
+    report = _close_stop_report(
+        tmp_path,
+        "def decide(ctx):\n"
+        "    current_close = 10.0\n"
+        "    return [{\n"
+        "        'action': 'OPEN',\n"
+        "        'bracket': {'stop_loss': current_close * 0.98},\n"
+        "    }]\n\n"
+        "def build_strategy(params):\n    return None\n",
+    )
+    assert _check(report, "no_close_only_stop_tp")["passed"] is True
+
+
 def test_bracket_escape_hatch_must_be_code_not_comment(tmp_path: Path) -> None:
     report = _close_stop_report(
         tmp_path,


### PR DESCRIPTION
Found while reviewing the xyz-scalp-lab watcher's first proposals.

`no_close_only_stop_tp` greps code for `(stop|take_profit|tp).*close` with escape hatches only for `BracketEngine` / `ohlc_`. A strategy that prices its bracket level off the close — `"bracket": {"stop_loss": current_close * (1 - stop_pct)}` — is the COMPLIANT pattern (the engine evaluates the level intrabar per `ohlc_rules`), yet it trips the regex because "stop" and "close" share a line.

Effect in the wild: the xyz-scalp-lab worker correctly diagnosed the failure as a scanner false positive, but since it can't change the SDK, it staged a cosmetic proposal splitting the assignment across two lines purely to appease the regex (`prop-code-change-88c54d12`, pending review — can be rejected once this lands). Two earlier attempts churned, one introducing a real bug its own validation loop then caught.

Fix: recognize an intent `bracket` dict key (in code, not comments — `_code_only_text` strips those first) as a third escape hatch. Regression test uses the exact shape that false-positived.

Full `test_execution_timing_validation.py` suite passes (22).