### PR TITLE
jobs: campaign-scoped scan families + factorial attribution (quant-loop PR 2)

### DIFF
--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -676,6 +676,12 @@ def signal_check_cmd(
     help="Skip the job's workspace/src/signals.py defs and sweep the "
     "canonical library only.",
 )
+@click.option(
+    "--campaign",
+    default=None,
+    help="Declared campaign name: scan ONLY workspace defs as their own BH "
+    "family (canonical library untaxed). Recorded in the trial ledger.",
+)
 def signal_scan_cmd(
     job_id: str,
     symbols: str | None,
@@ -683,10 +689,12 @@ def signal_scan_cmd(
     timeframes: str | None,
     holdout_fraction: float,
     no_workspace_signals: bool,
+    campaign: str | None,
 ) -> None:
     store = JobStore()
     result = signal_scan_job(
         job_id,
+        campaign=campaign,
         symbols=[s.strip() for s in symbols.split(",")] if symbols else None,
         horizons=[int(h) for h in horizons.split(",")] if horizons else None,
         timeframes=[t.strip() for t in timeframes.split(",")] if timeframes else None,

--- a/wayfinder_paths/jobs/execution/simulator.py
+++ b/wayfinder_paths/jobs/execution/simulator.py
@@ -90,6 +90,10 @@ class ExecutionGridResult:
     # the search settings when not an exhaustive grid.
     optimizer: str = "grid"
     search: dict[str, Any] | None = None
+    # Additive: per-factor marginal effects + interaction checks over a
+    # factorial grid (grid_factor_attribution) — the ablation summary a
+    # compound proposal must cite.
+    factor_attribution: dict[str, Any] | None = None
     # Additive: neighbor-robustness of the top cell (grid_plateau) — only for
     # exhaustive dict-of-lists grids; None for optuna and list-of-dicts.
     plateau: dict[str, Any] | None = None
@@ -598,6 +602,93 @@ def grid_plateau(
     return result
 
 
+def grid_factor_attribution(
+    run_rows: list[dict[str, Any]],
+    param_grid: Mapping[str, list[Any]],
+    *,
+    rank_by: str,
+) -> dict[str, Any] | None:
+    """Per-factor marginal effects over a factorial grid — the ablation
+    summary a compound proposal must cite.
+
+    Treats every swept axis as a factor: per-level means of the rank_by
+    metric across ALL cells, the marginal effect for 2-level factors
+    (mean(on) - mean(off)), and a pairwise interaction check for 2-level
+    factors (does A's effect flip sign conditional on B's level). This is
+    how "the improvement is mostly the exit change; the volume gate only
+    helps when the MTF filter is on" becomes a stated, checkable claim
+    instead of a guess about the winning cell."""
+    valid = [row for row in run_rows if row["validation"]["execution_valid"]]
+    axes = {key: list(values) for key, values in param_grid.items() if len(values) > 1}
+    if not valid or not axes:
+        return None
+
+    def metric(row: dict[str, Any]) -> float:
+        return float(row.get(rank_by) or 0.0)
+
+    def mean_where(predicate: Any) -> float | None:
+        rows = [metric(r) for r in valid if predicate(r)]
+        return round(sum(rows) / len(rows), 6) if rows else None
+
+    factors: dict[str, Any] = {}
+    for axis, levels in axes.items():
+        level_means = {
+            str(level): mean_where(lambda r, a=axis, v=level: r["params"].get(a) == v)
+            for level in levels
+        }
+        entry: dict[str, Any] = {"levels": level_means}
+        if len(levels) == 2:
+            low, high = level_means[str(levels[0])], level_means[str(levels[1])]
+            if low is not None and high is not None:
+                entry["marginal_effect"] = round(high - low, 6)
+        factors[axis] = entry
+
+    interactions: list[dict[str, Any]] = []
+    two_level = [axis for axis, levels in axes.items() if len(levels) == 2]
+    for i, a in enumerate(two_level):
+        for b in two_level[i + 1 :]:
+            effects = []
+            for b_level in axes[b]:
+                on = mean_where(
+                    lambda r, a=a, b=b, bl=b_level: r["params"].get(a) == axes[a][1]
+                    and r["params"].get(b) == bl
+                )
+                off = mean_where(
+                    lambda r, a=a, b=b, bl=b_level: r["params"].get(a) == axes[a][0]
+                    and r["params"].get(b) == bl
+                )
+                effects.append(
+                    round(on - off, 6) if on is not None and off is not None else None
+                )
+            known = [e for e in effects if e is not None]
+            sign_flip = len(known) == 2 and (known[0] > 0) != (known[1] > 0)
+            interactions.append(
+                {
+                    "factor": a,
+                    "conditioner": b,
+                    "effect_by_conditioner_level": dict(
+                        zip((str(v) for v in axes[b]), effects, strict=True)
+                    ),
+                    "sign_flip": sign_flip,
+                }
+            )
+
+    top = max(valid, key=metric)
+    return {
+        "rank_by": rank_by,
+        "factors": factors,
+        "interactions": interactions,
+        "top_params": top["params"],
+        "top_metric": round(metric(top), 6),
+        "read": (
+            "Marginal effects are averaged across ALL cells (not just the "
+            "winner); a compound proposal must cite them, and a factor whose "
+            "marginal effect is negative does not ship unless a documented "
+            "sign_flip interaction is the finding itself."
+        ),
+    }
+
+
 def available_cpu_count() -> int:
     """Usable CPUs for backtest fan-out. Respects a cgroup CPU quota (Fly
     machines are quota-limited, and os.cpu_count() reports the host's cores,
@@ -716,6 +807,11 @@ def run_execution_grid(
         },
         plateau=(
             grid_plateau(run_rows, param_grid, rank_by=rank_by)
+            if isinstance(param_grid, Mapping)
+            else None
+        ),
+        factor_attribution=(
+            grid_factor_attribution(run_rows, param_grid, rank_by=rank_by)
             if isinstance(param_grid, Mapping)
             else None
         ),

--- a/wayfinder_paths/jobs/research.py
+++ b/wayfinder_paths/jobs/research.py
@@ -844,6 +844,7 @@ def scan_signals(
     fee_bps: float = 5.0,
     slippage_bps: float = 3.5,
     extra_signals: Sequence[SignalDef] = (),
+    include_canonical: bool = True,
 ) -> dict[str, Any]:
     """Event-study EVERY canonical library trigger against one symbol's bars
     — across timeframes, in a single pass — the breadth tool that replaces
@@ -900,7 +901,9 @@ def scan_signals(
         frames_by_tf[tf_name] = bars
         close = bars["close"].astype(float).to_numpy()
         n = len(close)
-        signals = build_signal_frame(bars, extra_signals)
+        signals = build_signal_frame(
+            bars, extra_signals, include_canonical=include_canonical
+        )
         tf_horizons = sorted(
             {int(h) for h in horizons}
             if horizons
@@ -1627,6 +1630,7 @@ def signal_scan_job(
     timeframes: list[str] | None = None,
     holdout_fraction: float = 0.15,
     include_workspace: bool = True,
+    campaign: str | None = None,
     store: Any | None = None,
 ) -> dict[str, Any]:
     """Scan the ENTIRE canonical trigger library against the job's dataset —
@@ -1680,6 +1684,19 @@ def signal_scan_job(
                 frame[frame["symbol"] == symbol].reset_index(drop=True),
             )
     extra_signals = workspace.defs if workspace is not None else ()
+    # A campaign is its own declared BH family: workspace defs only, pooled
+    # only with each other — the canonical library neither taxes nor is taxed
+    # by the campaign. Provenance (name + defs sha) lands in the ledger so a
+    # renamed re-run is visible snooping, exactly like workspace sha tracking.
+    if campaign is not None:
+        if not extra_signals:
+            raise ValueError(
+                "a campaign scan needs workspace signals — declare the "
+                "campaign's defs in workspace/src/signals.py first"
+            )
+        if not str(campaign).strip():
+            raise ValueError("campaign name must be non-empty")
+    include_canonical = campaign is None
     per_symbol = {
         symbol: scan_signals(
             frame[frame["symbol"] == symbol].reset_index(drop=True),
@@ -1690,6 +1707,7 @@ def signal_scan_job(
             fee_bps=fee_bps,
             slippage_bps=slippage_bps,
             extra_signals=extra_signals,
+            include_canonical=include_canonical,
         )
         for symbol in targets
     }
@@ -1722,6 +1740,7 @@ def signal_scan_job(
             },
             "workspace_signals": [spec.name for spec in extra_signals],
             "workspace_signals_sha": workspace.sha if workspace else None,
+            "campaign": campaign,
         }
     ]
     # EVERY executed test is a recorded trial — not just the survivors.
@@ -1744,12 +1763,14 @@ def signal_scan_job(
                     "folds_agreeing": row.get("folds_agreeing"),
                     "verdict": row.get("verdict"),
                     "library": row.get("library"),
+                    "campaign": campaign,
                 }
             )
     _append_scan_ledger(root, ledger_rows)
     cumulative_tests = prior_tests + sum(s["tests_run"] for s in per_symbol.values())
     result: dict[str, Any] = {
         "per_symbol": per_symbol,
+        "campaign": campaign,
         "workspace_signals": [spec.name for spec in extra_signals],
         "holdout": {
             "fraction": holdout_fraction,

--- a/wayfinder_paths/jobs/signal_library.py
+++ b/wayfinder_paths/jobs/signal_library.py
@@ -484,15 +484,21 @@ SIGNAL_LIBRARY: tuple[SignalDef, ...] = (
 
 
 def build_signal_frame(
-    frame: pd.DataFrame, extra_signals: Sequence[SignalDef] = ()
+    frame: pd.DataFrame,
+    extra_signals: Sequence[SignalDef] = (),
+    *,
+    include_canonical: bool = True,
 ) -> pd.DataFrame:
     """All library signals for one symbol's OHLCV frame, as boolean columns
     row-aligned with the input. NaN warmup rows resolve to False.
 
     `extra_signals` (validated workspace defs) are materialized after the
-    canonical library so the scan sweeps both under one test family."""
+    canonical library so the scan sweeps both under one test family. A
+    CAMPAIGN scan sets include_canonical=False: its declared defs are their
+    own family and must not tax (or be taxed by) the canonical library."""
     out = pd.DataFrame(index=frame.index)
-    for spec in (*SIGNAL_LIBRARY, *extra_signals):
+    library = SIGNAL_LIBRARY if include_canonical else ()
+    for spec in (*library, *extra_signals):
         out[spec.name] = (
             spec.build(frame).fillna(False).astype(bool)
             if len(frame) >= spec.min_bars

--- a/wayfinder_paths/mcp/tools/jobs.py
+++ b/wayfinder_paths/mcp/tools/jobs.py
@@ -170,6 +170,7 @@ async def core_jobs(
     signal: str | None = None,
     horizon: int | None = None,
     symbol: str | None = None,
+    campaign: str | None = None,
     timeframe: str | None = None,
     bars: int = 96,
     indicators: list[str] | None = None,
@@ -404,6 +405,7 @@ async def core_jobs(
                 "horizons": horizons,
                 "timeframes": timeframes,
                 "holdout_fraction": holdout_fraction,
+                "campaign": campaign,
             },
         )
 

--- a/wayfinder_paths/tests/test_jobs_campaign_factorial.py
+++ b/wayfinder_paths/tests/test_jobs_campaign_factorial.py
@@ -1,0 +1,107 @@
+"""Campaign-scoped scan families and factorial attribution."""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from wayfinder_paths.jobs.execution.primitives import ExecutionSpec
+from wayfinder_paths.jobs.execution.simulator import grid_factor_attribution
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.research import signal_scan_job
+from wayfinder_paths.jobs.signal_library import SIGNAL_LIBRARY, build_signal_frame
+from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.jobs.workspace_signals import SignalDef
+
+
+def _frame(count: int = 200) -> pd.DataFrame:
+    base = pd.Timestamp("2026-07-01T00:00:00Z")
+    rows = []
+    for i in range(count):
+        price = 100 + 5 * math.sin(i / 9)
+        rows.append(
+            {
+                "timestamp": (base + pd.Timedelta(minutes=5 * i)).isoformat(),
+                "symbol": "LIT",
+                "open": price,
+                "high": price + 0.4,
+                "low": price - 0.4,
+                "close": price + 0.1,
+                "volume": 10.0,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def test_campaign_frame_excludes_canonical_library() -> None:
+    frame = _frame()
+    extra = [
+        SignalDef(
+            name="camp_up",
+            family="campaign",
+            description="close above 20-bar mean",
+            min_bars=20,
+            build=lambda f: f["close"].astype(float)
+            > f["close"].astype(float).rolling(20).mean(),
+        )
+    ]
+    full = build_signal_frame(frame, extra)
+    assert "camp_up" in full.columns and len(full.columns) == len(SIGNAL_LIBRARY) + 1
+    campaign_only = build_signal_frame(frame, extra, include_canonical=False)
+    assert list(campaign_only.columns) == ["camp_up"]
+
+
+def test_campaign_scan_requires_workspace_defs(tmp_path: Path) -> None:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        "camp-demo",
+        script=".wayfinder/jobs/camp-demo/workspace/src/strategy.py",
+        interval_seconds=300,
+    )
+    spec = ExecutionSpec()
+    spec.data_contract["bar_interval"] = "5m"
+    job.execution_spec = spec.to_dict()
+    store.save(job)
+    root = store.job_dir(job.id)
+    bars_path = root / "results" / "backtest" / "input_bars.json"
+    bars_path.parent.mkdir(parents=True, exist_ok=True)
+    bars_path.write_text(json.dumps(_frame(400).to_dict("records")), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="campaign scan needs workspace signals"):
+        signal_scan_job(job.id, campaign="volume_v1", store=store)
+
+
+def _cell(params: dict, metric: float) -> dict:
+    return {
+        "run_id": "r",
+        "params": params,
+        "stats": {"net_return": metric},
+        "validation": {"execution_valid": True},
+        "net_return": metric,
+    }
+
+
+def test_factor_attribution_marginals_and_interaction() -> None:
+    # 2x2: exit change carries the improvement; the gate only helps when the
+    # filter is on (sign flip).
+    rows = [
+        _cell({"gate": False, "mfe_target": 0}, 0.10),
+        _cell({"gate": True, "mfe_target": 0}, 0.06),
+        _cell({"gate": False, "mfe_target": 60}, 0.20),
+        _cell({"gate": True, "mfe_target": 60}, 0.26),
+    ]
+    grid = {"gate": [False, True], "mfe_target": [0, 60]}
+    result = grid_factor_attribution(rows, grid, rank_by="net_return")
+    assert result is not None
+    assert result["factors"]["mfe_target"]["marginal_effect"] == pytest.approx(0.15)
+    assert result["factors"]["gate"]["marginal_effect"] == pytest.approx(0.01)
+    interaction = next(i for i in result["interactions"] if i["factor"] == "gate")
+    assert interaction["sign_flip"] is True
+    assert result["top_params"] == {"gate": True, "mfe_target": 60}
+
+    # No swept axis -> None
+    assert grid_factor_attribution(rows, {"gate": [True]}, rank_by="net_return") is None


### PR DESCRIPTION
Stacked on #556 (merge order: #555 → #556 → this).

## Campaign-scoped multiplicity

`signal-scan --campaign NAME` (CLI + MCP): sweeps ONLY the declared workspace defs as **their own BH family** — the canonical 37-trigger library neither taxes nor is taxed by a speculative campaign. This removes the economics that trained the watcher into conservatism: previously every workspace def raised the promotion bar for the entire pooled family (after one 0-for-8 campaign it deleted its own `signals.py` to keep the gate clean). Honesty preserved: a campaign must be declared (fails loud without workspace defs), and the campaign name lands on `scan_meta` and every `scan_test` trial-ledger row — renaming to relaunch is visible snooping, exactly like the workspace sha.

## Factorial attribution

`grid_factor_attribution` (additive on `ExecutionGridResult`, beside `grid_plateau`): for factor-shaped grids (`{volume_gate: [false,true], mfe_target_bps: [0,60], ...}`) — per-factor **marginal effects averaged across all cells**, pairwise **interaction sign-flip checks** for 2-level factors, and the winning cell. This is the ablation summary a compound proposal must cite: "the improvement is mostly the exit change; the gate only helps when the MTF filter is on" as a stated, checkable claim.

Tests: campaign frame excludes the canonical library; campaign scan without defs fails loud; synthetic 2×2 factorial reproduces hand-computed marginals + a planted sign-flip interaction. 88 pass across scan/grid suites; ruff clean.