### PR TITLE
jobs: research agenda — cumulative ideation state for the worker

### DIFF
--- a/.opencode/agents/wayfinder-job-worker.md
+++ b/.opencode/agents/wayfinder-job-worker.md
@@ -184,6 +184,11 @@ every wake.
      `rank-check`. Open interest is DEFERRED — no history source exists yet;
      do not improvise one.
 
+2b. CONSULT the research agenda (`research/agenda.md`) before generating
+   ideas: Dead-map entries are settled (reopening requires NAMED new
+   evidence), Starved entries wake up only when their unlock condition is
+   met, Open entries are the queue — verify those before inventing new ones.
+
 3. SCORE each candidate: expected edge, evidence strength, overfit risk,
    complexity, reversibility, risk impact. Check the candidates ledger and
    rejected proposals FIRST — never re-explore a candidate family already
@@ -247,6 +252,41 @@ Composed defs must each cite a hypothesis (fingerprint quadrant, path_stats
 shape, or a failure-table row from strategy-search §2b) — breadth inflates
 the BH denominator for the whole family, so twelve strong hypotheses beat
 fifty permutations arithmetically.
+
+## Research agenda — cumulative exploration state
+
+`research/agenda.md` is the job's living research map. The ledger tails in
+your context show only the last 20 rows — the agenda is the COMPACTED view
+that keeps ideation cumulative instead of amnesiac. You maintain it; never
+restart it. Format (keep under ~150 lines total, compact in place):
+
+```markdown
+# Research agenda — <job_id>
+Last ideation session: <ISO timestamp>
+
+## Dead map (refuted — reopening requires NAMED new evidence)
+- <hypothesis>: <one line of evidence, e.g. "best t=-2.35, q~0.999 over 462 trials">
+
+## Open hypotheses (ranked; each cites its evidence)
+1. <hypothesis> — evidence: <fingerprint quadrant / path_stats / world fact>
+   next: <the concrete test — scan def, rank-check column, feature to fetch>
+
+## Starved (insufficient data — each with an explicit unlock condition)
+- <hypothesis>: revisit when <condition, e.g. ">40 funding-positive events"
+  or "60d of history" or "next earnings date">
+```
+
+IDEATION sessions (the wake-ladder cadence rung): start from the agenda plus
+the durable-memory asset dossier; pull world context with the research tools
+— what the assets ARE (sector siblings, earnings calendar, index membership,
+who trades them and when) is evidence, not trivia. Generate structurally
+different hypotheses, RANK them, append the best 1-3 as Open entries with
+their next concrete test, and move settled ones to Dead/Starved with their
+one-line verdicts. An ideation session that concludes "nothing new, agenda
+stands" is a valid outcome — say so and stamp the timestamp. Statuses flow:
+Open -> (tested) -> Dead with evidence | Starved with unlock | promoted into
+a candidate/proposal. Never delete Dead entries to make room — summarize
+whole families into one line instead.
 
 ## Kill switch
 

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -72,6 +72,10 @@ def _build_worker_prompt_sections(
     memory_md = _read_text(root / "memory.md", max_chars=6000)
     memory_json = store.read_json(job_id, "memory.json", default={}) or {}
     recent_journal = _read_text(root / "journal.jsonl", max_chars=4000)
+    # The cumulative research state — a curated map (dead hypotheses, open
+    # ones, starved ones with unlock conditions), NOT a scrolling log. The
+    # 20-row ledger tails forget; this is what makes ideation build on itself.
+    research_agenda = _read_text(root / "research" / "agenda.md", max_chars=5000)
     stable_payload = {
         "job": _drop_volatile_stable_keys(snapshot["job"]),
         "memory_json": _drop_volatile_stable_keys(memory_json),
@@ -260,6 +264,21 @@ def _build_worker_prompt_sections(
             "only: no workspace/ or job.yaml edits, and no proposals whose "
             "evidence is the sub-floor forward sample. Monitor-mode wakes stay "
             "read-only.\n"
+            "- Ideation cadence: research/agenda.md is the cumulative "
+            "research state — sections: Dead map (refuted, one line of "
+            "evidence each), Open hypotheses (ranked, each citing its "
+            "evidence), Starved (insufficient data, each with an explicit "
+            "unlock condition), and a Last-ideation timestamp. If that "
+            "timestamp is older than ~24h and operations are healthy, spend "
+            "THIS wake as an IDEATION session: start from the agenda plus "
+            "the durable-memory asset dossier, pull world context with the "
+            "research tools (what these assets ARE — sector links, earnings "
+            "calendar, market structure — is evidence), generate and RANK "
+            "structurally different hypotheses, append the best as Open "
+            "entries, and retire or starve stale ones. Reopening a refuted "
+            "hypothesis requires NAMED new evidence. Keep the agenda compact "
+            "(~150 lines): it is a curated map, not a log — compact it in "
+            "place as part of updating it.\n"
             "- If propose returns a failed validation, read ALL failed check "
             "names and fix them in ONE follow-up propose; after 2 failed propose "
             "attempts in a wake, stop and report the blocker instead of "
@@ -270,6 +289,9 @@ def _build_worker_prompt_sections(
         f"{DYNAMIC_CONTEXT_MARKER}\n"
         "Current snapshot:\n"
         f"{_canonical_json(dynamic_payload, max_chars=12000)}\n\n"
+        "Research agenda (research/agenda.md — cumulative exploration "
+        "state; maintain it, do not restart it):\n"
+        f"{research_agenda or '(none yet — bootstrap it on the next healthy ideation wake)'}\n\n"
         "Recent journal:\n"
         f"{recent_journal}\n\n"
         "Task:\n"

--- a/wayfinder_paths/tests/test_wayfinder_jobs.py
+++ b/wayfinder_paths/tests/test_wayfinder_jobs.py
@@ -1164,6 +1164,24 @@ def test_worker_prompt_intervene_ladder_and_retry_budget(tmp_path: Path) -> None
     # research-side analysis.
     assert "Exploration vs exploitation" in prompt
     assert "gates EXPLOITATION only" in prompt
+    # The ideation cadence rung + the agenda bootstrap marker (no agenda file
+    # exists in this fixture).
+    assert "Ideation cadence" in prompt
+    assert "bootstrap it on the next healthy ideation wake" in prompt
+
+    # A seeded agenda is embedded verbatim in the dynamic context.
+    agenda_dir = store.job_dir(job.id) / "research"
+    agenda_dir.mkdir(parents=True, exist_ok=True)
+    (agenda_dir / "agenda.md").write_text(
+        "# Research agenda\nLast ideation session: 2026-07-22T00:00:00Z\n"
+    )
+    seeded = _build_worker_prompt_sections(
+        store=store,
+        job_id=job.id,
+        mode="intervene",
+        snapshot=_worker_snapshot(job),
+    )["prompt"]
+    assert "Last ideation session: 2026-07-22T00:00:00Z" in seeded
     # The ladder is intervene/monitor task guidance, not part of the apply wake.
     apply_prompt = _build_worker_prompt_sections(
         store=store,


### PR DESCRIPTION
Follow-on to the research-space expansion (#538–#540), addressing the watcher's imagination limits: ideation was amnesiac (each wake starts from zero) and repetition-prone (the wake sees only the last 20 ledger rows, so old `no_edge` verdicts scroll out of view).

**`research/agenda.md`** — a curated, compacted research map the worker maintains in place:
- **Dead map**: refuted hypotheses, one line of evidence each; reopening requires NAMED new evidence
- **Open hypotheses**: ranked, each citing its evidence and its next concrete test
- **Starved**: insufficient data, each with an explicit *unlock condition* (">40 funding-positive events", "60d of history", "next earnings") — on 17 days of history most ideas are early, not dead; this turns forbidden repetition into scheduled revisit
- **Last-ideation timestamp** — the self-scheduling signal

**Wake changes** (`worker.py`): the agenda is embedded in dynamic context (5k cap, bootstrap marker when absent), and the ladder gains an **ideation cadence rung**: timestamp older than ~24h + healthy ops → this wake is an IDEATION session — start from the agenda + the durable-memory asset dossier, pull world context via the research tools (what the assets ARE — sector siblings, earnings calendar, market structure — is evidence, not trivia), generate and RANK structurally different hypotheses, append the best as Open. Self-scheduled off the artifact; zero new plumbing.

**Persona** (`wayfinder-job-worker.md`): agenda format + statuses, CONSULT step in the improve loop, and the maintenance discipline (compact in place, never delete Dead entries — summarize families).

Alongside this PR I'm seeding the box job with an asset dossier in durable memory (MU/SNDK are same-sector memory semis, 24/7 perps on 6.5h/day underlyings, session structure, earnings) and an initial agenda distilled from the 1,591 recorded trials.

Tests: prompt assertions for the rung, bootstrap marker, and verbatim agenda embedding; full `test_wayfinder_jobs.py` passes (32). One prompt-cache invalidation from the ladder text.