### PR TITLE
jobs: chart fails loud when around_trade is beyond the dataset end

### DIFF
--- a/wayfinder_paths/jobs/chart.py
+++ b/wayfinder_paths/jobs/chart.py
@@ -151,6 +151,17 @@ def chart_job(
         exit_ts = pd.Timestamp(str(trade.get("closed_at")))
         if exit_ts.tzinfo is None:
             exit_ts = exit_ts.tz_localize("UTC")
+        last_stamp = stamps.iloc[-1]
+        if exit_ts > last_stamp:
+            # The dataset is refreshed by fetch_dataset/backtests, not by live
+            # ticks — a trade newer than the last dataset bar would silently
+            # chart the wrong window. Fail loud with the fix instead.
+            raise ValueError(
+                f"trade closed {exit_ts.isoformat()} is BEYOND the dataset "
+                f"end ({last_stamp.isoformat()}) — refresh first with "
+                'core_jobs(action="fetch_dataset", job_id=...) or '
+                "`wayfinder job fetch-dataset`, then re-chart"
+            )
         center = int((stamps <= exit_ts).sum()) - 1
         lo = max(0, center - bars // 2)
         window = frame.iloc[lo : lo + bars]
@@ -202,6 +213,10 @@ def chart_job(
         "regime_at_end": regime_snapshot(frame, last_ts),
         "window_note": window_note,
         "marks": sum(len(v) for v in marks.values()),
+        # Data recency, always visible: the dataset is refreshed by
+        # fetch_dataset/backtests, not live ticks — stale data silently
+        # invalidates chart-based reasoning about recent trades.
+        "dataset_end": (stamps.iloc[-1].isoformat() if len(stamps) else None),
     }
     return {
         "header": header,

--- a/wayfinder_paths/tests/test_jobs_chart_analogs.py
+++ b/wayfinder_paths/tests/test_jobs_chart_analogs.py
@@ -214,3 +214,29 @@ def test_forensics_rows_carry_regime_tags() -> None:
     regime = rows[0]["regime_at_entry"]
     assert regime.get("trend") in {"up", "down"}
     assert regime.get("session") in {"asia", "europe", "us", "late"}
+
+
+def test_chart_around_trade_beyond_dataset_end_fails_loud(tmp_path: Path) -> None:
+    frame = _wavy_frame(280)
+    store, job_id = _make_chart_job(tmp_path, frame)
+    forward = store.job_dir(job_id) / "results" / "forward"
+    forward.mkdir(parents=True, exist_ok=True)
+    beyond = (
+        pd.Timestamp(frame["timestamp"].iloc[-1]) + pd.Timedelta(hours=6)
+    ).isoformat()
+    (forward / "trades.jsonl").write_text(
+        json.dumps({"symbol": "LIT", "side": "buy", "price": 99.0, "closed_at": beyond})
+        + "\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="BEYOND the dataset end"):
+        chart_job(job_id, around_trade="last", store=store)
+
+
+def test_chart_header_reports_dataset_end(tmp_path: Path) -> None:
+    frame = _wavy_frame(120)
+    store, job_id = _make_chart_job(tmp_path, frame)
+    result = chart_job(job_id, bars=20, store=store)
+    assert pd.Timestamp(result["header"]["dataset_end"]) == pd.Timestamp(
+        frame["timestamp"].iloc[-1]
+    )


### PR DESCRIPTION
Found live-demoing #546: charting `around_trade` for a trade newer than the last dataset bar **silently rendered the latest available window instead** — a wrong window the agent would reason from without noticing. The dataset is refreshed by `fetch_dataset`/backtests, not live ticks, so this is a routine state for recent trades.

- `around_trade` beyond the dataset end now **raises** with the exact remedy in the message (`fetch_dataset`, then re-chart). I went one step past the discussed header warning: for an autonomous reader, a silently wrong chart is worse than an error, and the error text is self-healing — the agent runs the named action and retries. Matches the repo's fail-hard style.
- Every chart header now carries `dataset_end`, so data recency is visible on every call, not just when it bites.

2 new tests (fail-loud path, header recency field); 8 pass in the lenses suite; ruff clean.