### PR TITLE
jobs: research frames merge undeclared feature-store columns (fixes derive-features live)

### DIFF
--- a/wayfinder_paths/jobs/chart.py
+++ b/wayfinder_paths/jobs/chart.py
@@ -48,7 +48,7 @@ def _load_symbol_frame(
     job_data = _load_job_yaml(root)
     spec_data, _ = resolve_execution_spec(root, job_data)
     spec = ExecutionSpec.from_dict(spec_data)
-    dataset = _load_dataset(root, spec, job_data)
+    dataset = _load_dataset(root, spec, job_data, include_store_features=True)
     frame = dataset.bars.to_frame()
     symbols = sorted(frame["symbol"].astype(str).unique())
     if symbol is None:

--- a/wayfinder_paths/jobs/execution/job.py
+++ b/wayfinder_paths/jobs/execution/job.py
@@ -283,17 +283,49 @@ def _load_job_yaml(root: Path) -> dict[str, Any]:
             raise ValueError(f"Invalid job.yaml: {path}")
 
 
+def _store_feature_specs(roots: tuple[Path, ...], declared: set[str]) -> list[Any]:
+    """FeatureSpecs for every feature-store name NOT in the data contract.
+
+    Research loaders merge these so undeclared research-side columns
+    (derive-features output) are visible to rank-check/--column/workspace
+    defs; execution paths never call this — the contract still governs what
+    a LIVE strategy may consume."""
+    from wayfinder_paths.jobs.execution.features import (
+        DEFAULT_FEATURES_PATH,
+        FeatureSpec,
+    )
+
+    names: set[str] = set()
+    for root in roots:
+        path = root / DEFAULT_FEATURES_PATH
+        if not path.exists():
+            continue
+        for line in path.read_text(encoding="utf-8").splitlines():
+            try:
+                row = json.loads(line)
+            except ValueError:
+                continue
+            if isinstance(row, dict) and row.get("name"):
+                names.add(str(row["name"]))
+    return [FeatureSpec(name=name) for name in sorted(names - declared)]
+
+
 def _load_dataset(
     root: Path,
     spec: ExecutionSpec,
     job_data: dict[str, Any],
     *,
     feature_roots: tuple[Path, ...] | None = None,
+    include_store_features: bool = False,
 ) -> PreparedExecutionDataset:
     dataset = _resolve_dataset(root, spec, job_data)
     # Same feature merge the live driver applies per tick (as-of, backward):
     # backtest/live parity for exogenous data holds by construction.
     specs = parse_feature_specs(spec)
+    if include_store_features:
+        specs = specs + _store_feature_specs(
+            tuple(feature_roots or (root,)), {item.name for item in specs}
+        )
     if specs:
         frames = load_feature_rows(list(feature_roots or (root,)), specs)
         dataset = PreparedExecutionDataset(

--- a/wayfinder_paths/jobs/research.py
+++ b/wayfinder_paths/jobs/research.py
@@ -1526,7 +1526,7 @@ def signal_check_job(
     params = dict(job_data.get("execution_params") or {})
     script = store.resolve_script_entrypoint(job_id, job_data)
     strategy = _load_strategy(script, params)
-    dataset = _load_dataset(root, spec, job_data)
+    dataset = _load_dataset(root, spec, job_data, include_store_features=True)
     view = apply_precompute(strategy, dataset.bars)
     frame = view.to_frame()
     results: dict[str, Any] = {}
@@ -1665,7 +1665,7 @@ def signal_scan_job(
     bar_seconds = bar_interval_seconds(spec.data_contract.get("bar_interval")) or 3600
     fee_bps = float(params.get("fee_bps") or 5.0)
     slippage_bps = float(params.get("slippage_bps") or 3.5)
-    dataset = _load_dataset(root, spec, job_data)
+    dataset = _load_dataset(root, spec, job_data, include_store_features=True)
     frame = dataset.bars.to_frame()
     available = sorted(frame["symbol"].astype(str).unique())
     targets = [str(s) for s in symbols] if symbols else available
@@ -1840,7 +1840,7 @@ def holdout_check_job(
     tf_seconds = bar_interval_seconds(tf_name)
     if not tf_seconds:
         raise ValueError(f"unparseable timeframe {tf_name!r}")
-    dataset = _load_dataset(root, spec, job_data)
+    dataset = _load_dataset(root, spec, job_data, include_store_features=True)
     frame = dataset.bars.to_frame()
     available = sorted(frame["symbol"].astype(str).unique())
     targets = [str(s) for s in symbols] if symbols else available
@@ -1978,7 +1978,7 @@ def rank_check_job(
     params = dict(job_data.get("execution_params") or {})
     script = store.resolve_script_entrypoint(job_id, job_data)
     strategy = _load_strategy(script, params)
-    dataset = _load_dataset(root, spec, job_data)
+    dataset = _load_dataset(root, spec, job_data, include_store_features=True)
     view = apply_precompute(strategy, dataset.bars)
     frame = view.to_frame()
     symbols = sorted(frame["symbol"].astype(str).unique())

--- a/wayfinder_paths/tests/test_jobs_derived_features.py
+++ b/wayfinder_paths/tests/test_jobs_derived_features.py
@@ -116,3 +116,29 @@ def test_venue_basis_per_symbol(tmp_path: Path) -> None:
         job_id, sets=("venue",), store=store, fetch_closes=fetch
     )
     assert result["per_feature"].get("venue_basis_bps", 0) > 0
+
+
+def test_derived_columns_reach_research_frames(tmp_path: Path) -> None:
+    # The bug the watcher hit live: derive-features wrote rows, but research
+    # frames only merged CONTRACT-declared features -> "available non-bar
+    # columns: []". Research loaders must merge store features too.
+    from wayfinder_paths.jobs.execution.job import _load_dataset, _load_job_yaml
+    from wayfinder_paths.jobs.execution.validation import resolve_execution_spec
+
+    store, job_id = _make_job(tmp_path)
+    derive_features_job(
+        job_id, sets=("cross", "exog"), store=store, fetch_closes=_fake_fetch
+    )
+    root = store.job_dir(job_id)
+    job_data = _load_job_yaml(root)
+    spec_data, _ = resolve_execution_spec(root, job_data)
+    spec = ExecutionSpec.from_dict(spec_data)
+
+    research = _load_dataset(root, spec, job_data, include_store_features=True)
+    frame = research.bars.to_frame()
+    assert "btc_trend" in frame.columns
+    assert "breadth_sma50" in frame.columns
+
+    # Execution path unchanged: undeclared features stay out of live frames.
+    execution = _load_dataset(root, spec, job_data)
+    assert "btc_trend" not in execution.bars.to_frame().columns


### PR DESCRIPTION
The watcher hit this within hours of the quant-loop deploy: `rank-check` on the new derived features failed with **"available non-bar columns: []"** — and its self-diagnosis was exactly right. The dataset loader merges only contract-declared features; `derive-features` deliberately doesn't declare (declaring restamps the revision → gate red), so the columns never reached research frames despite the module's doc claiming they would.

**Fix**: research entry points (signal-scan/-check, rank-check, holdout-check, chart) load with `include_store_features=True` — every name present in `state/features.jsonl` is merged into research frames, declared or not. **Execution paths unchanged**: backtest/live frames still merge contract-declared features only, so backtest/live parity holds and consuming a feature in the live strategy remains a proposal-gated contract change.

Regression test pins both sides (derived column visible to the research frame, absent from the execution frame). All research/scan/chart suites green; ruff clean.

Small PR — worth merging promptly so the watcher's cross-symbol/exogenous probing unblocks; I'll fold it into the next bake.