### PR TITLE
jobs: refresh derived features on the wake path — stop silent staleness

### DIFF
--- a/wayfinder_paths/jobs/derived_features.py
+++ b/wayfinder_paths/jobs/derived_features.py
@@ -218,3 +218,55 @@ def derive_features_job(
             "one in the LIVE strategy is a proposal-gated change."
         ),
     }
+
+
+REFRESH_STAMP_PATH = "results/research/derived_refresh.json"
+# Just under the hourly design cadence so a 30m wake rhythm refreshes every
+# other wake instead of aliasing to 90m.
+REFRESH_MAX_AGE_S = 3300
+_REFRESH_SETS = ("cross", "exog", "venue", "regime")
+
+
+def refresh_derived_features_if_stale(
+    job_id: str,
+    *,
+    store: JobStore | None = None,
+    max_age_seconds: int = REFRESH_MAX_AGE_S,
+    derive: Callable[..., dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Keep research-side derived features live from the wake path.
+
+    The derive op alone rots: a one-time backfill leaves btc_trend/cross
+    columns silently frozen (they merge cleanly into scans with stale
+    values). The consumer of these columns is the agent wake's research, so
+    the wake is the refresh point — stamp-gated to the design's hourly
+    cadence, and NEVER raising: a broken exog fetch degrades to a journaled
+    skip, not a dead wake."""
+    store = store or JobStore()
+    stamp = store.read_json(job_id, REFRESH_STAMP_PATH) or {}
+    refreshed_at = str(stamp.get("refreshed_at") or "")
+    if refreshed_at:
+        age = (
+            dt.datetime.now(dt.UTC) - dt.datetime.fromisoformat(refreshed_at)
+        ).total_seconds()
+        if age < max_age_seconds:
+            return {"refreshed": False, "reason": f"fresh ({int(age)}s old)"}
+    run = derive or derive_features_job
+    try:
+        result = run(job_id, sets=_REFRESH_SETS, store=store)
+    except Exception as exc:  # noqa: BLE001 — wake must not die on research prep
+        store.append_journal(
+            job_id,
+            {"type": "derived_features_refresh_failed", "error": str(exc)[:300]},
+        )
+        return {"refreshed": False, "reason": f"failed: {exc}"}
+    store.write_json(
+        job_id,
+        REFRESH_STAMP_PATH,
+        {
+            "refreshed_at": str(dt.datetime.now(dt.UTC)),
+            "rows_appended": result.get("rows_appended"),
+            "sets": result.get("sets"),
+        },
+    )
+    return {"refreshed": True, "rows_appended": result.get("rows_appended")}

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -9,6 +9,7 @@ from typing import Any
 from loguru import logger
 
 from wayfinder_paths.core.clients.OpenCodeClient import OPENCODE_CLIENT
+from wayfinder_paths.jobs.derived_features import refresh_derived_features_if_stale
 from wayfinder_paths.jobs.forward import is_forward_empty
 from wayfinder_paths.jobs.ledger import tail_ledger
 from wayfinder_paths.jobs.memory_hygiene import sanitize_job_memory
@@ -543,6 +544,13 @@ def prepare_job_worker_prompt(
     # unsupported performance claims from durable memory before the agent reads
     # it, so a prior wake's confabulation cannot propagate. No-op otherwise.
     sanitize_job_memory(store, job.id, forward=snapshot.get("forward"))
+
+    # Research-side derived features (cross/exog/venue/regime) refresh here
+    # because THIS wake's scans are their consumer — a one-time backfill
+    # otherwise goes silently stale (btc_trend froze for 4 days while
+    # merging cleanly into every scan frame). Stamp-gated hourly; never
+    # raises.
+    refresh_derived_features_if_stale(job.id, store=store)
 
     prompt_sections = _build_worker_prompt_sections(
         store=store,

--- a/wayfinder_paths/tests/test_jobs_derived_features.py
+++ b/wayfinder_paths/tests/test_jobs_derived_features.py
@@ -142,3 +142,44 @@ def test_derived_columns_reach_research_frames(tmp_path: Path) -> None:
     # Execution path unchanged: undeclared features stay out of live frames.
     execution = _load_dataset(root, spec, job_data)
     assert "btc_trend" not in execution.bars.to_frame().columns
+
+
+def test_refresh_if_stale_gates_and_journals(tmp_path) -> None:
+    from wayfinder_paths.jobs.derived_features import (
+        REFRESH_STAMP_PATH,
+        refresh_derived_features_if_stale,
+    )
+    from wayfinder_paths.jobs.models import WayfinderJob
+    from wayfinder_paths.jobs.store import JobStore
+
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("refresh-demo", agent_mode="intervene")
+    store.save(job)
+
+    calls: list[str] = []
+
+    def fake_derive(job_id, **kwargs):
+        calls.append(job_id)
+        return {"rows_appended": 7, "sets": list(kwargs["sets"])}
+
+    # Stale (no stamp) -> derives and stamps.
+    first = refresh_derived_features_if_stale(job.id, store=store, derive=fake_derive)
+    assert first == {"refreshed": True, "rows_appended": 7}
+    assert calls == [job.id]
+    stamp = store.read_json(job.id, REFRESH_STAMP_PATH)
+    assert stamp["rows_appended"] == 7 and "regime" in stamp["sets"]
+
+    # Fresh stamp -> no second derive.
+    second = refresh_derived_features_if_stale(job.id, store=store, derive=fake_derive)
+    assert second["refreshed"] is False and calls == [job.id]
+
+    # Failure: journaled, degraded, no stamp update, never raises.
+    store.write_json(job.id, REFRESH_STAMP_PATH, {})
+
+    def boom(job_id, **kwargs):
+        raise RuntimeError("exog feed down")
+
+    degraded = refresh_derived_features_if_stale(job.id, store=store, derive=boom)
+    assert degraded["refreshed"] is False and "exog feed down" in degraded["reason"]
+    journal = (store.job_dir(job.id) / "journal.jsonl").read_text(encoding="utf-8")
+    assert "derived_features_refresh_failed" in journal


### PR DESCRIPTION
Root-cause fix for the bug found on majors-5m-lab: derived features (`btc_trend`, cross-symbol, venue basis, regime code) were backfilled once and then froze for four days — merging cleanly into every scan frame with stale values, no error anywhere. The agent's top-prior lane (BTC-exog regime gating) sat STARVED on pure plumbing, feeding the EXHAUSTED pipeline status.

**Fix**: the consumer of these columns is the agent wake's research, so the wake is the refresh point. `prepare_job_worker_prompt` calls `refresh_derived_features_if_stale`:

- stamp-gated (`results/research/derived_refresh.json`) to the design's hourly cadence — 3300s so a 30-minute wake rhythm refreshes every other wake instead of aliasing to 90m
- refreshes all four sets (`cross`, `exog`, `venue`, `regime`); append dedup keeps the store coarse
- never raises: a broken exog fetch journals `derived_features_refresh_failed` and degrades — a wake can't die on research prep

This replaces the interim ops fix (hand-registered runner job on the box) with harness behavior every jobs deployment gets by construction — including the end-to-end test box.

Tests: stamp gating (no double-derive within the window), stamp contents, failure path journals + degrades without raising. 9 pass incl. worker cache eval; ruff clean.