### PR TITLE
Tokens - Resolve swap wallet leg by chain for cross-chain routes

### DIFF
--- a/wayfinder_paths/core/utils/wallets.py
+++ b/wayfinder_paths/core/utils/wallets.py
@@ -18,6 +18,7 @@ from wayfinder_paths.core.config import (
     load_wallet_mnemonic,
     write_wallet_mnemonic,
 )
+from wayfinder_paths.core.constants.chains import SVM_CHAIN_IDS
 from wayfinder_paths.policies.session import build_session_policy, build_strategy_policy
 
 _DEFAULT_EVM_ACCOUNT_PATH_TEMPLATE = "m/44'/60'/0'/0/{index}"
@@ -117,6 +118,29 @@ async def find_wallet_by_label(label: str) -> dict[str, Any] | None:
         return None
     for w in await load_wallets():
         if str(w.get("label", "")).strip() == want:
+            return w
+    return None
+
+
+async def find_wallet_leg_for_chain(label: str, chain_id: int) -> dict[str, Any] | None:
+    """Resolve the ring leg (by label) that transacts on ``chain_id``.
+
+    A wallet ring shares one label across its EVM and SVM legs; a cross-chain
+    swap sends from the source-chain leg and receives on the destination-chain
+    leg. Returns ``None`` when no leg for that chain family is loaded (e.g. the
+    SVM leg is absent because Solana is disabled).
+    """
+    want = str(label).strip()
+    if not want:
+        return None
+    want_type = (
+        CHAIN_TYPE_SOLANA if int(chain_id) in SVM_CHAIN_IDS else CHAIN_TYPE_ETHEREUM
+    )
+    for w in await load_wallets():
+        if (
+            str(w.get("label", "")).strip() == want
+            and wallet_chain_type(w) == want_type
+        ):
             return w
     return None
 
@@ -335,6 +359,20 @@ async def get_wallet_signing_callback(label: str):
     wallet = await find_wallet_by_label(label)
     if not wallet:
         raise ValueError(f"Wallet '{label}' not found.")
+    return _build_signing_callback(wallet, label)
+
+
+async def get_wallet_signing_callback_for_chain(label: str, chain_id: int):
+    """Async — resolve the ring leg that signs on ``chain_id`` and return
+    (sign_callback, address).
+
+    A source tx is signed by its own chain's leg: EVM legs sign EVM txs, the SVM
+    leg signs Solana txs. Falls back to the default label lookup when no leg for
+    that chain family is loaded, preserving legacy single-leg behavior.
+    """
+    wallet = await find_wallet_leg_for_chain(label, chain_id)
+    if not wallet:
+        return await get_wallet_signing_callback(label)
     return _build_signing_callback(wallet, label)
 
 

--- a/wayfinder_paths/core/utils/wallets.py
+++ b/wayfinder_paths/core/utils/wallets.py
@@ -122,27 +122,30 @@ async def find_wallet_by_label(label: str) -> dict[str, Any] | None:
     return None
 
 
-async def find_wallet_leg_for_chain(label: str, chain_id: int) -> dict[str, Any] | None:
-    """Resolve the ring leg (by label) that transacts on ``chain_id``.
+async def load_wallet_ring(label: str) -> list[dict[str, Any]]:
+    """All legs (EVM + SVM) of the wallet ring sharing ``label``, loaded once."""
+    want = str(label).strip()
+    return [w for w in await load_wallets() if str(w.get("label", "")).strip() == want]
+
+
+def leg_for_chain(ring: list[dict[str, Any]], chain_id: int) -> dict[str, Any] | None:
+    """Pick the ring leg that transacts on ``chain_id`` (SVM vs EVM), or None.
 
     A wallet ring shares one label across its EVM and SVM legs; a cross-chain
-    swap sends from the source-chain leg and receives on the destination-chain
-    leg. Returns ``None`` when no leg for that chain family is loaded (e.g. the
-    SVM leg is absent because Solana is disabled).
+    swap sends from the source-chain leg and lands on the destination-chain leg.
     """
-    want = str(label).strip()
-    if not want:
-        return None
     want_type = (
         CHAIN_TYPE_SOLANA if int(chain_id) in SVM_CHAIN_IDS else CHAIN_TYPE_ETHEREUM
     )
-    for w in await load_wallets():
-        if (
-            str(w.get("label", "")).strip() == want
-            and wallet_chain_type(w) == want_type
-        ):
+    for w in ring:
+        if wallet_chain_type(w) == want_type:
             return w
     return None
+
+
+async def find_wallet_leg_for_chain(label: str, chain_id: int) -> dict[str, Any] | None:
+    """Resolve the ring leg (by label) that transacts on ``chain_id``."""
+    return leg_for_chain(await load_wallet_ring(label), chain_id)
 
 
 # ---------------------------------------------------------------------------

--- a/wayfinder_paths/mcp/tools/execute.py
+++ b/wayfinder_paths/mcp/tools/execute.py
@@ -27,7 +27,8 @@ from wayfinder_paths.core.utils.tokens import (
 from wayfinder_paths.core.utils.transaction import send_transaction
 from wayfinder_paths.core.utils.units import from_erc20_raw
 from wayfinder_paths.core.utils.wallets import (
-    get_wallet_signing_callback,
+    find_wallet_leg_for_chain,
+    get_wallet_signing_callback_for_chain,
     is_solana_enabled,
 )
 from wayfinder_paths.mcp.state.profile_store import WalletProfileStore
@@ -270,14 +271,6 @@ async def onchain_swap(
     if slippage_bps < 0:
         return err("invalid_request", "slippage_bps must be >= 0")
 
-    sign_callback, sender = await get_wallet_signing_callback(wallet_label)
-    rcpt = normalize_address(recipient) or sender
-    response: dict[str, Any] = {
-        "sender": sender,
-        "recipient": rcpt,
-        "effects": {},
-    }
-
     try:
         from_meta = await TokenResolver.resolve_token_meta(from_token)
         to_meta = await TokenResolver.resolve_token_meta(to_token)
@@ -294,8 +287,25 @@ async def onchain_swap(
             "Could not resolve chain_id for one or more tokens",
             {"from_chain_id": from_chain_id, "to_chain_id": to_chain_id},
         )
-    if is_solana_chain(from_chain_id) and not await is_solana_enabled():
+    if (
+        is_solana_chain(from_chain_id) or is_solana_chain(to_chain_id)
+    ) and not await is_solana_enabled():
         return err("solana_disabled", "Solana is not enabled for this account.")
+
+    # Sign the source tx with the source-chain leg; default the recipient to the
+    # ring's destination-chain leg (cross-chain lands on the paired leg).
+    sign_callback, sender = await get_wallet_signing_callback_for_chain(
+        wallet_label, from_chain_id
+    )
+    to_leg = await find_wallet_leg_for_chain(wallet_label, to_chain_id)
+    dest_default = normalize_address(to_leg.get("address")) if to_leg else sender
+    rcpt = normalize_address(recipient) or dest_default
+    response: dict[str, Any] = {
+        "sender": sender,
+        "recipient": rcpt,
+        "effects": {},
+    }
+
     if not from_token_addr or not to_token_addr:
         return err(
             "invalid_token",
@@ -530,16 +540,9 @@ async def onchain_send(
     if token_q.lower() == "native" and chain_id is None:
         return err("invalid_request", "chain_id is required when token='native'")
 
-    sign_callback, sender = await get_wallet_signing_callback(wallet_label)
     rcpt = normalize_address(recipient)
     if not rcpt:
         return err("invalid_request", "recipient address is required")
-
-    response: dict[str, Any] = {
-        "sender": sender,
-        "recipient": rcpt,
-        "effects": {},
-    }
 
     try:
         token_meta = await TokenResolver.resolve_token_meta(token_q, chain_id=chain_id)
@@ -559,6 +562,16 @@ async def onchain_send(
 
     if is_solana_chain(int(resolved_chain_id)) and not await is_solana_enabled():
         return err("solana_disabled", "Solana is not enabled for this account.")
+
+    # Sign with the leg for the resolved chain (SVM sends sign with the SVM leg).
+    sign_callback, sender = await get_wallet_signing_callback_for_chain(
+        wallet_label, int(resolved_chain_id)
+    )
+    response: dict[str, Any] = {
+        "sender": sender,
+        "recipient": rcpt,
+        "effects": {},
+    }
 
     try:
         amount_raw = parse_amount_to_raw(amount, decimals)

--- a/wayfinder_paths/mcp/tools/quotes.py
+++ b/wayfinder_paths/mcp/tools/quotes.py
@@ -9,6 +9,7 @@ from wayfinder_paths.mcp.utils import (
     catch_errors,
     err,
     find_wallet_by_label,
+    find_wallet_leg_for_chain,
     normalize_address,
     ok,
     parse_amount_to_raw,
@@ -96,9 +97,6 @@ async def onchain_quote_swap(
     w = await find_wallet_by_label(wallet_label)
     if not w:
         return err("not_found", f"Unknown wallet_label: {wallet_label}")
-    sender = normalize_address(w.get("address"))
-    if not sender:
-        return err("invalid_wallet", f"Wallet {wallet_label} missing address")
 
     try:
         from_meta, to_meta = await asyncio.gather(
@@ -131,7 +129,17 @@ async def onchain_quote_swap(
     except ValueError as exc:
         return err("invalid_amount", str(exc))
 
-    rcpt = normalize_address(recipient) or sender
+    # Cross-chain swaps send from the source-chain leg and land on the
+    # destination-chain leg of the same wallet ring (e.g. EVM→Solana pays out to
+    # the ring's SVM address). Same-chain swaps resolve both to the one leg;
+    # missing a chain-specific leg falls back to the default (EVM) leg.
+    from_leg = await find_wallet_leg_for_chain(wallet_label, from_chain_id) or w
+    to_leg = await find_wallet_leg_for_chain(wallet_label, to_chain_id) or w
+    sender = normalize_address(from_leg.get("address"))
+    if not sender:
+        return err("invalid_wallet", f"Wallet {wallet_label} missing address")
+
+    rcpt = normalize_address(recipient) or normalize_address(to_leg.get("address"))
     slip = _slippage_float(slippage_bps)
 
     try:

--- a/wayfinder_paths/mcp/tools/quotes.py
+++ b/wayfinder_paths/mcp/tools/quotes.py
@@ -8,8 +8,8 @@ from wayfinder_paths.core.utils.token_resolver import TokenResolver
 from wayfinder_paths.mcp.utils import (
     catch_errors,
     err,
-    find_wallet_by_label,
-    find_wallet_leg_for_chain,
+    leg_for_chain,
+    load_wallet_ring,
     normalize_address,
     ok,
     parse_amount_to_raw,
@@ -94,8 +94,8 @@ async def onchain_quote_swap(
         `{preview, quote: {best_quote, quote_count, providers}, suggested_swap_request, ...}`.
         `preview` flags `⚠ RECIPIENT DIFFERS FROM SENDER` when applicable.
     """
-    w = await find_wallet_by_label(wallet_label)
-    if not w:
+    ring = await load_wallet_ring(wallet_label)
+    if not ring:
         return err("not_found", f"Unknown wallet_label: {wallet_label}")
 
     try:
@@ -133,8 +133,8 @@ async def onchain_quote_swap(
     # destination-chain leg of the same wallet ring (e.g. EVM→Solana pays out to
     # the ring's SVM address). Same-chain swaps resolve both to the one leg;
     # missing a chain-specific leg falls back to the default (EVM) leg.
-    from_leg = await find_wallet_leg_for_chain(wallet_label, from_chain_id) or w
-    to_leg = await find_wallet_leg_for_chain(wallet_label, to_chain_id) or w
+    from_leg = leg_for_chain(ring, from_chain_id) or ring[0]
+    to_leg = leg_for_chain(ring, to_chain_id) or ring[0]
     sender = normalize_address(from_leg.get("address"))
     if not sender:
         return err("invalid_wallet", f"Wallet {wallet_label} missing address")

--- a/wayfinder_paths/mcp/utils.py
+++ b/wayfinder_paths/mcp/utils.py
@@ -16,10 +16,12 @@ import yaml
 from wayfinder_paths.core.clients.MetricsClient import METRICS_CLIENT
 from wayfinder_paths.core.utils.wallets import (  # noqa: F401
     find_wallet_by_label,
+    find_wallet_leg_for_chain,
     get_local_sign_typed_data_callback,
     get_private_key,
     get_wallet_sign_typed_data_callback,
     get_wallet_signing_callback,
+    get_wallet_signing_callback_for_chain,
     load_wallets,
     resolve_wallet,
 )

--- a/wayfinder_paths/mcp/utils.py
+++ b/wayfinder_paths/mcp/utils.py
@@ -16,12 +16,12 @@ import yaml
 from wayfinder_paths.core.clients.MetricsClient import METRICS_CLIENT
 from wayfinder_paths.core.utils.wallets import (  # noqa: F401
     find_wallet_by_label,
-    find_wallet_leg_for_chain,
     get_local_sign_typed_data_callback,
     get_private_key,
     get_wallet_sign_typed_data_callback,
     get_wallet_signing_callback,
-    get_wallet_signing_callback_for_chain,
+    leg_for_chain,
+    load_wallet_ring,
     load_wallets,
     resolve_wallet,
 )

--- a/wayfinder_paths/tests/test_mcp_quote_swap.py
+++ b/wayfinder_paths/tests/test_mcp_quote_swap.py
@@ -65,8 +65,8 @@ async def test_quote_swap_returns_compact_best_quote_by_default():
 
     with (
         patch(
-            "wayfinder_paths.mcp.tools.quotes.find_wallet_by_label",
-            return_value=fake_wallet,
+            "wayfinder_paths.mcp.tools.quotes.load_wallet_ring",
+            return_value=[fake_wallet],
         ),
         patch(
             "wayfinder_paths.mcp.tools.quotes.TokenResolver.resolve_token_meta",
@@ -141,8 +141,8 @@ async def test_quote_swap_can_include_calldata_when_requested():
 
     with (
         patch(
-            "wayfinder_paths.mcp.tools.quotes.find_wallet_by_label",
-            return_value=fake_wallet,
+            "wayfinder_paths.mcp.tools.quotes.load_wallet_ring",
+            return_value=[fake_wallet],
         ),
         patch(
             "wayfinder_paths.mcp.tools.quotes.TokenResolver.resolve_token_meta",
@@ -206,8 +206,8 @@ async def test_quote_swap_accepts_top_level_brap_shape():
 
     with (
         patch(
-            "wayfinder_paths.mcp.tools.quotes.find_wallet_by_label",
-            return_value=fake_wallet,
+            "wayfinder_paths.mcp.tools.quotes.load_wallet_ring",
+            return_value=[fake_wallet],
         ),
         patch(
             "wayfinder_paths.mcp.tools.quotes.TokenResolver.resolve_token_meta",

--- a/wayfinder_paths/tests/test_solana_swap_send.py
+++ b/wayfinder_paths/tests/test_solana_swap_send.py
@@ -116,7 +116,7 @@ async def test_swap_solana_route_broadcasts_via_svm_and_skips_allowance():
 
     with (
         patch(
-            "wayfinder_paths.mcp.tools.execute.get_wallet_signing_callback",
+            "wayfinder_paths.mcp.tools.execute.get_wallet_signing_callback_for_chain",
             new=AsyncMock(return_value=(_svm_callback(), SENDER)),
         ),
         patch(
@@ -194,7 +194,7 @@ async def test_swap_solana_route_detected_by_chain_id_without_chaintype():
 
     with (
         patch(
-            "wayfinder_paths.mcp.tools.execute.get_wallet_signing_callback",
+            "wayfinder_paths.mcp.tools.execute.get_wallet_signing_callback_for_chain",
             new=AsyncMock(return_value=(_svm_callback(), SENDER)),
         ),
         patch(
@@ -248,7 +248,7 @@ async def test_swap_solana_route_missing_serialized_tx_errors():
 
     with (
         patch(
-            "wayfinder_paths.mcp.tools.execute.get_wallet_signing_callback",
+            "wayfinder_paths.mcp.tools.execute.get_wallet_signing_callback_for_chain",
             new=AsyncMock(return_value=(_svm_callback(), SENDER)),
         ),
         patch(
@@ -298,7 +298,7 @@ async def test_send_solana_spl_builds_envelope_and_broadcasts_via_svm():
 
     with (
         patch(
-            "wayfinder_paths.mcp.tools.execute.get_wallet_signing_callback",
+            "wayfinder_paths.mcp.tools.execute.get_wallet_signing_callback_for_chain",
             new=AsyncMock(return_value=(_svm_callback(), SENDER)),
         ),
         patch(
@@ -372,7 +372,7 @@ async def test_send_solana_native_sol_uses_native_label():
 
     with (
         patch(
-            "wayfinder_paths.mcp.tools.execute.get_wallet_signing_callback",
+            "wayfinder_paths.mcp.tools.execute.get_wallet_signing_callback_for_chain",
             new=AsyncMock(return_value=(_svm_callback(), SENDER)),
         ),
         patch(
@@ -421,7 +421,7 @@ async def test_send_solana_insufficient_balance_short_circuits_before_build():
     }
     with (
         patch(
-            "wayfinder_paths.mcp.tools.execute.get_wallet_signing_callback",
+            "wayfinder_paths.mcp.tools.execute.get_wallet_signing_callback_for_chain",
             new=AsyncMock(return_value=(_svm_callback(), SENDER)),
         ),
         patch(
@@ -475,7 +475,7 @@ async def test_swap_solana_blocked_when_flag_disabled():
             return_value=False,
         ),
         patch(
-            "wayfinder_paths.mcp.tools.execute.get_wallet_signing_callback",
+            "wayfinder_paths.mcp.tools.execute.get_wallet_signing_callback_for_chain",
             new=AsyncMock(return_value=(_svm_callback(), SENDER)),
         ),
         patch(
@@ -512,7 +512,7 @@ async def test_send_solana_blocked_when_flag_disabled():
             return_value=False,
         ),
         patch(
-            "wayfinder_paths.mcp.tools.execute.get_wallet_signing_callback",
+            "wayfinder_paths.mcp.tools.execute.get_wallet_signing_callback_for_chain",
             new=AsyncMock(return_value=(_svm_callback(), SENDER)),
         ),
         patch(

--- a/wayfinder_paths/tests/test_wallet_leg_resolution.py
+++ b/wayfinder_paths/tests/test_wallet_leg_resolution.py
@@ -1,0 +1,67 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from wayfinder_paths.core.constants.chains import CHAIN_ID_SOLANA
+from wayfinder_paths.core.utils.wallets import (
+    find_wallet_leg_for_chain,
+    get_wallet_signing_callback_for_chain,
+)
+
+EVM_ADDR = "0x000000000000000000000000000000000000dEaD"
+SVM_ADDR = "BTXGZD6APaEPLUnELUT3Q1HWUYaWatu42WXT3YCU1vxY"
+ARBITRUM = 42161
+
+RING = [
+    {"address": EVM_ADDR, "label": "main", "type": "remote", "chain_type": "ethereum"},
+    {"address": SVM_ADDR, "label": "main", "type": "remote", "chain_type": "solana"},
+]
+
+
+def _patch_wallets(wallets):
+    return patch(
+        "wayfinder_paths.core.utils.wallets.load_wallets",
+        new=AsyncMock(return_value=wallets),
+    )
+
+
+@pytest.mark.asyncio
+async def test_leg_for_evm_chain_returns_evm_leg():
+    with _patch_wallets(RING):
+        leg = await find_wallet_leg_for_chain("main", ARBITRUM)
+    assert leg["address"] == EVM_ADDR
+
+
+@pytest.mark.asyncio
+async def test_leg_for_solana_chain_returns_svm_leg():
+    with _patch_wallets(RING):
+        leg = await find_wallet_leg_for_chain("main", CHAIN_ID_SOLANA)
+    assert leg["address"] == SVM_ADDR
+
+
+@pytest.mark.asyncio
+async def test_leg_absent_for_chain_returns_none():
+    evm_only = [RING[0]]
+    with _patch_wallets(evm_only):
+        assert await find_wallet_leg_for_chain("main", CHAIN_ID_SOLANA) is None
+
+
+@pytest.mark.asyncio
+async def test_signing_callback_falls_back_to_default_leg_when_absent():
+    # No SVM leg loaded: the chain-aware callback falls back to the label default.
+    evm_only = [RING[0]]
+    with (
+        _patch_wallets(evm_only),
+        patch(
+            "wayfinder_paths.core.utils.wallets.find_wallet_by_label",
+            new=AsyncMock(return_value=RING[0]),
+        ),
+        patch(
+            "wayfinder_paths.core.utils.wallets.get_remote_sign_callback",
+            return_value=lambda tx: b"",
+        ),
+    ):
+        _, address = await get_wallet_signing_callback_for_chain(
+            "main", CHAIN_ID_SOLANA
+        )
+    assert address == EVM_ADDR

--- a/wayfinder_paths/tests/test_wallet_leg_resolution.py
+++ b/wayfinder_paths/tests/test_wallet_leg_resolution.py
@@ -6,6 +6,7 @@ from wayfinder_paths.core.constants.chains import CHAIN_ID_SOLANA
 from wayfinder_paths.core.utils.wallets import (
     find_wallet_leg_for_chain,
     get_wallet_signing_callback_for_chain,
+    leg_for_chain,
 )
 
 EVM_ADDR = "0x000000000000000000000000000000000000dEaD"
@@ -23,6 +24,13 @@ def _patch_wallets(wallets):
         "wayfinder_paths.core.utils.wallets.load_wallets",
         new=AsyncMock(return_value=wallets),
     )
+
+
+def test_leg_for_chain_picks_by_chain_family():
+    assert leg_for_chain(RING, ARBITRUM)["address"] == EVM_ADDR
+    assert leg_for_chain(RING, CHAIN_ID_SOLANA)["address"] == SVM_ADDR
+    assert leg_for_chain([RING[0]], CHAIN_ID_SOLANA) is None
+    assert leg_for_chain([], ARBITRUM) is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary
Cross-chain swaps now sign the source transaction with the wallet's source-chain leg and default the recipient to its destination-chain leg, so an EVM→Solana route pays out to the wallet's Solana address (and the reverse). Same-chain swaps and sends are unchanged. Token sends sign with the leg for the resolved chain.