### PR TITLE
jobs: post-apply shadow counterfactual — mechanical prior-revision A/B

### DIFF
--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -19,6 +19,7 @@ from wayfinder_paths.jobs.backtest_artifacts import (
     load_backtest_view,
 )
 from wayfinder_paths.jobs.compiler import JobCompiler, compile_job
+from wayfinder_paths.jobs.counterfactual import counterfactual_job
 from wayfinder_paths.jobs.execution.driver import tick_job
 from wayfinder_paths.jobs.execution.experiments import (
     list_experiments,
@@ -1054,6 +1055,30 @@ def forward_view_cmd(
         include_prices=not no_prices,
     )
     _echo_json({"ok": True, "result": result})
+
+
+@job_cli.command(
+    name="counterfactual",
+    help="Post-apply shadow A/B: replay the PRE-apply strategy (rollback "
+    "backup) over the forward bars since apply and diff it against the "
+    "actual book — skipped/added entries and net-PnL delta. This is how "
+    "entry-gating changes are adjudicated; their cost never prints in the "
+    "live book.",
+)
+@click.argument("job_id")
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Recompute even if the cached artifact is fresh.",
+)
+def counterfactual_cmd(job_id: str, force: bool) -> None:
+    _echo_json(
+        {
+            "ok": True,
+            "result": counterfactual_job(job_id, store=JobStore(), force=force),
+        }
+    )
 
 
 @job_cli.command(

--- a/wayfinder_paths/jobs/counterfactual.py
+++ b/wayfinder_paths/jobs/counterfactual.py
@@ -1,0 +1,422 @@
+"""Post-apply shadow counterfactual: replay the pre-apply strategy over the
+forward window and diff it against the actual book.
+
+A proposal that gates or reshapes entries leaves no live evidence of what it
+cost — skipped trades never print. This module makes the counterfactual
+mechanical instead of something the agent must remember to reconstruct: after
+any promoted proposal, the rollback backup (`applications/{pid}/backup/`)
+holds the exact pre-apply strategy, so we run it through the same simulator
+the backtests use, over venue bars covering the forward window, and diff the
+shadow book against the actual one. The wake prompt renders the result, so
+"the old revision is beating the new one" is read, not recomputed.
+
+Basis caveat (recorded in the artifact): the shadow sizes off the simulator's
+base equity while the live book sizes off its own equity at apply time, so
+absolute PnL is comparable in direction and rough magnitude, not to the cent.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from wayfinder_paths.jobs.models import utc_now_iso
+from wayfinder_paths.jobs.store import JobStore
+
+COUNTERFACTUAL_PATH = "results/forward/counterfactual.json"
+# EMA-50 on a 30m view derived from 5m bars needs 600 bars; 720 covers the
+# slowest indicator families in the priors library with margin.
+_WARMUP_BARS = 720
+# Hyperliquid's candle endpoint caps near 5000 rows per request.
+_MAX_FETCH_BARS = 4500
+_MIN_WINDOW_BARS = 12
+_RECOMPUTE_AFTER_S = 6 * 3600
+_EXAMPLE_LIMIT = 5
+
+BASIS_NOTE = (
+    "Shadow book = the PRE-apply strategy (rollback backup) replayed by the "
+    "backtest simulator over the same forward bars; actual = the live paper "
+    "book. delta_net_pnl = actual - shadow: negative means the pre-change "
+    "revision would have done better since apply. Shadow sizes off simulator "
+    "base equity, so compare direction and magnitude, not cents. "
+    "entries_skipped_by_change fired in the shadow but not the live book "
+    "(what the change suppressed); entries_added_by_change is the reverse."
+)
+
+
+def load_counterfactual(store: JobStore, job_id: str) -> dict[str, Any] | None:
+    doc = store.read_json(job_id, COUNTERFACTUAL_PATH)
+    return doc if isinstance(doc, dict) else None
+
+
+def last_promotion(root: Path) -> dict[str, Any] | None:
+    path = root / "versions" / "revisions.jsonl"
+    if not path.exists():
+        return None
+    last: dict[str, Any] | None = None
+    for line in path.read_text(encoding="utf-8").splitlines():
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(row, dict) and row.get("proposal_id"):
+            last = row
+    return last
+
+
+def counterfactual_job(
+    job_id: str,
+    *,
+    store: JobStore | None = None,
+    force: bool = False,
+    fetch_bars: Callable[..., list[dict[str, Any]]] | None = None,
+    simulate: Callable[..., Any] | None = None,
+) -> dict[str, Any]:
+    store = store or JobStore()
+    root = store.job_dir(job_id)
+
+    promotion = last_promotion(root)
+    if not promotion:
+        return _unavailable("no promoted proposal on record")
+    proposal_id = str(promotion["proposal_id"])
+    applied_at = str(promotion.get("ts") or "")
+    revision = str(promotion.get("revision") or "")
+
+    backup_root = root / "applications" / proposal_id / "backup"
+    backup_yaml = backup_root / "job.yaml"
+    if not (backup_root / "workspace").is_dir() or not backup_yaml.exists():
+        return _unavailable(f"rollback backup missing for {proposal_id}")
+
+    trades_path = root / "results" / "forward" / "trades.jsonl"
+    actual_closes_total = _count_lines(trades_path)
+    cached = load_counterfactual(store, job_id)
+    if not force and cached and cached.get("available"):
+        fingerprint = cached.get("fingerprint") or {}
+        fresh = (
+            fingerprint.get("revision") == revision
+            and fingerprint.get("actual_closes_total") == actual_closes_total
+            and _age_seconds(str(cached.get("computed_at"))) < _RECOMPUTE_AFTER_S
+        )
+        if fresh:
+            return cached
+
+    try:
+        artifact = _compute(
+            store,
+            job_id,
+            root,
+            backup_root=backup_root,
+            proposal_id=proposal_id,
+            applied_at=applied_at,
+            revision=revision,
+            fetch_bars=fetch_bars,
+            simulate=simulate,
+        )
+    except Exception as exc:  # noqa: BLE001 — wake context must not die on this
+        store.append_journal(
+            job_id,
+            {
+                "type": "counterfactual_failed",
+                "proposal_id": proposal_id,
+                "error": str(exc)[:400],
+            },
+        )
+        return _unavailable(f"compute failed: {exc}")
+
+    artifact["fingerprint"] = {
+        "revision": revision,
+        "actual_closes_total": actual_closes_total,
+    }
+    store.write_json(job_id, COUNTERFACTUAL_PATH, artifact)
+    return artifact
+
+
+def _compute(
+    store: JobStore,
+    job_id: str,
+    root: Path,
+    *,
+    backup_root: Path,
+    proposal_id: str,
+    applied_at: str,
+    revision: str,
+    fetch_bars: Callable[..., list[dict[str, Any]]] | None,
+    simulate: Callable[..., Any] | None,
+) -> dict[str, Any]:
+    import pandas as pd
+    import yaml
+
+    from wayfinder_paths.jobs.execution.primitives import (
+        ExecutionSpec,
+        bar_interval_seconds,
+    )
+    from wayfinder_paths.jobs.execution.simulator import (
+        PreparedExecutionDataset,
+        simulate_execution,
+    )
+    from wayfinder_paths.jobs.execution.validation import resolve_execution_spec
+
+    active_data = yaml.safe_load((root / "job.yaml").read_text(encoding="utf-8")) or {}
+    backup_data = (
+        yaml.safe_load(backup_root.joinpath("job.yaml").read_text(encoding="utf-8"))
+        or {}
+    )
+
+    active_spec_data, _ = resolve_execution_spec(root, active_data)
+    # The spec file lives at the job root (outside the backup), so an embedded
+    # spec in the backup job.yaml wins and the active file is the fallback.
+    backup_spec_data, _ = resolve_execution_spec(root, backup_data)
+    if not backup_spec_data:
+        raise RuntimeError("execution_spec unresolvable for backup revision")
+    if (active_spec_data or {}).get("data_contract") != backup_spec_data.get(
+        "data_contract"
+    ):
+        return _unavailable(
+            "data contract changed by the proposal — shadow not comparable"
+        )
+
+    spec = ExecutionSpec.from_dict(backup_spec_data)
+    params = dict(backup_data.get("execution_params") or {})
+    bar_interval = spec.data_contract.get("bar_interval")
+    interval_seconds = bar_interval_seconds(bar_interval)
+    if not interval_seconds:
+        raise RuntimeError("execution_spec.data_contract.bar_interval missing")
+    symbols = [
+        str(symbol)
+        for symbol in (params.get("symbols") or spec.data_contract.get("symbols") or [])
+    ]
+    if not symbols:
+        raise RuntimeError("no symbols configured")
+
+    script = store.resolve_script_entrypoint(
+        job_id, backup_data, candidate_dir=backup_root
+    )
+    if script is None or not script.exists():
+        raise RuntimeError(f"backup entrypoint not found: {script}")
+
+    now = pd.Timestamp.now(tz="UTC")
+    apply_ts = pd.Timestamp(applied_at)
+    if apply_ts.tzinfo is None:
+        apply_ts = apply_ts.tz_localize("UTC")
+    bars_since_apply = int((now - apply_ts).total_seconds() // interval_seconds)
+    if bars_since_apply < _MIN_WINDOW_BARS:
+        return _unavailable(
+            f"only {bars_since_apply} bars since apply — too fresh to compare"
+        )
+    lookback = min(bars_since_apply + _WARMUP_BARS, _MAX_FETCH_BARS)
+
+    fetch = fetch_bars or _fetch_venue_bars
+    rows = fetch(
+        spec=spec,
+        params=params,
+        symbols=symbols,
+        bar_interval=str(bar_interval),
+        lookback_bars=lookback,
+        as_of=now,
+    )
+    if not rows:
+        raise RuntimeError("no bars returned for the counterfactual window")
+    dataset = PreparedExecutionDataset.from_rows(
+        rows, {"source": "counterfactual_venue_fetch", "lookback_bars": lookback}
+    )
+    timestamps = sorted({pd.Timestamp(row["timestamp"]) for row in rows})
+    # If the fetch could not reach back a full warmup before apply, indicators
+    # are still warming inside the window — start the comparison late instead
+    # of comparing a half-warmed shadow.
+    warm_index = min(_WARMUP_BARS, max(len(timestamps) - 1, 0))
+    warm_ready = timestamps[warm_index]
+    if warm_ready.tzinfo is None:
+        warm_ready = warm_ready.tz_localize("UTC")
+    effective_from = max(apply_ts, warm_ready)
+
+    run = simulate or simulate_execution
+    result = run(script, dataset, spec, params)
+    shadow_rows = [dict(row) for row in result.trades]
+
+    shadow_entries = _entries(shadow_rows, effective_from, interval_seconds)
+    shadow_closes = [
+        row
+        for row in shadow_rows
+        if row.get("reduce_only") and _ts(row.get("timestamp")) >= effective_from
+    ]
+    shadow_net = sum(
+        float(row.get("realized_pnl_delta") or 0.0) for row in shadow_closes
+    )
+
+    actual_close_rows = [
+        row
+        for row in _read_jsonl(root / "results" / "forward" / "trades.jsonl")
+        if _ts(row.get("closed_at") or row.get("timestamp")) >= effective_from
+    ]
+    actual_net = sum(float(row.get("net_pnl") or 0.0) for row in actual_close_rows)
+    actual_fill_rows = [
+        row
+        for row in _read_jsonl(root / "results" / "forward" / "fills.jsonl")
+        if str(row.get("status") or "filled") == "filled" and not row.get("reduce_only")
+    ]
+    actual_entries = _entries(actual_fill_rows, effective_from, interval_seconds)
+
+    skipped = sorted(set(shadow_entries) - set(actual_entries))
+    added = sorted(set(actual_entries) - set(shadow_entries))
+
+    by_symbol: dict[str, dict[str, Any]] = {}
+    for symbol in symbols:
+        by_symbol[symbol] = {
+            "actual_net_pnl": round(
+                sum(
+                    float(row.get("net_pnl") or 0.0)
+                    for row in actual_close_rows
+                    if str(row.get("symbol")) == symbol
+                ),
+                4,
+            ),
+            "shadow_net_pnl": round(
+                sum(
+                    float(row.get("realized_pnl_delta") or 0.0)
+                    for row in shadow_closes
+                    if str(row.get("symbol")) == symbol
+                ),
+                4,
+            ),
+            "actual_closes": sum(
+                1 for row in actual_close_rows if str(row.get("symbol")) == symbol
+            ),
+            "shadow_closes": sum(
+                1 for row in shadow_closes if str(row.get("symbol")) == symbol
+            ),
+        }
+
+    return {
+        "available": True,
+        "proposal_id": proposal_id,
+        "applied_at": applied_at,
+        "active_revision": revision,
+        "window": {
+            "from": effective_from.isoformat(),
+            "to": now.isoformat(),
+            "days": round((now - effective_from).total_seconds() / 86400.0, 1),
+            "warmup_truncated": bool(effective_from > apply_ts),
+        },
+        "actual": {"closes": len(actual_close_rows), "net_pnl": round(actual_net, 4)},
+        "shadow": {"closes": len(shadow_closes), "net_pnl": round(shadow_net, 4)},
+        "delta_net_pnl": round(actual_net - shadow_net, 4),
+        "by_symbol": by_symbol,
+        "entries_skipped_by_change": {
+            "count": len(skipped),
+            "examples": [_entry_dict(item) for item in skipped[:_EXAMPLE_LIMIT]],
+        },
+        "entries_added_by_change": {
+            "count": len(added),
+            "examples": [_entry_dict(item) for item in added[:_EXAMPLE_LIMIT]],
+        },
+        "_basis": BASIS_NOTE,
+        "computed_at": utc_now_iso(),
+    }
+
+
+def _fetch_venue_bars(
+    *,
+    spec: Any,
+    params: dict[str, Any],
+    symbols: list[str],
+    bar_interval: str,
+    lookback_bars: int,
+    as_of: Any,
+) -> list[dict[str, Any]]:
+    import asyncio
+
+    from wayfinder_paths.jobs.execution.primitives import CompletedBarsView
+    from wayfinder_paths.jobs.execution.venues import build_adapter
+
+    async def _fetch() -> list[dict[str, Any]]:
+        rows: list[dict[str, Any]] = []
+        # mode="paper" builds the read-only market-data side; no signing/keys.
+        for venue in spec.venues or ["hyperliquid"]:
+            adapter = build_adapter(venue, mode="paper", spec=spec, params=params)
+            view = await adapter.feed.get_completed_bars(
+                symbols, bar_interval, lookback_bars=lookback_bars, as_of=as_of
+            )
+            rows.extend(view.to_rows())
+        if not rows:
+            raise RuntimeError("no completed bars returned by any venue feed")
+        return CompletedBarsView.from_rows(rows).to_rows()
+
+    return asyncio.run(_fetch())
+
+
+def _entries(
+    rows: list[dict[str, Any]], effective_from: Any, interval_seconds: int
+) -> list[tuple[str, str, str]]:
+    """Entry identity keys: (symbol, bar-floored ts, position side)."""
+    import pandas as pd
+
+    keys: list[tuple[str, str, str]] = []
+    for row in rows:
+        if row.get("reduce_only"):
+            continue
+        ts = _ts(row.get("timestamp"))
+        if ts is pd.NaT or ts < effective_from:
+            continue
+        floored = pd.Timestamp(
+            (ts.value // (interval_seconds * 1_000_000_000))
+            * interval_seconds
+            * 1_000_000_000,
+            tz="UTC",
+        )
+        side = "long" if str(row.get("side") or "").lower() == "buy" else "short"
+        keys.append((str(row.get("symbol")), floored.isoformat(), side))
+    return keys
+
+
+def _entry_dict(key: tuple[str, str, str]) -> dict[str, str]:
+    symbol, ts, side = key
+    return {"symbol": symbol, "ts": ts, "side": side}
+
+
+def _ts(value: Any) -> Any:
+    import pandas as pd
+
+    ts = pd.Timestamp(str(value)) if value else pd.NaT
+    if ts is not pd.NaT and ts.tzinfo is None:
+        ts = ts.tz_localize("UTC")
+    return ts
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(row, dict):
+            rows.append(row)
+    return rows
+
+
+def _count_lines(path: Path) -> int:
+    if not path.exists():
+        return 0
+    return sum(
+        1 for line in path.read_text(encoding="utf-8").splitlines() if line.strip()
+    )
+
+
+def _age_seconds(computed_at: str) -> float:
+    import pandas as pd
+
+    try:
+        computed = pd.Timestamp(computed_at)
+    except ValueError:
+        return float("inf")
+    if computed.tzinfo is None:
+        computed = computed.tz_localize("UTC")
+    return float((pd.Timestamp.now(tz="UTC") - computed).total_seconds())
+
+
+def _unavailable(reason: str) -> dict[str, Any]:
+    return {"available": False, "reason": reason}

--- a/wayfinder_paths/jobs/prompts/research_priors.md
+++ b/wayfinder_paths/jobs/prompts/research_priors.md
@@ -66,3 +66,5 @@ block's archetype counts and pick the family that treats YOUR disease.
   owner rejections bind on the change, not its neighborhood.
 - **Long runs via CLI in-session (detached with a log), never MCP ops** —
   the 300s op timeout cannot hold a grid.
+
+**Post-apply shadow (mechanical counterfactual).** After any applied proposal the harness replays the pre-apply strategy over the forward bars and diffs it against the actual book (`post_apply_shadow` in the wake context; `wayfinder job counterfactual <job_id>` on demand). Entry-gating changes are adjudicated HERE — a filter's cost is invisible in the live book because skipped trades never print. Shadow sustainably ahead => revert/adjust proposal citing the block; active ahead => log the forward validation in the decisions ledger. Never hand-recompute counterfactuals.

--- a/wayfinder_paths/jobs/sync.py
+++ b/wayfinder_paths/jobs/sync.py
@@ -197,6 +197,7 @@ def snapshot_job(job_id: str, *, store: JobStore | None = None) -> dict[str, Any
         "runner_links": runner_links,
         "proposals": store.proposals(job_id),
         "probation": store.read_json(job_id, "probation.json", default={"legs": []}),
+        "post_apply_shadow": _shadow_topline(store, job_id),
         "proposal_queue": store.proposal_queue(job_id),
         "reports": {
             "monitor": latest_monitor,
@@ -273,3 +274,15 @@ def apply_script_mode(
     result = JobCompiler(store=store).compile(job)
     sync_all_jobs(store=store)
     return {"job_id": job_id, "mode": mode, "compile": result}
+
+
+def _shadow_topline(store: JobStore, job_id: str) -> dict[str, Any]:
+    """Read-only topline of the post-apply counterfactual for the UI — the
+    artifact is computed on the wake path, never during sync."""
+    from wayfinder_paths.jobs.counterfactual import load_counterfactual
+
+    doc = load_counterfactual(store, job_id)
+    if not doc or not doc.get("available"):
+        return {}
+    keys = ("proposal_id", "applied_at", "window", "actual", "shadow", "delta_net_pnl")
+    return {key: doc[key] for key in keys if key in doc}

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -118,6 +118,34 @@ def _attribution_block(root: Path) -> dict[str, Any]:
     return block
 
 
+def _counterfactual_block(store: JobStore, job_id: str) -> dict[str, Any]:
+    """Mechanical post-apply A/B: the pre-apply strategy (rollback backup)
+    replayed over the forward bars since apply, diffed against the actual
+    book. Computed here (cached, ~6h refresh) so the evidence EXISTS every
+    wake — the agent reads it, it never reconstructs counterfactuals."""
+    from wayfinder_paths.jobs.counterfactual import counterfactual_job
+
+    try:
+        doc = counterfactual_job(job_id, store=store)
+    except Exception as exc:  # noqa: BLE001 — wake context must not die on this
+        return {"_status": f"unavailable: {exc}"}
+    if not doc.get("available"):
+        return {"_status": str(doc.get("reason") or "unavailable")}
+    keys = (
+        "proposal_id",
+        "applied_at",
+        "window",
+        "actual",
+        "shadow",
+        "delta_net_pnl",
+        "by_symbol",
+        "entries_skipped_by_change",
+        "entries_added_by_change",
+        "_basis",
+    )
+    return {key: doc[key] for key in keys if key in doc}
+
+
 def _drop_volatile_stable_keys(value: Any) -> Any:
     match value:
         case dict():
@@ -206,6 +234,7 @@ def _build_worker_prompt_sections(
         },
         "trade_forensics": _trade_forensics_block(root),
         "attribution": _attribution_block(root),
+        "post_apply_shadow": _counterfactual_block(store, job_id),
     }
 
     stable_prefix = (
@@ -376,6 +405,19 @@ def _build_worker_prompt_sections(
             "grid+WF-validated exit change motivated by them is a legitimate "
             "proposal even below the forward-sample floor, because its "
             "evidence is the backtest population, not the forward sample.\n"
+            "- Post-apply shadow lane: `post_apply_shadow` in the dynamic "
+            "context is a MECHANICAL A/B — the pre-apply strategy (rollback "
+            "backup) replayed over the forward bars since apply, diffed "
+            "against the actual book. Read it on every wake while a change "
+            "is live; never hand-recompute counterfactuals. If the shadow "
+            "outperforms the active book by a meaningful sustained margin "
+            "(>=14 days of divergence, or entries_skipped_by_change whose "
+            "shadow outcomes are clearly positive), that is first-class "
+            "evidence for a revert/adjust proposal — cite the block. If the "
+            "active book leads, record that in the decisions ledger as the "
+            "change's forward validation. This is how entry-gating changes "
+            "(filters) are adjudicated: their cost never prints in the live "
+            "book, only here.\n"
             "- EVIDENCE TIERS: verdict 'promote' (unchanged full gates) -> "
             "full-size leg. Verdict 'probation' (near-miss alive NOW, "
             "regime-conditional edge in the CURRENT regime, or a declared "

--- a/wayfinder_paths/tests/test_jobs_counterfactual.py
+++ b/wayfinder_paths/tests/test_jobs_counterfactual.py
@@ -1,0 +1,239 @@
+"""Post-apply shadow counterfactual: replay the pre-apply strategy over the
+forward window, diff against the actual book, surface skipped/added entries."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pandas as pd
+import yaml
+
+from wayfinder_paths.jobs.counterfactual import (
+    COUNTERFACTUAL_PATH,
+    counterfactual_job,
+    load_counterfactual,
+)
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.store import JobStore
+
+_SPEC = {
+    "data_contract": {"bar_interval": "5m", "symbols": ["LIT"]},
+    "venues": ["hyperliquid"],
+}
+
+
+def _mk_job(tmp_path, *, applied_hours_ago: float = 24.0) -> tuple[JobStore, str]:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("cf-demo", agent_mode="intervene")
+    store.save(job)
+    root = store.job_dir(job.id)
+
+    job_yaml = {
+        "id": job.id,
+        "script_loop": {"enabled": True, "entrypoint": "workspace/src/strategy.py"},
+        "execution_spec": _SPEC,
+        "execution_params": {"symbols": ["LIT"]},
+    }
+    (root / "job.yaml").write_text(yaml.safe_dump(job_yaml), encoding="utf-8")
+
+    backup = root / "applications" / "prop-x" / "backup"
+    (backup / "workspace" / "src").mkdir(parents=True)
+    (backup / "workspace" / "src" / "strategy.py").write_text(
+        "def build_strategy():\n    raise NotImplementedError\n", encoding="utf-8"
+    )
+    (backup / "job.yaml").write_text(yaml.safe_dump(job_yaml), encoding="utf-8")
+
+    applied = pd.Timestamp.now(tz="UTC") - pd.Timedelta(hours=applied_hours_ago)
+    versions = root / "versions"
+    versions.mkdir(exist_ok=True)
+    (versions / "revisions.jsonl").write_text(
+        json.dumps(
+            {"ts": applied.isoformat(), "revision": "rev-new", "proposal_id": "prop-x"}
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return store, job.id
+
+
+def _bars(*, count: int = 1100, interval_s: int = 300) -> list[dict]:
+    end = pd.Timestamp.now(tz="UTC").floor("5min")
+    rows = []
+    for i in range(count):
+        ts = end - pd.Timedelta(seconds=interval_s * (count - i))
+        rows.append(
+            {
+                "timestamp": ts.isoformat(),
+                "symbol": "LIT",
+                "open": 2.0,
+                "high": 2.1,
+                "low": 1.9,
+                "close": 2.0,
+                "volume": 10.0,
+            }
+        )
+    return rows
+
+
+def _fill(ts: pd.Timestamp, *, side: str, reduce_only: bool, pnl: float = 0.0) -> dict:
+    return {
+        "symbol": "LIT",
+        "side": side,
+        "reduce_only": reduce_only,
+        "status": "filled",
+        "filled_size": 1.0,
+        "avg_price": 2.0,
+        "timestamp": ts.isoformat(),
+        "realized_pnl_delta": pnl,
+    }
+
+
+def test_counterfactual_diffs_shadow_against_actual(tmp_path) -> None:
+    store, job_id = _mk_job(tmp_path)
+    root = store.job_dir(job_id)
+    now = pd.Timestamp.now(tz="UTC").floor("5min")
+    t_shared = now - pd.Timedelta(hours=6)
+    t_skipped = now - pd.Timedelta(hours=4)
+
+    # Shadow (pre-apply strategy) trades BOTH entries; the live book only took
+    # the shared one — t_skipped is what the change suppressed, and its shadow
+    # close won +0.9.
+    shadow_trades = [
+        _fill(t_shared, side="sell", reduce_only=False),
+        _fill(
+            t_shared + pd.Timedelta(minutes=80), side="buy", reduce_only=True, pnl=-0.2
+        ),
+        _fill(t_skipped, side="sell", reduce_only=False),
+        _fill(
+            t_skipped + pd.Timedelta(minutes=80), side="buy", reduce_only=True, pnl=0.9
+        ),
+    ]
+    forward = root / "results" / "forward"
+    forward.mkdir(parents=True, exist_ok=True)
+    (forward / "fills.jsonl").write_text(
+        json.dumps(_fill(t_shared, side="sell", reduce_only=False)) + "\n",
+        encoding="utf-8",
+    )
+    (forward / "trades.jsonl").write_text(
+        json.dumps(
+            {
+                "symbol": "LIT",
+                "side": "buy",
+                "price": 2.02,
+                "net_pnl": -0.25,
+                "closed_at": (t_shared + pd.Timedelta(minutes=80)).isoformat(),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    captured: dict = {}
+
+    def fake_fetch(**kwargs) -> list[dict]:
+        captured["lookback"] = kwargs["lookback_bars"]
+        return _bars()
+
+    def fake_sim(script, dataset, spec, params):
+        captured["script"] = str(script)
+        return SimpleNamespace(trades=shadow_trades)
+
+    doc = counterfactual_job(
+        job_id, store=store, fetch_bars=fake_fetch, simulate=fake_sim
+    )
+    assert doc["available"] is True
+    assert doc["proposal_id"] == "prop-x"
+    assert "applications/prop-x/backup" in captured["script"]
+
+    assert doc["actual"] == {"closes": 1, "net_pnl": -0.25}
+    assert doc["shadow"] == {"closes": 2, "net_pnl": 0.7}
+    assert doc["delta_net_pnl"] == -0.95
+    assert doc["entries_skipped_by_change"]["count"] == 1
+    assert doc["entries_skipped_by_change"]["examples"][0]["side"] == "short"
+    assert doc["entries_added_by_change"]["count"] == 0
+    assert doc["by_symbol"]["LIT"]["shadow_closes"] == 2
+
+    # Artifact persisted and served from cache while inputs are unchanged.
+    assert load_counterfactual(store, job_id)["delta_net_pnl"] == -0.95
+    captured["script"] = None
+    again = counterfactual_job(
+        job_id, store=store, fetch_bars=fake_fetch, simulate=fake_sim
+    )
+    assert again["computed_at"] == doc["computed_at"]
+    assert captured["script"] is None  # sim was not re-run
+
+    # A new actual close invalidates the fingerprint and recomputes.
+    with (forward / "trades.jsonl").open("a", encoding="utf-8") as fh:
+        fh.write(
+            json.dumps(
+                {
+                    "symbol": "LIT",
+                    "side": "buy",
+                    "price": 2.0,
+                    "net_pnl": 0.1,
+                    "closed_at": now.isoformat(),
+                }
+            )
+            + "\n"
+        )
+    recomputed = counterfactual_job(
+        job_id, store=store, fetch_bars=fake_fetch, simulate=fake_sim
+    )
+    assert recomputed["actual"]["closes"] == 2
+    assert captured["script"] is not None
+
+
+def test_counterfactual_unavailable_paths(tmp_path) -> None:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("cf-empty", agent_mode="intervene")
+    store.save(job)
+    doc = counterfactual_job(job.id, store=store)
+    assert doc["available"] is False
+    assert "no promoted proposal" in doc["reason"]
+
+    # Too fresh: applied minutes ago -> refuse to compare noise.
+    store2, job2 = _mk_job(tmp_path / "j2", applied_hours_ago=0.1)
+    doc2 = counterfactual_job(job2, store=store2)
+    assert doc2["available"] is False
+    assert "too fresh" in doc2["reason"]
+
+    # Simulator blowing up must journal + degrade, never raise.
+    store3, job3 = _mk_job(tmp_path / "j3")
+
+    def boom(**kwargs):
+        raise RuntimeError("venue down")
+
+    doc3 = counterfactual_job(job3, store=store3, fetch_bars=boom)
+    assert doc3["available"] is False
+    journal = (store3.job_dir(job3) / "journal.jsonl").read_text(encoding="utf-8")
+    assert "counterfactual_failed" in journal
+
+
+def test_worker_block_renders_topline(tmp_path) -> None:
+    from wayfinder_paths.jobs.worker import _counterfactual_block
+
+    store, job_id = _mk_job(tmp_path)
+    store.write_json(
+        job_id,
+        COUNTERFACTUAL_PATH,
+        {
+            "available": True,
+            "proposal_id": "prop-x",
+            "applied_at": "2026-07-26T11:02:00+00:00",
+            "window": {"days": 3.0},
+            "actual": {"closes": 4, "net_pnl": -0.5},
+            "shadow": {"closes": 6, "net_pnl": 0.4},
+            "delta_net_pnl": -0.9,
+            "by_symbol": {},
+            "entries_skipped_by_change": {"count": 2, "examples": []},
+            "entries_added_by_change": {"count": 0, "examples": []},
+            "_basis": "note",
+            "computed_at": pd.Timestamp.now(tz="UTC").isoformat(),
+            "fingerprint": {"revision": "rev-new", "actual_closes_total": 0},
+        },
+    )
+    block = _counterfactual_block(store, job_id)
+    assert block["delta_net_pnl"] == -0.9
+    assert block["proposal_id"] == "prop-x"
+    assert "fingerprint" not in block and "computed_at" not in block


### PR DESCRIPTION
Follow-up to the LIT regime-filter proposal discussion: an entry-gating change's cost is invisible in the live book (skipped trades never print), and requiring the owner to attach counterfactual instructions to every approval doesn't scale. This makes the counterfactual part of the flow.

**Mechanism** — after any promoted proposal, the harness replays the **pre-apply strategy** (the rollback backup every apply already keeps) through the existing backtest simulator over venue bars covering the forward window, and diffs the shadow book against the actual one:

- topline: actual vs shadow net PnL since apply + `delta_net_pnl`
- per-symbol split (a symbol-scoped filter shows up directly)
- `entries_skipped_by_change` / `entries_added_by_change` with examples (bar-floored symbol+side identity)

**Honesty details**: comparison window starts only once indicators are warm (`_WARMUP_BARS`); refuses to compare when the proposal changed the data contract or is <12 bars old; artifact records the sizing-basis caveat (shadow sizes off sim base equity). Cached by revision + actual-trade-count fingerprint with a 6h refresh; any failure degrades to an unavailable block + journaled `counterfactual_failed` — a wake can never die on it.

**Surfaces**:
- `post_apply_shadow` block in the wake dynamic context + a stable-prefix lane: shadow sustainably ahead (≥14d divergence or clearly-positive skipped-entry outcomes) ⇒ revert/adjust proposal citing the block; active ahead ⇒ record the change's forward validation in the decisions ledger. Never hand-recompute counterfactuals.
- job snapshot gains a read-only `post_apply_shadow` topline (backend/UI ride-along, no compute during sync).
- `wayfinder job counterfactual <job_id> [--force]` CLI.
- `research_priors.md`: entry-gating changes are adjudicated here.

Tests: full diff path with injected bars/sim (skipped-entry detection, per-symbol split, cache fingerprint + invalidation), unavailable paths (no promotion / too fresh / venue failure journals and degrades), worker block topline rendering. 41+2 adjacent tests pass; ruff clean.