### PR TITLE
jobs: forward view — long/short marker direction + full joined trades

### DIFF
--- a/wayfinder_paths/jobs/forward_artifacts.py
+++ b/wayfinder_paths/jobs/forward_artifacts.py
@@ -120,6 +120,7 @@ def load_forward_view(
         return {"available": False}
 
     markers = _fill_markers(fills)
+    trades = _closed_trades(forward_dir, fills)
     series: list[dict[str, Any]] = [_pnl_series(job_id, ticks, store=store)]
 
     price_note: str | None = None
@@ -204,7 +205,9 @@ def load_forward_view(
             "markers": selected_markers,
             "events": events,
         },
-        "trades": _tail_jsonl(forward_dir / Path(DEFAULT_FORWARD_TRADES).name, 50),
+        # Full entry-joined trade record (direction, duration, reasons) —
+        # replaces the raw 50-row tail the UI could not interpret.
+        "trades": trades,
     }
 
 
@@ -295,19 +298,85 @@ def _fill_markers(fills: list[dict[str, Any]]) -> list[dict[str, Any]]:
         raw = fill.get("raw") or {}
         meta = raw.get("intent_metadata") or {}
         reason = meta.get("entry_reason") or meta.get("exit_reason")
+        # POSITION direction, not fill side: a buy that reduces closes a
+        # SHORT. The chart should say long/short — buy/sell is ambiguous.
+        fill_side = str(fill.get("side") or "").lower()
+        if kind == "entry":
+            direction = "long" if fill_side == "buy" else "short"
+        else:
+            direction = "short" if fill_side == "buy" else "long"
         markers.append(
             {
                 "timestamp": str(timestamp),
                 "symbol": str(fill.get("symbol") or ""),
                 "side": fill.get("side"),
+                "direction": direction,
                 "price": fill.get("avg_price"),
                 "kind": kind,
                 "mode": mode,
-                "label": f"{mode} {kind}" + (f": {reason}" if reason else ""),
+                "label": f"{mode} {direction} {kind}"
+                + (f": {reason}" if reason else ""),
             }
         )
     markers.sort(key=lambda marker: str(marker["timestamp"]))
     return markers
+
+
+def _closed_trades(
+    forward_dir: Path, fills: list[dict[str, Any]], *, limit: int = 500
+) -> list[dict[str, Any]]:
+    """Every closed trade, entry-joined: direction, entry/exit ts+px,
+    duration, reasons. The snapshot's recent_trades tail is for the wake
+    prompt; this is the owner's full record."""
+    import pandas as pd
+
+    from wayfinder_paths.jobs.trade_forensics import (
+        _closing_fill_reason,
+        match_entry_fill,
+        position_side_of_close,
+    )
+
+    rows = _read_jsonl(forward_dir / Path(DEFAULT_FORWARD_TRADES).name)[-limit:]
+    trades: list[dict[str, Any]] = []
+    for trade in rows:
+        symbol = str(trade.get("symbol") or "")
+        exit_raw = trade.get("closed_at") or trade.get("timestamp")
+        if not exit_raw:
+            continue
+        exit_ts = pd.Timestamp(str(exit_raw))
+        if exit_ts.tzinfo is None:
+            exit_ts = exit_ts.tz_localize("UTC")
+        entry = match_entry_fill(fills, symbol=symbol, exit_ts=exit_ts)
+        entry_ts = None
+        if entry is not None:
+            entry_ts = pd.Timestamp(str(entry.get("timestamp")))
+            if entry_ts.tzinfo is None:
+                entry_ts = entry_ts.tz_localize("UTC")
+        entry_meta = ((entry or {}).get("raw") or {}).get("intent_metadata") or {}
+        trades.append(
+            {
+                "symbol": symbol,
+                "direction": position_side_of_close(str(trade.get("side"))),
+                "entry_ts": entry_ts.isoformat() if entry_ts is not None else None,
+                "entry_price": (entry or {}).get("avg_price"),
+                "exit_ts": exit_ts.isoformat(),
+                "exit_price": trade.get("price") or trade.get("avg_price"),
+                "duration_minutes": (
+                    round((exit_ts - entry_ts).total_seconds() / 60)
+                    if entry_ts is not None
+                    else None
+                ),
+                "net_pnl": trade.get("net_pnl"),
+                "entry_reason": entry_meta.get("entry_reason"),
+                "exit_reason": _closing_fill_reason(
+                    fills, symbol=symbol, exit_ts=exit_ts
+                )
+                or "bracket_stop",
+                "mode": str(trade.get("mode") or "paper"),
+            }
+        )
+    trades.sort(key=lambda t: str(t["exit_ts"]), reverse=True)
+    return trades
 
 
 def _pnl_series(

--- a/wayfinder_paths/tests/test_jobs_tiered_evidence.py
+++ b/wayfinder_paths/tests/test_jobs_tiered_evidence.py
@@ -246,3 +246,69 @@ def test_probation_registry_lifecycle(tmp_path) -> None:
     journal = (store.job_dir(job.id) / "journal.jsonl").read_text()
     assert "probation_leg_opened" in journal
     assert "probation_leg_killed" in journal
+
+
+def test_forward_view_trades_and_marker_directions(tmp_path) -> None:
+    import json as _json
+
+    from wayfinder_paths.jobs.forward_artifacts import load_forward_view
+    from wayfinder_paths.jobs.models import WayfinderJob
+    from wayfinder_paths.jobs.store import JobStore
+
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("view-demo", agent_mode="intervene")
+    store.save(job)
+    forward = store.job_dir(job.id) / "results" / "forward"
+    forward.mkdir(parents=True, exist_ok=True)
+    fills = [
+        {
+            "symbol": "LIT",
+            "side": "sell",
+            "reduce_only": False,
+            "status": "filled",
+            "timestamp": "2026-07-22T15:05:00+00:00",
+            "avg_price": 2.3308,
+            "raw": {"intent_metadata": {"entry_reason": "fade"}},
+        },
+        {
+            "symbol": "LIT",
+            "side": "buy",
+            "reduce_only": True,
+            "status": "filled",
+            "timestamp": "2026-07-22T16:05:00+00:00",
+            "avg_price": 2.3908,
+            "raw": {"intent_metadata": {"exit_reason": ""}},
+        },
+    ]
+    (forward / "fills.jsonl").write_text(
+        "\n".join(_json.dumps(f) for f in fills) + "\n", encoding="utf-8"
+    )
+    (forward / "trades.jsonl").write_text(
+        _json.dumps(
+            {
+                "symbol": "LIT",
+                "side": "buy",
+                "price": 2.3908,
+                "net_pnl": -0.644,
+                "closed_at": "2026-07-22T16:05:00+00:00",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (forward / "ticks.jsonl").write_text("", encoding="utf-8")
+
+    view = load_forward_view(job.id, store=store, include_prices=False)
+    # Markers say LONG/SHORT, not buy/sell: a sell entry is a SHORT entry
+    # and the buy that closes it is a SHORT exit.
+    entry, exit_ = view["visualization"]["markers"]
+    assert entry["direction"] == "short" and entry["kind"] == "entry"
+    assert exit_["direction"] == "short" and exit_["kind"] == "exit"
+    assert "short entry" in entry["label"]
+    # Full trades list: entry-joined with direction and duration.
+    trade = view["trades"][0]
+    assert trade["direction"] == "short"
+    assert trade["entry_price"] == 2.3308 and trade["exit_price"] == 2.3908
+    assert trade["duration_minutes"] == 60
+    assert trade["entry_reason"] == "fade"
+    assert trade["exit_reason"] == "bracket_stop"


### PR DESCRIPTION
Owner-facing data-contract fixes for the jobs UI:

1. **Chart markers say long/short, not buy/sell.** A buy that reduces closes a SHORT — fill side is ambiguous on a chart. Markers now carry `direction` (entry: buy=long, sell=short; exit inverted) and labels read `paper short entry: fade`.
2. **Full trades record replaces the raw tail.** The forward-view payload's top-level `trades` is now the complete entry-joined record (capped at 500, newest first): `direction`, `entry_ts`/`entry_price`, `exit_ts`/`exit_price`, `duration_minutes`, `net_pnl`, `entry_reason`, `exit_reason` (closing-fill metadata with `bracket_stop` fallback), `mode` — reusing the forensics entry-matching helpers so join semantics are identical to the analytics.

Companion FE PR (all-trades table + L/S marker rendering) follows in vault-frontend. Test covers the short round-trip (marker directions both legs + joined trade fields). 38 pass; ruff clean.