### PR TITLE
jobs: fix campaign scan iteration + workspace dataclass loading (live failures)

### DIFF
--- a/wayfinder_paths/jobs/execution/primitives.py
+++ b/wayfinder_paths/jobs/execution/primitives.py
@@ -703,9 +703,17 @@ def _load_module_from_path(path: Path) -> ModuleType:
         raise ValueError(f"Cannot load strategy script: {path}")
     module = importlib.util.module_from_spec(spec)
     old_path = list(sys.path)
+    # Register BEFORE exec: stdlib machinery resolves cls.__module__ through
+    # sys.modules — without this, a @dataclass defined in a workspace module
+    # dies inside dataclasses._process_class (hit live: an agent's signals.py
+    # using a dataclass crashed the campaign scan).
+    sys.modules[module_name] = module
     try:
         sys.path.insert(0, str(path.parent))
         spec.loader.exec_module(module)
+    except BaseException:
+        sys.modules.pop(module_name, None)
+        raise
     finally:
         sys.path = old_path
     return module

--- a/wayfinder_paths/jobs/research.py
+++ b/wayfinder_paths/jobs/research.py
@@ -920,7 +920,11 @@ def scan_signals(
                 continue
             fwd = np.log(close[h:] / close[:-h])
             drift = float(fwd.mean())
-            for spec in (*SIGNAL_LIBRARY, *extra_signals):
+            # Iterate the SAME def set the frame was built from: a campaign
+            # frame has only workspace columns, so scoring the canonical
+            # library against it would KeyError (hit live 2026-07-26).
+            library = SIGNAL_LIBRARY if include_canonical else ()
+            for spec in (*library, *extra_signals):
                 sig = signals[spec.name].to_numpy()
                 events = _decimate_events(sig[: n - h], h)
                 n_events = int(events.sum())

--- a/wayfinder_paths/tests/test_jobs_campaign_factorial.py
+++ b/wayfinder_paths/tests/test_jobs_campaign_factorial.py
@@ -121,3 +121,50 @@ def test_worker_prompt_carries_priors_and_quant_loop(tmp_path: Path) -> None:
     assert "signal-scan --campaign" in prompt
     assert "factor_attribution" in prompt
     assert "pre-registered kill/re-arm threshold" in prompt
+
+
+def test_campaign_scan_scores_only_workspace_defs() -> None:
+    # The live KeyError: a campaign frame has only workspace columns, so the
+    # scan loop must iterate the same def set the frame was built from.
+    from wayfinder_paths.jobs.research import scan_signals
+
+    frame = _frame(600)
+    extra = [
+        SignalDef(
+            name="camp_dip",
+            family="campaign",
+            description="close below 20-bar mean",
+            min_bars=20,
+            build=lambda f: f["close"].astype(float)
+            < f["close"].astype(float).rolling(20).mean(),
+        )
+    ]
+    result = scan_signals(
+        frame,
+        bar_seconds=300,
+        extra_signals=extra,
+        include_canonical=False,
+        min_events=5,
+        holdout_fraction=0.1,
+    )
+    assert result["tests_run"] > 0
+    tested = {row["signal"] for row in result["_all_rows"]}
+    assert tested == {"camp_dip"}
+
+
+def test_workspace_module_may_use_dataclasses(tmp_path: Path) -> None:
+    # The live AttributeError: a module loaded outside sys.modules cannot
+    # define dataclasses (stdlib resolves cls.__module__ via sys.modules).
+    from wayfinder_paths.jobs.execution.primitives import _load_module_from_path
+
+    module_path = tmp_path / "signals.py"
+    module_path.write_text(
+        "from dataclasses import dataclass\n"
+        "@dataclass\n"
+        "class Config:\n"
+        "    span: int = 9\n"
+        "CONFIG = Config()\n",
+        encoding="utf-8",
+    )
+    module = _load_module_from_path(module_path)
+    assert module.CONFIG.span == 9


### PR DESCRIPTION
Trace audit of the watcher's first campaign attempt (`adverse_entry_v1`, 01:03Z) found two real bugs beyond the already-fixed feature-merge (#560):

1. **Campaign scans crashed with `KeyError: 'new_low_5'`** — #557 gated the signal-frame construction on `include_canonical` but not the scan loop, which still iterated the full canonical library against a workspace-only frame. The loop now iterates exactly the def set the frame was built from. (Campaign scans have never successfully run on the box; this unblocks them.)
2. **`@dataclass` in a workspace `signals.py` crashed in stdlib `dataclasses._process_class`** — `_load_module_from_path` never registered the loaded module in `sys.modules`, so `cls.__module__` resolution returned None. Registers before exec now (unregisters on failure). Removes an undocumented authoring landmine for the agent.

Also confirmed working-as-designed in the same trace: the chart dataset-end guard fired with its remedy, and the **causality gate correctly rejected two non-causal level-fade defs** (current-day-level leakage) — the honesty machinery catching exactly what it should.

Regression tests pin both fixes; 100+ tests green across scan/workspace/execution suites; ruff clean. Merge alongside #560 — one bake covers both.