### PR TITLE
Delta Lab - Correct APY response examples

### DIFF
--- a/.claude/skills/using-delta-lab/MCP_INTEGRATION.md
+++ b/.claude/skills/using-delta-lab/MCP_INTEGRATION.md
@@ -42,16 +42,29 @@ research_get_top_apy(lookback_days="14", limit="100")
 **Parameters:**
 - `basis_symbol` - Uppercase symbol (e.g., `"BTC"`, `"ETH"`, `"HYPE"`)
 - `lookback_days` - Days to average over (default `"7"`, min `"1"`)
-- `limit` - Max opportunities to return (default `"10"`, max `"1000"`)
+- `limit` - Max opportunities to return (default `"25"`, max `"1000"`)
 
 **Examples:**
 ```python
-# Default: 7-day lookback, top 10
+# Default: 7-day lookback, top 25
 research_get_basis_apy_sources(basis_symbol="BTC")
 
 # Custom: 30-day lookback, top 100
 research_get_basis_apy_sources(basis_symbol="BTC", lookback_days="30", limit="100")
 ```
+
+**Response:**
+
+MCP tools use the standard `{"ok": true, "result": ...}` wrapper. The result is
+the same APY-sources envelope returned by the Python client; opportunities are
+grouped under `directions.LONG` and `directions.SHORT`.
+
+```python
+long_opps = response["result"]["directions"]["LONG"]
+```
+
+See [rules/response-structures.md](rules/response-structures.md) for the full
+result envelope and opportunity fields.
 
 ### 3. Basis Symbols
 **Tool:** `research_get_basis_symbols()`

--- a/.claude/skills/using-delta-lab/SKILL.md
+++ b/.claude/skills/using-delta-lab/SKILL.md
@@ -13,7 +13,15 @@ metadata:
 from wayfinder_paths.core.clients.DeltaLabClient import DELTA_LAB_CLIENT
 
 # Core discovery
-await DELTA_LAB_CLIENT.get_basis_apy_sources(basis_symbol="BTC", lookback_days=7)   # analytic opps
+apy_sources = await DELTA_LAB_CLIENT.get_basis_apy_sources(
+    basis_symbol="BTC",
+    lookback_days=7,
+)
+long_opps = apy_sources["directions"]["LONG"]
+valid_long_opps = [
+    opp for opp in long_opps if (opp.get("apy") or {}).get("value") is not None
+]
+
 await DELTA_LAB_CLIENT.get_best_delta_neutral_pairs(basis_symbol="ETH", limit=20)
 
 # v2 surface (also on DELTA_LAB_CLIENT — see rules/v2-surface.md for the full list)
@@ -28,7 +36,8 @@ from wayfinder_paths.core.clients.delta_lab_types import DeltaLabAPIError
 
 **Critical gotchas:**
 - Use uppercase symbols: `"BTC"` not `"bitcoin"` or `"btc"`
-- APY can be `null` - always filter: `[o for o in opps if o["apy"]["value"] is not None]`
+- `get_basis_apy_sources(...)` returns an envelope, not a list. Read opportunities from `result["directions"]["LONG"]` / `["SHORT"]`; there is no top-level `result["opportunities"]`.
+- APY can be `null` - filter the selected direction before sorting, as shown above.
 - Delta Lab is **read-only** (no execution, just discovery)
 - Two "opportunity" shapes: `search_opportunities` = trimmed discovery (~14 fields, scan); `get_basis_apy_sources` = enriched analytic (apy/risk/summary, decide). Don't mix them up.
 - `*_latest(...)` returns `None` on sparse-data 404 (not an error). Use `DeltaLabAPIError` for real failures.

--- a/.claude/skills/using-delta-lab/rules/gotchas.md
+++ b/.claude/skills/using-delta-lab/rules/gotchas.md
@@ -14,7 +14,7 @@ Common mistakes and important considerations when using Delta Lab.
 | `candidate["net_apy"]["value"]` | `candidate["net_apy"]` | net_apy is a float, not a dict |
 | `basis_symbol="bitcoin"` | `basis_symbol="BTC"` | Use root symbol, not coingecko ID |
 | **Negative funding = good for shorts** | **Negative funding = shorts PAY longs** | **CRITICAL: Sign is backwards from intuition** |
-| `max(opps, key=lambda x: x["apy"]["value"])` | `max([o for o in opps if o["apy"]["value"]], ...)` | APY can be null |
+| `max(opps, key=lambda x: x["apy"]["value"])` | `max([o for o in opps if o["apy"]["value"] is not None], ...)` | APY can be null |
 | Using `candidates[0]` for lowest risk | Use `pareto_frontier` | Candidates sorted by APY, not risk |
 | Ignoring `warnings` field | Always check `result["warnings"]` | Data quality issues affect decisions |
 | `get_asset_timeseries(symbol="USDC", series="lending", limit=1000)` (no venue) | Add `venue="moonwell"` when you want one venue | Without venue filter, limit is shared across all venues — data gets cut off |
@@ -44,7 +44,10 @@ Common mappings: USDC/USDT/DAI → `USD`, wstETH/cbETH → `ETH`, cbBTC/WBTC →
 
 ## 0b. apy-sources Is Cross-Instrument, Not Venue-Specific
 
-`get_basis_apy_sources()` returns a **ranked cross-instrument list** (perps, LPs, lending, Pendle, Boros) sorted by APY. A small `limit` (e.g. 20) will only show the highest-APY instruments — standard lending markets at 2-5% get crowded out by perps at 20%+.
+`get_basis_apy_sources()` returns an envelope with ranked cross-instrument lists
+under `directions.LONG` and `directions.SHORT` (perps, LPs, lending, Pendle,
+Boros). A small `limit` (e.g. 20) will only show the highest-APY instruments —
+standard lending markets at 2-5% get crowded out by perps at 20%+.
 
 **If you want lending rates specifically:**
 - Use `screen_lending(basis="USD")` for a cross-venue snapshot
@@ -123,22 +126,23 @@ The API accepts lowercase but prefers uppercase root symbols.
 
 **WRONG:**
 ```python
-opportunities = result["opportunities"]
+opportunities = result["directions"]["LONG"]
 highest = max(opportunities, key=lambda x: x["apy"]["value"])  # Crashes if value is null!
 ```
 
 **RIGHT:**
 ```python
-opportunities = result["opportunities"]
+opportunities = result["directions"]["LONG"]
 # Filter out null APYs first
-valid_opps = [o for o in opportunities if o["apy"]["value"] is not None]
+valid_opps = [
+    opp
+    for opp in opportunities
+    if (opp.get("apy") or {}).get("value") is not None
+]
 if valid_opps:
     highest = max(valid_opps, key=lambda x: x["apy"]["value"])
 else:
     print("No opportunities with valid APY")
-
-# Or use a default
-highest = max(opportunities, key=lambda x: x["apy"]["value"] or 0)
 ```
 
 APY can be `null` for several reasons:

--- a/.claude/skills/using-delta-lab/rules/high-value-reads.md
+++ b/.claude/skills/using-delta-lab/rules/high-value-reads.md
@@ -139,7 +139,7 @@ from wayfinder_paths.core.clients.DeltaLabClient import DELTA_LAB_CLIENT
 result = await DELTA_LAB_CLIENT.get_basis_apy_sources(
     basis_symbol="BTC",
     lookback_days=7,  # Default: 7, min: 1
-    limit=500,  # Default: 500, max: 1000
+    limit=25,  # Default: 25, max: 1000
     as_of=None,  # Default: now (optional datetime)
 )
 ```
@@ -156,7 +156,6 @@ result = await DELTA_LAB_CLIENT.get_basis_apy_sources(
         "basis_asset_ids": [1, 123, 456]
     },
     "as_of": "2024-02-12T12:00:00Z",
-    "lookback_days": 7,
     "summary": {
         "instrument_type_counts": {
             "PERP": 15,
@@ -171,7 +170,6 @@ result = await DELTA_LAB_CLIENT.get_basis_apy_sources(
         "LONG": [...],  # Opportunities where you take the LONG side
         "SHORT": [...]  # Opportunities where you take the SHORT side
     },
-    "opportunities": [...],  # All opportunities combined
     "warnings": [
         {
             "type": "stale_data",
@@ -186,9 +184,11 @@ result = await DELTA_LAB_CLIENT.get_basis_apy_sources(
 
 - `directions.LONG` - Opportunities where `side="LONG"` (supply/lend, hold yield token/PT, receive fixed rate, long perp)
 - `directions.SHORT` - Opportunities where `side="SHORT"` (borrow, pay fixed rate, short perp)
-- `opportunities` - All opportunities regardless of direction
 - `summary.instrument_type_counts` - Count by instrument type
 - `warnings` - List of warning objects (often empty)
+
+The response is an envelope, not an opportunity list. Iterating `result` yields
+top-level keys such as `"basis"` and `"directions"`, not opportunity objects.
 
 ## 2. Get Best Delta-Neutral Pairs
 
@@ -278,16 +278,20 @@ result = await DELTA_LAB_CLIENT.get_asset(asset_id=1)
 result = await DELTA_LAB_CLIENT.get_basis_apy_sources(
     basis_symbol="ETH",
     lookback_days=7,
-    limit=500
+    limit=25,
 )
 
 # Filter LONG opportunities (yield-generating)
-long_opps = result["directions"]["LONG"]
+long_opps = [
+    opp
+    for opp in result["directions"]["LONG"]
+    if (opp.get("apy") or {}).get("value") is not None
+]
 
 # Sort by APY descending
 sorted_opps = sorted(
     long_opps,
-    key=lambda x: x["apy"]["value"] or 0,
+    key=lambda x: x["apy"]["value"],
     reverse=True
 )
 
@@ -336,20 +340,30 @@ highest_yield = max(pareto, key=lambda x: x["net_apy"]) if pareto else None
 result = await DELTA_LAB_CLIENT.get_basis_apy_sources(
     basis_symbol="HYPE",
     lookback_days=7,
-    limit=500
+    limit=100
 )
 
 # Group by venue
 from collections import defaultdict
 by_venue = defaultdict(list)
-for opp in result["opportunities"]:
+opportunities = [
+    *result["directions"]["LONG"],
+    *result["directions"]["SHORT"],
+]
+for opp in opportunities:
     venue = opp.get("venue") or "unknown"
     by_venue[venue].append(opp)
 
 # Compare average APY by venue
 for venue, opps in by_venue.items():
-    avg_apy = sum(o["apy"]["value"] or 0 for o in opps) / len(opps)
-    print(f"{venue}: {avg_apy:.2%} avg APY ({len(opps)} opportunities)")
+    values = [
+        opp["apy"]["value"]
+        for opp in opps
+        if (opp.get("apy") or {}).get("value") is not None
+    ]
+    if values:
+        avg_apy = sum(values) / len(values)
+        print(f"{venue}: {avg_apy:.2%} avg APY ({len(values)} opportunities)")
 ```
 
 ## 4. Get Assets by Address

--- a/.claude/skills/using-delta-lab/rules/response-structures.md
+++ b/.claude/skills/using-delta-lab/rules/response-structures.md
@@ -15,6 +15,49 @@ Detailed breakdown of Delta Lab response types.
 
 **Applies to all fields:** `apy.value`, `net_apy`, `funding_rate`, `implied_apy`, `underlying_apy`, `reward_apr`, `fixed_rate_mark`, etc.
 
+## Basis APY Sources Envelope
+
+`get_basis_apy_sources(...)` returns a dictionary containing metadata and two
+ranked opportunity lists. It does not return a list directly and does not have
+a top-level `opportunities` field.
+
+```python
+{
+    "as_of": "2024-02-12T12:00:00Z",
+    "basis": {
+        "input_symbol": "BTC",
+        "root_symbol": "BTC",
+        "root_asset_id": 1,
+        "basis_group_id": 42,
+        "basis_asset_ids": [1, 123, 456],
+    },
+    "summary": {
+        "instrument_type_counts": {
+            "PERP": 15,
+            "LENDING_SUPPLY": 8,
+        },
+    },
+    "warnings": [],
+    "directions": {
+        "LONG": [...],
+        "SHORT": [...],
+    },
+}
+```
+
+Select a direction before filtering or iterating:
+
+```python
+result = await DELTA_LAB_CLIENT.get_basis_apy_sources(
+    basis_symbol="BTC",
+    limit=25,
+)
+long_opps = result["directions"]["LONG"]
+valid_long_opps = [
+    opp for opp in long_opps if (opp.get("apy") or {}).get("value") is not None
+]
+```
+
 ## Opportunity Object
 
 The core data structure representing a yield opportunity.


### PR DESCRIPTION
### Summary

- Correct Delta Lab APY-source examples to use the `directions.LONG` and `directions.SHORT` response envelope.
- Document the MCP `ok/result` wrapper, null-APY filtering, and current default limit.
- Remove stale examples using the nonexistent top-level `opportunities` field.