### PR TITLE
jobs: tag forward price series with their venue (re-land)

### DIFF
--- a/wayfinder_paths/jobs/forward_artifacts.py
+++ b/wayfinder_paths/jobs/forward_artifacts.py
@@ -391,6 +391,8 @@ def _fetch_price_series(
         window_bars = _MAX_PRICE_BARS
     lookback_bars = min(max(window_bars + _WARMUP_BARS, _WARMUP_BARS), _MAX_PRICE_BARS)
 
+    venue_by_symbol: dict[str, str] = {}
+
     async def _fetch() -> CompletedBarsView:
         rows: list[Mapping[str, Any]] = []
         # mode="paper" builds the read-only market-data side; no signing/keys.
@@ -399,7 +401,10 @@ def _fetch_price_series(
             view = await adapter.feed.get_completed_bars(
                 symbols, str(bar_interval), lookback_bars=lookback_bars, as_of=now
             )
-            rows.extend(view.to_rows())
+            venue_rows = view.to_rows()
+            for row in venue_rows:
+                venue_by_symbol.setdefault(str(row["symbol"]), str(venue))
+            rows.extend(venue_rows)
         if not rows:
             raise RuntimeError("no completed bars returned by any venue feed")
         return CompletedBarsView.from_rows(rows)
@@ -427,6 +432,9 @@ def _fetch_price_series(
                 "name": f"{symbol}_price",
                 "kind": "market_price",
                 "symbol": symbol,
+                # The venue whose feed produced these bars — lets the UI swap
+                # the static payload for that venue's live streaming chart.
+                "venue": venue_by_symbol.get(symbol),
                 "points": points,
             }
         )

--- a/wayfinder_paths/tests/test_jobs_forward_view.py
+++ b/wayfinder_paths/tests/test_jobs_forward_view.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from wayfinder_paths.jobs.forward import load_forward_snapshot
 from wayfinder_paths.jobs.forward_artifacts import forward_events, load_forward_view
 from wayfinder_paths.jobs.models import WayfinderJob
@@ -271,6 +273,62 @@ def test_downsampling_caps_points(tmp_path: Path) -> None:
     # First and last points survive the stride.
     assert equity["points"][0]["realized_pnl"] == 0.0
     assert equity["points"][-1]["realized_pnl"] == 599.0
+
+
+def test_price_series_tagged_with_venue(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Market-price series carry the venue whose feed produced their bars so
+    the UI can swap the static payload for that venue's live chart."""
+    import wayfinder_paths.jobs.execution.venues as venues_module
+    from wayfinder_paths.jobs.execution.primitives import CompletedBarsView
+
+    store = _seed_job(tmp_path)
+    spec_path = store.job_dir("carry") / "execution_spec.json"
+    spec_path.write_text(
+        json.dumps(
+            {
+                "data_contract": {
+                    "bar_interval": "1h",
+                    "symbols": ["IMX"],
+                    "market_kind": "swap",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    class _Feed:
+        async def get_completed_bars(
+            self, symbols: list[str], interval: str, **_: object
+        ) -> CompletedBarsView:
+            return CompletedBarsView.from_rows(
+                [
+                    {
+                        "timestamp": "2026-07-14T00:00:00+00:00",
+                        "symbol": symbol,
+                        "open": 0.13,
+                        "high": 0.14,
+                        "low": 0.12,
+                        "close": 0.13,
+                    }
+                    for symbol in symbols
+                ]
+            )
+
+    class _Adapter:
+        feed = _Feed()
+
+    monkeypatch.setattr(
+        venues_module, "build_adapter", lambda *args, **kwargs: _Adapter()
+    )
+
+    result = load_forward_view("carry", store=store, include_prices=True)
+    price = next(
+        s for s in result["visualization"]["series"] if s["kind"] == "market_price"
+    )
+    assert price["symbol"] == "IMX"
+    assert price["venue"] == "hyperliquid"
 
 
 def test_price_fetch_failure_degrades_with_note(tmp_path: Path) -> None:


### PR DESCRIPTION
Re-lands the venue-tag commit from #533's branch: that PR was merged at 21:25Z, five minutes before this commit was pushed to its branch, so the tag never reached `wayfinder-jobs-v1` — the jobs UI's live-candle switch (vault-frontend#1844/#1845) keys on `series.venue === "hyperliquid"` and silently falls back to the static workspace chart without it.

Clean cherry-pick of `3e2d2bd6`; forward-view test suite passes (14).