### PR TITLE
jobs: derived-features bridge — cross-symbol, exogenous, venue columns (quant-loop PR 1.5)

### DIFF
--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -780,6 +780,31 @@ def analogs_cmd(
 
 
 @job_cli.command(
+    name="derive-features",
+    help="Append cross-symbol/exogenous/venue derived feature rows to the "
+    "feature store (research-side; coarse cadence; execution contract "
+    "untouched). Sets: cross, exog, venue.",
+)
+@click.argument("job_id")
+@click.option("--sets", default="cross,exog", show_default=True)
+@click.option("--exog-symbols", default="BTC", show_default=True)
+@click.option("--every-bars", type=int, default=12, show_default=True)
+def derive_features_cmd(
+    job_id: str, sets: str, exog_symbols: str, every_bars: int
+) -> None:
+    from wayfinder_paths.jobs.derived_features import derive_features_job
+
+    result = derive_features_job(
+        job_id,
+        sets=tuple(s.strip() for s in sets.split(",") if s.strip()),
+        exog_symbols=tuple(s.strip() for s in exog_symbols.split(",") if s.strip()),
+        every_bars=every_bars,
+        store=JobStore(),
+    )
+    _echo_json({"ok": True, "result": result})
+
+
+@job_cli.command(
     name="attribution",
     help="PnL attribution: backtest + forward decomposed by symbol/reason/"
     "session/regime/archetype/hold-bucket, with forward-vs-backtest "

--- a/wayfinder_paths/jobs/derived_features.py
+++ b/wayfinder_paths/jobs/derived_features.py
@@ -1,0 +1,200 @@
+"""Derived research features: the cross-symbol / exogenous / venue bridge.
+
+Workspace signals and scans see ONE symbol's frame at a time, so any
+information that lives BETWEEN symbols (correlation state, ratio spreads,
+breadth), OUTSIDE the panel (BTC regime), or BETWEEN venues (basis) must
+arrive as feature columns — the funding pattern: rows appended to
+`state/features.jsonl`, carried into every frame by `merge_features` and the
+resample. This op computes those rows deterministically from the job dataset
+(+ a Hyperliquid candle fetch for exogenous/venue sets).
+
+Resource discipline: features are written at a coarser cadence
+(`every_bars`, default 12 = hourly on 5m bars) — merge_asof-backward gives
+step-wise values between writes, which is the right semantic for regime-ish
+features and keeps the store small. Research-side only: nothing here touches
+the execution data contract; a strategy consuming one of these columns is a
+proposal-gated change like any other.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import json
+from collections.abc import Callable
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from wayfinder_paths.jobs.execution.job import _load_dataset, _load_job_yaml
+from wayfinder_paths.jobs.execution.primitives import ExecutionSpec
+from wayfinder_paths.jobs.execution.validation import resolve_execution_spec
+from wayfinder_paths.jobs.models import utc_now_iso
+from wayfinder_paths.jobs.store import JobStore
+
+CORR_BARS = 12
+RATIO_Z_BARS = 96
+BREADTH_SMA = 50
+EXOG_TREND_SMA = 50
+DEFAULT_EVERY_BARS = 12
+MAX_APPEND_ROWS = 200_000
+
+
+def _native_hl_closes(coin: str, start_ms: int, end_ms: int) -> pd.Series:
+    from wayfinder_paths.core.clients.HyperliquidDataClient import (
+        HyperliquidDataClient,
+    )
+
+    async def _fetch() -> Any:
+        client = HyperliquidDataClient()
+        rows = await client.get_candles(
+            coin, start_ms=start_ms, end_ms=end_ms, interval="5m"
+        )
+        return rows if isinstance(rows, list) else rows.get("rows", [])
+
+    rows = asyncio.run(_fetch())
+    if not rows:
+        return pd.Series(dtype=float)
+    stamps = [pd.Timestamp(int(r["t"]), unit="ms", tz="UTC") for r in rows]
+    return pd.Series([float(r["c"]) for r in rows], index=pd.Index(stamps)).sort_index()
+
+
+def derive_features_job(
+    job_id: str,
+    *,
+    sets: tuple[str, ...] = ("cross", "exog"),
+    exog_symbols: tuple[str, ...] = ("BTC",),
+    every_bars: int = DEFAULT_EVERY_BARS,
+    store: JobStore | None = None,
+    fetch_closes: Callable[[str, int, int], pd.Series] | None = None,
+) -> dict[str, Any]:
+    """Compute and append derived feature rows. Sets: cross, exog, venue."""
+    unknown = set(sets) - {"cross", "exog", "venue"}
+    if unknown:
+        raise ValueError(f"unknown feature sets: {sorted(unknown)}")
+    store = store or JobStore()
+    root = store.job_dir(job_id)
+    job_data = _load_job_yaml(root)
+    spec_data, _ = resolve_execution_spec(root, job_data)
+    dataset = _load_dataset(root, ExecutionSpec.from_dict(spec_data), job_data)
+    frame = dataset.bars.to_frame()
+    frame["timestamp"] = pd.to_datetime(frame["timestamp"], utc=True)
+    closes = frame.pivot_table(
+        index="timestamp", columns="symbol", values="close", aggfunc="last"
+    ).sort_index()
+    symbols = [str(s) for s in closes.columns]
+    fetch = fetch_closes or _native_hl_closes
+
+    columns: dict[str, pd.DataFrame] = {}
+
+    def _add(name: str, wide: pd.DataFrame | pd.Series) -> None:
+        # A Series is panel-wide (same value for every symbol).
+        if isinstance(wide, pd.Series):
+            wide = pd.DataFrame(dict.fromkeys(symbols, wide))
+        columns[name] = wide
+
+    if "cross" in sets:
+        returns = closes.pct_change()
+        for symbol in symbols:
+            for sibling in symbols:
+                if sibling == symbol:
+                    continue
+                corr = returns[symbol].rolling(CORR_BARS).corr(returns[sibling])
+                columns.setdefault(
+                    f"corr_{sibling.lower()}{CORR_BARS}", pd.DataFrame()
+                )[symbol] = corr
+                ratio = np.log(closes[symbol] / closes[sibling])
+                z = (ratio - ratio.rolling(RATIO_Z_BARS).mean()) / ratio.rolling(
+                    RATIO_Z_BARS
+                ).std()
+                columns.setdefault(
+                    f"ratioz_{sibling.lower()}{RATIO_Z_BARS}", pd.DataFrame()
+                )[symbol] = z
+        above = (closes > closes.rolling(BREADTH_SMA).mean()).sum(axis=1)
+        _add(f"breadth_sma{BREADTH_SMA}", above.astype(float))
+        _add("panelret_lag1", returns.mean(axis=1).shift(1))
+
+    if "exog" in sets or "venue" in sets:
+        start_ms = int(closes.index[0].timestamp() * 1000)
+        end_ms = int(closes.index[-1].timestamp() * 1000) + 300_000
+        if "exog" in sets:
+            for coin in exog_symbols:
+                exog = fetch(coin, start_ms, end_ms).reindex(closes.index).ffill()
+                _add(f"{coin.lower()}_ret{CORR_BARS}", exog.pct_change(CORR_BARS))
+                _add(
+                    f"{coin.lower()}_trend",
+                    (exog > exog.rolling(EXOG_TREND_SMA).mean()).astype(float),
+                )
+        if "venue" in sets:
+            for symbol in symbols:
+                hl = fetch(symbol, start_ms, end_ms).reindex(closes.index).ffill()
+                basis = (hl / closes[symbol] - 1) * 1e4
+                columns.setdefault("venue_basis_bps", pd.DataFrame())[symbol] = basis
+
+    # Serialize at the coarse cadence with the fetch-funding dedup semantics.
+    features_path = root / "state" / "features.jsonl"
+    features_path.parent.mkdir(parents=True, exist_ok=True)
+    existing: set[tuple[str, str, str]] = set()
+    if features_path.exists():
+        for line in features_path.read_text(encoding="utf-8").splitlines():
+            try:
+                row = json.loads(line)
+            except ValueError:
+                continue
+            if isinstance(row, dict):
+                existing.add(
+                    (
+                        str(row.get("timestamp")),
+                        str(row.get("name")),
+                        str(row.get("symbol")),
+                    )
+                )
+    written_at = utc_now_iso()
+    stamps = closes.index[::every_bars]
+    appended: dict[str, int] = {}
+    total = 0
+    with features_path.open("a", encoding="utf-8") as handle:
+        for name, wide in columns.items():
+            for symbol in symbols:
+                if symbol not in getattr(wide, "columns", []):
+                    continue
+                series = wide[symbol].loc[wide.index.intersection(stamps)].dropna()
+                for ts, value in series.items():
+                    if total >= MAX_APPEND_ROWS:
+                        raise ValueError(
+                            f"append cap {MAX_APPEND_ROWS} hit — raise every_bars"
+                        )
+                    key = (ts.isoformat(), name, symbol)
+                    if key in existing:
+                        continue
+                    existing.add(key)
+                    handle.write(
+                        json.dumps(
+                            {
+                                "timestamp": ts.isoformat(),
+                                "name": name,
+                                "value": round(float(value), 8),
+                                "symbol": symbol,
+                                "written_at": written_at,
+                            }
+                        )
+                        + "\n"
+                    )
+                    appended[name] = appended.get(name, 0) + 1
+                    total += 1
+    return {
+        "sets": list(sets),
+        "every_bars": every_bars,
+        "features": sorted(columns),
+        "rows_appended": total,
+        "per_feature": dict(sorted(appended.items())),
+        "generated_at": str(dt.datetime.now(dt.UTC)),
+        "read": (
+            "Research-side derived features appended to the feature store — "
+            "they now ride merge_features into every symbol frame for "
+            "workspace signals, --column checks, and rank-check. Values are "
+            "step-wise between writes (coarse cadence by design). Consuming "
+            "one in the LIVE strategy is a proposal-gated change."
+        ),
+    }

--- a/wayfinder_paths/jobs/execution/op_runner.py
+++ b/wayfinder_paths/jobs/execution/op_runner.py
@@ -59,6 +59,10 @@ def _run(op: str, kwargs: dict[str, Any]) -> Any:
         from wayfinder_paths.jobs.chart import analogs_job
 
         return analogs_job(kwargs.pop("job_id"), **kwargs)
+    if op == "derive_features":
+        from wayfinder_paths.jobs.derived_features import derive_features_job
+
+        return derive_features_job(kwargs.pop("job_id"), **kwargs)
     if op == "attribution":
         from wayfinder_paths.jobs.attribution import attribution_job
 

--- a/wayfinder_paths/mcp/tools/jobs.py
+++ b/wayfinder_paths/mcp/tools/jobs.py
@@ -47,6 +47,7 @@ JobAction = Literal[
     "chart",
     "analogs",
     "attribution",
+    "derive_features",
     "holdout_check",
     "rank_check",
     "strategy_library",
@@ -405,6 +406,9 @@ async def core_jobs(
                 "holdout_fraction": holdout_fraction,
             },
         )
+
+    if action == "derive_features":
+        return await _run_job_op("derive_features", {"job_id": job_id})
 
     if action == "attribution":
         return await _run_job_op("attribution", {"job_id": job_id})

--- a/wayfinder_paths/tests/test_jobs_derived_features.py
+++ b/wayfinder_paths/tests/test_jobs_derived_features.py
@@ -1,0 +1,118 @@
+"""Derived-features bridge: cross-symbol/exogenous columns into the feature
+store so single-symbol scans can see between symbols and outside the panel."""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from wayfinder_paths.jobs.derived_features import derive_features_job
+from wayfinder_paths.jobs.execution.primitives import ExecutionSpec
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.store import JobStore
+
+
+def _panel_frame(count: int = 400) -> list[dict]:
+    base = pd.Timestamp("2026-07-01T00:00:00Z")
+    rows = []
+    for i in range(count):
+        ts = (base + pd.Timedelta(minutes=5 * i)).isoformat()
+        for symbol, phase in (("LIT", 0.0), ("SOL", 0.7)):
+            price = (
+                100 + 5 * math.sin(i / 9 + phase) + (0.01 * i if symbol == "SOL" else 0)
+            )
+            rows.append(
+                {
+                    "timestamp": ts,
+                    "symbol": symbol,
+                    "open": price,
+                    "high": price + 0.4,
+                    "low": price - 0.4,
+                    "close": price + 0.1,
+                    "volume": 10.0,
+                }
+            )
+    return rows
+
+
+def _make_job(tmp_path: Path) -> tuple[JobStore, str]:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        "derive-demo",
+        script=".wayfinder/jobs/derive-demo/workspace/src/strategy.py",
+        interval_seconds=300,
+    )
+    spec = ExecutionSpec()
+    spec.data_contract["bar_interval"] = "5m"
+    job.execution_spec = spec.to_dict()
+    store.save(job)
+    root = store.job_dir(job.id)
+    bars_path = root / "results" / "backtest" / "input_bars.json"
+    bars_path.parent.mkdir(parents=True, exist_ok=True)
+    bars_path.write_text(json.dumps(_panel_frame()), encoding="utf-8")
+    return store, job.id
+
+
+def _fake_fetch(coin: str, start_ms: int, end_ms: int) -> pd.Series:
+    stamps = pd.date_range(
+        pd.Timestamp(start_ms, unit="ms", tz="UTC"),
+        pd.Timestamp(end_ms, unit="ms", tz="UTC"),
+        freq="5min",
+    )
+    values = [50_000 + i for i in range(len(stamps))]
+    return pd.Series(values, index=stamps, dtype=float)
+
+
+def test_derive_features_appends_and_dedupes(tmp_path: Path) -> None:
+    store, job_id = _make_job(tmp_path)
+
+    result = derive_features_job(
+        job_id, sets=("cross", "exog"), store=store, fetch_closes=_fake_fetch
+    )
+
+    assert result["rows_appended"] > 0
+    names = set(result["per_feature"])
+    assert {"breadth_sma50", "panelret_lag1", "btc_ret12", "btc_trend"} <= names
+    assert any(n.startswith("corr_sol") for n in names)  # LIT gets corr to SOL
+    assert any(n.startswith("ratioz_") for n in names)
+
+    rows = [
+        json.loads(line)
+        for line in (store.job_dir(job_id) / "state" / "features.jsonl")
+        .read_text()
+        .splitlines()
+    ]
+    sample = next(r for r in rows if r["name"] == "btc_trend")
+    assert sample["symbol"] in {"LIT", "SOL"}
+    assert sample["value"] in (0.0, 1.0)
+
+    # Idempotent: re-run appends nothing (dedup on timestamp/name/symbol).
+    again = derive_features_job(
+        job_id, sets=("cross", "exog"), store=store, fetch_closes=_fake_fetch
+    )
+    assert again["rows_appended"] == 0
+
+    with pytest.raises(ValueError, match="unknown feature sets"):
+        derive_features_job(job_id, sets=("magic",), store=store)
+
+
+def test_venue_basis_per_symbol(tmp_path: Path) -> None:
+    store, job_id = _make_job(tmp_path)
+
+    def fetch(coin: str, start_ms: int, end_ms: int) -> pd.Series:
+        # HL trades 10bps above the dataset price for every symbol.
+        stamps = pd.date_range(
+            pd.Timestamp(start_ms, unit="ms", tz="UTC"),
+            pd.Timestamp(end_ms, unit="ms", tz="UTC"),
+            freq="5min",
+        )
+        return pd.Series(100.0 * 1.001, index=stamps)
+
+    result = derive_features_job(
+        job_id, sets=("venue",), store=store, fetch_closes=fetch
+    )
+    assert result["per_feature"].get("venue_basis_bps", 0) > 0


### PR DESCRIPTION
Stacked on #555 (merge that first; this PR's base is its branch — retarget to wayfinder-jobs-v1 after #555 lands or merge in order).

Workspace signals and scans receive ONE symbol's frame, so the whole cross-symbol/exogenous idea space was untestable. This bridge computes those as **feature-store columns** (the funding pattern — rows ride `merge_features` into every frame, resample-carried):

- **cross**: rolling correlation to each sibling (`corr_sol12`), log-ratio z-scores (`ratioz_pol96`), `breadth_sma50`, `panelret_lag1` (lead-lag testing via rank-check)
- **exog**: BTC/ETH `_ret12` + `_trend` columns from a research-side HL fetch — NOT added to the execution data contract
- **venue**: per-symbol `venue_basis_bps` (HL close vs dataset close)

Resource discipline per the plan: coarse cadence (`--every-bars 12` → step-wise values, right semantic for regime features), hard append cap, dedup on (timestamp,name,symbol), on-demand only. Tests: append+dedup+idempotency with a fake fetch, venue basis per symbol, unknown-set fail-loud. Ruff clean.