### PR TITLE
jobs: deterministic proposal apply + application watchdog — an apply can never stall a job

### DIFF
--- a/wayfinder_paths/jobs/application.py
+++ b/wayfinder_paths/jobs/application.py
@@ -68,6 +68,18 @@ def claim_application(store: JobStore, job_id: str, proposal_id: str) -> dict[st
         raise ValueError(
             f"Proposal application is not queued: {proposal_id} ({application_status})"
         )
+    # Claiming pauses the job's loops — make sure the recovery owner exists
+    # before entering the risk window. Best-effort: registration failure must
+    # never block an apply. Lazy import: watchdog imports this module.
+    try:
+        from wayfinder_paths.jobs.watchdog import ensure_application_watchdog
+
+        ensure_application_watchdog(store=store)
+    except Exception as exc:
+        store.append_journal(
+            job_id,
+            {"type": "application_watchdog_ensure_failed", "error": str(exc)},
+        )
     paused = pause_job_loops(store, job_id)
     try:
         candidate = _prepare_candidate_workspace(
@@ -264,12 +276,18 @@ def _complete_applied_application(
 
     root = store.job_dir(job_id)
     backup_dir = root / "applications" / proposal_id / "backup"
-    if backup_dir.exists():
+    active_workspace = root / "workspace"
+    # Rebuild the backup only while the active workspace exists. After a crash
+    # mid-promotion the active workspace may be gone and the existing backup is
+    # the ONLY copy of the pre-apply state — rebuilding from the torn tree
+    # would destroy it and leave rollback with nothing to restore.
+    if backup_dir.exists() and active_workspace.exists():
         shutil.rmtree(backup_dir)
-    backup_dir.mkdir(parents=True, exist_ok=True)
-    if (root / "workspace").exists():
-        shutil.copytree(root / "workspace", backup_dir / "workspace")
-    shutil.copy2(root / "job.yaml", backup_dir / "job.yaml")
+    if not backup_dir.exists():
+        backup_dir.mkdir(parents=True, exist_ok=True)
+        if active_workspace.exists():
+            shutil.copytree(active_workspace, backup_dir / "workspace")
+        shutil.copy2(root / "job.yaml", backup_dir / "job.yaml")
 
     outcome = _ApplicationOutcome(
         final_status="applied",

--- a/wayfinder_paths/jobs/apply_launcher.py
+++ b/wayfinder_paths/jobs/apply_launcher.py
@@ -1,0 +1,141 @@
+"""Deterministic proposal application.
+
+An approved proposal must never be able to stall its job: `claim_application`
+pauses both runner loops, so whatever completes the application has to be
+guaranteed to run. This module owns that guarantee — the approval path claims
+in-process (fast) and spawns a detached completer child that runs the full
+deterministic validation via `complete_application(status="applied")`, which
+promotes on pass and rolls back + resumes loops on fail. No LLM session sits
+in the critical path; the application watchdog backstops a dead completer.
+
+Only proposals carrying a propose-time `candidate_report` take this path —
+their candidate is already staged and validated, so completion is pure
+mechanics. Ungated proposals (CLI `--allow-ungated`) have no staged change and
+still need an agent wake to author the candidate; that wake claims for itself
+and is watchdog-bounded.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Callable
+from typing import Any
+
+from wayfinder_paths.jobs.application import claim_application, complete_application
+from wayfinder_paths.jobs.models import utc_now_iso
+from wayfinder_paths.jobs.store import JobStore
+
+
+def _apply_worker_cmd(job_id: str, proposal_id: str) -> list[str]:
+    return [
+        sys.executable,
+        "-m",
+        "wayfinder_paths.jobs.apply_launcher",
+        job_id,
+        proposal_id,
+    ]
+
+
+def _default_spawn(*, job_id: str, proposal_id: str, store: JobStore) -> int:
+    from wayfinder_paths.runner.lifecycle import spawn_detached
+
+    log_path = store.job_dir(job_id) / "applications" / proposal_id / "apply.log"
+    return spawn_detached(
+        cmd=_apply_worker_cmd(job_id, proposal_id),
+        repo_root=store.repo_root,
+        log_path=log_path,
+        banner="[apply-worker]",
+        env=os.environ.copy(),
+    )
+
+
+def start_application(
+    store: JobStore,
+    job_id: str,
+    proposal_id: str,
+    *,
+    spawn: Callable[..., int] | None = None,
+) -> dict[str, Any]:
+    """Claim the application and hand completion to a detached worker.
+
+    A spawn failure is completed as failed synchronously — every exit from
+    this function leaves the runner loops either running or owned by a live
+    completer process.
+    """
+    claim = claim_application(store, job_id, proposal_id)
+    spawn_fn = spawn or _default_spawn
+    try:
+        pid = spawn_fn(job_id=job_id, proposal_id=proposal_id, store=store)
+    except Exception as exc:
+        failed = complete_application(
+            store,
+            job_id,
+            proposal_id,
+            status="failed",
+            error=f"apply worker spawn failed: {exc}",
+        )
+        return {"mode": "deterministic", "spawned": False, **failed}
+
+    proposal = store.load_proposal(job_id, proposal_id)
+    proposal["application"]["apply_worker"] = {
+        "pid": int(pid),
+        "spawned_at": utc_now_iso(),
+        "log": str(store.job_dir(job_id) / "applications" / proposal_id / "apply.log"),
+    }
+    store.write_proposal(job_id, proposal)
+    store.append_journal(
+        job_id,
+        {
+            "type": "application_apply_spawned",
+            "proposal_id": proposal_id,
+            "pid": int(pid),
+        },
+    )
+    return {
+        "mode": "deterministic",
+        "spawned": True,
+        "proposal": proposal,
+        "apply_worker": proposal["application"]["apply_worker"],
+        "paused_runner_jobs": claim.get("paused_runner_jobs"),
+    }
+
+
+def launch_application(
+    store: JobStore, job_id: str, proposal_id: str
+) -> dict[str, Any]:
+    """Route an approved proposal to its apply path.
+
+    candidate_report present → deterministic claim + detached completion.
+    Absent (ungated/legacy) → agent wake; the agent claims for itself, so a
+    dropped wake leaves the application queued with loops still running.
+    """
+    proposal = store.load_proposal(job_id, proposal_id)
+    if proposal.get("candidate_report"):
+        return start_application(store, job_id, proposal_id)
+    from wayfinder_paths.jobs.worker import run_job_worker
+
+    wakeup = run_job_worker(job_id, mode="intervene", apply_proposal_id=proposal_id)
+    return {"mode": "agent_wake", "wakeup": wakeup}
+
+
+def _main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: python -m wayfinder_paths.jobs.apply_launcher <job> <proposal>")
+        return 2
+    job_id, proposal_id = argv
+    store = JobStore()
+    try:
+        result = complete_application(store, job_id, proposal_id, status="applied")
+    except ValueError as exc:
+        # Lost the race to the watchdog or a manual completion — the
+        # application is already terminal, which is the outcome we wanted.
+        print(f"[apply-worker] already completed: {exc}")
+        return 0
+    status = (result.get("proposal") or {}).get("application", {}).get("status")
+    print(f"[apply-worker] completed {proposal_id}: {status}")
+    return 0 if status == "applied" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main(sys.argv[1:]))

--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -13,6 +13,7 @@ from wayfinder_paths.jobs.application import (
     ensure_jobs_v1_contract,
     validate_application_candidate,
 )
+from wayfinder_paths.jobs.apply_launcher import launch_application
 from wayfinder_paths.jobs.backtest_artifacts import (
     diagnose_backtest,
     load_backtest_view,
@@ -1019,12 +1020,23 @@ def proposals_cmd(job_id: str) -> None:
     _echo_json({"ok": True, "result": store.proposals(job_id)})
 
 
-def _wakeup_with_proposal(
+def _launch_with_proposal(
     store: JobStore, job_id: str, proposal_id: str, proposal: dict[str, Any]
 ) -> None:
-    wakeup = run_job_worker(job_id, mode="intervene", apply_proposal_id=proposal_id)
+    # Deterministic apply for gated proposals (claim + detached completer);
+    # ungated proposals fall back to an agent wake that claims for itself.
+    application = launch_application(store, job_id, proposal_id)
     sync_all_jobs(store=store)
-    _echo_json({"ok": True, "result": {"proposal": proposal, "wakeup": wakeup}})
+    _echo_json(
+        {
+            "ok": True,
+            "result": {
+                "proposal": proposal,
+                "application": application,
+                "wakeup": application.get("wakeup"),
+            },
+        }
+    )
 
 
 @job_cli.command(name="approve", help="Approve a pending proposal.")
@@ -1058,7 +1070,7 @@ def approve_cmd(
         raise click.ClickException(
             "legacy jobs cannot enter the versioned-change flow"
         ) from exc
-    _wakeup_with_proposal(
+    _launch_with_proposal(
         store,
         job_id,
         proposal_id,
@@ -1147,7 +1159,7 @@ def reject_cmd(job_id: str, proposal_id: str) -> None:
 @click.argument("proposal_id")
 def apply_proposal_cmd(job_id: str, proposal_id: str) -> None:
     store = JobStore()
-    _wakeup_with_proposal(
+    _launch_with_proposal(
         store,
         job_id,
         proposal_id,
@@ -1212,6 +1224,19 @@ def complete_application_cmd(
             ),
         }
     )
+
+
+@job_cli.command(
+    name="recover-stalled-applications",
+    help="Scan every job for stalled proposal applications (applying with a "
+    "dead completer, or approved+queued with no spawn) and drive them to a "
+    "terminal status, resuming paused runner loops. Same primitive the "
+    "runner watchdog job runs every few minutes.",
+)
+def recover_stalled_applications_cmd() -> None:
+    from wayfinder_paths.jobs.watchdog import recover_stalled_applications
+
+    _echo_json({"ok": True, "result": recover_stalled_applications()})
 
 
 def _pause_resume_loops(job_id: str, action: Literal["pause", "resume"]) -> None:

--- a/wayfinder_paths/jobs/compiler.py
+++ b/wayfinder_paths/jobs/compiler.py
@@ -28,6 +28,16 @@ class JobCompiler:
         job_env = self._job_env(job, root)
         if start_daemon:
             self.bridge.ensure_started()
+            # Every job that can ever carry a proposal registers the
+            # application watchdog. Best-effort — a down runner or a test
+            # FakeBridge without add_or_update_script_job must not break
+            # compile. Lazy import: watchdog -> application -> compiler.
+            try:
+                from wayfinder_paths.jobs.watchdog import ensure_application_watchdog
+
+                ensure_application_watchdog(store=self.store, bridge=self.bridge)
+            except Exception:
+                pass
 
         linked: list[dict[str, Any]] = []
         if job.script_loop.enabled:

--- a/wayfinder_paths/jobs/watchdog.py
+++ b/wayfinder_paths/jobs/watchdog.py
@@ -1,0 +1,252 @@
+"""Application watchdog: no proposal apply may stall a job.
+
+`claim_application` pauses both runner loops, so an application stuck in
+"applying" leaves the job dark — its own loops can never self-heal (they are
+paused) and `triggers.py` suppresses agent wakes mid-apply. This watchdog is
+the independent owner of that state: a runner-registered interval job that
+scans every job's proposals and drives any stalled application to a terminal
+status, which always resumes the loops.
+
+Recovery policy: an approved candidate the user already signed off on is
+worth landing, so a stalled deterministic apply is re-completed as "applied"
+(full validation still gates the promotion; failure rolls back and resumes).
+Agent-owned applies (no candidate_report — nothing staged to validate) are
+failed after a longer window; claim allows retry from "failed".
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from textwrap import dedent
+from typing import Any
+
+from wayfinder_paths.jobs.application import complete_application
+from wayfinder_paths.jobs.runner_bridge import RunnerBridge
+from wayfinder_paths.jobs.store import JobStore
+
+WATCHDOG_RUNNER_JOB_NAME = "wayfinder-application-watchdog"
+WATCHDOG_INTERVAL_SECONDS = 300
+WATCHDOG_TIMEOUT_SECONDS = 2700
+
+# Deterministic applies (candidate_report staged): completer child normally
+# finishes in 1-3 minutes; a dead completer past this age is recovered.
+DETERMINISTIC_APPLYING_TIMEOUT = timedelta(minutes=15)
+# Agent-owned applies (ungated, agent claims itself): sessions legitimately
+# take longer, but past this the session is presumed dead.
+AGENT_APPLYING_TIMEOUT = timedelta(minutes=60)
+# Approved + queued with a staged candidate but no spawn: the approve process
+# crashed between queueing and spawning the completer.
+QUEUED_TIMEOUT = timedelta(minutes=10)
+# A completer pid that is still alive but has made no progress for this long
+# is wedged: kill its process group, then recover.
+HARD_KILL_TIMEOUT = timedelta(minutes=45)
+
+
+def _pid_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def _kill_process_group(pid: int) -> None:
+    try:
+        os.killpg(os.getpgid(pid), signal.SIGKILL)
+    except OSError:
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except OSError:
+            pass
+
+
+def _age(now: datetime, stamp: Any) -> timedelta:
+    """Age of an ISO timestamp; unparseable/missing stamps count as expired
+    so a malformed application record cannot stall forever."""
+    try:
+        parsed = datetime.fromisoformat(str(stamp))
+    except (TypeError, ValueError):
+        return timedelta.max
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return now - parsed
+
+
+def _recover_applying(
+    store: JobStore,
+    job_id: str,
+    proposal: dict[str, Any],
+    now: datetime,
+) -> dict[str, Any] | None:
+    proposal_id = str(proposal["proposal_id"])
+    application = proposal["application"]
+    age = _age(now, application.get("started_at") or proposal.get("updated_at"))
+
+    worker = application.get("apply_worker") or {}
+    pid = int(worker.get("pid") or 0)
+    if _pid_alive(pid):
+        if age < HARD_KILL_TIMEOUT:
+            return None
+        _kill_process_group(pid)
+
+    deterministic = bool(proposal.get("candidate_report"))
+    timeout = (
+        DETERMINISTIC_APPLYING_TIMEOUT if deterministic else AGENT_APPLYING_TIMEOUT
+    )
+    if age < timeout:
+        return None
+
+    action = "complete_applied" if deterministic else "complete_failed"
+    try:
+        if deterministic:
+            complete_application(store, job_id, proposal_id, status="applied")
+        else:
+            complete_application(
+                store,
+                job_id,
+                proposal_id,
+                status="failed",
+                error="watchdog: apply session stalled; loops resumed",
+            )
+    except ValueError as exc:
+        # Already terminal — a live completer or manual recovery won the race.
+        store.append_journal(
+            job_id,
+            {
+                "type": "application_watchdog_skipped",
+                "proposal_id": proposal_id,
+                "reason": str(exc),
+            },
+        )
+        return None
+    outcome = store.load_proposal(job_id, proposal_id)["application"]["status"]
+    event = {
+        "type": "application_watchdog_recovered",
+        "proposal_id": proposal_id,
+        "stalled_status": "applying",
+        "age_seconds": int(age.total_seconds()) if age != timedelta.max else None,
+        "action": action,
+        "outcome": outcome,
+    }
+    store.append_journal(job_id, event)
+    return event
+
+
+def _recover_queued(
+    store: JobStore,
+    job_id: str,
+    proposal: dict[str, Any],
+    now: datetime,
+) -> dict[str, Any] | None:
+    if proposal.get("status") != "approved" or not proposal.get("candidate_report"):
+        # Ungated queued proposals are agent-owned and queued never pauses
+        # loops — no stall to recover.
+        return None
+    application = proposal["application"]
+    age = _age(now, application.get("requested_at") or proposal.get("updated_at"))
+    if age < QUEUED_TIMEOUT:
+        return None
+    proposal_id = str(proposal["proposal_id"])
+    from wayfinder_paths.jobs.apply_launcher import start_application
+
+    try:
+        start_application(store, job_id, proposal_id)
+    except ValueError as exc:
+        store.append_journal(
+            job_id,
+            {
+                "type": "application_watchdog_skipped",
+                "proposal_id": proposal_id,
+                "reason": str(exc),
+            },
+        )
+        return None
+    event = {
+        "type": "application_watchdog_recovered",
+        "proposal_id": proposal_id,
+        "stalled_status": "queued",
+        "age_seconds": int(age.total_seconds()) if age != timedelta.max else None,
+        "action": "start_application",
+        "outcome": "applying",
+    }
+    store.append_journal(job_id, event)
+    return event
+
+
+def recover_stalled_applications(
+    *, store: JobStore | None = None, now: datetime | None = None
+) -> dict[str, Any]:
+    """Scan every job for stalled proposal applications and recover them.
+
+    Never raises: a broken job record must not stop recovery of the others.
+    """
+    store = store or JobStore()
+    now = now or datetime.now(UTC)
+    scanned = 0
+    recovered: list[dict[str, Any]] = []
+    errors: list[dict[str, Any]] = []
+    for job in store.list_jobs():
+        try:
+            proposals = store.proposals(job.id)
+        except Exception as exc:
+            errors.append({"job_id": job.id, "error": str(exc)})
+            continue
+        for proposal in proposals:
+            scanned += 1
+            status = proposal["application"]["status"]
+            try:
+                if status == "applying":
+                    event = _recover_applying(store, job.id, proposal, now)
+                elif status == "queued":
+                    event = _recover_queued(store, job.id, proposal, now)
+                else:
+                    event = None
+            except Exception as exc:
+                errors.append(
+                    {
+                        "job_id": job.id,
+                        "proposal_id": proposal.get("proposal_id"),
+                        "error": str(exc),
+                    }
+                )
+                continue
+            if event is not None:
+                recovered.append({"job_id": job.id, **event})
+    return {"scanned": scanned, "recovered": recovered, "errors": errors}
+
+
+def ensure_application_watchdog(
+    *, store: JobStore, bridge: RunnerBridge | None = None
+) -> dict[str, Any]:
+    """Register the watchdog as a runner interval job (idempotent)."""
+    bridge = bridge or RunnerBridge(repo_root=store.repo_root)
+    store.runs_jobs_dir.mkdir(parents=True, exist_ok=True)
+    driver: Path = store.runs_jobs_dir / "application_watchdog.py"
+    driver.write_text(
+        dedent(
+            """
+            from __future__ import annotations
+
+            import json
+
+            from wayfinder_paths.jobs.watchdog import recover_stalled_applications
+
+            if __name__ == "__main__":
+                print(json.dumps(recover_stalled_applications(), default=str))
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    response = bridge.add_or_update_script_job(
+        name=WATCHDOG_RUNNER_JOB_NAME,
+        script_path=str(driver.relative_to(store.repo_root)),
+        interval_seconds=WATCHDOG_INTERVAL_SECONDS,
+        timeout_seconds=WATCHDOG_TIMEOUT_SECONDS,
+        env={"WAYFINDER_WATCHDOG": "1"},
+    )
+    return {"runner_job_name": WATCHDOG_RUNNER_JOB_NAME, "response": response}

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -9,7 +9,6 @@ from typing import Any
 from loguru import logger
 
 from wayfinder_paths.core.clients.OpenCodeClient import OPENCODE_CLIENT
-from wayfinder_paths.jobs.application import claim_application, complete_application
 from wayfinder_paths.jobs.forward import is_forward_empty
 from wayfinder_paths.jobs.ledger import tail_ledger
 from wayfinder_paths.jobs.memory_hygiene import sanitize_job_memory
@@ -175,11 +174,14 @@ def _build_worker_prompt_sections(
         f"{STABLE_PREFIX_END_MARKER}\n"
     )
     task_line = (
-        f"- Apply approved proposal `{apply_proposal_id}`. The SDK wake path may "
-        "have already claimed it, so check `proposal_queue`/proposal application "
-        "status first. If it is still queued, call "
+        f"- Apply approved proposal `{apply_proposal_id}`. Check "
+        "`proposal_queue`/proposal application status first: if it is queued, "
+        "claim it yourself with "
         '`core_jobs(action="claim_application", job_id=..., proposal_id=...)`; '
-        "if it is applying, do not claim again. Apply edits in the candidate "
+        "if it is already applying, do not claim again. Claiming pauses the "
+        "runner loops and starts a watchdog clock: complete the application "
+        "(applied or failed) within ~60 minutes or the SDK will fail it and "
+        "resume the loops without you. Apply edits in the candidate "
         "workspace recorded on the proposal application, not the active workspace. "
         'Proposals created via `core_jobs(action="propose")` stage their change '
         "in the candidate at propose time and the claim REUSES that candidate — "
@@ -315,9 +317,14 @@ def prepare_job_worker_prompt(
     job_id: str,
     mode: str,
     apply_proposal_id: str | None = None,
-    claim_application_before_prompt: bool = False,
 ) -> dict[str, Any]:
-    """Prepare the exact prompt payload used for a job worker wakeup."""
+    """Prepare the exact prompt payload used for a job worker wakeup.
+
+    Never claims the application: claiming pauses the runner loops, and prompt
+    delivery to an LLM session is not guaranteed — a dropped prompt after a
+    claim stalls the job (2026-07-22 incident). Deterministic applies claim in
+    apply_launcher; agent-owned applies claim from inside the live session.
+    """
     job = store.load(job_id)
     mode = normalize_agent_mode(mode) if mode else job.agent_loop.mode
     if mode == "off":
@@ -325,15 +332,6 @@ def prepare_job_worker_prompt(
     mode_typed: AgentMode = mode
 
     snapshot = snapshot_job(job.id, store=store)
-    application_claim: dict[str, Any] | None = None
-    if apply_proposal_id and claim_application_before_prompt:
-        proposal = store.load_proposal(job.id, apply_proposal_id)
-        application_claim = (
-            {"proposal": proposal, "already_claimed": True}
-            if proposal["application"]["status"] == "applying"
-            else claim_application(store, job.id, apply_proposal_id)
-        )
-        snapshot = snapshot_job(job.id, store=store)
 
     # Deterministic memory hygiene: on a wake with no forward telemetry, strip
     # unsupported performance claims from durable memory before the agent reads
@@ -351,7 +349,6 @@ def prepare_job_worker_prompt(
         **prompt_sections,
         "job_id": job.id,
         "mode": mode_typed,
-        "application_claim": application_claim,
     }
 
 
@@ -405,30 +402,12 @@ def run_job_worker(
     session_id = _ensure_worker_session(job.id, mode_typed)
     queued = False
     error: str | None = None
-    application_claim: dict[str, Any] | None = None
-    prompt_sections: dict[str, Any] | None = None
-    if session_id and apply_proposal_id:
-        try:
-            prompt_sections = prepare_job_worker_prompt(
-                store=store,
-                job_id=job.id,
-                mode=mode_typed,
-                apply_proposal_id=apply_proposal_id,
-                claim_application_before_prompt=True,
-            )
-            application_claim = prompt_sections["application_claim"]
-        except Exception as exc:
-            error = f"Application claim failed: {exc}"
-            session_id = None
-
-    if prompt_sections is None:
-        prompt_sections = prepare_job_worker_prompt(
-            store=store,
-            job_id=job.id,
-            mode=mode_typed,
-            apply_proposal_id=apply_proposal_id,
-            claim_application_before_prompt=False,
-        )
+    prompt_sections = prepare_job_worker_prompt(
+        store=store,
+        job_id=job.id,
+        mode=mode_typed,
+        apply_proposal_id=apply_proposal_id,
+    )
     prompt = prompt_sections["prompt"]
 
     if session_id:
@@ -440,17 +419,11 @@ def run_job_worker(
             else JOB_WORKER_AGENT_NAME,
         )
         if not queued:
+            # No cleanup needed: the wake never claims, so a dropped prompt
+            # leaves the application queued with the runner loops running.
             error = "OpenCode prompt_async failed"
-            if apply_proposal_id and application_claim:
-                complete_application(
-                    store,
-                    job.id,
-                    apply_proposal_id,
-                    status="failed",
-                    error=error,
-                )
     else:
-        error = error or "OpenCode server unavailable"
+        error = "OpenCode server unavailable"
 
     report = _write_report(
         store=store,

--- a/wayfinder_paths/mcp/tools/jobs.py
+++ b/wayfinder_paths/mcp/tools/jobs.py
@@ -11,6 +11,7 @@ from wayfinder_paths.jobs.application import (
     ensure_jobs_v1_contract,
     validate_application_candidate,
 )
+from wayfinder_paths.jobs.apply_launcher import launch_application
 from wayfinder_paths.jobs.backtest_artifacts import diagnose_backtest
 from wayfinder_paths.jobs.compiler import JobCompiler
 from wayfinder_paths.jobs.execution.experiments import list_experiments
@@ -529,11 +530,18 @@ async def core_jobs(
                 if action == "approve_proposal"
                 else store.queue_proposal_application(job_id, proposal_id)
             )
-            wakeup = run_job_worker(
-                job_id, mode="intervene", apply_proposal_id=proposal_id
-            )
+            # Deterministic apply: gated proposals claim + spawn a detached
+            # completer child; only ungated/legacy proposals fall back to an
+            # agent wake (and that wake claims for itself).
+            application = launch_application(store, job_id, proposal_id)
             sync_all_jobs(store=store)
-            return ok({"proposal": proposal, "wakeup": wakeup})
+            return ok(
+                {
+                    "proposal": proposal,
+                    "application": application,
+                    "wakeup": application.get("wakeup"),
+                }
+            )
         if action == "reject_proposal":
             proposal = store.reject_proposal(job_id, proposal_id)
             sync_all_jobs(store=store)

--- a/wayfinder_paths/tests/test_jobs_apply_watchdog.py
+++ b/wayfinder_paths/tests/test_jobs_apply_watchdog.py
@@ -1,0 +1,469 @@
+"""Deterministic apply + application watchdog: no proposal apply may stall a
+job. Covers the launcher (claim + detached completer, spawn-failure safety),
+the watchdog recovery matrix (applying/queued x deterministic/agent-owned x
+completer liveness), the torn-workspace backup preservation, and the removal
+of the worker's claim-before-prompt path."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from wayfinder_paths.jobs.application import claim_application, complete_application
+from wayfinder_paths.jobs.apply_launcher import launch_application, start_application
+from wayfinder_paths.jobs.models import WayfinderJob, utc_now_iso
+from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.jobs.watchdog import (
+    WATCHDOG_RUNNER_JOB_NAME,
+    ensure_application_watchdog,
+    recover_stalled_applications,
+)
+from wayfinder_paths.jobs.worker import run_job_worker
+from wayfinder_paths.tests.test_wayfinder_jobs import (
+    _intent_contract,
+    _prepare_candidate_script,
+    _scenario_plan,
+)
+
+
+def _patch_runner(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, str]]:
+    calls: list[tuple[str, str]] = []
+
+    class FakeBridge:
+        def __init__(self, *, repo_root=None):  # noqa: ANN001
+            self.repo_root = repo_root
+
+        def pause(self, name: str) -> dict:
+            calls.append(("pause", name))
+            return {"ok": True}
+
+        def resume(self, name: str) -> dict:
+            calls.append(("resume", name))
+            return {"ok": True}
+
+        def add_or_update_script_job(self, **kwargs):  # noqa: ANN003
+            calls.append(("ensure_watchdog", kwargs["name"]))
+            return {"ok": True}
+
+    class FakeCompiler:
+        def __init__(self, *, store=None):  # noqa: ANN001
+            self.store = store
+
+        def compile(self, job):  # noqa: ANN001
+            calls.append(("compile", job.id))
+            return {"job_id": job.id, "jobs": []}
+
+    monkeypatch.setattr("wayfinder_paths.jobs.application.RunnerBridge", FakeBridge)
+    monkeypatch.setattr("wayfinder_paths.jobs.application.JobCompiler", FakeCompiler)
+    monkeypatch.setattr("wayfinder_paths.jobs.watchdog.RunnerBridge", FakeBridge)
+    return calls
+
+
+def _make_job(store: JobStore, job_id: str) -> WayfinderJob:
+    job = WayfinderJob.new(
+        job_id,
+        script=".wayfinder_runs/demo.py",
+        interval_seconds=60,
+        agent_mode="intervene",
+    )
+    store.save(job)
+    return job
+
+
+def _write_proposal(
+    store: JobStore,
+    job_id: str,
+    proposal_id: str,
+    *,
+    status: str = "approved",
+    application: dict | None = None,
+    candidate_report: dict | None = None,
+) -> None:
+    proposal = {
+        "proposal_id": proposal_id,
+        "job_id": job_id,
+        "status": status,
+        "application": application or {"status": "queued"},
+        "proposed_change": {"summary": "Tighten the entry guard."},
+        "intent_contract": _intent_contract(),
+        "scenario_plan": _scenario_plan(),
+    }
+    if candidate_report is not None:
+        proposal["candidate_report"] = candidate_report
+    store.write_proposal(job_id, proposal)
+
+
+def _journal_types(store: JobStore, job_id: str) -> list[str]:
+    path = store.job_dir(job_id) / "journal.jsonl"
+    if not path.exists():
+        return []
+    return [
+        json.loads(line)["type"]
+        for line in path.read_text(encoding="utf-8").splitlines()
+    ]
+
+
+def _iso_ago(minutes: float) -> str:
+    return (datetime.now(UTC) - timedelta(minutes=minutes)).isoformat()
+
+
+def test_start_application_claims_spawns_and_records_pid(
+    tmp_path: Path, monkeypatch
+) -> None:
+    calls = _patch_runner(monkeypatch)
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "spawn-demo")
+    _write_proposal(store, job.id, "prop_spawn", candidate_report={"gate": "green"})
+
+    spawned: list[dict] = []
+
+    def fake_spawn(*, job_id, proposal_id, store):  # noqa: ANN001
+        spawned.append({"job_id": job_id, "proposal_id": proposal_id})
+        return 4242
+
+    result = start_application(store, job.id, "prop_spawn", spawn=fake_spawn)
+
+    assert result["spawned"] is True
+    assert spawned == [{"job_id": job.id, "proposal_id": "prop_spawn"}]
+    proposal = store.load_proposal(job.id, "prop_spawn")
+    assert proposal["application"]["status"] == "applying"
+    assert proposal["application"]["apply_worker"]["pid"] == 4242
+    assert ("pause", "spawn-demo-script") in calls
+    assert ("pause", "spawn-demo-agent") in calls
+    assert "application_apply_spawned" in _journal_types(store, job.id)
+
+
+def test_start_application_spawn_failure_fails_and_resumes(
+    tmp_path: Path, monkeypatch
+) -> None:
+    calls = _patch_runner(monkeypatch)
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "spawn-fail-demo")
+    _write_proposal(store, job.id, "prop_boom", candidate_report={"gate": "green"})
+
+    def broken_spawn(**_kwargs):  # noqa: ANN003
+        raise OSError("fork bomb prevention")
+
+    result = start_application(store, job.id, "prop_boom", spawn=broken_spawn)
+
+    assert result["spawned"] is False
+    proposal = store.load_proposal(job.id, "prop_boom")
+    assert proposal["application"]["status"] == "failed"
+    assert ("resume", "spawn-fail-demo-script") in calls
+    assert ("resume", "spawn-fail-demo-agent") in calls
+
+
+def test_launch_application_routes_by_candidate_report(
+    tmp_path: Path, monkeypatch
+) -> None:
+    calls = _patch_runner(monkeypatch)
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "route-demo")
+
+    wakes: list[str] = []
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.worker.run_job_worker",
+        lambda job_id, mode="monitor", *, apply_proposal_id=None: wakes.append(
+            apply_proposal_id
+        )
+        or {"status": "green"},
+    )
+
+    _write_proposal(store, job.id, "prop_ungated")
+    ungated = launch_application(store, job.id, "prop_ungated")
+
+    assert ungated["mode"] == "agent_wake"
+    assert wakes == ["prop_ungated"]
+    # The ungated path must NOT claim: loops keep running, status stays queued.
+    assert (
+        store.load_proposal(job.id, "prop_ungated")["application"]["status"] == "queued"
+    )
+    assert ("pause", "route-demo-script") not in calls
+
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.apply_launcher._default_spawn",
+        lambda *, job_id, proposal_id, store: 4243,
+    )
+    _write_proposal(store, job.id, "prop_gated", candidate_report={"gate": "green"})
+    gated = launch_application(store, job.id, "prop_gated")
+    assert gated["mode"] == "deterministic"
+    assert gated["spawned"] is True
+    assert ("pause", "route-demo-script") in calls
+
+
+def test_watchdog_recovers_stalled_deterministic_applying(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _patch_runner(monkeypatch)
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "wd-det-demo")
+    _write_proposal(
+        store,
+        job.id,
+        "prop_stalled",
+        application={"status": "applying", "started_at": _iso_ago(30)},
+        candidate_report={"gate": "green"},
+    )
+
+    completions: list[tuple[str, str, str]] = []
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.watchdog.complete_application",
+        lambda store, job_id, proposal_id, *, status, **kw: completions.append(
+            (job_id, proposal_id, status)
+        )
+        or {},
+    )
+
+    report = recover_stalled_applications(store=store)
+
+    assert completions == [(job.id, "prop_stalled", "applied")]
+    assert report["errors"] == []
+    assert len(report["recovered"]) == 1
+    assert "application_watchdog_recovered" in _journal_types(store, job.id)
+
+
+def test_watchdog_fails_stalled_agent_owned_applying(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _patch_runner(monkeypatch)
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "wd-agent-demo")
+
+    completions: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.watchdog.complete_application",
+        lambda store, job_id, proposal_id, *, status, **kw: completions.append(
+            (proposal_id, status)
+        )
+        or {},
+    )
+
+    # Inside the agent window: untouched.
+    _write_proposal(
+        store,
+        job.id,
+        "prop_agent_fresh",
+        application={"status": "applying", "started_at": _iso_ago(30)},
+    )
+    recover_stalled_applications(store=store)
+    assert completions == []
+
+    # Past the agent window: failed so loops resume; claim can retry later.
+    _write_proposal(
+        store,
+        job.id,
+        "prop_agent_stale",
+        application={"status": "applying", "started_at": _iso_ago(90)},
+    )
+    recover_stalled_applications(store=store)
+    assert completions == [("prop_agent_stale", "failed")]
+
+
+def test_watchdog_skips_live_completer(tmp_path: Path, monkeypatch) -> None:
+    _patch_runner(monkeypatch)
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "wd-live-demo")
+    _write_proposal(
+        store,
+        job.id,
+        "prop_live",
+        application={
+            "status": "applying",
+            "started_at": _iso_ago(20),
+            "apply_worker": {"pid": os.getpid(), "spawned_at": utc_now_iso()},
+        },
+        candidate_report={"gate": "green"},
+    )
+
+    completions: list[str] = []
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.watchdog.complete_application",
+        lambda *a, **kw: completions.append("called") or {},
+    )
+
+    report = recover_stalled_applications(store=store)
+
+    assert completions == []
+    assert report["recovered"] == []
+
+
+def test_watchdog_recovers_queued_approved_with_candidate_report(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _patch_runner(monkeypatch)
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "wd-queued-demo")
+
+    started: list[str] = []
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.apply_launcher.start_application",
+        lambda store, job_id, proposal_id, **kw: started.append(proposal_id) or {},
+    )
+
+    # Ungated queued: agent-owned, loops running — never touched.
+    _write_proposal(
+        store,
+        job.id,
+        "prop_q_ungated",
+        application={"status": "queued", "requested_at": _iso_ago(30)},
+    )
+    # Gated queued, fresh: inside the window — untouched.
+    _write_proposal(
+        store,
+        job.id,
+        "prop_q_fresh",
+        application={"status": "queued", "requested_at": _iso_ago(2)},
+        candidate_report={"gate": "green"},
+    )
+    # Gated queued, stale: approve→spawn crash window — recovered.
+    _write_proposal(
+        store,
+        job.id,
+        "prop_q_stale",
+        application={"status": "queued", "requested_at": _iso_ago(30)},
+        candidate_report={"gate": "green"},
+    )
+
+    recover_stalled_applications(store=store)
+
+    assert started == ["prop_q_stale"]
+
+
+def test_watchdog_race_already_completed_is_skipped(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _patch_runner(monkeypatch)
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "wd-race-demo")
+    _write_proposal(
+        store,
+        job.id,
+        "prop_race",
+        application={"status": "applying", "started_at": _iso_ago(30)},
+        candidate_report={"gate": "green"},
+    )
+
+    def losing_complete(*_a, **_kw):
+        raise ValueError("Proposal application is not applying")
+
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.watchdog.complete_application", losing_complete
+    )
+
+    report = recover_stalled_applications(store=store)
+
+    assert report["errors"] == []
+    assert report["recovered"] == []
+    assert "application_watchdog_skipped" in _journal_types(store, job.id)
+
+
+def test_torn_workspace_backup_preserved(tmp_path: Path, monkeypatch) -> None:
+    """Crash between rmtree(active) and copytree(candidate): the re-run must
+    not rebuild the backup from the missing active tree — the old backup is
+    the only copy of the pre-apply workspace."""
+    _patch_runner(monkeypatch)
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "torn-demo")
+    _write_proposal(store, job.id, "prop_torn")
+
+    claim_application(store, job.id, "prop_torn")
+    _prepare_candidate_script(
+        store,
+        job.id,
+        "prop_torn",
+        rearm_reason="rearm_guard: SNX still below SMA50.",
+    )
+
+    root = store.job_dir(job.id)
+    backup_dir = root / "applications" / "prop_torn" / "backup"
+    (backup_dir / "workspace").mkdir(parents=True)
+    (backup_dir / "workspace" / "ORIGINAL.md").write_text(
+        "pre-apply state", encoding="utf-8"
+    )
+    (backup_dir / "job.yaml").write_text(
+        (root / "job.yaml").read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    # Simulate the torn state: active workspace is gone.
+    import shutil
+
+    shutil.rmtree(root / "workspace")
+
+    completed = complete_application(
+        store,
+        job.id,
+        "prop_torn",
+        status="applied",
+        changed_files=["workspace/src/fast_loop.py"],
+        allow_legacy=True,
+    )
+
+    assert completed["proposal"]["application"]["status"] == "applied"
+    # The pre-apply backup survived the re-run…
+    assert (backup_dir / "workspace" / "ORIGINAL.md").read_text(
+        encoding="utf-8"
+    ) == "pre-apply state"
+    # …and the active workspace was restored from the candidate.
+    assert (root / "workspace" / "src" / "fast_loop.py").exists()
+
+
+def test_run_job_worker_apply_does_not_claim(tmp_path: Path, monkeypatch) -> None:
+    calls = _patch_runner(monkeypatch)
+
+    class FakeOpenCodeClient:
+        def healthy(self) -> bool:
+            return True
+
+        def find_child_session(self, *, parent_id, title):  # noqa: ANN001
+            return None
+
+        def create_session(self, *, parent_id=None, title=None, agent=None):  # noqa: ANN001
+            return "session-no-claim"
+
+        def prompt_async(self, session_id: str, text: str, *, agent=None) -> bool:  # noqa: ANN001
+            return True
+
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "no-claim-demo")
+    _write_proposal(store, job.id, "prop_noclaim", candidate_report={"gate": "green"})
+    monkeypatch.setattr("wayfinder_paths.jobs.worker.JobStore", lambda: store)
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.worker.OPENCODE_CLIENT", FakeOpenCodeClient()
+    )
+
+    report = run_job_worker(job.id, mode="intervene", apply_proposal_id="prop_noclaim")
+
+    assert report["status"] == "green"
+    assert (
+        store.load_proposal(job.id, "prop_noclaim")["application"]["status"] == "queued"
+    )
+    assert not any(call for call in calls if call[0] == "pause")
+
+
+def test_ensure_application_watchdog_idempotent(tmp_path: Path, monkeypatch) -> None:
+    registrations: list[dict] = []
+
+    class FakeBridge:
+        def __init__(self, *, repo_root=None):  # noqa: ANN001
+            self.repo_root = repo_root
+
+        def add_or_update_script_job(self, **kwargs):  # noqa: ANN003
+            registrations.append(kwargs)
+            return {"ok": True}
+
+    store = JobStore(repo_root=tmp_path)
+    bridge = FakeBridge(repo_root=tmp_path)
+
+    first = ensure_application_watchdog(store=store, bridge=bridge)
+    second = ensure_application_watchdog(store=store, bridge=bridge)
+
+    assert first["runner_job_name"] == WATCHDOG_RUNNER_JOB_NAME
+    assert second["runner_job_name"] == WATCHDOG_RUNNER_JOB_NAME
+    assert len(registrations) == 2
+    assert all(r["name"] == WATCHDOG_RUNNER_JOB_NAME for r in registrations)
+    driver = store.runs_jobs_dir / "application_watchdog.py"
+    assert driver.exists()
+    assert "recover_stalled_applications" in driver.read_text(encoding="utf-8")

--- a/wayfinder_paths/tests/test_wayfinder_jobs.py
+++ b/wayfinder_paths/tests/test_wayfinder_jobs.py
@@ -415,7 +415,9 @@ def test_worker_prompt_includes_apply_lifecycle(tmp_path: Path) -> None:
     )["prompt"]
 
     assert "Apply approved proposal `prop_001`" in prompt
-    assert "if it is applying, do not claim again" in prompt
+    assert "if it is already applying, do not claim again" in prompt
+    assert "claim it yourself" in prompt
+    assert "watchdog clock" in prompt
     assert 'core_jobs(action="claim_application"' in prompt
     assert 'core_jobs(action="validate_application"' in prompt
     assert 'core_jobs(action="complete_application"' in prompt


### PR DESCRIPTION
## Incident

Approving `prop-code-change-cffa09cf` on `majors-5m-lab` (2026-07-22 16:37 UTC) claimed the application — pausing both runner loops — then queued an OpenCode agent prompt that the server silently dropped. Nothing owned the "applying" state: the paper job sat dark for ~2 hours until manual recovery via `wayfinder job complete-application --status applied`, which ran the full deterministic validation, promoted, and resumed the loops. The LLM session was never a mandatory part of the happy path — it was just the only driver.

## Fix: three layers

**1. The LLM is out of the apply critical path** (`apply_launcher.py`). For proposals with a propose-time `candidate_report` (all MCP/frontend approvals), approval now claims in-process and spawns a detached completer child (`python -m wayfinder_paths.jobs.apply_launcher <job> <proposal>`) that runs `complete_application(status="applied")`: full deterministic validation, promote on pass, rollback + resume on fail — always resumes loops. Spawn failure is completed as failed synchronously. Ungated proposals (CLI `--allow-ungated`, no staged candidate) keep the agent-wake path, but the wake no longer claims before prompting — the agent claims for itself from inside the live session, so a dropped prompt leaves the application queued with loops running.

**2. Watchdog** (`watchdog.py`): a runner-registered interval job (300s) scanning every job for stalled applications:
- `applying` + candidate_report + ≥15min + completer PID dead → re-complete as applied (the user approved it — try to land it; validation still gates)
- `applying` + agent-owned + ≥60min → complete as failed (loops resume; claim allows retry)
- completer PID alive → skip, hard-kill + recover at 45min
- `queued` + approved + candidate_report + ≥10min → claim + spawn (approve→spawn crash window)
- ValueError race guard (already-terminal), journal `application_watchdog_recovered`/`_skipped`, never raises. Registered best-effort at `JobCompiler.compile` and `claim_application` time. Manual entry: `wayfinder job recover-stalled-applications`.

**3. Torn-workspace fix** (`application.py`): a crash between `rmtree(active_workspace)` and `copytree(candidate)` followed by a re-run used to rebuild the pre-apply backup from the now-missing active tree — destroying the only rollback copy. The backup is now only rebuilt while the active workspace exists.

## Tests

11 new tests in `test_jobs_apply_watchdog.py` (launcher claim/spawn/PID record, spawn-failure resume, candidate_report routing, watchdog recovery matrix incl. live-PID skip and race guard, torn-workspace backup preservation, worker-no-longer-claims, idempotent registration). 48 total pass across the apply suites; ruff clean; no new mypy errors.

## Ops note

After merge + box roll: the watchdog registers itself on the first compile/claim. The stalled incident proposal was already recovered manually (revision `97c75e77953c` promoted, loops resumed).