### PR TITLE
runner: restore the scheduled-jobs registry push — fixes the empty Activity tab

### DIFF
--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -409,14 +409,36 @@ class RunnerDaemon:
             return
 
         def _sync() -> None:
-            # Push the wayfinder-jobs snapshot (per-mode session ids for the
-            # Conversations panel, proposals, and the reconciled scorecard/mode)
-            # so the Strategies UI reflects runtime state. This is the daemon's
-            # periodic refresh: the event-driven paths (agent wakes, propose,
-            # MCP core_jobs) already call sync_all_jobs, but between them the UI
-            # went stale — the daemon's push had been left on the removed legacy
-            # `/jobs/sync/` endpoint (404). Lazy-imported to avoid any import
-            # cycle with the jobs package at daemon startup.
+            # Two backend pushes, both required:
+            #
+            # 1. Scheduled-jobs registry (bulk_sync): registers each runner job
+            #    so the backend accepts its per-run reports — report_run 404s
+            #    for any job the backend has never seen, which empties the
+            #    Strategies UI Activity tab. #520 dropped this push believing
+            #    the /jobs/sync/ endpoint was dead; it is alive, and without
+            #    the registration every run report for jobs created since then
+            #    404'd (observed: 345 straight failures on the jobs dev box).
+            registry = []
+            for listed in self._db.list_jobs():
+                try:
+                    job, state = self._db.get_job(name=listed["name"])
+                except KeyError:
+                    continue
+                registry.append(
+                    {
+                        "job_name": job.name,
+                        "job_type": job.type,
+                        "status": state.status,
+                        "interval_seconds": job.interval_seconds,
+                        "payload": job.payload,
+                    }
+                )
+            SCHEDULED_JOBS_CLIENT.bulk_sync(registry)
+
+            # 2. Wayfinder-jobs snapshot (per-mode session ids for the
+            #    Conversations panel, proposals, and the reconciled
+            #    scorecard/mode). Lazy-imported to avoid any import cycle with
+            #    the jobs package at daemon startup.
             from wayfinder_paths.jobs.store import JobStore
             from wayfinder_paths.jobs.sync import sync_all_jobs
 

--- a/wayfinder_paths/tests/test_runner_reconcile.py
+++ b/wayfinder_paths/tests/test_runner_reconcile.py
@@ -1,9 +1,11 @@
-"""The runner daemon keeps the wayfinder-jobs backend fresh.
+"""The runner daemon keeps the backend fresh with TWO pushes per sync.
 
-The event-driven paths (agent wakes, propose, MCP core_jobs) already call
-sync_all_jobs; the daemon adds the periodic/after-run push so the Strategies UI
-(conversations, proposals, reconciled mode) doesn't go stale between wakes. This
-replaced the daemon's dead legacy `/jobs/sync/` push (ScheduledJobsClient).
+1. Scheduled-jobs registry (ScheduledJobsClient.bulk_sync): registers each
+   runner job so the backend accepts its per-run reports — report_run 404s for
+   unregistered jobs, which empties the Strategies UI Activity tab. (#520
+   removed this push believing /jobs/sync/ was dead; the endpoint is alive.)
+2. Wayfinder-jobs snapshot (sync_all_jobs): conversations, proposals, and the
+   reconciled scorecard/mode, so the UI doesn't go stale between agent wakes.
 """
 
 from __future__ import annotations
@@ -42,16 +44,23 @@ def _add_local(daemon: RunnerDaemon, name: str) -> None:
     )
 
 
-def test_sync_pushes_wayfinder_snapshot(
+def test_sync_pushes_registry_and_wayfinder_snapshot(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("OPENCODE_INSTANCE_ID", "inst-xyz")
     daemon = RunnerDaemon(paths=_paths(tmp_path))
+    _add_local(daemon, "job-a")
+    _add_local(daemon, "job-b")
 
     stores: list[object] = []
     monkeypatch.setattr(
         "wayfinder_paths.jobs.sync.sync_all_jobs",
         lambda *, store: stores.append(store),
+    )
+    registries: list[list[dict]] = []
+    monkeypatch.setattr(
+        "wayfinder_paths.runner.daemon.SCHEDULED_JOBS_CLIENT.bulk_sync",
+        lambda jobs: registries.append(jobs),
     )
     # Run the side-effect callback inline so the assertion is deterministic.
     monkeypatch.setattr(daemon, "_run_side_effect", lambda _label, cb: cb())
@@ -61,6 +70,14 @@ def test_sync_pushes_wayfinder_snapshot(
     assert len(stores) == 1
     # The store is rooted at the daemon's repo_root so it resolves the job dirs.
     assert stores[0].repo_root == tmp_path.resolve()
+    # Registry push carries every local runner job so subsequent report_run
+    # calls do not 404 (the Activity-tab regression from #520).
+    assert len(registries) == 1
+    assert {j["job_name"] for j in registries[0]} == {"job-a", "job-b"}
+    sample = next(j for j in registries[0] if j["job_name"] == "job-a")
+    assert sample["job_type"] == JOB_TYPE_SCRIPT
+    assert sample["interval_seconds"] == 60
+    assert sample["payload"] == {"script_path": "x.py"}
 
 
 def test_sync_noop_when_not_opencode(
@@ -68,17 +85,24 @@ def test_sync_noop_when_not_opencode(
 ) -> None:
     monkeypatch.delenv("OPENCODE_INSTANCE_ID", raising=False)
     daemon = RunnerDaemon(paths=_paths(tmp_path))
+    _add_local(daemon, "job-a")
 
     stores: list[object] = []
     monkeypatch.setattr(
         "wayfinder_paths.jobs.sync.sync_all_jobs",
         lambda *, store: stores.append(store),
     )
+    registries: list[list[dict]] = []
+    monkeypatch.setattr(
+        "wayfinder_paths.runner.daemon.SCHEDULED_JOBS_CLIENT.bulk_sync",
+        lambda jobs: registries.append(jobs),
+    )
     monkeypatch.setattr(daemon, "_run_side_effect", lambda _label, cb: cb())
 
     daemon._sync_to_backend_async()
 
     assert stores == []
+    assert registries == []
 
 
 def test_finish_run_triggers_backend_sync(


### PR DESCRIPTION
## Symptom

The Activity tab on the Strategies jobs page is empty for every job created in the last ~2 months (reported on `majors-5m-lab`; applies to `xyz-scalp-lab` and all others too).

## Root cause

The Activity tab reads `FlyOpenCodeScheduledRun` rows, which the box's runner daemon pushes per finished run (`report_run`). The backend 404s that POST unless the job was first registered via the `/jobs/sync/` registry push (`bulk_sync`). **#520 rewired `_sync_to_backend_async` to push the wayfinder-jobs snapshot *instead of* the registry**, on the belief the registry endpoint was dead — it is alive (verified live against the deployed dev backend: `bulk_sync` → 200, synced 15 jobs). Since #520, every new runner job was unknown to the backend and every run report 404'd — the jobs dev box daemon log shows **345 consecutive `Failed to report run` warnings**.

## Fix

`_sync_to_backend_async` now does both pushes: scheduled-jobs registry first (so run reports land), then the wayfinder-jobs snapshot (conversations/proposals/scorecard). The daemon syncs at startup and after every finished run, so registration self-heals within one cycle of a daemon restart.

Tests: registry+snapshot both asserted in `test_runner_reconcile.py` (payload shape included), non-opencode noop still skips both; 20 runner tests pass; docstring corrected (it had enshrined the wrong 'dead endpoint' belief).

## Note

I manually `bulk_sync`'d the dev box as part of diagnosis, so its registry is already populated — Activity there will start filling on the next ticks even before this merges. The SDK fix makes it survive restarts and covers future jobs/boxes.