### PR TITLE
jobs: trade forensics — the watcher can now see what the chart shows

### DIFF
--- a/wayfinder_paths/jobs/application.py
+++ b/wayfinder_paths/jobs/application.py
@@ -497,6 +497,7 @@ def _promote_candidate(store: JobStore, job_id: str, candidate_dir: Path) -> Non
     for relative in (
         Path("results") / "backtest" / "latest.json",
         Path("results") / "backtest" / "visualization.json",
+        Path("results") / "backtest" / "trade_forensics.json",
         Path("reports") / "preflight" / "latest.json",
         Path("reports") / "validation" / "latest.json",
     ):

--- a/wayfinder_paths/jobs/execution/driver.py
+++ b/wayfinder_paths/jobs/execution/driver.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 import pandas as pd
+from loguru import logger
 
 from wayfinder_paths.jobs.execution.engine import (
     EngineState,
@@ -364,6 +365,10 @@ async def tick_job(
         now=now,
         engine_state_pre=engine_state_pre,
     )
+    try:
+        _record_pending_trade_forensics(root, view)
+    except Exception as exc:  # noqa: BLE001 — telemetry must never fail a tick
+        logger.debug(f"trade forensics skipped: {exc}")
     for note in mode_notes:
         store.append_journal(
             job.id,
@@ -562,3 +567,74 @@ def _record(
 def view_hash(view: CompletedBarsView) -> str:
     encoded = json.dumps(view.to_rows(), sort_keys=True, default=str).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()[:16]
+
+
+FORENSICS_POST_BARS = 16
+_FORENSICS_SCAN_TRADES = 40
+_FORENSICS_SCAN_FILLS = 400
+
+
+def _read_jsonl_tail(path: Path, limit: int) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines()[-limit:]:
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(row, dict):
+            rows.append(row)
+    return rows
+
+
+def _record_pending_trade_forensics(root: Path, view: CompletedBarsView) -> int:
+    """Lazily append path forensics for closed trades once the bars window
+    covers their post-exit horizon.
+
+    Post-exit excursion needs FUTURE bars, so forensics for a trade land
+    ~FORENSICS_POST_BARS bars after its close — computed from the live view
+    already in memory (no extra fetches), keyed by (symbol, exit ts) so each
+    trade is written exactly once.
+    """
+    from wayfinder_paths.jobs.trade_forensics import forensics_for_closed_trades
+
+    trades_path = root / "results" / "forward" / "trades.jsonl"
+    out_path = root / "results" / "forward" / "trade_forensics.jsonl"
+    trades = _read_jsonl_tail(trades_path, _FORENSICS_SCAN_TRADES)
+    if not trades:
+        return 0
+    done = {
+        (str(row.get("symbol")), str(row.get("exit_ts")))
+        for row in _read_jsonl_tail(out_path, _FORENSICS_SCAN_TRADES * 2)
+    }
+    timestamps = view.timestamps
+    if not timestamps:
+        return 0
+
+    pending: list[dict[str, Any]] = []
+    for trade in trades:
+        exit_ts = pd.Timestamp(str(trade.get("closed_at") or trade.get("timestamp")))
+        if exit_ts.tzinfo is None:
+            exit_ts = exit_ts.tz_localize("UTC")
+        if (str(trade.get("symbol")), exit_ts.isoformat()) in done:
+            continue
+        post_available = sum(1 for ts in timestamps if ts > exit_ts)
+        if post_available < FORENSICS_POST_BARS:
+            continue
+        pending.append(trade)
+    if not pending:
+        return 0
+
+    fills = _read_jsonl_tail(
+        root / "results" / "forward" / "fills.jsonl", _FORENSICS_SCAN_FILLS
+    )
+    bars_by_symbol = {symbol: view.symbol_frame(symbol) for symbol in view.symbols}
+    rows = forensics_for_closed_trades(bars_by_symbol, pending, fills)
+    if not rows:
+        return 0
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("a", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, sort_keys=True, default=str) + "\n")
+    return len(rows)

--- a/wayfinder_paths/jobs/execution/job.py
+++ b/wayfinder_paths/jobs/execution/job.py
@@ -199,6 +199,9 @@ def backtest_execution_job(
         params = job_data.get("execution_params") or {}
         result = simulate_execution(script, dataset, spec, params)
         artifacts = write_backtest_artifacts(result, output_dir, extra=stamp)
+        artifacts["trade_forensics"] = _write_trade_forensics(
+            result, dataset, output_dir, stamp=stamp
+        )
         payload = {
             "type": "single",
             "result": result.to_dict(),
@@ -208,6 +211,65 @@ def backtest_execution_job(
     validation = validate_execution_job(job_id, store=store)
     payload["validation"] = validation
     return payload
+
+
+_FORENSICS_MAX_TRADES = 120
+
+
+def _write_trade_forensics(
+    result: Any,
+    dataset: PreparedExecutionDataset,
+    output_dir: Path,
+    *,
+    stamp: Mapping[str, Any],
+) -> str | None:
+    """Per-trade path forensics + population aggregate for the baseline run.
+
+    The aggregate (by exit reason: MAE/MFE, post-exit excursion, stop-survival
+    rates) is the statistically meaningful exit-quality view the intervention
+    agent reasons from; forward per-trade rows are only hypothesis fuel.
+    Best-effort: a forensics failure must not fail the backtest.
+    """
+    try:
+        from wayfinder_paths.jobs.trade_forensics import (
+            aggregate_trade_forensics,
+            forensics_for_closed_trades,
+        )
+
+        trades = list(result.trades or [])
+        # A backtest close row keys prices under avg_price/timestamp; align
+        # copies with the forward trade-close shape the shared helper expects
+        # (copies: result.trades feeds payload["result"] afterwards).
+        closes = [
+            {
+                **row,
+                "price": row.get("avg_price"),
+                "closed_at": row.get("timestamp"),
+                "net_pnl": row.get("realized_pnl_delta"),
+            }
+            for row in trades
+            if row.get("reduce_only")
+        ][-_FORENSICS_MAX_TRADES:]
+        view = dataset.bars
+        bars_by_symbol = {symbol: view.symbol_frame(symbol) for symbol in view.symbols}
+        rows = forensics_for_closed_trades(bars_by_symbol, closes, trades)
+        path = Path(output_dir) / "trade_forensics.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "aggregate": aggregate_trade_forensics(rows),
+                    "trades": rows,
+                    **dict(stamp),
+                },
+                indent=2,
+                default=str,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return str(path)
+    except Exception:  # noqa: BLE001 — telemetry must never fail a backtest
+        return None
 
 
 def _load_job_yaml(root: Path) -> dict[str, Any]:

--- a/wayfinder_paths/jobs/trade_forensics.py
+++ b/wayfinder_paths/jobs/trade_forensics.py
@@ -1,0 +1,264 @@
+"""Per-trade price-path forensics: what the chart shows that PnL rows hide.
+
+A closed-trade row says what a trade *made*; it says nothing about the path —
+how far price moved against the position during the hold (MAE), how much
+favorable move existed (MFE), and what happened in the bars right AFTER the
+exit. Those are exactly the facts a human reads off the chart when judging an
+exit rule ("the stop-out kept falling for 20 more minutes"), and exactly what
+the intervention agent could not see. This module computes them
+deterministically for both backtest and forward trades.
+
+Honesty contract: single-trade counterfactuals are HYPOTHESIS FUEL, not
+evidence. `aggregate_trade_forensics` over the backtest population is where an
+exit tweak gets its first real test; the experiments grid + walk-forward
+adjudicate before any proposal.
+
+All excursions are in bps of the ENTRY price and are direction-aware:
+positive = in the trade's favor.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
+
+import pandas as pd
+
+POST_BARS = (4, 8, 16)
+STOP_GRID = (0.02, 0.025, 0.03, 0.035)
+
+
+def _bps(value: float, entry_price: float) -> float:
+    return round(value / entry_price * 1e4, 1)
+
+
+def position_side_of_close(close_fill_side: str) -> str:
+    """A reduce-only fill's side is the EXIT side: buying closes a short."""
+    return "short" if str(close_fill_side).lower() == "buy" else "long"
+
+
+def match_entry_fill(
+    fills: Iterable[Mapping[str, Any]],
+    *,
+    symbol: str,
+    exit_ts: pd.Timestamp,
+) -> Mapping[str, Any] | None:
+    """Latest non-reduce-only fill for the symbol strictly before the exit.
+
+    Valid under the one-position-per-symbol model jobs_v1 strategies use; a
+    partial-fill ladder would need explicit trade ids instead.
+    """
+    best: Mapping[str, Any] | None = None
+    best_ts: pd.Timestamp | None = None
+    for fill in fills:
+        if str(fill.get("symbol")) != symbol or fill.get("reduce_only"):
+            continue
+        ts = pd.Timestamp(str(fill.get("timestamp")))
+        if ts.tzinfo is None:
+            ts = ts.tz_localize("UTC")
+        if ts >= exit_ts:
+            continue
+        if best_ts is None or ts > best_ts:
+            best, best_ts = fill, ts
+    return best
+
+
+def compute_trade_forensics(
+    bars: pd.DataFrame,
+    *,
+    side: str,
+    entry_ts: pd.Timestamp,
+    entry_price: float,
+    exit_ts: pd.Timestamp,
+    exit_price: float,
+    exit_reason: str | None = None,
+    post_bars: Sequence[int] = POST_BARS,
+    stop_grid: Sequence[float] = STOP_GRID,
+) -> dict[str, Any]:
+    """Path metrics for one closed trade from a single-symbol bars frame.
+
+    ``bars`` needs timestamp/high/low/close columns sorted ascending; the
+    frame may be partial — coverage flags say what was computable.
+    """
+    direction = 1.0 if side == "long" else -1.0
+    stamps = pd.to_datetime(bars["timestamp"], utc=True)
+    high = bars["high"].astype(float)
+    low = bars["low"].astype(float)
+    close = bars["close"].astype(float)
+
+    hold_mask = (stamps > entry_ts) & (stamps <= exit_ts)
+    post_mask = stamps > exit_ts
+    hold_high, hold_low = high[hold_mask], low[hold_mask]
+    post_close = close[post_mask].head(max(post_bars))
+    post_high = high[post_mask].head(max(post_bars))
+    post_low = low[post_mask].head(max(post_bars))
+
+    realized_bps = _bps(direction * (exit_price - entry_price), entry_price)
+
+    hold_covered = bool(hold_mask.any()) and bool(stamps.iloc[0] <= entry_ts)
+    if hold_mask.any():
+        favorable_extreme = hold_high.max() if side == "long" else hold_low.min()
+        adverse_extreme = hold_low.min() if side == "long" else hold_high.max()
+        mfe_bps = _bps(direction * (favorable_extreme - entry_price), entry_price)
+        mae_bps = _bps(direction * (entry_price - adverse_extreme), entry_price)
+    else:
+        mfe_bps = mae_bps = None
+
+    post_favorable: dict[str, float | None] = {}
+    for k in post_bars:
+        if len(post_close) >= k:
+            post_favorable[f"+{k}"] = _bps(
+                direction * (post_close.iloc[k - 1] - exit_price), entry_price
+            )
+        else:
+            post_favorable[f"+{k}"] = None
+    if len(post_close):
+        best_extreme = post_high.max() if side == "long" else post_low.min()
+        post_best_bps = _bps(direction * (best_extreme - exit_price), entry_price)
+        # Did price come back through the entry after the exit? For a
+        # stopped-out trade this is the "the stop was noise" signature.
+        reentered = (
+            bool((post_low <= entry_price).any())
+            if side == "short"
+            else bool((post_high >= entry_price).any())
+        )
+    else:
+        post_best_bps = None
+        reentered = None
+
+    stop_survival = {
+        f"{pct:g}": (mae_bps is not None and mae_bps < pct * 1e4) for pct in stop_grid
+    }
+
+    return {
+        "side": side,
+        "entry_ts": entry_ts.isoformat(),
+        "exit_ts": exit_ts.isoformat(),
+        "entry_price": entry_price,
+        "exit_price": exit_price,
+        "exit_reason": exit_reason,
+        "realized_bps": realized_bps,
+        "hold_mfe_bps": mfe_bps,
+        "hold_mae_bps": mae_bps,
+        "post_exit_favorable_bps": post_favorable,
+        "post_exit_best_bps": post_best_bps,
+        "post_exit_through_entry": reentered,
+        "stop_survives": stop_survival,
+        "coverage": {
+            "hold": hold_covered,
+            "post_bars": int(len(post_close)),
+            "post_bars_wanted": int(max(post_bars)),
+        },
+    }
+
+
+def forensics_for_closed_trades(
+    bars_by_symbol: Mapping[str, pd.DataFrame],
+    closed_trades: Sequence[Mapping[str, Any]],
+    fills: Sequence[Mapping[str, Any]],
+    *,
+    post_bars: Sequence[int] = POST_BARS,
+    stop_grid: Sequence[float] = STOP_GRID,
+) -> list[dict[str, Any]]:
+    """Forensics for each closed trade whose entry fill can be matched.
+
+    ``closed_trades`` rows are the recorded trade-close shape (symbol, the
+    CLOSING fill's side, price/avg_price, timestamp/closed_at, optional raw
+    intent metadata); ``fills`` supplies entry candidates.
+    """
+    rows: list[dict[str, Any]] = []
+    for trade in closed_trades:
+        symbol = str(trade.get("symbol"))
+        bars = bars_by_symbol.get(symbol)
+        if bars is None or bars.empty:
+            continue
+        exit_ts = pd.Timestamp(str(trade.get("closed_at") or trade.get("timestamp")))
+        if exit_ts.tzinfo is None:
+            exit_ts = exit_ts.tz_localize("UTC")
+        entry = match_entry_fill(fills, symbol=symbol, exit_ts=exit_ts)
+        if entry is None:
+            continue
+        entry_ts = pd.Timestamp(str(entry.get("timestamp")))
+        if entry_ts.tzinfo is None:
+            entry_ts = entry_ts.tz_localize("UTC")
+        raw = trade.get("raw") or {}
+        meta = raw.get("intent_metadata") or {}
+        entry_raw = entry.get("raw") or {}
+        entry_meta = entry_raw.get("intent_metadata") or {}
+        row = compute_trade_forensics(
+            bars,
+            side=position_side_of_close(str(trade.get("side"))),
+            entry_ts=entry_ts,
+            entry_price=float(entry.get("avg_price") or 0.0),
+            exit_ts=exit_ts,
+            exit_price=float(trade.get("price") or trade.get("avg_price") or 0.0),
+            exit_reason=meta.get("exit_reason") or trade.get("exit_reason"),
+            post_bars=post_bars,
+            stop_grid=stop_grid,
+        )
+        row["symbol"] = symbol
+        row["entry_reason"] = entry_meta.get("entry_reason")
+        row["net_pnl"] = trade.get("net_pnl") or trade.get("realized_pnl_delta")
+        rows.append(row)
+    return rows
+
+
+def aggregate_trade_forensics(rows: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    """Population-level exit-quality summary, grouped by exit reason.
+
+    This is the statistically meaningful view — per-trade rows are anecdotes.
+    """
+
+    def _mean(values: list[float]) -> float | None:
+        return round(sum(values) / len(values), 1) if values else None
+
+    by_reason: dict[str, list[Mapping[str, Any]]] = {}
+    for row in rows:
+        by_reason.setdefault(str(row.get("exit_reason") or "unknown"), []).append(row)
+
+    groups: dict[str, Any] = {}
+    for reason, members in sorted(by_reason.items()):
+        realized = [float(m["realized_bps"]) for m in members]
+        maes = [
+            float(m["hold_mae_bps"])
+            for m in members
+            if m.get("hold_mae_bps") is not None
+        ]
+        mfes = [
+            float(m["hold_mfe_bps"])
+            for m in members
+            if m.get("hold_mfe_bps") is not None
+        ]
+        post: dict[str, float | None] = {}
+        for key in members[0].get("post_exit_favorable_bps") or {}:
+            vals = [
+                float(m["post_exit_favorable_bps"][key])
+                for m in members
+                if (m.get("post_exit_favorable_bps") or {}).get(key) is not None
+            ]
+            post[key] = _mean(vals)
+        survival: dict[str, float] = {}
+        for width in members[0].get("stop_survives") or {}:
+            flags = [
+                bool(m["stop_survives"][width])
+                for m in members
+                if m.get("stop_survives")
+            ]
+            survival[width] = round(sum(flags) / len(flags), 3) if flags else 0.0
+        through = [m.get("post_exit_through_entry") for m in members]
+        through_known = [t for t in through if t is not None]
+        groups[reason] = {
+            "count": len(members),
+            "avg_realized_bps": _mean(realized),
+            "total_realized_bps": round(sum(realized), 1),
+            "avg_hold_mae_bps": _mean(maes),
+            "avg_hold_mfe_bps": _mean(mfes),
+            "avg_post_exit_favorable_bps": post,
+            "stop_survival_rate": survival,
+            "post_exit_through_entry_rate": (
+                round(sum(bool(t) for t in through_known) / len(through_known), 3)
+                if through_known
+                else None
+            ),
+        }
+    return {"trades": len(rows), "by_exit_reason": groups}

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -45,6 +45,47 @@ def _canonical_json(data: Any, *, max_chars: int | None = None) -> str:
     return text
 
 
+def _trade_forensics_block(root: Path) -> dict[str, Any]:
+    """Compact exit-quality context: per-trade path metrics the agent cannot
+    read off PnL rows (MAE/MFE during the hold, post-exit excursion, stop
+    survival) plus the backtest-population aggregate that adjudicates them."""
+    block: dict[str, Any] = {}
+    forward_path = root / "results" / "forward" / "trade_forensics.jsonl"
+    if forward_path.exists():
+        rows = []
+        for line in forward_path.read_text(encoding="utf-8").splitlines()[-5:]:
+            try:
+                row = json.loads(line)
+            except ValueError:
+                continue
+            if isinstance(row, dict):
+                row.pop("coverage", None)
+                rows.append(row)
+        if rows:
+            block["recent_forward_trades"] = rows
+    backtest_path = root / "results" / "backtest" / "trade_forensics.json"
+    if backtest_path.exists():
+        try:
+            doc = json.loads(backtest_path.read_text(encoding="utf-8"))
+        except ValueError:
+            doc = {}
+        aggregate = doc.get("aggregate")
+        if aggregate:
+            block["backtest_aggregate"] = aggregate
+    if block:
+        block["_basis"] = (
+            "Exit-quality path metrics, bps of entry price, positive = in the "
+            "trade's favor. hold_mae/mfe = worst/best excursion DURING the "
+            "hold; post_exit_favorable = move in the trade's direction AFTER "
+            "the exit (what a later exit would have captured); stop_survives "
+            "= whether that stop width would have held. Forward rows are "
+            "single-trade ANECDOTES — hypothesis fuel only. Adjudicate any "
+            "exit tweak on backtest_aggregate + an experiments grid over the "
+            "exit params with walk-forward before proposing."
+        )
+    return block
+
+
 def _drop_volatile_stable_keys(value: Any) -> Any:
     match value:
         case dict():
@@ -125,6 +166,7 @@ def _build_worker_prompt_sections(
             "candidates": tail_ledger(store, job_id, "candidates", limit=20),
             "decisions": tail_ledger(store, job_id, "decisions", limit=20),
         },
+        "trade_forensics": _trade_forensics_block(root),
     }
 
     stable_prefix = (
@@ -266,6 +308,22 @@ def _build_worker_prompt_sections(
             "only: no workspace/ or job.yaml edits, and no proposals whose "
             "evidence is the sub-floor forward sample. Monitor-mode wakes stay "
             "read-only.\n"
+            "- Exit-quality lane: `trade_forensics` in the dynamic context "
+            "shows each closed trade's PATH — hold MAE/MFE, post-exit "
+            "favorable excursion (what a later exit would have captured), "
+            "stop-survival counterfactuals — plus the backtest-population "
+            "aggregate by exit reason. When forward trades show a pattern "
+            "(e.g. stop-outs where price then runs far in the trade's favor, "
+            "or time-exits leaving large post-exit moves), treat it as a "
+            "HYPOTHESIS about the exit params, then adjudicate on the "
+            "population: run an experiments grid over the pre-registered exit "
+            "params (e.g. hold_scale, stop_pct) with walk-forward, require "
+            "the improvement to hold in OOS folds and across neighbor cells "
+            "(plateau), and only then propose. A handful of forward "
+            "anecdotes NEVER justifies a retune directly — but a "
+            "grid+WF-validated exit change motivated by them is a legitimate "
+            "proposal even below the forward-sample floor, because its "
+            "evidence is the backtest population, not the forward sample.\n"
             "- Ideation cadence: research/agenda.md is the cumulative "
             "research state — sections: Dead map (refuted, one line of "
             "evidence each), Open hypotheses (ranked, each citing its "

--- a/wayfinder_paths/tests/test_execution_contract.py
+++ b/wayfinder_paths/tests/test_execution_contract.py
@@ -250,6 +250,11 @@ def test_job_backtest_and_validate_write_artifacts(tmp_path: Path) -> None:
     assert (root / "results" / "backtest" / "visualization.json").exists()
     assert validation["status"] == "passed"
     assert (root / "reports" / "validation" / "latest.json").exists()
+    forensics_path = root / "results" / "backtest" / "trade_forensics.json"
+    assert forensics_path.exists()
+    forensics = json.loads(forensics_path.read_text(encoding="utf-8"))
+    assert "aggregate" in forensics and "trades" in forensics
+    assert forensics["aggregate"]["trades"] == len(forensics["trades"])
 
 
 def test_backtest_artifact_summary_and_view_are_bounded(tmp_path: Path) -> None:

--- a/wayfinder_paths/tests/test_trade_forensics.py
+++ b/wayfinder_paths/tests/test_trade_forensics.py
@@ -1,0 +1,315 @@
+"""Trade forensics: path metrics per closed trade (MAE/MFE, post-exit
+excursion, stop-survival counterfactuals) and the population aggregate."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from wayfinder_paths.jobs.execution.driver import _record_pending_trade_forensics
+from wayfinder_paths.jobs.execution.primitives import CompletedBarsView
+from wayfinder_paths.jobs.trade_forensics import (
+    aggregate_trade_forensics,
+    compute_trade_forensics,
+    forensics_for_closed_trades,
+    match_entry_fill,
+    position_side_of_close,
+)
+
+
+def _ts(minute: int) -> pd.Timestamp:
+    return pd.Timestamp("2026-07-22T10:00:00Z") + pd.Timedelta(minutes=5 * minute)
+
+
+def _bars(prices: list[tuple[float, float, float, float]]) -> pd.DataFrame:
+    """One 5m bar per (open, high, low, close) tuple starting at minute 0."""
+    return pd.DataFrame(
+        [
+            {
+                "timestamp": _ts(i).isoformat(),
+                "symbol": "LIT",
+                "open": o,
+                "high": h,
+                "low": low,
+                "close": c,
+                "volume": 1.0,
+            }
+            for i, (o, h, low, c) in enumerate(prices)
+        ]
+    )
+
+
+def test_short_stop_out_with_post_exit_collapse() -> None:
+    # Short entered at 100 on bar0 close; price squeezes to 103 (stop) then
+    # collapses to 95 in the bars after the exit — the chart pattern that
+    # motivated this module.
+    bars = _bars(
+        [
+            (100, 100.5, 99.5, 100.0),  # bar0: entry bar
+            (100, 102.0, 99.9, 101.5),  # bar1: adverse
+            (101.5, 103.0, 101.0, 102.8),  # bar2: stop hit intra-bar
+            (102.8, 102.9, 99.0, 99.5),  # bar3: collapse begins
+            (99.5, 99.6, 96.0, 96.5),  # bar4
+            (96.5, 97.0, 95.0, 95.2),  # bar5
+            (95.2, 95.8, 94.8, 95.5),  # bar6
+        ]
+    )
+    row = compute_trade_forensics(
+        bars,
+        side="short",
+        entry_ts=_ts(0),
+        entry_price=100.0,
+        exit_ts=_ts(2),
+        exit_price=103.0,
+        exit_reason="stop_loss",
+        post_bars=(2, 4),
+        stop_grid=(0.025, 0.035),
+    )
+    assert row["realized_bps"] == -300.0
+    # Hold covers bars 1-2: adverse extreme high=103 -> MAE 300bps; the
+    # favorable extreme low=99.9 -> MFE 1bps... low is 99.9 in bar1, 101.0 in
+    # bar2 -> best favorable = 100 - 99.9 = 0.1 -> 10bps.
+    assert row["hold_mae_bps"] == 300.0
+    assert row["hold_mfe_bps"] == 10.0
+    # Post-exit (short's favor = down, measured vs exit 103, bps of entry):
+    # +2 bars close 96.5 -> (103 - 96.5) / 100 = 650bps
+    assert row["post_exit_favorable_bps"]["+2"] == 650.0
+    assert row["post_exit_favorable_bps"]["+4"] == 750.0
+    # Best low within 4 post bars (bars 3-6) = 94.8 -> 820bps
+    assert row["post_exit_best_bps"] == 820.0
+    # Price fell back through the entry (100) after the stop: whipsaw signature.
+    assert row["post_exit_through_entry"] is True
+    assert row["stop_survives"] == {"0.025": False, "0.035": True}
+    assert row["coverage"] == {"hold": True, "post_bars": 4, "post_bars_wanted": 4}
+
+
+def test_long_winner_with_truncated_post_window() -> None:
+    bars = _bars(
+        [
+            (100, 100.5, 99.5, 100.0),
+            (100, 102.0, 99.8, 101.8),
+            (101.8, 103.5, 101.5, 103.0),
+            (103.0, 103.2, 102.0, 102.5),  # only 1 post-exit bar available
+        ]
+    )
+    row = compute_trade_forensics(
+        bars,
+        side="long",
+        entry_ts=_ts(0),
+        entry_price=100.0,
+        exit_ts=_ts(2),
+        exit_price=103.0,
+        exit_reason="time_exit",
+        post_bars=(2, 4),
+        stop_grid=(0.02,),
+    )
+    assert row["realized_bps"] == 300.0
+    assert row["hold_mfe_bps"] == 350.0  # high 103.5
+    assert row["hold_mae_bps"] == 20.0  # low 99.8
+    assert row["post_exit_favorable_bps"] == {"+2": None, "+4": None}
+    assert row["post_exit_best_bps"] == 20.0  # high 103.2 vs exit 103.0
+    assert row["stop_survives"] == {"0.02": True}
+    assert row["coverage"]["post_bars"] == 1
+
+
+def test_match_entry_fill_and_close_side() -> None:
+    fills = [
+        {
+            "symbol": "LIT",
+            "side": "sell",
+            "reduce_only": False,
+            "timestamp": _ts(0).isoformat(),
+            "avg_price": 100.0,
+        },
+        {
+            "symbol": "XRP",
+            "side": "buy",
+            "reduce_only": False,
+            "timestamp": _ts(1).isoformat(),
+            "avg_price": 3.0,
+        },
+        {
+            "symbol": "LIT",
+            "side": "buy",
+            "reduce_only": True,
+            "timestamp": _ts(2).isoformat(),
+            "avg_price": 103.0,
+        },
+    ]
+    entry = match_entry_fill(fills, symbol="LIT", exit_ts=_ts(2))
+    assert entry is not None and entry["avg_price"] == 100.0
+    # The recorded trade row carries the CLOSING fill's side.
+    assert position_side_of_close("buy") == "short"
+    assert position_side_of_close("sell") == "long"
+
+
+def test_forensics_for_closed_trades_end_to_end() -> None:
+    bars = _bars(
+        [
+            (100, 100.5, 99.5, 100.0),
+            (100, 102.0, 99.9, 101.5),
+            (101.5, 103.0, 101.0, 103.0),
+            (103.0, 103.1, 99.0, 99.5),
+            (99.5, 99.6, 96.0, 96.5),
+        ]
+    )
+    fills = [
+        {
+            "symbol": "LIT",
+            "side": "sell",
+            "reduce_only": False,
+            "timestamp": _ts(0).isoformat(),
+            "avg_price": 100.0,
+            "raw": {"intent_metadata": {"entry_reason": "compression_break_fade"}},
+        },
+    ]
+    trades = [
+        {
+            "symbol": "LIT",
+            "side": "buy",
+            "price": 103.0,
+            "net_pnl": -0.64,
+            "closed_at": _ts(2).isoformat(),
+            "raw": {"intent_metadata": {"exit_reason": "stop_loss"}},
+        },
+    ]
+    rows = forensics_for_closed_trades({"LIT": bars}, trades, fills, post_bars=(2,))
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["symbol"] == "LIT"
+    assert row["side"] == "short"
+    assert row["entry_reason"] == "compression_break_fade"
+    assert row["exit_reason"] == "stop_loss"
+    assert row["realized_bps"] == -300.0
+    assert row["net_pnl"] == -0.64
+
+
+def test_aggregate_groups_by_exit_reason() -> None:
+    rows = [
+        {
+            "exit_reason": "stop_loss",
+            "realized_bps": -250.0,
+            "hold_mae_bps": 260.0,
+            "hold_mfe_bps": 5.0,
+            "post_exit_favorable_bps": {"+4": 200.0},
+            "stop_survives": {"0.035": True},
+            "post_exit_through_entry": True,
+        },
+        {
+            "exit_reason": "stop_loss",
+            "realized_bps": -260.0,
+            "hold_mae_bps": 270.0,
+            "hold_mfe_bps": 15.0,
+            "post_exit_favorable_bps": {"+4": -50.0},
+            "stop_survives": {"0.035": False},
+            "post_exit_through_entry": False,
+        },
+        {
+            "exit_reason": "time_exit",
+            "realized_bps": 51.0,
+            "hold_mae_bps": 70.0,
+            "hold_mfe_bps": 142.0,
+            "post_exit_favorable_bps": {"+4": -19.0},
+            "stop_survives": {"0.035": True},
+            "post_exit_through_entry": False,
+        },
+    ]
+    aggregate = aggregate_trade_forensics(rows)
+    assert aggregate["trades"] == 3
+    stops = aggregate["by_exit_reason"]["stop_loss"]
+    assert stops["count"] == 2
+    assert stops["avg_realized_bps"] == -255.0
+    assert stops["avg_post_exit_favorable_bps"]["+4"] == 75.0
+    assert stops["stop_survival_rate"]["0.035"] == 0.5
+    assert stops["post_exit_through_entry_rate"] == 0.5
+    assert aggregate["by_exit_reason"]["time_exit"]["count"] == 1
+
+
+def test_driver_lazy_forensics_writes_once(tmp_path: Path) -> None:
+    root = tmp_path
+    forward = root / "results" / "forward"
+    forward.mkdir(parents=True)
+    (forward / "fills.jsonl").write_text(
+        json.dumps(
+            {
+                "symbol": "LIT",
+                "side": "sell",
+                "reduce_only": False,
+                "timestamp": _ts(0).isoformat(),
+                "avg_price": 100.0,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (forward / "trades.jsonl").write_text(
+        json.dumps(
+            {
+                "symbol": "LIT",
+                "side": "buy",
+                "price": 103.0,
+                "net_pnl": -0.64,
+                "closed_at": _ts(2).isoformat(),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    # Window with only 3 post-exit bars: below FORENSICS_POST_BARS -> deferred.
+    short_view = CompletedBarsView.from_rows(
+        _bars([(100, 101, 99, 100)] * 6).to_dict("records")
+    )
+    assert _record_pending_trade_forensics(root, short_view) == 0
+    assert not (forward / "trade_forensics.jsonl").exists()
+
+    # Window covering exit + 16 bars -> computed exactly once.
+    full_view = CompletedBarsView.from_rows(
+        _bars([(100, 101, 99, 100)] * 20).to_dict("records")
+    )
+    assert _record_pending_trade_forensics(root, full_view) == 1
+    rows = [
+        json.loads(line)
+        for line in (forward / "trade_forensics.jsonl").read_text().splitlines()
+    ]
+    assert len(rows) == 1
+    assert rows[0]["symbol"] == "LIT"
+    assert rows[0]["side"] == "short"
+
+    # Idempotent: a later tick with the same window appends nothing.
+    assert _record_pending_trade_forensics(root, full_view) == 0
+
+
+def test_worker_forensics_block_reads_both_sources(tmp_path: Path) -> None:
+    from wayfinder_paths.jobs.worker import _trade_forensics_block
+
+    assert _trade_forensics_block(tmp_path) == {}
+
+    forward = tmp_path / "results" / "forward"
+    forward.mkdir(parents=True)
+    (forward / "trade_forensics.jsonl").write_text(
+        "\n".join(
+            json.dumps({"symbol": "LIT", "realized_bps": bps, "coverage": {}})
+            for bps in (-250.0, 51.0)
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    backtest = tmp_path / "results" / "backtest"
+    backtest.mkdir(parents=True)
+    (backtest / "trade_forensics.json").write_text(
+        json.dumps({"aggregate": {"trades": 332}, "trades": []}),
+        encoding="utf-8",
+    )
+
+    block = _trade_forensics_block(tmp_path)
+    assert [row["realized_bps"] for row in block["recent_forward_trades"]] == [
+        -250.0,
+        51.0,
+    ]
+    # Verbose per-trade coverage flags are stripped from the prompt payload.
+    assert "coverage" not in block["recent_forward_trades"][0]
+    assert block["backtest_aggregate"] == {"trades": 332}
+    assert "hypothesis fuel" in block["_basis"]


### PR DESCRIPTION
## Problem

The intervention agent gets trade *outcomes* (entry, exit, PnL) but never the *price path* — MAE/MFE during the hold, and what happened in the bars right after the exit. A human looks at the LIT chart and says "the stop-out kept falling for 20 more minutes"; the agent had no numeric equivalent, so exit rules never received evidence-based scrutiny and wakes defaulted to no-change.

Motivating case (majors-5m-lab, 2026-07-22, computed by this module):
- **LIT short #1 (stop-out −257bps)**: MFE during hold −6bps (never in favor), then **+196bps in the short's favor within 4 bars after the stop**, +294bps best-in-window. Stop at 3%+ would have survived — but the 16-bar time exit would still have lost −62bps. "Would have been a winner" is a two-parameter claim (stop AND hold) — exactly the nuance the eyeball misses and the numbers force.
- **LIT short #2 (time-exit +51bps)**: only +41bps more was available post-exit — that exit was fine.

## What ships

- **`trade_forensics.py`** (pure): per closed trade — hold MAE/MFE, post-exit favorable excursion (+4/+8/+16 bars, best-in-window), price-back-through-entry ("stop was noise" signature), stop-width survival counterfactuals; entries matched from fills; population **aggregate by exit reason**.
- **Forward (driver)**: lazy per-tick hook appends `results/forward/trade_forensics.jsonl` once the live bars window covers a trade's post-exit horizon (~16 bars after close). No extra fetches, idempotent, can never fail a tick.
- **Backtest**: baseline runs write `results/backtest/trade_forensics.json` (rows capped at 120 + aggregate); copied on proposal promotion with the other revision-stamped artifacts.
- **Wake context**: compact `trade_forensics` block (last 5 forward rows + backtest aggregate) with a `_basis` note fixing units/semantics.
- **Guidance (exit-quality lane)**: forward path anecdotes are HYPOTHESIS FUEL only. Adjudication = experiments grid over the pre-registered exit params (`hold_scale`, `stop_pct`) with walk-forward OOS + plateau. A grid+WF-validated exit change motivated by forward anecdotes is a legitimate proposal even below the 20-trade floor — its evidence is the backtest population, not the forward sample. That's the honest path from "I see it on the chart" to a shippable change.

## Tests

7 new in `test_trade_forensics.py` (direction-aware short/long math against hand-computed bars, truncated windows, entry matching, close-side inversion, aggregate, driver lazy-hook write-once/deferral) + backtest artifact assertion in `test_execution_contract.py`. 71 tests pass across the affected suites; ruff clean; no new mypy errors.