### PR TITLE
jobs: chart + analogs lenses — let the agent look at price, not just test it

### DIFF
--- a/wayfinder_paths/jobs/chart.py
+++ b/wayfinder_paths/jobs/chart.py
@@ -1,0 +1,320 @@
+"""Agent chart lenses: text chart browsing and historical-analog search.
+
+`chart_job` is the agent's window onto price: any symbol/timeframe window of
+the job dataset rendered as compact per-bar rows with whatever indicator
+columns the agent asks for, forward trades annotated inline, and a regime
+header — the numeric equivalent of dragging indicators onto the chart and
+zooming into the hours around a trade.
+
+`analogs_job` answers "when has this happened before?": z-scores a recent
+close window, finds the nearest non-overlapping historical analogs, and
+reports the forward-outcome distribution of the matches. Exploratory by
+construction — anything it suggests still goes through the scan/holdout gate.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from wayfinder_paths.jobs.execution.job import _load_dataset, _load_job_yaml
+from wayfinder_paths.jobs.execution.primitives import (
+    ExecutionSpec,
+    bar_interval_seconds,
+)
+from wayfinder_paths.jobs.execution.validation import resolve_execution_spec
+from wayfinder_paths.jobs.indicators import compute_indicators, regime_snapshot
+from wayfinder_paths.jobs.research import resample_ohlcv
+from wayfinder_paths.jobs.store import JobStore
+
+MAX_CHART_ROWS = 240
+TIMEFRAME_SECONDS = {
+    "5m": 300,
+    "15m": 900,
+    "30m": 1800,
+    "1h": 3600,
+    "4h": 14400,
+    "1d": 86400,
+}
+
+
+def _load_symbol_frame(
+    job_id: str, symbol: str | None, store: JobStore
+) -> tuple[pd.DataFrame, str, int, Path]:
+    root = store.job_dir(job_id)
+    job_data = _load_job_yaml(root)
+    spec_data, _ = resolve_execution_spec(root, job_data)
+    spec = ExecutionSpec.from_dict(spec_data)
+    dataset = _load_dataset(root, spec, job_data)
+    frame = dataset.bars.to_frame()
+    symbols = sorted(frame["symbol"].astype(str).unique())
+    if symbol is None:
+        symbol = symbols[0]
+    if symbol not in symbols:
+        raise ValueError(f"unknown symbol {symbol!r}; dataset has {symbols}")
+    out = frame[frame["symbol"].astype(str) == symbol].reset_index(drop=True)
+    declared = bar_interval_seconds(spec.data_contract.get("bar_interval"))
+    if declared:
+        bar_seconds = int(declared)
+    else:
+        stamps = pd.to_datetime(out["timestamp"], utc=True)
+        bar_seconds = int(stamps.diff().median().total_seconds())
+    return out, symbol, bar_seconds, root
+
+
+def _resample(
+    frame: pd.DataFrame, timeframe: str | None, bar_seconds: int
+) -> tuple[pd.DataFrame, int]:
+    if not timeframe:
+        return frame, bar_seconds
+    rule = TIMEFRAME_SECONDS.get(timeframe)
+    if rule is None:
+        raise ValueError(
+            f"unknown timeframe {timeframe!r}; known: {sorted(TIMEFRAME_SECONDS)}"
+        )
+    return resample_ohlcv(frame, rule, bar_seconds=bar_seconds), rule
+
+
+def _forward_trade_marks(
+    root: Path, symbol: str, rule_seconds: int
+) -> dict[str, list[str]]:
+    """Bar-timestamp -> annotation labels from the forward record. Fills mark
+    entries; trade closes mark exits (bucketed to the display timeframe's
+    right-closed label)."""
+    from wayfinder_paths.jobs.execution.driver import _read_jsonl_tail
+
+    def _bucket(ts: pd.Timestamp) -> str:
+        stamp = ts.ceil(f"{rule_seconds}s")
+        return stamp.isoformat()
+
+    marks: dict[str, list[str]] = {}
+    fills = _read_jsonl_tail(root / "results" / "forward" / "fills.jsonl", 400)
+    for fill in fills:
+        if str(fill.get("symbol")) != symbol:
+            continue
+        ts = pd.Timestamp(str(fill.get("timestamp")))
+        if ts.tzinfo is None:
+            ts = ts.tz_localize("UTC")
+        meta = (fill.get("raw") or {}).get("intent_metadata") or {}
+        if fill.get("reduce_only"):
+            label = f"EXIT:{meta.get('exit_reason') or 'bracket_stop'}"
+        else:
+            label = f"ENTRY:{fill.get('side')}:{meta.get('entry_reason') or ''}"
+        marks.setdefault(_bucket(ts), []).append(label.rstrip(":"))
+    return marks
+
+
+def chart_job(
+    job_id: str,
+    *,
+    symbol: str | None = None,
+    timeframe: str | None = None,
+    bars: int = 96,
+    indicators: list[str] | None = None,
+    around_trade: str | None = None,
+    store: JobStore | None = None,
+) -> dict[str, Any]:
+    store = store or JobStore()
+    frame, symbol, bar_seconds, root = _load_symbol_frame(job_id, symbol, store)
+    frame, rule_seconds = _resample(frame, timeframe, bar_seconds)
+    if frame.empty:
+        raise ValueError("dataset has no bars for this symbol/timeframe")
+
+    stamps = pd.to_datetime(frame["timestamp"], utc=True)
+    window_note = None
+    if around_trade:
+        from wayfinder_paths.jobs.execution.driver import _read_jsonl_tail
+
+        trades = [
+            t
+            for t in _read_jsonl_tail(root / "results" / "forward" / "trades.jsonl", 60)
+            if str(t.get("symbol")) == symbol
+        ]
+        if not trades:
+            raise ValueError(f"no forward trades for {symbol} to center on")
+        if around_trade == "last":
+            trade = trades[-1]
+        else:
+            wanted = pd.Timestamp(around_trade)
+            if wanted.tzinfo is None:
+                wanted = wanted.tz_localize("UTC")
+            trade = min(
+                trades,
+                key=lambda t: abs(
+                    pd.Timestamp(str(t.get("closed_at"))).tz_localize(None)
+                    - wanted.tz_localize(None)
+                ),
+            )
+        exit_ts = pd.Timestamp(str(trade.get("closed_at")))
+        if exit_ts.tzinfo is None:
+            exit_ts = exit_ts.tz_localize("UTC")
+        center = int((stamps <= exit_ts).sum()) - 1
+        lo = max(0, center - bars // 2)
+        window = frame.iloc[lo : lo + bars]
+        window_note = f"centered on trade closed {exit_ts.isoformat()}"
+    else:
+        window = frame.tail(bars)
+    window = window.tail(MAX_CHART_ROWS)
+
+    indicator_cols = compute_indicators(frame, indicators or ["ema:9", "ema:50"])
+    marks = _forward_trade_marks(root, symbol, rule_seconds)
+
+    columns = ["ts", "open", "high", "low", "close", "volume"]
+    columns += list(indicator_cols)
+    columns.append("mark")
+    rows: list[list[Any]] = []
+    for idx in window.index:
+        ts = pd.Timestamp(window.at[idx, "timestamp"])
+        if ts.tzinfo is None:
+            ts = ts.tz_localize("UTC")
+        row: list[Any] = [ts.isoformat()]
+        for col in ("open", "high", "low", "close", "volume"):
+            row.append(round(float(window.at[idx, col]), 6))
+        for series in indicator_cols.values():
+            value = series.loc[idx] if idx in series.index else np.nan
+            row.append(None if pd.isna(value) else round(float(value), 6))
+        row.append(";".join(marks.get(ts.isoformat(), [])) or None)
+        rows.append(row)
+
+    closes = window["close"].astype(float)
+    window_return_bps = (
+        (closes.iloc[-1] / closes.iloc[0] - 1) * 1e4 if len(closes) > 1 else 0.0
+    )
+    last_ts = pd.Timestamp(window["timestamp"].iloc[-1])
+    if last_ts.tzinfo is None:
+        last_ts = last_ts.tz_localize("UTC")
+    header = {
+        "symbol": symbol,
+        "timeframe": timeframe or f"{bar_seconds}s",
+        "bars_shown": len(rows),
+        "window_return_bps": round(float(window_return_bps), 1),
+        "window_range_bps": round(
+            float(
+                (window["high"].astype(float).max() - window["low"].astype(float).min())
+                / closes.iloc[-1]
+                * 1e4
+            ),
+            1,
+        ),
+        "regime_at_end": regime_snapshot(frame, last_ts),
+        "window_note": window_note,
+        "marks": sum(len(v) for v in marks.values()),
+    }
+    return {
+        "header": header,
+        "columns": columns,
+        "rows": rows,
+        "read": (
+            "Per-bar view with the requested indicator lenses; marks are "
+            "forward entries/exits. A pattern seen here is an OBSERVATION — "
+            "turn it into a workspace SignalDef or grid hypothesis and let "
+            "the scan/holdout gate adjudicate."
+        ),
+    }
+
+
+def analogs_job(
+    job_id: str,
+    *,
+    symbol: str | None = None,
+    timeframe: str | None = None,
+    window: int = 24,
+    at: str | None = None,
+    top: int = 15,
+    horizon: int = 12,
+    store: JobStore | None = None,
+) -> dict[str, Any]:
+    store = store or JobStore()
+    frame, symbol, bar_seconds, _root = _load_symbol_frame(job_id, symbol, store)
+    frame, _rule = _resample(frame, timeframe, bar_seconds)
+    closes = frame["close"].astype(float).to_numpy()
+    stamps = pd.to_datetime(frame["timestamp"], utc=True).reset_index(drop=True)
+    if len(closes) < window * 3 + horizon:
+        raise ValueError(
+            f"need at least {window * 3 + horizon} bars, dataset has {len(closes)}"
+        )
+
+    if at is None:
+        query_end = len(closes)
+    else:
+        wanted = pd.Timestamp(at)
+        if wanted.tzinfo is None:
+            wanted = wanted.tz_localize("UTC")
+        query_end = int((stamps <= wanted).sum())
+        if query_end < window:
+            raise ValueError("not enough history before --at for the query window")
+    query = closes[query_end - window : query_end]
+
+    def _zscore(values: np.ndarray) -> np.ndarray | None:
+        std = values.std()
+        if not np.isfinite(std) or std == 0:
+            return None
+        return (values - values.mean()) / std
+
+    query_z = _zscore(query)
+    if query_z is None:
+        raise ValueError("query window has zero variance")
+
+    candidates: list[tuple[float, int]] = []
+    # Candidate windows must leave room for the forward horizon and must not
+    # overlap the query window itself.
+    for start in range(0, query_end - 2 * window - horizon + 1):
+        segment_z = _zscore(closes[start : start + window])
+        if segment_z is None:
+            continue
+        distance = float(np.sqrt(np.mean((segment_z - query_z) ** 2)))
+        candidates.append((distance, start))
+    candidates.sort()
+
+    matches: list[dict[str, Any]] = []
+    taken: list[int] = []
+    for distance, start in candidates:
+        if any(abs(start - other) < window // 2 for other in taken):
+            continue
+        taken.append(start)
+        end = start + window
+        outcome_bps = (closes[end - 1 + horizon] / closes[end - 1] - 1) * 1e4
+        matches.append(
+            {
+                "start_ts": stamps.iloc[start].isoformat(),
+                "end_ts": stamps.iloc[end - 1].isoformat(),
+                "distance": round(distance, 4),
+                f"fwd_{horizon}bar_bps": round(float(outcome_bps), 1),
+            }
+        )
+        if len(matches) >= top:
+            break
+
+    outcomes = np.array([m[f"fwd_{horizon}bar_bps"] for m in matches])
+    summary = {
+        "matches": len(matches),
+        "mean_bps": round(float(outcomes.mean()), 1) if len(outcomes) else None,
+        "median_bps": round(float(np.median(outcomes)), 1) if len(outcomes) else None,
+        "hit_rate_up": round(float((outcomes > 0).mean()), 3)
+        if len(outcomes)
+        else None,
+        "q25_bps": round(float(np.quantile(outcomes, 0.25)), 1)
+        if len(outcomes)
+        else None,
+        "q75_bps": round(float(np.quantile(outcomes, 0.75)), 1)
+        if len(outcomes)
+        else None,
+    }
+    return {
+        "symbol": symbol,
+        "window_bars": window,
+        "horizon_bars": horizon,
+        "query_end_ts": stamps.iloc[query_end - 1].isoformat(),
+        "summary": summary,
+        "matches": matches,
+        "read": (
+            "EXPLORATORY analog search — nearest z-scored close windows and "
+            "what followed them. This is hypothesis fuel, not evidence: no "
+            "multiplicity control, shape-only matching. Chart the matches, "
+            "form a rule, and put it through signal-scan/holdout before "
+            "believing it."
+        ),
+    }

--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -698,6 +698,88 @@ def signal_scan_cmd(
 
 
 @job_cli.command(
+    name="chart",
+    help="Text chart lens: per-bar OHLCV + requested indicator columns with "
+    "forward trades annotated inline and a regime header. The numeric "
+    "equivalent of dragging indicators onto the chart and zooming into the "
+    "hours around a trade.",
+)
+@click.argument("job_id")
+@click.option("--symbol", default=None, help="Symbol (default: first in dataset).")
+@click.option("--timeframe", default=None, help="Resample: 5m/15m/30m/1h/4h/1d.")
+@click.option("--bars", type=int, default=96, show_default=True)
+@click.option(
+    "--indicators",
+    default=None,
+    help="Comma-separated specs, e.g. ema:9,ema:50,rsi:14,bb:20:2,atr:14,"
+    "macd:12:26:9,don:20,vwap,volpct:14 (default ema:9,ema:50).",
+)
+@click.option(
+    "--around-trade",
+    "around_trade",
+    default=None,
+    help="'last' or a close timestamp — center the window on that forward trade.",
+)
+def chart_cmd(
+    job_id: str,
+    symbol: str | None,
+    timeframe: str | None,
+    bars: int,
+    indicators: str | None,
+    around_trade: str | None,
+) -> None:
+    from wayfinder_paths.jobs.chart import chart_job
+
+    result = chart_job(
+        job_id,
+        symbol=symbol,
+        timeframe=timeframe,
+        bars=bars,
+        indicators=[i.strip() for i in indicators.split(",")] if indicators else None,
+        around_trade=around_trade,
+        store=JobStore(),
+    )
+    _echo_json({"ok": True, "result": result})
+
+
+@job_cli.command(
+    name="analogs",
+    help="Historical analog search: z-score a recent close window, find the "
+    "nearest non-overlapping analogs in history, report the forward-outcome "
+    "distribution. EXPLORATORY — hypothesis fuel for the scan pipeline.",
+)
+@click.argument("job_id")
+@click.option("--symbol", default=None)
+@click.option("--timeframe", default=None)
+@click.option("--window", type=int, default=24, show_default=True)
+@click.option("--at", default=None, help="Query window end (default: latest bar).")
+@click.option("--top", type=int, default=15, show_default=True)
+@click.option("--horizon", type=int, default=12, show_default=True)
+def analogs_cmd(
+    job_id: str,
+    symbol: str | None,
+    timeframe: str | None,
+    window: int,
+    at: str | None,
+    top: int,
+    horizon: int,
+) -> None:
+    from wayfinder_paths.jobs.chart import analogs_job
+
+    result = analogs_job(
+        job_id,
+        symbol=symbol,
+        timeframe=timeframe,
+        window=window,
+        at=at,
+        top=top,
+        horizon=horizon,
+        store=JobStore(),
+    )
+    _echo_json({"ok": True, "result": result})
+
+
+@job_cli.command(
     name="holdout-check",
     help="One-shot confirmation of a FROZEN scan candidate (signal + "
     "timeframe + horizon + direction) on the reserved holdout tail. Spend "

--- a/wayfinder_paths/jobs/execution/op_runner.py
+++ b/wayfinder_paths/jobs/execution/op_runner.py
@@ -51,6 +51,14 @@ def _run(op: str, kwargs: dict[str, Any]) -> Any:
         from wayfinder_paths.jobs.research import signal_scan_job
 
         return signal_scan_job(kwargs.pop("job_id"), **kwargs)
+    if op == "chart":
+        from wayfinder_paths.jobs.chart import chart_job
+
+        return chart_job(kwargs.pop("job_id"), **kwargs)
+    if op == "analogs":
+        from wayfinder_paths.jobs.chart import analogs_job
+
+        return analogs_job(kwargs.pop("job_id"), **kwargs)
     if op == "holdout_check":
         from wayfinder_paths.jobs.research import holdout_check_job
 

--- a/wayfinder_paths/jobs/indicators.py
+++ b/wayfinder_paths/jobs/indicators.py
@@ -1,0 +1,161 @@
+"""On-demand indicator engine for the agent's chart lens.
+
+Parses compact indicator specs ("ema:9", "rsi:14", "bb:20:2", "macd:12:26:9")
+and computes the columns on a single-symbol OHLCV frame. Conventions match the
+strategies and the signal library (Wilder RSI via ewm(alpha=1/n), right-closed
+resamples upstream) so what the agent sees is what the stats test.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+import pandas as pd
+
+MAX_INDICATORS = 8
+
+
+def wilder_rsi(close: pd.Series, period: int = 14) -> pd.Series:
+    delta = close.diff()
+    gain = delta.clip(lower=0.0).ewm(alpha=1 / period, adjust=False).mean()
+    loss = (-delta.clip(upper=0.0)).ewm(alpha=1 / period, adjust=False).mean()
+    rs = gain / loss.replace(0.0, np.nan)
+    return 100 - 100 / (1 + rs)
+
+
+def atr(frame: pd.DataFrame, period: int = 14) -> pd.Series:
+    high = frame["high"].astype(float)
+    low = frame["low"].astype(float)
+    prev_close = frame["close"].astype(float).shift(1)
+    true_range = pd.concat(
+        [high - low, (high - prev_close).abs(), (low - prev_close).abs()], axis=1
+    ).max(axis=1)
+    return true_range.ewm(alpha=1 / period, adjust=False).mean()
+
+
+def _spec_error(spec: str, reason: str) -> ValueError:
+    return ValueError(
+        f"bad indicator spec {spec!r}: {reason}. Known specs: sma:N, ema:N, "
+        "rsi:N, atr:N, bb:N:K (bollinger %B and bandwidth), macd:F:S:SIG, "
+        "don:N (donchian position), vwap, vr:N (variance ratio), "
+        "volpct:N (ATR percentile)"
+    )
+
+
+def compute_indicator(frame: pd.DataFrame, spec: str) -> dict[str, pd.Series]:
+    """One spec -> one or more named columns (e.g. macd yields line+signal)."""
+    parts = [p for p in spec.strip().lower().split(":") if p]
+    if not parts:
+        raise _spec_error(spec, "empty")
+    name, args = parts[0], parts[1:]
+    try:
+        nums = [float(a) for a in args]
+    except ValueError as exc:
+        raise _spec_error(spec, "non-numeric parameter") from exc
+    close = frame["close"].astype(float)
+
+    def _one(default: float) -> int:
+        if len(nums) > 1:
+            raise _spec_error(spec, "expected at most one parameter")
+        return int(nums[0]) if nums else int(default)
+
+    match name:
+        case "sma":
+            n = _one(20)
+            return {f"sma{n}": close.rolling(n).mean()}
+        case "ema":
+            n = _one(20)
+            return {f"ema{n}": close.ewm(span=n, adjust=False).mean()}
+        case "rsi":
+            n = _one(14)
+            return {f"rsi{n}": wilder_rsi(close, n)}
+        case "atr":
+            n = _one(14)
+            return {f"atr{n}": atr(frame, n)}
+        case "vwap":
+            if nums:
+                raise _spec_error(spec, "vwap takes no parameters")
+            typical = (
+                frame["high"].astype(float) + frame["low"].astype(float) + close
+            ) / 3
+            volume = frame["volume"].astype(float)
+            return {"vwap": (typical * volume).cumsum() / volume.cumsum()}
+        case "bb":
+            if len(nums) > 2:
+                raise _spec_error(spec, "expected bb:N:K")
+            n = int(nums[0]) if nums else 20
+            k = float(nums[1]) if len(nums) > 1 else 2.0
+            mid = close.rolling(n).mean()
+            std = close.rolling(n).std()
+            upper, lower = mid + k * std, mid - k * std
+            width = upper - lower
+            return {
+                f"bb{n}_pctb": (close - lower) / width.replace(0.0, np.nan),
+                f"bb{n}_bw": width / mid,
+            }
+        case "macd":
+            if nums and len(nums) != 3:
+                raise _spec_error(spec, "expected macd:FAST:SLOW:SIGNAL")
+            fast, slow, signal = (int(x) for x in (nums or [12, 26, 9]))
+            line = (
+                close.ewm(span=fast, adjust=False).mean()
+                - close.ewm(span=slow, adjust=False).mean()
+            )
+            return {
+                f"macd{fast}_{slow}": line,
+                f"macds{signal}": line.ewm(span=signal, adjust=False).mean(),
+            }
+        case "don":
+            n = _one(20)
+            hi = frame["high"].astype(float).rolling(n).max()
+            lo = frame["low"].astype(float).rolling(n).min()
+            return {f"don{n}_pos": (close - lo) / (hi - lo).replace(0.0, np.nan)}
+        case "vr":
+            n = _one(24)
+            r1 = close.pct_change()
+            rn = close.pct_change(n)
+            return {f"vr{n}": rn.rolling(200).var() / (n * r1.rolling(200).var())}
+        case "volpct":
+            n = _one(14)
+            series = atr(frame, n) / close
+            return {f"volpct{n}": series.expanding(min_periods=n).rank(pct=True) * 100}
+        case _:
+            raise _spec_error(spec, "unknown indicator")
+
+
+def compute_indicators(
+    frame: pd.DataFrame, specs: Sequence[str]
+) -> dict[str, pd.Series]:
+    if len(specs) > MAX_INDICATORS:
+        raise ValueError(
+            f"too many indicators ({len(specs)} > {MAX_INDICATORS}) — pick the "
+            "lenses that test THIS hypothesis"
+        )
+    columns: dict[str, pd.Series] = {}
+    for spec in specs:
+        for key, series in compute_indicator(frame, spec).items():
+            columns[key] = series
+    return columns
+
+
+def regime_snapshot(frame: pd.DataFrame, at: pd.Timestamp) -> dict[str, object]:
+    """Compact market-state tags at a timestamp: the context a human absorbs
+    from the chart without thinking. Computed causally (data through `at`)."""
+    stamps = pd.to_datetime(frame["timestamp"], utc=True)
+    history = frame.loc[stamps <= at]
+    if len(history) < 60:
+        return {"insufficient_history": True}
+    close = history["close"].astype(float)
+    sma50 = close.rolling(50).mean().iloc[-1]
+    atr14 = atr(history, 14) / close
+    vol_pctile = float((atr14.iloc[-1] > atr14.dropna()).mean() * 100)
+    hour = pd.Timestamp(at).tz_convert("UTC").hour
+    session = (
+        "asia" if hour < 7 else "europe" if hour < 13 else "us" if hour < 21 else "late"
+    )
+    return {
+        "trend": "up" if close.iloc[-1] > sma50 else "down",
+        "vol_pctile": round(vol_pctile, 1),
+        "session": session,
+    }

--- a/wayfinder_paths/jobs/trade_forensics.py
+++ b/wayfinder_paths/jobs/trade_forensics.py
@@ -199,6 +199,11 @@ def forensics_for_closed_trades(
         row["symbol"] = symbol
         row["entry_reason"] = entry_meta.get("entry_reason")
         row["net_pnl"] = trade.get("net_pnl") or trade.get("realized_pnl_delta")
+        # Market-state tags at entry (trend vs SMA50, vol percentile, session)
+        # so regime patterns across winners/losers are visible at a glance.
+        from wayfinder_paths.jobs.indicators import regime_snapshot
+
+        row["regime_at_entry"] = regime_snapshot(bars, entry_ts)
         rows.append(row)
     return rows
 

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -324,6 +324,20 @@ def _build_worker_prompt_sections(
             "grid+WF-validated exit change motivated by them is a legitimate "
             "proposal even below the forward-sample floor, because its "
             "evidence is the backtest population, not the forward sample.\n"
+            "- Chart lenses (LOOK before hypothesizing): "
+            '`core_jobs(action="chart", job_id=..., symbol=..., '
+            'timeframe="30m", indicators=["ema:9","ema:50","rsi:14"], '
+            'around_trade="last")` renders the bars around any trade (or the '
+            "latest window) as per-bar rows with whatever indicator columns "
+            "you request, forward entries/exits annotated, plus a regime "
+            'header. `core_jobs(action="analogs", job_id=..., symbol=..., '
+            "window=24, horizon=12)` finds the nearest historical analogs of "
+            "the recent window and reports what followed them. Use chart to "
+            "eyeball every loser before proposing anything about exits; use "
+            "analogs when a pattern 'looks familiar'. Both are OBSERVATION "
+            "tools — no multiplicity control — so what they suggest becomes a "
+            "workspace SignalDef or grid hypothesis for the scan/holdout "
+            "gate, never direct evidence.\n"
             "- Ideation cadence: research/agenda.md is the cumulative "
             "research state — sections: Dead map (refuted, one line of "
             "evidence each), Open hypotheses (ranked, each citing its "

--- a/wayfinder_paths/mcp/tools/jobs.py
+++ b/wayfinder_paths/mcp/tools/jobs.py
@@ -44,6 +44,8 @@ JobAction = Literal[
     "pair_check",
     "signal_check",
     "signal_scan",
+    "chart",
+    "analogs",
     "holdout_check",
     "rank_check",
     "strategy_library",
@@ -165,6 +167,14 @@ async def core_jobs(
     holdout_fraction: float = 0.15,
     signal: str | None = None,
     horizon: int | None = None,
+    symbol: str | None = None,
+    timeframe: str | None = None,
+    bars: int = 96,
+    indicators: list[str] | None = None,
+    around_trade: str | None = None,
+    window: int = 24,
+    at: str | None = None,
+    top: int = 15,
 ) -> dict[str, Any]:
     """Manage high-level Wayfinder jobs.
 
@@ -392,6 +402,33 @@ async def core_jobs(
                 "horizons": horizons,
                 "timeframes": timeframes,
                 "holdout_fraction": holdout_fraction,
+            },
+        )
+
+    if action == "chart":
+        return await _run_job_op(
+            "chart",
+            {
+                "job_id": job_id,
+                "symbol": symbol,
+                "timeframe": timeframe,
+                "bars": bars,
+                "indicators": indicators,
+                "around_trade": around_trade,
+            },
+        )
+
+    if action == "analogs":
+        return await _run_job_op(
+            "analogs",
+            {
+                "job_id": job_id,
+                "symbol": symbol,
+                "timeframe": timeframe,
+                "window": window,
+                "at": at,
+                "top": top,
+                "horizon": horizon if horizon is not None else 12,
             },
         )
 

--- a/wayfinder_paths/tests/test_jobs_chart_analogs.py
+++ b/wayfinder_paths/tests/test_jobs_chart_analogs.py
@@ -1,0 +1,216 @@
+"""Agent chart lenses: indicator engine, text chart op, analog search, and
+regime-tagged forensics."""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from wayfinder_paths.jobs.chart import analogs_job, chart_job
+from wayfinder_paths.jobs.execution.primitives import ExecutionSpec
+from wayfinder_paths.jobs.indicators import (
+    compute_indicator,
+    compute_indicators,
+    regime_snapshot,
+)
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.jobs.trade_forensics import forensics_for_closed_trades
+
+
+def _wavy_frame(count: int = 300, *, symbol: str = "LIT") -> pd.DataFrame:
+    rows = []
+    base = pd.Timestamp("2026-07-01T00:00:00Z")
+    for i in range(count):
+        price = 100 + 5 * math.sin(i / 9) + i * 0.01
+        rows.append(
+            {
+                "timestamp": (base + pd.Timedelta(minutes=5 * i)).isoformat(),
+                "symbol": symbol,
+                "open": price,
+                "high": price + 0.4,
+                "low": price - 0.4,
+                "close": price + 0.1,
+                "volume": 10.0 + (i % 7),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def test_indicator_engine_specs_and_errors() -> None:
+    frame = _wavy_frame()
+    cols = compute_indicators(
+        frame, ["ema:9", "rsi:14", "bb:20:2", "atr:14", "macd:12:26:9", "don:20"]
+    )
+    assert set(cols) == {
+        "ema9",
+        "rsi14",
+        "bb20_pctb",
+        "bb20_bw",
+        "atr14",
+        "macd12_26",
+        "macds9",
+        "don20_pos",
+    }
+    rsi = cols["rsi14"].dropna()
+    assert rsi.between(0, 100).all() and rsi.std() > 1  # actually oscillates
+    assert cols["don20_pos"].dropna().between(-0.01, 1.01).all()
+    expected_ema = frame["close"].astype(float).ewm(span=9, adjust=False).mean()
+    pd.testing.assert_series_equal(cols["ema9"], expected_ema, check_names=False)
+
+    with pytest.raises(ValueError, match="unknown indicator"):
+        compute_indicator(frame, "wizardry:9")
+    with pytest.raises(ValueError, match="vwap takes no parameters"):
+        compute_indicator(frame, "vwap:3")
+    with pytest.raises(ValueError, match="too many indicators"):
+        compute_indicators(frame, [f"ema:{n}" for n in range(2, 12)])
+
+
+def test_regime_snapshot_tags() -> None:
+    frame = _wavy_frame(200)
+    at = pd.Timestamp(frame["timestamp"].iloc[-1])
+    snap = regime_snapshot(frame, at)
+    assert snap["trend"] in {"up", "down"}
+    assert 0 <= snap["vol_pctile"] <= 100
+    assert snap["session"] in {"asia", "europe", "us", "late"}
+    assert regime_snapshot(frame.head(10), at) == {"insufficient_history": True}
+
+
+def _make_chart_job(tmp_path: Path, frame: pd.DataFrame) -> tuple[JobStore, str]:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        "lens-demo",
+        script=".wayfinder/jobs/lens-demo/workspace/src/strategy.py",
+        interval_seconds=300,
+    )
+    spec = ExecutionSpec()
+    spec.data_contract["bar_interval"] = "5m"
+    job.execution_spec = spec.to_dict()
+    store.save(job)
+    root = store.job_dir(job.id)
+    bars_path = root / "results" / "backtest" / "input_bars.json"
+    bars_path.parent.mkdir(parents=True, exist_ok=True)
+    bars_path.write_text(json.dumps(frame.to_dict("records")), encoding="utf-8")
+    return store, job.id
+
+
+def test_chart_job_renders_window_with_marks(tmp_path: Path) -> None:
+    frame = _wavy_frame(280)
+    store, job_id = _make_chart_job(tmp_path, frame)
+    root = store.job_dir(job_id)
+    forward = root / "results" / "forward"
+    forward.mkdir(parents=True, exist_ok=True)
+    entry_ts = str(frame["timestamp"].iloc[250])
+    exit_ts = str(frame["timestamp"].iloc[260])
+    (forward / "fills.jsonl").write_text(
+        json.dumps(
+            {
+                "symbol": "LIT",
+                "side": "sell",
+                "reduce_only": False,
+                "timestamp": entry_ts,
+                "avg_price": 100.0,
+                "raw": {"intent_metadata": {"entry_reason": "fade"}},
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "symbol": "LIT",
+                "side": "buy",
+                "reduce_only": True,
+                "timestamp": exit_ts,
+                "avg_price": 99.0,
+                "raw": {"intent_metadata": {"exit_reason": "time_exit"}},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (forward / "trades.jsonl").write_text(
+        json.dumps(
+            {
+                "symbol": "LIT",
+                "side": "buy",
+                "price": 99.0,
+                "net_pnl": 0.25,
+                "closed_at": exit_ts,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = chart_job(
+        job_id,
+        indicators=["ema:9", "rsi:14"],
+        bars=60,
+        around_trade="last",
+        store=store,
+    )
+    assert result["header"]["symbol"] == "LIT"
+    assert result["header"]["window_note"] is not None
+    assert result["columns"][:6] == ["ts", "open", "high", "low", "close", "volume"]
+    assert "ema9" in result["columns"] and "rsi14" in result["columns"]
+    marks = {row[0]: row[-1] for row in result["rows"] if row[-1]}
+    assert any("ENTRY:sell:fade" in m for m in marks.values())
+    assert any("EXIT:time_exit" in m for m in marks.values())
+    assert len(result["rows"]) <= 60
+    assert result["header"]["regime_at_end"].get("trend") in {"up", "down"}
+
+
+def test_chart_job_resamples_timeframe(tmp_path: Path) -> None:
+    frame = _wavy_frame(288)
+    store, job_id = _make_chart_job(tmp_path, frame)
+    result = chart_job(job_id, timeframe="30m", bars=20, store=store)
+    stamps = [pd.Timestamp(row[0]) for row in result["rows"]]
+    assert all(
+        (b - a).total_seconds() == 1800
+        for a, b in zip(stamps, stamps[1:], strict=False)
+    )
+    with pytest.raises(ValueError, match="unknown timeframe"):
+        chart_job(job_id, timeframe="7m", store=store)
+
+
+def test_analogs_job_finds_planted_motif(tmp_path: Path) -> None:
+    # Sine-wave series: every full period is an analog of the current window,
+    # so the search must find multiple non-overlapping matches.
+    frame = _wavy_frame(400)
+    store, job_id = _make_chart_job(tmp_path, frame)
+    result = analogs_job(job_id, window=20, top=8, horizon=6, store=store)
+    assert result["summary"]["matches"] >= 3
+    assert result["summary"]["mean_bps"] is not None
+    starts = [pd.Timestamp(m["start_ts"]) for m in result["matches"]]
+    for a, b in zip(sorted(starts), sorted(starts)[1:], strict=False):
+        assert (b - a).total_seconds() >= 10 * 300  # non-overlap: >= window/2
+    assert "hypothesis fuel" in result["read"]
+
+    with pytest.raises(ValueError, match="need at least"):
+        analogs_job(job_id, window=200, horizon=50, store=store)
+
+
+def test_forensics_rows_carry_regime_tags() -> None:
+    frame = _wavy_frame(120)
+    entry_ts = str(frame["timestamp"].iloc[90])
+    exit_ts = str(frame["timestamp"].iloc[100])
+    fills = [
+        {
+            "symbol": "LIT",
+            "side": "sell",
+            "reduce_only": False,
+            "timestamp": entry_ts,
+            "avg_price": 100.0,
+        },
+    ]
+    trades = [
+        {"symbol": "LIT", "side": "buy", "price": 99.5, "closed_at": exit_ts},
+    ]
+    rows = forensics_for_closed_trades({"LIT": frame}, trades, fills, post_bars=(4,))
+    assert len(rows) == 1
+    regime = rows[0]["regime_at_entry"]
+    assert regime.get("trend") in {"up", "down"}
+    assert regime.get("session") in {"asia", "europe", "us", "late"}


### PR DESCRIPTION
## Why

The agent can run statistical sweeps and (since #544) sees trade-path forensics — but it had no way to **look around freely**: the equivalent of dragging indicators onto the chart and zooming into the hours around a stop-out. That cheap, high-bandwidth exploration a human does by eye had no numeric channel, which is a big part of why intervention wakes defaulted to no-change.

## What ships

- **`indicators.py`** — compact spec grammar (`ema:9`, `rsi:14`, `bb:20:2`, `macd:12:26:9`, `atr:14`, `don:20`, `vwap`, `vr:24`, `volpct:14`) → named columns. Wilder conventions match the strategies and signal library, so what the agent sees is what the stats test. Capped at 8 lenses per call. Plus `regime_snapshot`: causal trend / vol-percentile / session tags at any timestamp.
- **`job chart`** (CLI + `core_jobs(action="chart")`) — any symbol/timeframe window of the job dataset as per-bar rows with the requested indicator columns, **forward entries/exits annotated inline** (`--around-trade last` centers the window on a trade, pairing with its forensics row), a regime header, 240-row cap.
- **`job analogs`** (CLI + `core_jobs(action="analogs")`) — z-scored close-window nearest-neighbor search over history with the forward-outcome distribution of the non-overlapping matches: "when has this happened before?" as one call. Output explicitly labels itself exploratory (no multiplicity control).
- **Regime-tagged forensics** — every forensics row gains `regime_at_entry` (trend/vol/session), so "all the stop-outs were high-vol Europe entries" reads at a glance.
- **Guidance** — the worker prompt gains the LOOK-before-hypothesizing lane: chart every loser before proposing anything about exits; use analogs when a pattern "looks familiar"; observations become workspace SignalDefs or grid hypotheses for the scan/holdout gate, never direct evidence.

## Tests

6 new in `test_jobs_chart_analogs.py`: indicator math vs hand-computed references + spec-error surface + lens cap, regime tags, chart end-to-end with entry/exit marks on a synthetic job, timeframe resample correctness, analog search on a planted sine motif with non-overlap guarantee, forensics regime tags. 57 pass across affected suites; ruff clean; no new mypy errors.

## Merge note

Touches `trade_forensics.py` in the same region as #545 — merge #545 first; this branch rebases trivially if needed.
