### PR TITLE
jobs: forensics exit-reason labeling + honest stop counterfactual

### DIFF
--- a/wayfinder_paths/jobs/trade_forensics.py
+++ b/wayfinder_paths/jobs/trade_forensics.py
@@ -26,6 +26,9 @@ import pandas as pd
 
 POST_BARS = (4, 8, 16)
 STOP_GRID = (0.02, 0.025, 0.03, 0.035)
+# The engine's bracket fills carry no intent metadata — a close without an
+# exit_reason IS the protective stop (strategy closes always label themselves).
+BRACKET_EXIT_REASON = "bracket_stop"
 
 
 def _bps(value: float, entry_price: float) -> float:
@@ -61,6 +64,24 @@ def match_entry_fill(
         if best_ts is None or ts > best_ts:
             best, best_ts = fill, ts
     return best
+
+
+def _closing_fill_reason(
+    fills: Iterable[Mapping[str, Any]],
+    *,
+    symbol: str,
+    exit_ts: pd.Timestamp,
+) -> str | None:
+    for fill in fills:
+        if str(fill.get("symbol")) != symbol or not fill.get("reduce_only"):
+            continue
+        ts = pd.Timestamp(str(fill.get("timestamp")))
+        if ts.tzinfo is None:
+            ts = ts.tz_localize("UTC")
+        if ts == exit_ts:
+            meta = (fill.get("raw") or {}).get("intent_metadata") or {}
+            return meta.get("exit_reason") or None
+    return None
 
 
 def compute_trade_forensics(
@@ -126,8 +147,31 @@ def compute_trade_forensics(
         post_best_bps = None
         reentered = None
 
+    # Only bracket (stop) closes lack an exit_reason: strategy closes carry
+    # intent metadata, the engine's bracket fills do not. Label them instead
+    # of leaking None/"unknown" into the aggregate.
+    reason = exit_reason or BRACKET_EXIT_REASON
+
+    # Wider-stop counterfactual. For a stop-out the hypothetical wider-stop
+    # hold CONTINUES past the actual exit, so the adverse scan must extend
+    # through the post window too — scanning only the truncated hold would
+    # overstate survival. Time/signal exits end the position regardless of
+    # stop width, so their scan is exactly the hold.
+    if reason == BRACKET_EXIT_REASON and len(post_close):
+        adverse_scan_high = pd.concat([hold_high, post_high])
+        adverse_scan_low = pd.concat([hold_low, post_low])
+    else:
+        adverse_scan_high, adverse_scan_low = hold_high, hold_low
+    if len(adverse_scan_high):
+        scan_adverse = (
+            adverse_scan_low.min() if side == "long" else adverse_scan_high.max()
+        )
+        scan_mae_bps = _bps(direction * (entry_price - scan_adverse), entry_price)
+    else:
+        scan_mae_bps = None
     stop_survival = {
-        f"{pct:g}": (mae_bps is not None and mae_bps < pct * 1e4) for pct in stop_grid
+        f"{pct:g}": (scan_mae_bps is not None and scan_mae_bps < pct * 1e4)
+        for pct in stop_grid
     }
 
     return {
@@ -136,7 +180,7 @@ def compute_trade_forensics(
         "exit_ts": exit_ts.isoformat(),
         "entry_price": entry_price,
         "exit_price": exit_price,
-        "exit_reason": exit_reason,
+        "exit_reason": reason,
         "realized_bps": realized_bps,
         "hold_mfe_bps": mfe_bps,
         "hold_mae_bps": mae_bps,
@@ -185,6 +229,11 @@ def forensics_for_closed_trades(
         meta = raw.get("intent_metadata") or {}
         entry_raw = entry.get("raw") or {}
         entry_meta = entry_raw.get("intent_metadata") or {}
+        exit_reason = meta.get("exit_reason") or trade.get("exit_reason")
+        if not exit_reason:
+            # Forward trade-close rows carry no intent metadata — the reason
+            # lives on the CLOSING fill (same symbol/timestamp, reduce_only).
+            exit_reason = _closing_fill_reason(fills, symbol=symbol, exit_ts=exit_ts)
         row = compute_trade_forensics(
             bars,
             side=position_side_of_close(str(trade.get("side"))),
@@ -192,7 +241,7 @@ def forensics_for_closed_trades(
             entry_price=float(entry.get("avg_price") or 0.0),
             exit_ts=exit_ts,
             exit_price=float(trade.get("price") or trade.get("avg_price") or 0.0),
-            exit_reason=meta.get("exit_reason") or trade.get("exit_reason"),
+            exit_reason=exit_reason,
             post_bars=post_bars,
             stop_grid=stop_grid,
         )

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -77,11 +77,15 @@ def _trade_forensics_block(root: Path) -> dict[str, Any]:
             "Exit-quality path metrics, bps of entry price, positive = in the "
             "trade's favor. hold_mae/mfe = worst/best excursion DURING the "
             "hold; post_exit_favorable = move in the trade's direction AFTER "
-            "the exit (what a later exit would have captured); stop_survives "
-            "= whether that stop width would have held. Forward rows are "
-            "single-trade ANECDOTES — hypothesis fuel only. Adjudicate any "
-            "exit tweak on backtest_aggregate + an experiments grid over the "
-            "exit params with walk-forward before proposing."
+            "the exit (what a later exit would have captured); "
+            "exit_reason 'bracket_stop' = the protective stop fired (bracket "
+            "fills carry no strategy label); stop_survives = that stop width "
+            "was never breached — for bracket_stop trades the scan extends "
+            "through the post-exit window (the hypothetical wider-stop hold "
+            "continues), for labeled exits it covers the actual hold. Forward "
+            "rows are single-trade ANECDOTES — hypothesis fuel only. "
+            "Adjudicate any exit tweak on backtest_aggregate + an experiments "
+            "grid over the exit params with walk-forward before proposing."
         )
     return block
 

--- a/wayfinder_paths/tests/test_trade_forensics.py
+++ b/wayfinder_paths/tests/test_trade_forensics.py
@@ -63,10 +63,11 @@ def test_short_stop_out_with_post_exit_collapse() -> None:
         entry_price=100.0,
         exit_ts=_ts(2),
         exit_price=103.0,
-        exit_reason="stop_loss",
+        exit_reason=None,  # bracket fills carry no strategy label
         post_bars=(2, 4),
         stop_grid=(0.025, 0.035),
     )
+    assert row["exit_reason"] == "bracket_stop"
     assert row["realized_bps"] == -300.0
     # Hold covers bars 1-2: adverse extreme high=103 -> MAE 300bps; the
     # favorable extreme low=99.9 -> MFE 1bps... low is 99.9 in bar1, 101.0 in
@@ -105,6 +106,7 @@ def test_long_winner_with_truncated_post_window() -> None:
         post_bars=(2, 4),
         stop_grid=(0.02,),
     )
+    assert row["exit_reason"] == "time_exit"
     assert row["realized_bps"] == 300.0
     assert row["hold_mfe_bps"] == 350.0  # high 103.5
     assert row["hold_mae_bps"] == 20.0  # low 99.8
@@ -112,6 +114,51 @@ def test_long_winner_with_truncated_post_window() -> None:
     assert row["post_exit_best_bps"] == 20.0  # high 103.2 vs exit 103.0
     assert row["stop_survives"] == {"0.02": True}
     assert row["coverage"]["post_bars"] == 1
+
+
+def test_bracket_stop_survival_scans_post_window() -> None:
+    # Short stopped at 103; the post window squeezes HIGHER to 104.5 before
+    # reversing. A 3.5% stop survives the truncated hold (MAE 300bps) but NOT
+    # the continued hypothetical hold (450bps) — the extended scan must catch
+    # that, or the counterfactual overstates survival.
+    bars = _bars(
+        [
+            (100, 100.5, 99.5, 100.0),
+            (100, 103.0, 99.9, 102.8),  # stop hit
+            (102.8, 104.5, 102.5, 104.0),  # post: squeeze continues
+            (104.0, 104.2, 101.0, 101.5),
+            (101.5, 101.6, 99.0, 99.5),
+        ]
+    )
+    row = compute_trade_forensics(
+        bars,
+        side="short",
+        entry_ts=_ts(0),
+        entry_price=100.0,
+        exit_ts=_ts(1),
+        exit_price=103.0,
+        exit_reason=None,
+        post_bars=(2,),
+        stop_grid=(0.035, 0.05),
+    )
+    assert row["exit_reason"] == "bracket_stop"
+    assert row["hold_mae_bps"] == 300.0  # truncated-hold MAE alone
+    assert row["stop_survives"] == {"0.035": False, "0.05": True}
+
+    # The same path with a LABELED exit scans only the actual hold: the
+    # position would not exist post-exit under any stop width.
+    labeled = compute_trade_forensics(
+        bars,
+        side="short",
+        entry_ts=_ts(0),
+        entry_price=100.0,
+        exit_ts=_ts(1),
+        exit_price=103.0,
+        exit_reason="time_exit",
+        post_bars=(2,),
+        stop_grid=(0.035, 0.05),
+    )
+    assert labeled["stop_survives"] == {"0.035": True, "0.05": True}
 
 
 def test_match_entry_fill_and_close_side() -> None:
@@ -184,6 +231,51 @@ def test_forensics_for_closed_trades_end_to_end() -> None:
     assert row["exit_reason"] == "stop_loss"
     assert row["realized_bps"] == -300.0
     assert row["net_pnl"] == -0.64
+
+
+def test_exit_reason_falls_back_to_closing_fill() -> None:
+    # Forward trade-close rows carry no intent metadata: the reason lives on
+    # the closing fill. An unlabeled closing fill means the bracket fired.
+    bars = _bars(
+        [
+            (100, 100.5, 99.5, 100.0),
+            (100, 101, 99, 100.5),
+            (100.5, 101, 99, 100.0),
+            (100, 101, 99, 100.2),
+        ]
+    )
+    fills = [
+        {
+            "symbol": "LIT",
+            "side": "sell",
+            "reduce_only": False,
+            "timestamp": _ts(0).isoformat(),
+            "avg_price": 100.0,
+        },
+        {
+            "symbol": "LIT",
+            "side": "buy",
+            "reduce_only": True,
+            "timestamp": _ts(2).isoformat(),
+            "avg_price": 100.0,
+            "raw": {"intent_metadata": {"exit_reason": "time_exit"}},
+        },
+    ]
+    trades = [
+        {
+            "symbol": "LIT",
+            "side": "buy",
+            "price": 100.0,
+            "closed_at": _ts(2).isoformat(),
+        },
+    ]
+    rows = forensics_for_closed_trades({"LIT": bars}, trades, fills, post_bars=(1,))
+    assert rows[0]["exit_reason"] == "time_exit"
+
+    # Same trade but the closing fill has no label -> bracket_stop.
+    fills[1]["raw"] = {"intent_metadata": {"exit_reason": ""}}
+    rows = forensics_for_closed_trades({"LIT": bars}, trades, fills, post_bars=(1,))
+    assert rows[0]["exit_reason"] == "bracket_stop"
 
 
 def test_aggregate_groups_by_exit_reason() -> None:


### PR DESCRIPTION
Two defects found while verifying #544 live on the dev box:

1. **exit_reason was None/unknown everywhere.** Forward trade-close rows carry no intent metadata (the reason lives on the *closing fill*), and the engine's bracket fills carry no label at all — so forward rows showed `None` and all 7 backtest stop-outs aggregated under `unknown`. Fix: fall back to the closing fill's metadata, and label unlabeled closes **`bracket_stop`** (only bracket fills lack a strategy label, so an unlabeled close is by construction the protective stop).

2. **stop_survives overstated survival for stop-outs.** It scanned MAE over the truncated (stopped) hold — but under a hypothetically wider stop the hold *continues past the actual exit*. For `bracket_stop` trades the adverse scan now extends through the post-exit window; labeled exits still scan only the actual hold, since the position ends there regardless of stop width. New test pins the case where a wider stop survives the truncated hold but not the continued one.

Wake-prompt `_basis` note updated to the corrected semantics. 21 tests pass (3 new/updated); ruff clean.