### PR TITLE
jobs: claim survives a failed backend sync — telemetry must not strand a claim

### DIFF
--- a/wayfinder_paths/jobs/application.py
+++ b/wayfinder_paths/jobs/application.py
@@ -94,7 +94,17 @@ def claim_application(store: JobStore, job_id: str, proposal_id: str) -> dict[st
     except Exception:
         resume_job_loops(store, job_id)
         raise
-    sync_all_jobs(store=store)
+    # Best-effort: this sync is UI telemetry, but it sits between the claim
+    # (loops now paused) and the caller spawning the completer. A backend
+    # hiccup here severed that chain in production (2026-07-23): the claim
+    # stood, the completer never spawned, and the job sat dark until the
+    # watchdog's 15-minute recovery. Telemetry must never strand a claim.
+    try:
+        sync_all_jobs(store=store)
+    except Exception as exc:  # noqa: BLE001
+        store.append_journal(
+            job_id, {"type": "claim_sync_failed", "error": str(exc)[:300]}
+        )
     return {"proposal": proposal, "paused_runner_jobs": paused, "candidate": candidate}
 
 

--- a/wayfinder_paths/tests/test_jobs_apply_watchdog.py
+++ b/wayfinder_paths/tests/test_jobs_apply_watchdog.py
@@ -467,3 +467,24 @@ def test_ensure_application_watchdog_idempotent(tmp_path: Path, monkeypatch) -> 
     driver = store.runs_jobs_dir / "application_watchdog.py"
     assert driver.exists()
     assert "recover_stalled_applications" in driver.read_text(encoding="utf-8")
+
+
+def test_claim_survives_sync_failure(tmp_path: Path, monkeypatch) -> None:
+    # The post-claim backend sync is telemetry: a backend hiccup there must
+    # not sever the claim->spawn chain (2026-07-23 incident: claim stood,
+    # completer never spawned, job dark until watchdog recovery).
+    calls = _patch_runner(monkeypatch)
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "sync-fail-demo")
+    _write_proposal(store, job.id, "prop_syncfail", candidate_report={"gate": "ok"})
+
+    def broken_sync(*, store):  # noqa: ANN001
+        raise RuntimeError("backend 502")
+
+    monkeypatch.setattr("wayfinder_paths.jobs.application.sync_all_jobs", broken_sync)
+
+    claimed = claim_application(store, job.id, "prop_syncfail")
+
+    assert claimed["proposal"]["application"]["status"] == "applying"
+    assert ("pause", "sync-fail-demo-script") in calls
+    assert "claim_sync_failed" in _journal_types(store, job.id)


### PR DESCRIPTION
## Incident (2026-07-23 18:12 UTC)

Approving `prop-code-change-177df846` (the forensics-driven LIT stop widening) claimed the application — pausing both loops — then the **synchronous `sync_all_jobs` at the end of `claim_application`** hit a backend hiccup and raised. That severed the chain between the claim and spawning the deterministic completer: the claim stood, no completer existed, no local error was recorded, and the exception surfaced as a bare "failed" in the approve UI.

The **watchdog then delivered its first real live recovery**: `application_watchdog_recovered` at age 902s (first eligible cycle), full validation re-run, revision `2962807bd383` promoted, loops resumed — 16 minutes of bounded dark time, fully autonomous. The backstop works; this PR removes the reason it was needed.

## Fix

The post-claim sync is UI telemetry, not part of the apply contract. It's now best-effort inside `claim_application`: a failure journals `claim_sync_failed` and the claim→spawn chain proceeds — the completer's own completion sync (and the daemon's after-run syncs) refresh the backend moments later anyway.

Regression test pins it: sync raising during claim → claim still returns `applying`, loops paused, journal entry present. 12 pass in the apply/watchdog suite; ruff clean.

Note: the trailing syncs in `complete_application` are left as-is — they run after the terminal store write, so a failure there can only cosmetically error a response, never strand state.