### PR TITLE
jobs: workspace signals — agent-composed triggers swept by signal-scan

### DIFF
--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -668,12 +668,20 @@ def signal_check_cmd(
     help="Final fraction of history the scan NEVER sees — reserved for one "
     "holdout-check per frozen candidate. 0 disables (exploratory only).",
 )
+@click.option(
+    "--no-workspace-signals",
+    is_flag=True,
+    default=False,
+    help="Skip the job's workspace/src/signals.py defs and sweep the "
+    "canonical library only.",
+)
 def signal_scan_cmd(
     job_id: str,
     symbols: str | None,
     horizons: str | None,
     timeframes: str | None,
     holdout_fraction: float,
+    no_workspace_signals: bool,
 ) -> None:
     store = JobStore()
     result = signal_scan_job(
@@ -682,6 +690,7 @@ def signal_scan_cmd(
         horizons=[int(h) for h in horizons.split(",")] if horizons else None,
         timeframes=[t.strip() for t in timeframes.split(",")] if timeframes else None,
         holdout_fraction=holdout_fraction,
+        include_workspace=not no_workspace_signals,
         store=store,
     )
     _echo_json({"ok": True, "result": result})
@@ -694,7 +703,11 @@ def signal_scan_cmd(
     "it once per candidate — the trial ledger remembers repeat looks.",
 )
 @click.argument("job_id")
-@click.option("--signal", required=True, help="Canonical library signal name.")
+@click.option(
+    "--signal",
+    required=True,
+    help="Canonical library or workspace (workspace/src/signals.py) signal name.",
+)
 @click.option("--horizon", type=int, required=True, help="Forward horizon in bars.")
 @click.option(
     "--direction",

--- a/wayfinder_paths/jobs/research.py
+++ b/wayfinder_paths/jobs/research.py
@@ -40,7 +40,7 @@ from __future__ import annotations
 
 import json
 import math
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 import numpy as np
@@ -48,6 +48,7 @@ import pandas as pd
 
 from wayfinder_paths.jobs.signal_library import (
     SIGNAL_LIBRARY,
+    SignalDef,
     build_signal_frame,
     signal_defs,
     wilder_atr,
@@ -464,16 +465,32 @@ def resample_ohlcv(
     source bar lands exactly on its label (an in-progress bucket is not a
     completed bar). Both dataset feeds label bars by CLOSE time; an
     open-labeled source would silently leak one bar — keep it that way.
+
+    Non-OHLCV columns (merged feature columns like `funding`) are carried
+    with last-value aggregation — the value as-of the bucket close, matching
+    merge_asof(direction="backward") semantics — and coerced to numeric:
+    merge_features emits object dtype with Nones, and builders must see the
+    same dtype whether or not the timeframe resamples (identity path too).
+    Flow-like features wanting `sum` aggregation are not supported.
     """
     if rule_seconds <= 0 or bar_seconds <= 0 or rule_seconds % bar_seconds != 0:
         raise ValueError(
             f"rule_seconds ({rule_seconds}) must be a positive multiple of "
             f"bar_seconds ({bar_seconds})"
         )
+    bar_columns = ["timestamp", "symbol", "open", "high", "low", "close", "volume"]
+    extras = [c for c in frame.columns if c not in bar_columns]
     if rule_seconds == bar_seconds:
-        return frame.reset_index(drop=True)
+        out = frame.reset_index(drop=True)
+        if extras:
+            out = out.copy()
+            for column in extras:
+                out[column] = pd.to_numeric(out[column], errors="coerce")
+        return out
     symbol = str(frame["symbol"].iloc[0]) if len(frame) else ""
     indexed = frame.set_index(pd.to_datetime(frame["timestamp"], utc=True))
+    for column in extras:
+        indexed[column] = pd.to_numeric(indexed[column], errors="coerce")
     resampled = indexed.resample(f"{rule_seconds}s", closed="right", label="right").agg(
         {
             "open": "first",
@@ -482,6 +499,7 @@ def resample_ohlcv(
             "close": "last",
             "volume": "sum",
         }
+        | dict.fromkeys(extras, "last")
     )
     resampled = resampled.dropna(subset=["close"])
     if len(resampled) and len(indexed):
@@ -490,7 +508,7 @@ def resample_ohlcv(
             resampled = resampled.iloc[:-1]
     out = resampled.reset_index().rename(columns={"index": "timestamp"})
     out["symbol"] = symbol
-    return out[["timestamp", "symbol", "open", "high", "low", "close", "volume"]]
+    return out[bar_columns + extras]
 
 
 def bh_qvalues(pvalues: Sequence[float]) -> list[float]:
@@ -690,19 +708,22 @@ def holdout_event_study(
     timeframe_seconds: int | None = None,
     min_events: int = 10,
     t_threshold: float = 1.0,
+    extra_defs: Mapping[str, SignalDef] | None = None,
 ) -> dict[str, Any]:
     """One pre-registered confirmation of a FROZEN scan candidate on the
     reserved holdout tail. The bar is deliberately lower than the scan's
     q-gate (directional t >= 1, n >= 10) because this is a single declared
     test, not a search — and it is spendable ONCE per candidate (the scan
-    ledger remembers).
+    ledger remembers). `extra_defs` extends the lookup to validated
+    workspace signals so composed candidates confirm the same way.
 
     The signal is computed over the FULL series so holdout events get proper
     indicator warmup; the causal prefix property means this cannot leak."""
-    defs = signal_defs()
+    defs = {**signal_defs(), **(extra_defs or {})}
     if signal not in defs:
         raise KeyError(
-            f"signal {signal!r} not in the canonical library; available: {sorted(defs)}"
+            f"signal {signal!r} not in the canonical library or workspace "
+            f"signals; available: {sorted(defs)}"
         )
     if direction not in {"long", "short"}:
         raise ValueError(
@@ -822,10 +843,14 @@ def scan_signals(
     q_threshold: float = 0.10,
     fee_bps: float = 5.0,
     slippage_bps: float = 3.5,
+    extra_signals: Sequence[SignalDef] = (),
 ) -> dict[str, Any]:
     """Event-study EVERY canonical library trigger against one symbol's bars
     — across timeframes, in a single pass — the breadth tool that replaces
-    hand-rewriting `precompute()` once per trigger idea.
+    hand-rewriting `precompute()` once per trigger idea. `extra_signals`
+    (validated workspace defs) join the sweep as first-class family members:
+    same decimation, same folds, same pooled BH — composed trials pay the
+    same multiple-testing bill as canonical ones.
 
     Discipline built in:
     - A holdout tail (`holdout_fraction`, default the final 15%) is reserved
@@ -863,6 +888,7 @@ def scan_signals(
             )
             continue
         tf_specs.append((str(tf), seconds))
+    extra_names = {spec.name for spec in extra_signals}
     rows: list[dict[str, Any]] = []
     tests_run = 0
     tests_skipped = 0
@@ -874,7 +900,7 @@ def scan_signals(
         frames_by_tf[tf_name] = bars
         close = bars["close"].astype(float).to_numpy()
         n = len(close)
-        signals = build_signal_frame(bars)
+        signals = build_signal_frame(bars, extra_signals)
         tf_horizons = sorted(
             {int(h) for h in horizons}
             if horizons
@@ -891,7 +917,7 @@ def scan_signals(
                 continue
             fwd = np.log(close[h:] / close[:-h])
             drift = float(fwd.mean())
-            for spec in SIGNAL_LIBRARY:
+            for spec in (*SIGNAL_LIBRARY, *extra_signals):
                 sig = signals[spec.name].to_numpy()
                 events = _decimate_events(sig[: n - h], h)
                 n_events = int(events.sum())
@@ -917,6 +943,9 @@ def scan_signals(
                     {
                         "signal": spec.name,
                         "family": spec.family,
+                        "library": (
+                            "workspace" if spec.name in extra_names else "canonical"
+                        ),
                         "description": spec.description,
                         "timeframe": tf_name,
                         "horizon": h,
@@ -963,7 +992,8 @@ def scan_signals(
     promoted = [r for r in rows if r["verdict"] == "promote"]
     expected_lucky = round(tests_run * 0.05, 1)
     return {
-        "signals_tested": len(SIGNAL_LIBRARY),
+        "signals_tested": len(SIGNAL_LIBRARY) + len(extra_signals),
+        "workspace_signals": sorted(extra_names),
         "timeframes": [name for name, _ in tf_specs],
         "timeframes_skipped": timeframes_skipped,
         "horizons": horizons_used,
@@ -1596,6 +1626,7 @@ def signal_scan_job(
     horizons: list[int] | None = None,
     timeframes: list[str] | None = None,
     holdout_fraction: float = 0.15,
+    include_workspace: bool = True,
     store: Any | None = None,
 ) -> dict[str, Any]:
     """Scan the ENTIRE canonical trigger library against the job's dataset —
@@ -1616,6 +1647,10 @@ def signal_scan_job(
     from wayfinder_paths.jobs.execution.validation import resolve_execution_spec
     from wayfinder_paths.jobs.models import utc_now_iso
     from wayfinder_paths.jobs.store import JobStore
+    from wayfinder_paths.jobs.workspace_signals import (
+        load_workspace_signals,
+        validate_workspace_signals,
+    )
 
     store = store or JobStore()
     root = store.job_dir(job_id)
@@ -1635,6 +1670,16 @@ def signal_scan_job(
         raise ValueError(
             f"symbols {missing} not in the job dataset; available: {available}"
         )
+    workspace = load_workspace_signals(root) if include_workspace else None
+    if workspace is not None:
+        # Validation reads only pass/fail causality on the full frame — no
+        # statistic escapes, so touching the tail here is not snooping.
+        for symbol in targets:
+            validate_workspace_signals(
+                workspace.defs,
+                frame[frame["symbol"] == symbol].reset_index(drop=True),
+            )
+    extra_signals = workspace.defs if workspace is not None else ()
     per_symbol = {
         symbol: scan_signals(
             frame[frame["symbol"] == symbol].reset_index(drop=True),
@@ -1644,6 +1689,7 @@ def signal_scan_job(
             holdout_fraction=holdout_fraction,
             fee_bps=fee_bps,
             slippage_bps=slippage_bps,
+            extra_signals=extra_signals,
         )
         for symbol in targets
     }
@@ -1674,6 +1720,8 @@ def signal_scan_job(
             "cutoff_ts": {
                 sym: scan["holdout"]["cutoff_ts"] for sym, scan in per_symbol.items()
             },
+            "workspace_signals": [spec.name for spec in extra_signals],
+            "workspace_signals_sha": workspace.sha if workspace else None,
         }
     ]
     # EVERY executed test is a recorded trial — not just the survivors.
@@ -1695,12 +1743,14 @@ def signal_scan_job(
                     "q": row.get("q_value"),
                     "folds_agreeing": row.get("folds_agreeing"),
                     "verdict": row.get("verdict"),
+                    "library": row.get("library"),
                 }
             )
     _append_scan_ledger(root, ledger_rows)
     cumulative_tests = prior_tests + sum(s["tests_run"] for s in per_symbol.values())
     result: dict[str, Any] = {
         "per_symbol": per_symbol,
+        "workspace_signals": [spec.name for spec in extra_signals],
         "holdout": {
             "fraction": holdout_fraction,
             "cutoff_ts_per_symbol": {
@@ -1754,6 +1804,10 @@ def holdout_check_job(
     )
     from wayfinder_paths.jobs.execution.validation import resolve_execution_spec
     from wayfinder_paths.jobs.store import JobStore
+    from wayfinder_paths.jobs.workspace_signals import (
+        load_workspace_signals,
+        validate_workspace_signals,
+    )
 
     store = store or JobStore()
     root = store.job_dir(job_id)
@@ -1769,6 +1823,26 @@ def holdout_check_job(
     frame = dataset.bars.to_frame()
     available = sorted(frame["symbol"].astype(str).unique())
     targets = [str(s) for s in symbols] if symbols else available
+    workspace = load_workspace_signals(root)
+    extra_defs: dict[str, SignalDef] = {}
+    workspace_changed_since_scan = False
+    if workspace is not None and signal not in signal_defs():
+        # Highest-stakes read of a workspace def: re-run the causality gate,
+        # and compare the code sha against the scan that nominated it — a
+        # holdout on edited code is confirming something the scan never saw.
+        for symbol in targets:
+            validate_workspace_signals(
+                workspace.defs,
+                frame[frame["symbol"] == symbol].reset_index(drop=True),
+            )
+        extra_defs = {spec_.name: spec_ for spec_ in workspace.defs}
+        scanned_shas = [
+            row.get("workspace_signals_sha")
+            for row in _read_scan_ledger(root)
+            if row.get("kind") == "scan_meta" and row.get("workspace_signals_sha")
+        ]
+        if scanned_shas and scanned_shas[-1] != workspace.sha:
+            workspace_changed_since_scan = True
     scan_path = _scan_dir(root) / "scan.json"
     recorded_cutoffs: dict[str, Any] = {}
     if scan_path.exists():
@@ -1809,6 +1883,7 @@ def holdout_check_job(
             cutoff_ts=cutoff,
             bar_seconds=bar_seconds,
             timeframe_seconds=tf_seconds,
+            extra_defs=extra_defs,
         )
         if cutoff_note:
             report["cutoff_note"] = cutoff_note
@@ -1837,6 +1912,12 @@ def holdout_check_job(
         "per_symbol": per_symbol,
         "already_spent": already_spent,
     }
+    if workspace_changed_since_scan:
+        result["workspace_signals_changed_since_scan"] = True
+        result["workspace_warning"] = (
+            "workspace/src/signals.py changed since the last recorded scan — "
+            "this holdout is confirming code the scan never tested"
+        )
     if already_spent:
         result["read"] = (
             "this tail has already been used to confirm this candidate — a "

--- a/wayfinder_paths/jobs/signal_library.py
+++ b/wayfinder_paths/jobs/signal_library.py
@@ -21,7 +21,7 @@ changes past values) is pinned by tests.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
 import numpy as np
@@ -373,11 +373,16 @@ SIGNAL_LIBRARY: tuple[SignalDef, ...] = (
 )
 
 
-def build_signal_frame(frame: pd.DataFrame) -> pd.DataFrame:
+def build_signal_frame(
+    frame: pd.DataFrame, extra_signals: Sequence[SignalDef] = ()
+) -> pd.DataFrame:
     """All library signals for one symbol's OHLCV frame, as boolean columns
-    row-aligned with the input. NaN warmup rows resolve to False."""
+    row-aligned with the input. NaN warmup rows resolve to False.
+
+    `extra_signals` (validated workspace defs) are materialized after the
+    canonical library so the scan sweeps both under one test family."""
     out = pd.DataFrame(index=frame.index)
-    for spec in SIGNAL_LIBRARY:
+    for spec in (*SIGNAL_LIBRARY, *extra_signals):
         out[spec.name] = (
             spec.build(frame).fillna(False).astype(bool)
             if len(frame) >= spec.min_bars

--- a/wayfinder_paths/jobs/workspace_signals.py
+++ b/wayfinder_paths/jobs/workspace_signals.py
@@ -1,0 +1,194 @@
+"""Per-job workspace signals: agent-composed triggers swept by `signal-scan`.
+
+A job may declare extra `SignalDef`s in `workspace/src/signals.py`:
+
+    from wayfinder_paths.jobs.signal_library import SignalDef
+
+    WORKSPACE_SIGNALS = (
+        SignalDef(
+            "funding_neg_new_high_5",
+            "workspace",
+            "fresh 5-bar high while funding is negative",
+            9,
+            lambda f: (f["close"] > f["close"].shift(1).rolling(5).max())
+            & (f["funding"] < 0),
+        ),
+    )
+
+`signal_scan_job` sweeps these ALONGSIDE the canonical library under the same
+pooled Benjamini-Hochberg family, event decimation, fold-stability gate, and
+reserved holdout — that shared discipline is the whole point. Serial one-off
+`signal-check`s on hand-rolled columns have no multiple-testing control;
+declaring the composition here puts it back under one.
+
+The contract is a list of named defs — NOT a frame-level hook — because
+`holdout-check` must recompute one signal by name on the full frame,
+`min_bars` gates warmup junk per def, and the cap/validation need per-def
+identity. Validation is fail-loud: one bad def aborts the scan, because a
+silently shrunk family would falsify the declared BH denominator (the agent
+that wrote the file is awake in the same session and can fix it).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+import pandas as pd
+
+from wayfinder_paths.jobs.execution.primitives import _load_module_from_path
+from wayfinder_paths.jobs.signal_library import SignalDef, signal_defs
+
+WORKSPACE_SIGNALS_ATTR = "WORKSPACE_SIGNALS"
+WORKSPACE_SIGNALS_RELPATH = "workspace/src/signals.py"
+# Every def added to a scan inflates the BH denominator for the WHOLE family
+# — breadth costs power for everything else in the same scan. The cap keeps
+# one wake's composition budget honest; raising it is a deliberate decision,
+# not a workaround.
+WORKSPACE_SIGNAL_CAP = 12
+
+_NAME_RE = re.compile(r"^[a-z0-9_]{1,48}$")
+_CAUSALITY_TRUNCATE = 50
+
+
+@dataclass(frozen=True)
+class WorkspaceSignalSet:
+    defs: tuple[SignalDef, ...]
+    path: Path
+    # sha1 of the file bytes: scan/holdout provenance. The ledger records it
+    # so "rename the def and relaunch" is visible in audit as the same (or
+    # changed) code rather than a fresh trial family.
+    sha: str
+
+
+def load_workspace_signals(root: Path) -> WorkspaceSignalSet | None:
+    """Load `workspace/src/signals.py` for a job root, or None when absent.
+
+    Absent file → canonical-only scan, silently (most jobs never compose).
+    A present-but-broken file raises: the declared family must equal the
+    executed family.
+    """
+    path = root / WORKSPACE_SIGNALS_RELPATH
+    if not path.exists():
+        return None
+    module = _load_module_from_path(path)
+    raw = getattr(module, WORKSPACE_SIGNALS_ATTR, None)
+    if raw is None:
+        raise ValueError(
+            f"{path} exists but defines no {WORKSPACE_SIGNALS_ATTR}; "
+            "remove the file or declare the tuple"
+        )
+    defs = tuple(raw)
+    for entry in defs:
+        if not isinstance(entry, SignalDef):
+            raise ValueError(
+                f"{WORKSPACE_SIGNALS_ATTR} entries must be SignalDef, "
+                f"got {type(entry).__name__}"
+            )
+    sha = hashlib.sha1(path.read_bytes()).hexdigest()[:12]
+    return WorkspaceSignalSet(defs=defs, path=path, sha=sha)
+
+
+def validate_workspace_signals(
+    defs: Sequence[SignalDef],
+    probe: pd.DataFrame,
+    *,
+    truncate: int = _CAUSALITY_TRUNCATE,
+) -> None:
+    """Fail-loud validation of workspace defs against a real probe frame.
+
+    Checks: cap, name shape/uniqueness, disjointness from the canonical
+    library (the entire ledger-hash-collision defense — `_trial_hash` keys on
+    the signal NAME), boolean output of input length, and an automated
+    causality gate: building on a truncated frame must reproduce the full
+    frame's prefix. That catches centered rolling windows and full-frame
+    normalization; it cannot catch back-dated feature rows — the append-only
+    feature store owns that discipline.
+    """
+    problems: list[str] = []
+    if not defs:
+        problems.append("WORKSPACE_SIGNALS is empty — remove the file instead")
+    if len(defs) > WORKSPACE_SIGNAL_CAP:
+        problems.append(
+            f"{len(defs)} defs exceed the cap of {WORKSPACE_SIGNAL_CAP}; every "
+            "def raises the promote bar for the whole scan family — trim to "
+            "the strongest hypotheses"
+        )
+    canonical = set(signal_defs())
+    seen: set[str] = set()
+    for spec in defs:
+        if not _NAME_RE.match(spec.name):
+            problems.append(f"{spec.name!r}: name must match {_NAME_RE.pattern}")
+        if spec.name in canonical:
+            problems.append(f"{spec.name!r}: collides with a canonical library signal")
+        if spec.name in seen:
+            problems.append(f"{spec.name!r}: duplicate name")
+        seen.add(spec.name)
+    if problems:
+        raise ValueError("invalid workspace signals: " + "; ".join(problems))
+    if len(probe) <= truncate:
+        raise ValueError(
+            f"probe frame too short ({len(probe)} rows) to validate "
+            f"workspace signals (need > {truncate})"
+        )
+    for spec in defs:
+        try:
+            full = spec.build(probe)
+        except Exception as exc:
+            raise ValueError(f"{spec.name!r}: build raised {exc!r}") from exc
+        if len(full) != len(probe):
+            problems.append(
+                f"{spec.name!r}: output length {len(full)} != input {len(probe)}"
+            )
+            continue
+        coerced = full.fillna(False)
+        if not set(pd.unique(coerced)) <= {True, False}:
+            problems.append(
+                f"{spec.name!r}: output must be boolean (got dtype "
+                f"{full.dtype}); floats silently truthy-coerce"
+            )
+            continue
+        truncated = spec.build(probe.iloc[:-truncate]).fillna(False).astype(bool)
+        prefix = coerced.astype(bool).iloc[: len(truncated)]
+        if not truncated.reset_index(drop=True).equals(prefix.reset_index(drop=True)):
+            problems.append(
+                f"{spec.name!r}: non-causal — truncating the frame changed "
+                "earlier values (centered window or full-frame statistic?)"
+            )
+            continue
+        # Truncation only disagrees at the boundary row, which can coincide
+        # by luck (a rare-firing lookahead is mostly False either way). The
+        # stronger gate: violently perturb the TAIL both directions — any
+        # builder reading future rows cannot reproduce the original prefix
+        # under both x10 and x0.1 tails.
+        base_prefix = coerced.astype(bool).iloc[:-truncate].reset_index(drop=True)
+        numeric = [
+            c
+            for c in probe.columns
+            if c not in ("timestamp", "symbol")
+            and pd.api.types.is_numeric_dtype(probe[c])
+        ]
+        for scale in (10.0, 0.1):
+            perturbed = probe.copy()
+            perturbed.loc[perturbed.index[-truncate:], numeric] = (
+                perturbed.loc[perturbed.index[-truncate:], numeric] * scale
+            )
+            shifted = (
+                spec.build(perturbed)
+                .fillna(False)
+                .astype(bool)
+                .iloc[:-truncate]
+                .reset_index(drop=True)
+            )
+            if not shifted.equals(base_prefix):
+                problems.append(
+                    f"{spec.name!r}: non-causal — perturbing future bars "
+                    "changed earlier values (uses shift(-1) or a "
+                    "full-frame statistic?)"
+                )
+                break
+    if problems:
+        raise ValueError("invalid workspace signals: " + "; ".join(problems))

--- a/wayfinder_paths/tests/test_workspace_signals.py
+++ b/wayfinder_paths/tests/test_workspace_signals.py
@@ -1,0 +1,335 @@
+"""Workspace signal sweep: agent-composed defs join the canonical scan under
+one pooled BH family, feature columns survive timeframe resampling, the
+causality gate rejects lookahead compositions, and holdout confirms workspace
+candidates with sha provenance."""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from wayfinder_paths.jobs.research import (
+    holdout_check_job,
+    resample_ohlcv,
+    scan_signals,
+    signal_scan_job,
+)
+from wayfinder_paths.jobs.signal_library import (
+    SIGNAL_LIBRARY,
+    SignalDef,
+    build_signal_frame,
+)
+from wayfinder_paths.jobs.workspace_signals import (
+    WORKSPACE_SIGNAL_CAP,
+    load_workspace_signals,
+    validate_workspace_signals,
+)
+
+
+def _bars(closes: list[float], extra: dict[str, list] | None = None) -> pd.DataFrame:
+    n = len(closes)
+    opens = [closes[0], *closes[:-1]]
+    frame = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2026-01-01", periods=n, freq="1h", tz="UTC"),
+            "symbol": "IMX",
+            "open": opens,
+            "high": [max(o, c) * 1.002 for o, c in zip(opens, closes, strict=False)],
+            "low": [min(o, c) * 0.998 for o, c in zip(opens, closes, strict=False)],
+            "close": closes,
+            "volume": [100.0] * n,
+        }
+    )
+    for name, values in (extra or {}).items():
+        frame[name] = values
+    return frame
+
+
+def _wavy_closes(n: int) -> list[float]:
+    return [
+        100.0 + 8.0 * np.sin(i / 7.0) + 3.0 * np.sin(i / 23.0) - 0.01 * i
+        for i in range(n)
+    ]
+
+
+class TestResampleFeatureCarry:
+    def test_last_value_aggregation_and_dtype(self):
+        # Feature columns arrive from merge_features as object dtype with
+        # Nones; resampling must coerce to float and take the value as-of
+        # the bucket close.
+        funding: list = [None, None, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6]
+        frame = _bars([100.0 + i for i in range(8)], {"funding": funding})
+        frame["funding"] = frame["funding"].astype(object)
+        out = resample_ohlcv(frame, 4 * 3600, bar_seconds=3600)
+        assert out["funding"].dtype == float
+        # Bucket labeled 04:00 holds bars 1-4 -> last funding is 0.3.
+        assert out["funding"].iloc[1] == pytest.approx(0.3)
+
+    def test_identity_path_coerces_dtype(self):
+        frame = _bars([100.0, 101.0, 102.0], {"funding": [None, 0.1, 0.2]})
+        frame["funding"] = frame["funding"].astype(object)
+        out = resample_ohlcv(frame, 3600, bar_seconds=3600)
+        assert out["funding"].dtype == float
+        assert np.isnan(out["funding"].iloc[0])
+
+    def test_prefix_property_with_extras(self):
+        closes = _wavy_closes(400)
+        funding = [0.01 * np.sin(i / 5.0) for i in range(400)]
+        full = resample_ohlcv(
+            _bars(closes, {"funding": funding}), 4 * 3600, bar_seconds=3600
+        )
+        prefix = resample_ohlcv(
+            _bars(closes[:300], {"funding": funding[:300]}),
+            4 * 3600,
+            bar_seconds=3600,
+        )
+        pd.testing.assert_frame_equal(full.iloc[: len(prefix)], prefix)
+
+
+def _plain_def() -> SignalDef:
+    return SignalDef(
+        "ws_new_high_3",
+        "workspace",
+        "close above the prior 3 closes' maximum",
+        5,
+        lambda f: f["close"] > f["close"].shift(1).rolling(3).max(),
+    )
+
+
+class TestValidateWorkspaceSignals:
+    def _probe(self) -> pd.DataFrame:
+        return _bars(_wavy_closes(300))
+
+    def test_accepts_causal_boolean_defs(self):
+        validate_workspace_signals([_plain_def()], self._probe())
+
+    def test_rejects_over_cap(self):
+        defs = [
+            SignalDef(f"ws_sig_{i}", "workspace", "d", 3, lambda f: f["close"] > 0)
+            for i in range(WORKSPACE_SIGNAL_CAP + 1)
+        ]
+        with pytest.raises(ValueError, match="cap"):
+            validate_workspace_signals(defs, self._probe())
+
+    def test_rejects_canonical_collision(self):
+        clash = SignalDef("new_low_5", "workspace", "d", 3, lambda f: f["close"] > 0)
+        with pytest.raises(ValueError, match="collides"):
+            validate_workspace_signals([clash], self._probe())
+
+    def test_rejects_non_causal(self):
+        peek = SignalDef(
+            "ws_peek",
+            "workspace",
+            "tomorrow's close is higher (lookahead)",
+            3,
+            lambda f: f["close"].shift(-1) > f["close"],
+        )
+        with pytest.raises(ValueError, match="non-causal"):
+            validate_workspace_signals([peek], self._probe())
+
+    def test_rejects_float_output(self):
+        floaty = SignalDef(
+            "ws_floaty",
+            "workspace",
+            "returns a float column",
+            3,
+            lambda f: f["close"] - f["close"].shift(1),
+        )
+        with pytest.raises(ValueError, match="boolean"):
+            validate_workspace_signals([floaty], self._probe())
+
+
+class TestBuildSignalFrameExtras:
+    def test_extra_columns_materialize_after_library(self):
+        frame = _bars(_wavy_closes(300))
+        signals = build_signal_frame(frame, [_plain_def()])
+        assert "ws_new_high_3" in signals.columns
+        assert len(signals.columns) == len(SIGNAL_LIBRARY) + 1
+        assert signals["ws_new_high_3"].dtype == bool
+
+    def test_scan_counts_and_tags_workspace_rows(self):
+        result = scan_signals(
+            _bars(_wavy_closes(700)),
+            horizons=[4],
+            holdout_fraction=0.0,
+            extra_signals=[_plain_def()],
+        )
+        assert result["signals_tested"] == len(SIGNAL_LIBRARY) + 1
+        assert result["workspace_signals"] == ["ws_new_high_3"]
+        libraries = {row["signal"]: row["library"] for row in result["_all_rows"]}
+        assert libraries["ws_new_high_3"] == "workspace"
+        assert libraries["new_low_5"] == "canonical"
+
+
+_WORKSPACE_MODULE = """
+from wayfinder_paths.jobs.signal_library import SignalDef
+
+WORKSPACE_SIGNALS = (
+    SignalDef(
+        "ws_funding_neg_high_3",
+        "workspace",
+        "fresh 3-bar high while funding is negative",
+        5,
+        lambda f: (f["close"] > f["close"].shift(1).rolling(3).max())
+        & (f["funding"] < 0),
+    ),
+    SignalDef(
+        "ws_new_high_3",
+        "workspace",
+        "close above the prior 3 closes' maximum",
+        5,
+        lambda f: f["close"] > f["close"].shift(1).rolling(3).max(),
+    ),
+)
+"""
+
+
+def _scan_job_store(tmp_path, closes, *, with_workspace=True, with_funding=True):
+    from wayfinder_paths.jobs.store import JobStore
+
+    store = JobStore(repo_root=tmp_path)
+    root = store.job_dir("scan-job")
+    (root / "results" / "backtest").mkdir(parents=True, exist_ok=True)
+    (root / "job.yaml").write_text("id: scan-job\n")
+    features = [{"name": "funding"}] if with_funding else []
+    (root / "execution_spec.json").write_text(
+        json.dumps(
+            {
+                "market_kind": "perp",
+                "data_contract": {
+                    "bar_interval": "1h",
+                    "symbols": ["IMX"],
+                    "features": features,
+                },
+            }
+        )
+    )
+    bars = _bars(closes)
+    rows = bars.assign(timestamp=bars["timestamp"].astype(str)).to_dict("records")
+    (root / "results" / "backtest" / "input_bars.json").write_text(
+        json.dumps({"bars": rows})
+    )
+    if with_funding:
+        state = root / "state"
+        state.mkdir(parents=True, exist_ok=True)
+        feature_rows = [
+            {
+                "timestamp": str(ts),
+                "name": "funding",
+                "value": -0.01 if i % 2 == 0 else 0.01,
+                "symbol": "IMX",
+            }
+            for i, ts in enumerate(bars["timestamp"])
+        ]
+        (state / "features.jsonl").write_text(
+            "\n".join(json.dumps(row) for row in feature_rows) + "\n"
+        )
+    if with_workspace:
+        src = root / "workspace" / "src"
+        src.mkdir(parents=True, exist_ok=True)
+        (src / "signals.py").write_text(_WORKSPACE_MODULE)
+    return store
+
+
+class TestWorkspaceScanEndToEnd:
+    def _closes(self, n=1500):
+        rng = np.random.default_rng(7)
+        return list(100.0 * np.exp(np.cumsum(rng.normal(0, 0.004, n))))
+
+    def test_sweep_tags_and_ledger_provenance(self, tmp_path):
+        store = _scan_job_store(tmp_path, self._closes())
+        result = signal_scan_job("scan-job", store=store)
+        assert result["workspace_signals"] == [
+            "ws_funding_neg_high_3",
+            "ws_new_high_3",
+        ]
+        scan = result["per_symbol"]["IMX"]
+        assert scan["signals_tested"] == len(SIGNAL_LIBRARY) + 2
+        ws_rows = [
+            row
+            for row in scan["candidates"] + scan["promoted"]
+            if row["signal"].startswith("ws_")
+        ]
+        for row in ws_rows:
+            assert row["library"] == "workspace"
+            assert "q_value" in row
+        ledger_path = (
+            store.job_dir("scan-job")
+            / "results"
+            / "research"
+            / "signal_scan"
+            / "ledger.jsonl"
+        )
+        rows = [json.loads(line) for line in ledger_path.read_text().splitlines()]
+        meta = [row for row in rows if row.get("kind") == "scan_meta"]
+        assert meta[-1]["workspace_signals"] == [
+            "ws_funding_neg_high_3",
+            "ws_new_high_3",
+        ]
+        assert meta[-1]["workspace_signals_sha"]
+        tests = [row for row in rows if row.get("kind") == "scan_test"]
+        assert any(row.get("library") == "workspace" for row in tests)
+        assert any(row.get("library") == "canonical" for row in tests)
+
+    def test_no_workspace_flag_excludes(self, tmp_path):
+        store = _scan_job_store(tmp_path, self._closes())
+        result = signal_scan_job("scan-job", store=store, include_workspace=False)
+        assert result["workspace_signals"] == []
+        scan = result["per_symbol"]["IMX"]
+        assert scan["signals_tested"] == len(SIGNAL_LIBRARY)
+
+    def test_missing_workspace_file_scans_canonical_only(self, tmp_path):
+        store = _scan_job_store(tmp_path, self._closes(), with_workspace=False)
+        result = signal_scan_job("scan-job", store=store)
+        assert result["workspace_signals"] == []
+
+    def test_holdout_confirms_workspace_signal_and_spends_once(self, tmp_path):
+        store = _scan_job_store(tmp_path, self._closes())
+        signal_scan_job("scan-job", store=store)
+        spent = holdout_check_job(
+            "scan-job",
+            signal="ws_new_high_3",
+            horizon=4,
+            direction="long",
+            store=store,
+        )
+        assert spent["already_spent"] is False
+        assert "workspace_signals_changed_since_scan" not in spent
+        respent = holdout_check_job(
+            "scan-job",
+            signal="ws_new_high_3",
+            horizon=4,
+            direction="long",
+            store=store,
+        )
+        assert respent["already_spent"] is True
+
+    def test_holdout_flags_edited_workspace_code(self, tmp_path):
+        store = _scan_job_store(tmp_path, self._closes())
+        signal_scan_job("scan-job", store=store)
+        signals_path = store.job_dir("scan-job") / "workspace" / "src" / "signals.py"
+        signals_path.write_text(_WORKSPACE_MODULE + "\n# edited after scan\n")
+        report = holdout_check_job(
+            "scan-job",
+            signal="ws_new_high_3",
+            horizon=4,
+            direction="long",
+            store=store,
+        )
+        assert report["workspace_signals_changed_since_scan"] is True
+        assert "never tested" in report["workspace_warning"]
+
+
+class TestLoader:
+    def test_missing_file_returns_none(self, tmp_path):
+        assert load_workspace_signals(tmp_path) is None
+
+    def test_present_without_attr_raises(self, tmp_path):
+        src = tmp_path / "workspace" / "src"
+        src.mkdir(parents=True)
+        (src / "signals.py").write_text("x = 1\n")
+        with pytest.raises(ValueError, match="WORKSPACE_SIGNALS"):
+            load_workspace_signals(tmp_path)


### PR DESCRIPTION
First of the research-space expansion PRs (approved plan). The xyz-scalp-lab watcher exhausted the frozen 28-trigger library (924 tests, 0 promotions) and stalled — it had no sanctioned way to compose its own signals, and one-off `signal-check`s on hand-rolled columns have no multiple-testing control.

**Mechanism**: a job may declare up to 12 `SignalDef`s in `workspace/src/signals.py` (`WORKSPACE_SIGNALS` tuple). `signal-scan` sweeps them alongside the canonical library — one pooled BH family, same decimation, fold-stability, and reserved holdout. Composed trials pay the same multiple-testing bill as canonical ones; that IS the discipline.

**Guardrails (fail-loud — a silently shrunk family would falsify the declared BH denominator):**
- name regex + uniqueness + disjointness from the canonical library (the trial-ledger hash keys on signal name)
- boolean-output checks (floats silently truthy-coerce)
- automated causality gate: prefix truncation + two-sided tail perturbation (×10/×0.1) — catches `shift(-1)` lookaheads and full-frame statistics deterministically
- `scan_meta` ledger rows record the signals-file sha (rename-to-relaunch is auditable); `holdout-check` confirms workspace candidates and warns when the code changed since the scan that nominated them

**Feature carry**: `resample_ohlcv` now carries non-OHLCV columns (merged features like `funding`) with last-value aggregation — value as-of bucket close, matching `merge_asof(backward)` — and numeric coercion on both paths (merge_features emits object dtype).

CLI: `signal-scan --no-workspace-signals` opts out. MCP routing is kwargs-passthrough — no change.

Tests: 17 new (feature carry incl. dtype/prefix, end-to-end sweep with a feature-conditioned def, all rejection paths, workspace holdout + sha flag); signal-library/research/validation suites all pass (121 total).