### PR TITLE
jobs: canonical signal library additions — indicator crosses + US sessions (28→37)

### DIFF
--- a/wayfinder_paths/jobs/signal_library.py
+++ b/wayfinder_paths/jobs/signal_library.py
@@ -159,11 +159,56 @@ def _sma_cross(frame: pd.DataFrame, direction: int) -> pd.Series:
     return _cross(close, close.rolling(20).mean(), direction)
 
 
-def _ema_cross(frame: pd.DataFrame, direction: int) -> pd.Series:
+def _ema_cross(
+    frame: pd.DataFrame, direction: int, fast: int = 9, slow: int = 50
+) -> pd.Series:
     close = _close(frame)
-    fast = close.ewm(span=9, adjust=False).mean()
-    slow = close.ewm(span=50, adjust=False).mean()
-    return _cross(fast, slow, direction)
+    fast_ema = close.ewm(span=fast, adjust=False).mean()
+    slow_ema = close.ewm(span=slow, adjust=False).mean()
+    return _cross(fast_ema, slow_ema, direction)
+
+
+def _macd_cross(frame: pd.DataFrame, direction: int) -> pd.Series:
+    close = _close(frame)
+    macd = (
+        close.ewm(span=12, adjust=False).mean()
+        - close.ewm(span=26, adjust=False).mean()
+    )
+    signal = macd.ewm(span=9, adjust=False).mean()
+    return _cross(macd, signal, direction)
+
+
+def _rsi_cross(frame: pd.DataFrame, level: float, direction: int) -> pd.Series:
+    rsi = _wilder_rsi(_close(frame))
+    if direction > 0:
+        return (rsi > level) & (rsi.shift(1) <= level)
+    return (rsi < level) & (rsi.shift(1) >= level)
+
+
+def _et_stamps(frame: pd.DataFrame) -> pd.Series:
+    # DST-correct wall-clock in New York — the market whose hours shape
+    # tokenized-equity perp flow.
+    return pd.to_datetime(frame["timestamp"], utc=True).dt.tz_convert(
+        "America/New_York"
+    )
+
+
+def _session_window(
+    frame: pd.DataFrame, start_minute: int, end_minute: int
+) -> pd.Series:
+    """Bars whose CLOSE lands in (start, end] ET wall-clock, Mon-Fri.
+
+    Bars are close-labeled, so the half-open window on the close timestamp is
+    what keeps pre-window data out: a 15m bar labeled 09:30 holds 09:15-09:30
+    (pre-open) trade — the first open-hour bar is the one closing 09:45."""
+    stamps = _et_stamps(frame)
+    minutes = stamps.dt.hour * 60 + stamps.dt.minute
+    weekday = stamps.dt.dayofweek < 5
+    return weekday & (minutes > start_minute) & (minutes <= end_minute)
+
+
+def _weekend(frame: pd.DataFrame) -> pd.Series:
+    return _et_stamps(frame).dt.dayofweek >= 5
 
 
 def _trend_gated_extreme(frame: pd.DataFrame, direction: int) -> pd.Series:
@@ -369,6 +414,71 @@ SIGNAL_LIBRARY: tuple[SignalDef, ...] = (
         "staircase rally (24h and 72h up) making a fresh 12-bar high",
         85,
         lambda f: _extended(f, +1),
+    ),
+    SignalDef(
+        "macd_cross_up_12_26_9",
+        "trend",
+        "MACD(12,26) line crossed above its 9-EMA signal line this bar",
+        37,
+        lambda f: _macd_cross(f, +1),
+    ),
+    SignalDef(
+        "macd_cross_dn_12_26_9",
+        "trend",
+        "MACD(12,26) line crossed below its 9-EMA signal line this bar",
+        37,
+        lambda f: _macd_cross(f, -1),
+    ),
+    SignalDef(
+        "ema_cross_up_9_21",
+        "trend",
+        "9-EMA crossed above 21-EMA this bar (fast variant of 9/50)",
+        23,
+        lambda f: _ema_cross(f, +1, fast=9, slow=21),
+    ),
+    SignalDef(
+        "ema_cross_dn_9_21",
+        "trend",
+        "9-EMA crossed below 21-EMA this bar (fast variant of 9/50)",
+        23,
+        lambda f: _ema_cross(f, -1, fast=9, slow=21),
+    ),
+    SignalDef(
+        "rsi14_cross_up_50",
+        "momentum",
+        "Wilder RSI(14) crossed above 50 this bar (regime flip, not extreme)",
+        31,
+        lambda f: _rsi_cross(f, 50.0, +1),
+    ),
+    SignalDef(
+        "rsi14_cross_dn_50",
+        "momentum",
+        "Wilder RSI(14) crossed below 50 this bar (regime flip, not extreme)",
+        31,
+        lambda f: _rsi_cross(f, 50.0, -1),
+    ),
+    SignalDef(
+        "us_open_hour",
+        "session",
+        "bar CLOSED in the first US cash hour — (09:30, 10:30] ET, Mon-Fri "
+        "(never fires on 1d bars; dropped by the min-events gate there)",
+        2,
+        lambda f: _session_window(f, 9 * 60 + 30, 10 * 60 + 30),
+    ),
+    SignalDef(
+        "us_close_hour",
+        "session",
+        "bar CLOSED in the last US cash hour — (15:00, 16:00] ET, Mon-Fri "
+        "(never fires on 1d bars; dropped by the min-events gate there)",
+        2,
+        lambda f: _session_window(f, 15 * 60, 16 * 60),
+    ),
+    SignalDef(
+        "weekend",
+        "session",
+        "bar closed on Saturday or Sunday, New York time",
+        2,
+        lambda f: _weekend(f),
     ),
 )
 

--- a/wayfinder_paths/tests/test_signal_library.py
+++ b/wayfinder_paths/tests/test_signal_library.py
@@ -363,6 +363,57 @@ class TestScanJobLedger:
         assert "data snooping" in respent["read"]
 
 
+class TestSessionAndIndicatorAdditions:
+    def test_session_windows_across_dst_boundary(self):
+        # US spring-forward is 2026-03-08. Before it, 10:00 ET = 15:00 UTC;
+        # after it, 10:00 ET = 14:00 UTC. Hourly bars spanning the boundary
+        # must fire us_open_hour at the WALL-CLOCK hour on both sides.
+        n = 6 * 24
+        frame = _bars(_wavy_closes(n))
+        frame["timestamp"] = pd.date_range("2026-03-05", periods=n, freq="1h", tz="UTC")
+        signals = build_signal_frame(frame)
+        stamps = frame["timestamp"]
+        fri_open = signals["us_open_hour"] & (
+            stamps == pd.Timestamp("2026-03-06 15:00", tz="UTC")
+        )
+        mon_open = signals["us_open_hour"] & (
+            stamps == pd.Timestamp("2026-03-09 14:00", tz="UTC")
+        )
+        assert fri_open.any(), "pre-DST 10:00 ET close missed"
+        assert mon_open.any(), "post-DST 10:00 ET close missed"
+        # Half-open window on the close label: the 09:30 ET close (bar holding
+        # 08:30-09:30 pre-open data) must NOT count as the open hour... but on
+        # hourly bars closes land on :00, so assert the 15:00-pre-DST close is
+        # in and the 14:00 close that same pre-DST day (09:00 ET) is out.
+        pre_dst_nine_et = signals["us_open_hour"] & (
+            stamps == pd.Timestamp("2026-03-06 14:00", tz="UTC")
+        )
+        assert not pre_dst_nine_et.any()
+        # Weekend flags Saturday and Sunday ET; the DST-transition Sunday
+        # (Mar 8) is a weekend bar, never a session bar.
+        sunday = stamps.dt.tz_convert("America/New_York").dt.dayofweek == 6
+        assert (signals["weekend"] & sunday.to_numpy()).any()
+        assert not (signals["us_open_hour"] & sunday.to_numpy()).any()
+
+    def test_directional_indicator_pairs_are_distinct(self):
+        frame = _bars(_wavy_closes(500))
+        signals = build_signal_frame(frame)
+        for up, dn in [
+            ("macd_cross_up_12_26_9", "macd_cross_dn_12_26_9"),
+            ("ema_cross_up_9_21", "ema_cross_dn_9_21"),
+            ("rsi14_cross_up_50", "rsi14_cross_dn_50"),
+        ]:
+            assert signals[up].any() and signals[dn].any(), (up, dn)
+            assert not (signals[up] & signals[dn]).any(), (up, dn)
+
+    def test_session_families_and_counts(self):
+        defs = signal_defs()
+        assert len(SIGNAL_LIBRARY) == 37
+        assert defs["us_open_hour"].family == "session"
+        assert defs["macd_cross_up_12_26_9"].family == "trend"
+        assert defs["rsi14_cross_dn_50"].family == "momentum"
+
+
 class TestStrategyCatalog:
     def test_catalog_lists_ported_live_strategies(self):
         catalog = {entry["name"]: entry for entry in library_catalog()}


### PR DESCRIPTION
Second research-space expansion PR (approved plan; independent of #538).

Nine curated defs: **MACD(12,26,9) cross pair**, **EMA 9/21 cross pair**, **RSI-50 cross pair** (regime flip, not the extreme — the library already has the 70/30 extremes), and **us_open_hour / us_close_hour / weekend** — New York wall-clock, DST-correct, computed from the bars' own timestamps. Sessions are the one exogenous dimension that needs zero data plumbing, and the obvious structural axis for tokenized-equity perps (xyz:SNDK/MU/CL).

Correctness note: session windows are **half-open (start, end] on the CLOSE-labeled timestamp** — a 15m bar labeled 09:30 holds 09:15–09:30 pre-open data, so the first open-hour bar is the one closing 09:45. On 1d resamples the intraday session defs never fire and drop out via the min-events gate (noted in their descriptions).

**Honest cost, stated plainly**: +32% BH denominator on every future scan, forever. These nine are the most-asked-for crosses plus the free session axis; anything more exotic belongs in per-job workspace signals (#538) where only that job pays for the breadth.

Tests: DST-boundary session assertions across the 2026-03-08 spring-forward, directional-pair distinctness, family/count pins; the library-wide prefix-property and fires-somewhere sweeps auto-cover all new defs. Full library + research + validation suites pass.