### PR TITLE
jobs: quant-loop guidance — prior library, triage, compound protocol (quant-loop PR 3)

### DIFF
--- a/wayfinder_paths/jobs/prompts/research_priors.md
+++ b/wayfinder_paths/jobs/prompts/research_priors.md
@@ -1,0 +1,51 @@
+# Research prior library — idea families, their priors, and how to test them
+
+Methodology, not answers: each family says HOW to look and WHICH tool
+adjudicates. Prior strength = how much benefit of the doubt a hypothesis from
+this family earns in triage (STRONG priors are well-documented market
+effects; SPECULATIVE ones need a symptom match to justify the spend). Every
+family lists the failure archetypes it treats — start from the attribution
+block's archetype counts and pick the family that treats YOUR disease.
+
+| Family | Prior | Treats | Test path |
+|---|---|---|---|
+| Volume/participation: `volz:N` at signal time (real break vs dead tape), volume dry-up before compression, `clv` rejection closes | STRONG | noise_stopout, trend_fight | campaign workspace defs / `signal-check --column` |
+| Candle path-shape: `wickratio` sweep-and-reclaim (wick through a prior level, close back inside), inside-bar/narrow-range runs | STRONG intraday | noise_stopout, adverse_entry | campaign workspace defs |
+| Anchored levels: `daylevel` (prior-day H/L), `vwapdist`, round numbers | STRONG | adverse_entry (entries far from anchors), early_exit (targets at anchors) | campaign workspace defs |
+| Funding-settlement clock (`fundclock`) + funding rate-of-change columns | STRONG (perp-documented) | session-shaped anomalies in attribution | `fundclock` spec + derive-features funding set |
+| MTF alignment: 4h/1d state gating lower-TF entries | STRONG | trend_fight | resampled workspace defs (the 30m-on-5m pattern) |
+| Vol term structure & event clocks: `rvratio:N:M` adaptive squeeze, `sigmabars:K` clustering timer, post-cascade windows | MODERATE | noise_stopout, regime-slice anomalies | specs + campaign defs |
+| Correlation state: idiosyncratic vs beta moves via `corr_*` columns | MODERATE | trend_fight (fading beta moves) | derive-features cross set + `--column` |
+| Cross-symbol structure: `ratioz_*` pair reversion, lead-lag via `panelret_lag1`, `breadth_sma*` gates | MODERATE | portfolio-level anomalies | derive-features cross set + rank-check (research — NOT gated by the forward-trade floor) |
+| Exogenous regime: `btc_trend`/`btc_ret*` columns | STRONG for alts | regime-slice anomalies | derive-features exog set |
+| Cross-venue basis: `venue_basis_bps`, funding divergence | SPECULATIVE | execution-quality anomalies | derive-features venue set |
+| Exit-structure alpha: MFE targets, trailing, breakeven, scale-out — pre-registered strategy params (`mfe_target_bps`, `trail_bps`, …) in decide(), no engine change | STRONG when forensics show avg MFE >> avg realized | early_exit | compound factorial grid + WF |
+| Sizing overlays: vol-scaled legs, signal-strength scaling, regime-conditional size — pre-registered params | MODERATE | drawdown-shape anomalies | factorial grid + WF |
+| Event-aftermath / analogs-of-losers: what do the nearest analogs of each loser's pre-entry window share? | SPECULATIVE (ideation fuel) | any clustered archetype | `analogs` + `chart` lenses → then a campaign def |
+
+## Protocol reminders
+
+- **Diagnose before treating**: every hypothesis cites the attribution slice
+  or archetype count it treats, OR is explicitly labeled a prior-driven bet.
+- **Triage**: rank by prior strength × symptom match × cost-to-test. Each
+  ideation allocates a portfolio: >=1 cheap test, >=1 structural, <=1
+  moonshot, and >=1 family not yet in the dead map.
+- **Campaigns**: new-def sweeps run as `signal-scan --campaign NAME` — your
+  declared defs are their own BH family; the canonical library stays
+  untaxed. Declare the campaign's hypothesis families in the agenda BEFORE
+  scanning; renaming to relaunch is snooping (the ledger records it).
+- **Compound experiments** (second-order treatments): express a
+  multi-intervention causal story as 2-4 pre-registered factors (boolean
+  gates / structural params), run the factorial via the experiments grid.
+  Box discipline is TWO-STAGE: screen the full factorial with
+  `--workers 1 --quick 10000`, then full-history + walk-forward on ONLY the
+  winning cell and its one-factor neighbors. Cite `factor_attribution` in
+  the proposal; a factor with a negative marginal effect does not ship
+  unless a documented sign_flip interaction is the finding.
+- **Pre-mortem + kill criteria**: every proposal states its expected new
+  failure mode and a pre-registered kill/re-arm threshold in the intent
+  contract (the POL funding-gate pattern, generalized).
+- **Dead-map scope**: dead = the tested claim, never the asset or family;
+  owner rejections bind on the change, not its neighborhood.
+- **Long runs via CLI in-session (detached with a log), never MCP ops** —
+  the 300s op timeout cannot hold a grid.

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -142,6 +142,12 @@ def _build_worker_prompt_sections(
 ) -> dict[str, str]:
     root = store.job_dir(job_id)
     memory_md = _read_text(root / "memory.md", max_chars=6000)
+    # The research prior library: idea families, prior strengths, archetype
+    # mapping, and test paths. Lives in the STABLE prefix so it prompt-caches
+    # across wakes instead of taxing the dynamic budget.
+    research_priors = _read_text(
+        Path(__file__).parent / "prompts" / "research_priors.md", max_chars=7000
+    )
     memory_json = store.read_json(job_id, "memory.json", default={}) or {}
     recent_journal = _read_text(root / "journal.jsonl", max_chars=4000)
     # The cumulative research state — a curated map (dead hypotheses, open
@@ -254,6 +260,9 @@ def _build_worker_prompt_sections(
         "- Always write/return a compact structured finding.\n\n"
         "Stable job spec:\n"
         f"{_canonical_json(stable_payload, max_chars=12000)}\n\n"
+        "Research prior library (idea families -> priors -> archetypes -> "
+        "test paths — pick treatments from here):\n"
+        f"{research_priors}\n\n"
         "Durable job memory:\n"
         f"{memory_md}\n\n"
         f"{STABLE_PREFIX_END_MARKER}\n"
@@ -367,6 +376,26 @@ def _build_worker_prompt_sections(
             "grid+WF-validated exit change motivated by them is a legitimate "
             "proposal even below the forward-sample floor, because its "
             "evidence is the backtest population, not the forward sample.\n"
+            "- Quant loop (diagnose -> design -> ablate -> propose): start "
+            "from the `attribution` block — archetype counts name the "
+            "dominant failure mode; expectation_deltas name where forward "
+            "deviates from the model's own backtest. Every new hypothesis "
+            "cites the slice/archetype it treats or is labeled a prior-driven "
+            "bet from the Research prior library. Triage by prior x symptom "
+            "x cost; each ideation runs a PORTFOLIO (>=1 cheap, >=1 "
+            "structural, <=1 moonshot, >=1 family not in the dead map). "
+            "New-def sweeps go through `signal-scan --campaign NAME` (your "
+            "own BH family — the canonical library is untaxed, so "
+            "speculative campaigns are affordable; declare the campaign in "
+            "the agenda first). Multi-intervention treatments: 2-4 "
+            "pre-registered factors, two-stage factorial (screen "
+            "--workers 1 --quick 10000, then full-history+WF on the winner "
+            "and its one-factor neighbors), and the proposal must cite "
+            "factor_attribution. Every proposal carries a pre-mortem (its "
+            "expected new failure mode) and a pre-registered kill/re-arm "
+            "threshold. Dead-map scope: dead = the tested claim, never the "
+            "asset or family. Cross-symbol rank-check and derive-features "
+            "are RESEARCH — never gated by the forward-trade floor.\n"
             "- Chart lenses (LOOK before hypothesizing): "
             '`core_jobs(action="chart", job_id=..., symbol=..., '
             'timeframe="30m", indicators=["ema:9","ema:50","rsi:14"], '

--- a/wayfinder_paths/tests/test_jobs_campaign_factorial.py
+++ b/wayfinder_paths/tests/test_jobs_campaign_factorial.py
@@ -105,3 +105,19 @@ def test_factor_attribution_marginals_and_interaction() -> None:
 
     # No swept axis -> None
     assert grid_factor_attribution(rows, {"gate": [True]}, rank_by="net_return") is None
+
+
+def test_worker_prompt_carries_priors_and_quant_loop(tmp_path: Path) -> None:
+    from wayfinder_paths.jobs.worker import prepare_job_worker_prompt
+
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("prompt-demo", agent_mode="intervene")
+    store.save(job)
+    sections = prepare_job_worker_prompt(store=store, job_id=job.id, mode="intervene")
+    stable, prompt = sections["stable_prefix"], sections["prompt"]
+    assert "Research prior library" in stable  # cached, not dynamic-budget
+    assert "sweep-and-reclaim" in stable
+    assert "Quant loop (diagnose -> design -> ablate -> propose)" in prompt
+    assert "signal-scan --campaign" in prompt
+    assert "factor_attribution" in prompt
+    assert "pre-registered kill/re-arm threshold" in prompt


### PR DESCRIPTION
Final PR of the series (merge order: #555 → #556 → #557 → this).

- **`prompts/research_priors.md`** — the prior library: 13 idea families (volume/participation, path-shape incl. sweep-and-reclaim, anchored levels, settlement clock, MTF alignment, vol term structure, correlation state, cross-symbol structure, exogenous BTC regime, venue basis, exit-structure alpha, sizing overlays, analogs-of-losers), each with prior strength, the failure archetypes it treats, and the exact tool that tests it. Ships in the **stable prefix** — prompt-cached across wakes, no dynamic-budget cost.
- **The quant loop lane** in the worker prompt: diagnose from the attribution block (archetype counts + expectation deltas) → every hypothesis cites its slice/archetype or a named prior → triage by prior × symptom × cost with a per-ideation portfolio (≥1 cheap, ≥1 structural, ≤1 moonshot, ≥1 fresh family) → new-def sweeps as declared campaigns → compound treatments as 2–4 pre-registered factors with the **two-stage box factorial** (`--workers 1 --quick 10000` screen, full-history+WF on winner + one-factor neighbors) citing `factor_attribution` → pre-mortem + kill/re-arm threshold on every proposal → dead-map scope narrowed to the tested claim → cross-symbol rank-check/derive-features explicitly un-gated (research, not retunes).

Test asserts the priors land in the stable prefix and every protocol element reaches the assembled prompt. 37 pass; ruff clean.