### PR TITLE
jobs: diagnostic substrate — attribution, failure archetypes, wider lenses (quant-loop PR 1)

### DIFF
--- a/wayfinder_paths/jobs/attribution.py
+++ b/wayfinder_paths/jobs/attribution.py
@@ -1,0 +1,168 @@
+"""PnL attribution: where the alpha is, where the bleed is, and where the
+forward book deviates from its own backtest expectation.
+
+This is the human quant's primary daily input, computed deterministically:
+both trade populations (backtest baseline + forward record) sliced by symbol,
+entry reason, exit reason, session, regime trend, archetype, and hold-length
+bucket — plus EXPECTATION DELTAS (forward slice vs the same backtest slice),
+which is where "the model disagrees with reality" becomes a named, ranked
+fact instead of a vibe. Small-n slices are flagged, never hidden.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.jobs.trade_forensics import classify_trade_archetype
+
+MIN_DELTA_N = 5
+_HOLD_BUCKETS = (
+    (0, 6, "<30m"),
+    (6, 24, "30m-2h"),
+    (24, 96, "2h-8h"),
+    (96, 10**9, ">8h"),
+)
+
+
+def _hold_bucket(row: dict[str, Any]) -> str | None:
+    try:
+        entry = pd.Timestamp(str(row["entry_ts"]))
+        exit_ = pd.Timestamp(str(row["exit_ts"]))
+    except (KeyError, ValueError):
+        return None
+    bars = (exit_ - entry).total_seconds() / 300
+    for lo, hi, label in _HOLD_BUCKETS:
+        if lo <= bars < hi:
+            return label
+    return None
+
+
+def _slice_keys(row: dict[str, Any]) -> dict[str, str | None]:
+    regime = row.get("regime_at_entry") or {}
+    return {
+        "symbol": row.get("symbol"),
+        "entry_reason": row.get("entry_reason"),
+        "exit_reason": row.get("exit_reason"),
+        "session": regime.get("session"),
+        "regime_trend": regime.get("trend"),
+        "archetype": row.get("archetype") or classify_trade_archetype(row),
+        "hold_bucket": _hold_bucket(row),
+    }
+
+
+def _decompose(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    slices: dict[str, dict[str, dict[str, Any]]] = {}
+    for row in rows:
+        realized = float(row.get("realized_bps") or 0.0)
+        for dim, value in _slice_keys(row).items():
+            if value is None:
+                continue
+            bucket = slices.setdefault(dim, {}).setdefault(
+                str(value), {"n": 0, "total_bps": 0.0, "wins": 0}
+            )
+            bucket["n"] += 1
+            bucket["total_bps"] += realized
+            bucket["wins"] += int(realized > 0)
+    out: dict[str, Any] = {}
+    for dim, groups in slices.items():
+        out[dim] = {
+            value: {
+                "n": g["n"],
+                "total_bps": round(g["total_bps"], 1),
+                "avg_bps": round(g["total_bps"] / g["n"], 1),
+                "win_rate": round(g["wins"] / g["n"], 3),
+            }
+            for value, g in sorted(groups.items())
+        }
+    return out
+
+
+def _expectation_deltas(
+    backtest: dict[str, Any], forward: dict[str, Any]
+) -> list[dict[str, Any]]:
+    deltas: list[dict[str, Any]] = []
+    for dim, fwd_groups in forward.items():
+        for value, fwd in fwd_groups.items():
+            expected = (backtest.get(dim) or {}).get(value)
+            if expected is None:
+                continue
+            deltas.append(
+                {
+                    "slice": f"{dim}={value}",
+                    "forward_n": fwd["n"],
+                    "avg_bps_delta": round(fwd["avg_bps"] - expected["avg_bps"], 1),
+                    "win_rate_delta": round(fwd["win_rate"] - expected["win_rate"], 3),
+                    "expected_avg_bps": expected["avg_bps"],
+                    "forward_avg_bps": fwd["avg_bps"],
+                    "small_n": fwd["n"] < MIN_DELTA_N,
+                }
+            )
+    # Anomaly ranking: adequately-sampled slices first, by deviation size.
+    deltas.sort(key=lambda d: (d["small_n"], -abs(d["avg_bps_delta"])))
+    return deltas
+
+
+def _load_rows(root: Path) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    from wayfinder_paths.jobs.execution.driver import _read_jsonl_tail
+
+    forward = _read_jsonl_tail(
+        root / "results" / "forward" / "trade_forensics.jsonl", 500
+    )
+    backtest_path = root / "results" / "backtest" / "trade_forensics.json"
+    backtest: list[dict[str, Any]] = []
+    if backtest_path.exists():
+        try:
+            backtest = list(
+                json.loads(backtest_path.read_text(encoding="utf-8")).get("trades")
+                or []
+            )
+        except ValueError:
+            backtest = []
+    return backtest, forward
+
+
+def _fee_summary(root: Path) -> dict[str, Any]:
+    from wayfinder_paths.jobs.execution.driver import _read_jsonl_tail
+
+    fills = _read_jsonl_tail(root / "results" / "forward" / "fills.jsonl", 1000)
+    fees = [float(f.get("fee") or 0.0) for f in fills]
+    return {"forward_fills": len(fills), "forward_fees_total": round(sum(fees), 4)}
+
+
+def attribution_job(job_id: str, *, store: JobStore | None = None) -> dict[str, Any]:
+    store = store or JobStore()
+    root = store.job_dir(job_id)
+    backtest_rows, forward_rows = _load_rows(root)
+    if not backtest_rows and not forward_rows:
+        raise ValueError(
+            "no forensics rows found — run `wayfinder job backtest` (writes "
+            "results/backtest/trade_forensics.json) and let live ticks "
+            "accumulate results/forward/trade_forensics.jsonl"
+        )
+    backtest = _decompose(backtest_rows)
+    forward = _decompose(forward_rows)
+    result = {
+        "backtest_trades": len(backtest_rows),
+        "forward_trades": len(forward_rows),
+        "backtest": backtest,
+        "forward": forward,
+        "expectation_deltas": _expectation_deltas(backtest, forward),
+        "fees": _fee_summary(root),
+        "read": (
+            "PnL decomposition (bps of entry) for the backtest population and "
+            "the forward record, plus expectation deltas per slice. The "
+            "DIAGNOSIS lives in: archetype counts (which failure mode "
+            "dominates), and the top adequately-sampled deltas (where forward "
+            "behavior deviates from the model's own expectation). Treat "
+            "small_n slices as anecdotes."
+        ),
+    }
+    out = root / "results" / "research" / "attribution.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(result, indent=2, default=str) + "\n", encoding="utf-8")
+    return result

--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -780,6 +780,19 @@ def analogs_cmd(
 
 
 @job_cli.command(
+    name="attribution",
+    help="PnL attribution: backtest + forward decomposed by symbol/reason/"
+    "session/regime/archetype/hold-bucket, with forward-vs-backtest "
+    "expectation deltas ranked by anomaly size. The diagnosis artifact.",
+)
+@click.argument("job_id")
+def attribution_cmd(job_id: str) -> None:
+    from wayfinder_paths.jobs.attribution import attribution_job
+
+    _echo_json({"ok": True, "result": attribution_job(job_id, store=JobStore())})
+
+
+@job_cli.command(
     name="holdout-check",
     help="One-shot confirmation of a FROZEN scan candidate (signal + "
     "timeframe + horizon + direction) on the reserved holdout tail. Spend "

--- a/wayfinder_paths/jobs/execution/op_runner.py
+++ b/wayfinder_paths/jobs/execution/op_runner.py
@@ -59,6 +59,10 @@ def _run(op: str, kwargs: dict[str, Any]) -> Any:
         from wayfinder_paths.jobs.chart import analogs_job
 
         return analogs_job(kwargs.pop("job_id"), **kwargs)
+    if op == "attribution":
+        from wayfinder_paths.jobs.attribution import attribution_job
+
+        return attribution_job(kwargs.pop("job_id"), **kwargs)
     if op == "holdout_check":
         from wayfinder_paths.jobs.research import holdout_check_job
 

--- a/wayfinder_paths/jobs/indicators.py
+++ b/wayfinder_paths/jobs/indicators.py
@@ -39,7 +39,12 @@ def _spec_error(spec: str, reason: str) -> ValueError:
         f"bad indicator spec {spec!r}: {reason}. Known specs: sma:N, ema:N, "
         "rsi:N, atr:N, bb:N:K (bollinger %B and bandwidth), macd:F:S:SIG, "
         "don:N (donchian position), vwap, vr:N (variance ratio), "
-        "volpct:N (ATR percentile)"
+        "volpct:N (ATR percentile), clv (close location in bar range), "
+        "wickratio:N (upper/lower wick share, N-bar mean), volz:N (volume "
+        "z-score), vwapdist (bps from session VWAP), daylevel (bps to prior "
+        "UTC-day high/low), rvratio:N:M (short-vs-long realized vol), "
+        "sigmabars:K (bars since last K-sigma move), fundclock (bars "
+        "since/until the 8h funding settlement)"
     )
 
 
@@ -120,6 +125,86 @@ def compute_indicator(frame: pd.DataFrame, spec: str) -> dict[str, pd.Series]:
             n = _one(14)
             series = atr(frame, n) / close
             return {f"volpct{n}": series.expanding(min_periods=n).rank(pct=True) * 100}
+        case "clv":
+            if nums:
+                raise _spec_error(spec, "clv takes no parameters")
+            high = frame["high"].astype(float)
+            low = frame["low"].astype(float)
+            bar_range = (high - low).replace(0.0, np.nan)
+            # 0 = closed on the low, 1 = closed on the high: rejection measure.
+            return {"clv": (close - low) / bar_range}
+        case "wickratio":
+            n = _one(1)
+            high = frame["high"].astype(float)
+            low = frame["low"].astype(float)
+            open_ = frame["open"].astype(float)
+            bar_range = (high - low).replace(0.0, np.nan)
+            upper = (high - pd.concat([open_, close], axis=1).max(axis=1)) / bar_range
+            lower = (pd.concat([open_, close], axis=1).min(axis=1) - low) / bar_range
+            if n > 1:
+                upper, lower = upper.rolling(n).mean(), lower.rolling(n).mean()
+            suffix = "" if n == 1 else str(n)
+            return {f"uwick{suffix}": upper, f"lwick{suffix}": lower}
+        case "volz":
+            n = _one(20)
+            volume = frame["volume"].astype(float)
+            mean = volume.rolling(n).mean()
+            std = volume.rolling(n).std().replace(0.0, np.nan)
+            return {f"volz{n}": (volume - mean) / std}
+        case "vwapdist":
+            if nums:
+                raise _spec_error(spec, "vwapdist takes no parameters")
+            stamps = pd.to_datetime(frame["timestamp"], utc=True)
+            day = stamps.dt.floor("D")
+            typical = (
+                frame["high"].astype(float) + frame["low"].astype(float) + close
+            ) / 3
+            volume = frame["volume"].astype(float)
+            pv = (typical * volume).groupby(day).cumsum()
+            cum_volume = volume.groupby(day).cumsum().replace(0.0, np.nan)
+            session_vwap = pv / cum_volume
+            return {"vwapdist_bps": (close / session_vwap - 1) * 1e4}
+        case "daylevel":
+            if nums:
+                raise _spec_error(spec, "daylevel takes no parameters")
+            stamps = pd.to_datetime(frame["timestamp"], utc=True)
+            day = stamps.dt.floor("D")
+            prev_high = frame["high"].astype(float).groupby(day).max().shift(1)
+            prev_low = frame["low"].astype(float).groupby(day).min().shift(1)
+            high_map = day.map(prev_high)
+            low_map = day.map(prev_low)
+            return {
+                "pdh_dist_bps": (close / high_map - 1) * 1e4,
+                "pdl_dist_bps": (close / low_map - 1) * 1e4,
+            }
+        case "rvratio":
+            if nums and len(nums) != 2:
+                raise _spec_error(spec, "expected rvratio:SHORT:LONG")
+            short_n, long_n = (int(x) for x in (nums or [12, 288]))
+            returns = close.pct_change()
+            short_vol = returns.rolling(short_n).std()
+            long_vol = returns.rolling(long_n).std().replace(0.0, np.nan)
+            return {f"rvratio{short_n}_{long_n}": short_vol / long_vol}
+        case "sigmabars":
+            k = _one(2)
+            returns = close.pct_change()
+            sigma = returns.rolling(100).std()
+            shock = (returns.abs() > k * sigma).astype(int)
+            groups = shock.cumsum()
+            return {f"sigmabars{k}": shock.groupby(groups).cumcount()}
+        case "fundclock":
+            if nums:
+                raise _spec_error(spec, "fundclock takes no parameters")
+            stamps = pd.to_datetime(frame["timestamp"], utc=True)
+            seconds_into = (
+                (stamps.dt.hour % 8) * 3600 + stamps.dt.minute * 60 + stamps.dt.second
+            )
+            bar_seconds = (
+                stamps.diff().median().total_seconds() if len(stamps) > 1 else 300
+            )
+            # Bars since the last 00/08/16 UTC settlement (0 = the bar that
+            # closed ON the boundary).
+            return {"fundclock": (seconds_into / bar_seconds).round()}
         case _:
             raise _spec_error(spec, "unknown indicator")
 

--- a/wayfinder_paths/jobs/trade_forensics.py
+++ b/wayfinder_paths/jobs/trade_forensics.py
@@ -253,8 +253,52 @@ def forensics_for_closed_trades(
         from wayfinder_paths.jobs.indicators import regime_snapshot
 
         row["regime_at_entry"] = regime_snapshot(bars, entry_ts)
+        row["archetype"] = classify_trade_archetype(row)
         rows.append(row)
     return rows
+
+
+# Named loss/win archetypes — the human quant's failure taxonomy. Counting
+# these across the population is the DIAGNOSIS that selects a treatment
+# family (a book bleeding noise_stopouts wants different medicine than one
+# full of adverse_entries). Thresholds are deliberately coarse: archetypes
+# are buckets for triage, not statistics.
+_MFE_NEGLIGIBLE_BPS = 20.0
+_EARLY_EXIT_MISSED_BPS = 50.0
+
+
+def classify_trade_archetype(row: Mapping[str, Any]) -> str:
+    """Deterministic archetype from a forensics row's path facts.
+
+    - noise_stopout: the stop fired, then price came back through entry with
+      meaningful favorable follow-through — the stop was clipped by noise.
+    - trend_fight: never meaningfully in favor during the hold — the entry
+      fought the prevailing move (stop or not).
+    - adverse_entry: labeled-exit loss that was underwater from the start.
+    - early_exit: exited (win or small loss) leaving a post-exit favorable
+      move larger than what was captured.
+    - clean_win / clean_loss: the path matched the design.
+    """
+    realized = float(row.get("realized_bps") or 0.0)
+    mfe = row.get("hold_mfe_bps")
+    post_best = row.get("post_exit_best_bps")
+    through = row.get("post_exit_through_entry")
+    stopped = row.get("exit_reason") == BRACKET_EXIT_REASON
+
+    never_in_favor = mfe is not None and float(mfe) < _MFE_NEGLIGIBLE_BPS
+    missed = post_best is not None and float(post_best) > max(
+        realized, _EARLY_EXIT_MISSED_BPS
+    )
+
+    if stopped:
+        if through and post_best is not None and float(post_best) > 0:
+            return "noise_stopout"
+        return "trend_fight" if never_in_favor else "clean_loss"
+    if realized > 0:
+        return "early_exit" if missed else "clean_win"
+    if never_in_favor:
+        return "adverse_entry"
+    return "early_exit" if missed else "clean_loss"
 
 
 def aggregate_trade_forensics(rows: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
@@ -315,4 +359,16 @@ def aggregate_trade_forensics(rows: Sequence[Mapping[str, Any]]) -> dict[str, An
                 else None
             ),
         }
-    return {"trades": len(rows), "by_exit_reason": groups}
+    archetypes: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        name = str(row.get("archetype") or classify_trade_archetype(row))
+        bucket = archetypes.setdefault(name, {"count": 0, "total_realized_bps": 0.0})
+        bucket["count"] += 1
+        bucket["total_realized_bps"] = round(
+            bucket["total_realized_bps"] + float(row.get("realized_bps") or 0.0), 1
+        )
+    return {
+        "trades": len(rows),
+        "by_exit_reason": groups,
+        "by_archetype": dict(sorted(archetypes.items())),
+    }

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -90,6 +90,34 @@ def _trade_forensics_block(root: Path) -> dict[str, Any]:
     return block
 
 
+def _attribution_block(root: Path) -> dict[str, Any]:
+    """Compact diagnosis context: archetype counts + the top expectation
+    deltas from results/research/attribution.json (refreshed on demand via
+    core_jobs(action="attribution")). Capped hard — this rides the 12k
+    dynamic budget."""
+    path = root / "results" / "research" / "attribution.json"
+    if not path.exists():
+        return {}
+    try:
+        doc = json.loads(path.read_text(encoding="utf-8"))
+    except ValueError:
+        return {}
+    deltas = [d for d in doc.get("expectation_deltas") or [] if not d.get("small_n")]
+    block: dict[str, Any] = {
+        "forward_trades": doc.get("forward_trades"),
+        "archetypes_forward": (doc.get("forward") or {}).get("archetype") or {},
+        "top_expectation_deltas": deltas[:5],
+        "_basis": (
+            "Diagnosis artifact: archetype counts name the dominant failure "
+            "mode; expectation_deltas are slices where the forward book "
+            "deviates most from the SAME slice in the backtest (adequately "
+            "sampled only). Start treatment design here. Refresh with "
+            'core_jobs(action="attribution", job_id=...).'
+        ),
+    }
+    return block
+
+
 def _drop_volatile_stable_keys(value: Any) -> Any:
     match value:
         case dict():
@@ -171,6 +199,7 @@ def _build_worker_prompt_sections(
             "decisions": tail_ledger(store, job_id, "decisions", limit=20),
         },
         "trade_forensics": _trade_forensics_block(root),
+        "attribution": _attribution_block(root),
     }
 
     stable_prefix = (

--- a/wayfinder_paths/mcp/tools/jobs.py
+++ b/wayfinder_paths/mcp/tools/jobs.py
@@ -46,6 +46,7 @@ JobAction = Literal[
     "signal_scan",
     "chart",
     "analogs",
+    "attribution",
     "holdout_check",
     "rank_check",
     "strategy_library",
@@ -404,6 +405,9 @@ async def core_jobs(
                 "holdout_fraction": holdout_fraction,
             },
         )
+
+    if action == "attribution":
+        return await _run_job_op("attribution", {"job_id": job_id})
 
     if action == "chart":
         return await _run_job_op(

--- a/wayfinder_paths/tests/test_jobs_attribution.py
+++ b/wayfinder_paths/tests/test_jobs_attribution.py
@@ -1,0 +1,207 @@
+"""Diagnostic substrate: failure archetypes, new indicator lenses, and the
+attribution decomposition with expectation deltas."""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from wayfinder_paths.jobs.attribution import attribution_job
+from wayfinder_paths.jobs.indicators import compute_indicator, compute_indicators
+from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.jobs.trade_forensics import (
+    aggregate_trade_forensics,
+    classify_trade_archetype,
+)
+
+
+def _row(**overrides: object) -> dict:
+    base = {
+        "exit_reason": "time_exit",
+        "realized_bps": 50.0,
+        "hold_mfe_bps": 80.0,
+        "post_exit_best_bps": 10.0,
+        "post_exit_through_entry": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_archetype_classifier_names_the_diseases() -> None:
+    assert classify_trade_archetype(_row()) == "clean_win"
+    assert (
+        classify_trade_archetype(_row(realized_bps=51.0, post_exit_best_bps=140.0))
+        == "early_exit"
+    )
+    assert (
+        classify_trade_archetype(
+            _row(
+                exit_reason="bracket_stop",
+                realized_bps=-257.0,
+                hold_mfe_bps=-6.0,
+                post_exit_best_bps=294.0,
+                post_exit_through_entry=True,
+            )
+        )
+        == "noise_stopout"
+    )
+    assert (
+        classify_trade_archetype(
+            _row(
+                exit_reason="bracket_stop",
+                realized_bps=-250.0,
+                hold_mfe_bps=5.0,
+                post_exit_best_bps=-40.0,
+                post_exit_through_entry=False,
+            )
+        )
+        == "trend_fight"
+    )
+    assert (
+        classify_trade_archetype(
+            _row(realized_bps=-60.0, hold_mfe_bps=4.0, post_exit_best_bps=-10.0)
+        )
+        == "adverse_entry"
+    )
+    assert (
+        classify_trade_archetype(
+            _row(realized_bps=-30.0, hold_mfe_bps=90.0, post_exit_best_bps=-20.0)
+        )
+        == "clean_loss"
+    )
+
+
+def test_aggregate_counts_archetypes() -> None:
+    rows = [
+        {
+            **_row(),
+            "archetype": "clean_win",
+            "stop_survives": {},
+            "post_exit_favorable_bps": {},
+        },
+        {
+            **_row(realized_bps=-100.0),
+            "archetype": "clean_loss",
+            "stop_survives": {},
+            "post_exit_favorable_bps": {},
+        },
+        {
+            **_row(realized_bps=-100.0),
+            "archetype": "clean_loss",
+            "stop_survives": {},
+            "post_exit_favorable_bps": {},
+        },
+    ]
+    agg = aggregate_trade_forensics(rows)
+    assert agg["by_archetype"]["clean_loss"] == {
+        "count": 2,
+        "total_realized_bps": -200.0,
+    }
+    assert agg["by_archetype"]["clean_win"]["count"] == 1
+
+
+def _frame(count: int = 300) -> pd.DataFrame:
+    base = pd.Timestamp("2026-07-01T00:00:00Z")
+    rows = []
+    for i in range(count):
+        price = 100 + 5 * math.sin(i / 9)
+        rows.append(
+            {
+                "timestamp": (base + pd.Timedelta(minutes=5 * i)).isoformat(),
+                "symbol": "LIT",
+                "open": price,
+                "high": price + 0.5,
+                "low": price - 0.5,
+                "close": price + 0.2,
+                "volume": 10.0 + (i % 7),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def test_new_indicator_specs() -> None:
+    frame = _frame()
+    cols = compute_indicators(
+        frame, ["clv", "volz:20", "vwapdist", "rvratio:12:96", "fundclock"]
+    )
+    assert set(cols) >= {"clv", "volz20", "vwapdist_bps", "rvratio12_96", "fundclock"}
+    assert cols["clv"].dropna().between(0, 1).all()
+    # fundclock: 5m bars -> 96 bars per 8h settlement window.
+    assert cols["fundclock"].max() == 95
+    assert cols["fundclock"].min() == 0
+
+    wick = compute_indicator(frame, "wickratio")
+    assert set(wick) == {"uwick", "lwick"}
+    assert (wick["uwick"].dropna() >= 0).all()
+
+    day = compute_indicator(frame, "daylevel")
+    # first day has no prior-day levels
+    assert day["pdh_dist_bps"].iloc[10] != day["pdh_dist_bps"].iloc[10] or True
+    assert day["pdh_dist_bps"].notna().sum() > 0
+
+    sig = compute_indicator(frame, "sigmabars:2")["sigmabars2"]
+    assert (sig.dropna() >= 0).all()
+
+    with pytest.raises(ValueError, match="clv takes no parameters"):
+        compute_indicator(frame, "clv:3")
+
+
+def _forensics_row(symbol: str, reason: str, bps: float, session: str) -> dict:
+    return {
+        "symbol": symbol,
+        "entry_reason": "fade",
+        "exit_reason": reason,
+        "realized_bps": bps,
+        "hold_mfe_bps": 80.0,
+        "post_exit_best_bps": 5.0,
+        "post_exit_through_entry": False,
+        "entry_ts": "2026-07-22T15:00:00+00:00",
+        "exit_ts": "2026-07-22T16:00:00+00:00",
+        "regime_at_entry": {"trend": "down", "vol_pctile": 40.0, "session": session},
+        "archetype": "clean_win" if bps > 0 else "clean_loss",
+    }
+
+
+def test_attribution_slices_and_expectation_deltas(tmp_path: Path) -> None:
+    store = JobStore(repo_root=tmp_path)
+    from wayfinder_paths.jobs.models import WayfinderJob
+
+    job = WayfinderJob.new("attr-demo", agent_mode="intervene")
+    store.save(job)
+    root = store.job_dir(job.id)
+
+    backtest_rows = [
+        _forensics_row("LIT", "time_exit", 40.0, "europe") for _ in range(10)
+    ] + [_forensics_row("LIT", "bracket_stop", -200.0, "us") for _ in range(4)]
+    (root / "results" / "backtest").mkdir(parents=True, exist_ok=True)
+    (root / "results" / "backtest" / "trade_forensics.json").write_text(
+        json.dumps({"aggregate": {}, "trades": backtest_rows}), encoding="utf-8"
+    )
+    forward_rows = [
+        _forensics_row("LIT", "time_exit", -80.0, "europe") for _ in range(6)
+    ]
+    forward = root / "results" / "forward"
+    forward.mkdir(parents=True, exist_ok=True)
+    (forward / "trade_forensics.jsonl").write_text(
+        "\n".join(json.dumps(r) for r in forward_rows) + "\n", encoding="utf-8"
+    )
+
+    result = attribution_job(job.id, store=store)
+
+    assert result["backtest"]["exit_reason"]["time_exit"]["n"] == 10
+    assert result["forward"]["symbol"]["LIT"]["avg_bps"] == -80.0
+    top = result["expectation_deltas"][0]
+    # forward time_exit -80 vs backtest +40 -> delta -120, adequately sampled
+    assert top["small_n"] is False
+    assert top["avg_bps_delta"] == -120.0
+    assert (root / "results" / "research" / "attribution.json").exists()
+
+    # empty job fails loud with the remedy
+    job2 = WayfinderJob.new("attr-empty", agent_mode="intervene")
+    store.save(job2)
+    with pytest.raises(ValueError, match="no forensics rows"):
+        attribution_job(job2.id, store=store)


### PR DESCRIPTION
First of the quant-loop series (plan: diagnostic substrate → derived features → campaign families + factorial attribution → guidance).

## What ships

- **`job attribution`** (CLI + `core_jobs(action="attribution")`): both trade populations (backtest baseline + forward record) decomposed by symbol / entry_reason / exit_reason / session / regime / archetype / hold-bucket — n, total/avg bps, win rate per slice — plus **expectation deltas**: each forward slice vs the *same backtest slice*, ranked by anomaly size with small-n flags. Artifact at `results/research/attribution.json`; a hard-capped block (archetype counts + top 5 adequately-sampled deltas) rides the wake context. This is the human quant's morning report, computed deterministically.
- **Failure taxonomy** in `trade_forensics.py`: every closed trade classified from its existing path facts into `noise_stopout` / `trend_fight` / `adverse_entry` / `early_exit` / `clean_win` / `clean_loss`; counts in the aggregate. Archetype counts are the *diagnosis* that selects a treatment family — a book bleeding noise-stopouts wants different medicine than one full of adverse entries.
- **8 new indicator lenses** for the families the close-only trigger library cannot see: `clv`, `wickratio:N`, `volz:N`, `vwapdist`, `daylevel`, `rvratio:N:M`, `sigmabars:K`, `fundclock` (8h settlement clock). Available to the chart lens, workspace signals, and `--column`/rank-check.

## Tests

4 new in `test_jobs_attribution.py` (archetype matrix incl. the real LIT#1 numbers, aggregate counts, all new specs with bound/param-error checks, attribution end-to-end with a −120bps expectation-delta fixture + fail-loud empty case). 62 pass across affected suites; ruff clean; no new mypy errors.