### PR TITLE
jobs: research-substrate freshness in the wake context — staleness is data, not memory

### DIFF
--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -147,6 +147,59 @@ def _counterfactual_block(store: JobStore, job_id: str) -> dict[str, Any]:
     return {key: doc[key] for key in keys if key in doc}
 
 
+def _research_substrate_block(root: Path) -> dict[str, Any]:
+    """Freshness of the research substrate, computed from disk EVERY wake.
+
+    Staleness must be data the agent reads, not a memory it repeats: an
+    agenda entry that parked a lane as 'feed stale' otherwise outlives the
+    fix forever, because nothing in the context ever contradicts it (the
+    2026-07-27 BTC-exog wedge — columns were refreshed, three wakes kept
+    citing the old timestamps from the agenda)."""
+    block: dict[str, Any] = {}
+    bars_path = root / "results" / "backtest" / "input_bars.json"
+    if bars_path.exists():
+        try:
+            meta = (
+                json.loads(bars_path.read_text(encoding="utf-8")).get("metadata") or {}
+            )
+            block["dataset_fetched_at"] = meta.get("fetched_at")
+            block["dataset_days"] = meta.get("days")
+        except ValueError:
+            pass
+    feats = root / "state" / "features.jsonl"
+    if feats.exists():
+        newest = ""
+        # Appends are batched chronologically — the tail bounds the newest ts.
+        for line in feats.read_text(encoding="utf-8").splitlines()[-400:]:
+            try:
+                ts = str(json.loads(line).get("timestamp") or "")
+            except ValueError:
+                continue
+            newest = max(newest, ts)
+        if newest:
+            block["derived_features_newest_ts"] = newest
+    stamp_path = root / "results" / "research" / "derived_refresh.json"
+    if stamp_path.exists():
+        try:
+            block["derived_refresh_stamp"] = json.loads(
+                stamp_path.read_text(encoding="utf-8")
+            )
+        except ValueError:
+            pass
+    if block:
+        block["_basis"] = (
+            "Substrate freshness, read from disk THIS wake. Any agenda/"
+            "dead-map entry blocked on 'stale feed/columns' must be checked "
+            "against these timestamps EVERY wake: if they are current, the "
+            "blocker no longer exists — update the agenda and run the lane. "
+            "Never repeat a staleness claim from memory when this block "
+            "contradicts it. To advance the dataset yourself: "
+            "wayfinder job fetch-dataset (derived columns re-derive "
+            "automatically as part of the build)."
+        )
+    return block
+
+
 def _drop_volatile_stable_keys(value: Any) -> Any:
     match value:
         case dict():
@@ -236,6 +289,7 @@ def _build_worker_prompt_sections(
         "trade_forensics": _trade_forensics_block(root),
         "attribution": _attribution_block(root),
         "post_apply_shadow": _counterfactual_block(store, job_id),
+        "research_substrate": _research_substrate_block(root),
     }
 
     stable_prefix = (

--- a/wayfinder_paths/tests/test_jobs_derived_features.py
+++ b/wayfinder_paths/tests/test_jobs_derived_features.py
@@ -183,3 +183,43 @@ def test_refresh_if_stale_gates_and_journals(tmp_path) -> None:
     assert degraded["refreshed"] is False and "exog feed down" in degraded["reason"]
     journal = (store.job_dir(job.id) / "journal.jsonl").read_text(encoding="utf-8")
     assert "derived_features_refresh_failed" in journal
+
+
+def test_research_substrate_block_reads_disk(tmp_path) -> None:
+    import json as _json
+
+    from wayfinder_paths.jobs.models import WayfinderJob
+    from wayfinder_paths.jobs.store import JobStore
+    from wayfinder_paths.jobs.worker import _research_substrate_block
+
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("substrate-demo", agent_mode="intervene")
+    store.save(job)
+    root = store.job_dir(job.id)
+    (root / "results" / "backtest").mkdir(parents=True, exist_ok=True)
+    (root / "results" / "backtest" / "input_bars.json").write_text(
+        _json.dumps(
+            {
+                "bars": [],
+                "metadata": {"fetched_at": "2026-07-27T01:43:00+00:00", "days": 14},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (root / "state").mkdir(exist_ok=True)
+    rows = [
+        {"timestamp": "2026-07-26T01:05:00+00:00", "name": "btc_trend"},
+        {"timestamp": "2026-07-27T00:50:00+00:00", "name": "btc_trend"},
+    ]
+    (root / "state" / "features.jsonl").write_text(
+        "\n".join(_json.dumps(r) for r in rows) + "\n", encoding="utf-8"
+    )
+    block = _research_substrate_block(root)
+    assert block["dataset_fetched_at"] == "2026-07-27T01:43:00+00:00"
+    assert block["derived_features_newest_ts"] == "2026-07-27T00:50:00+00:00"
+    assert "EVERY wake" in block["_basis"]
+
+    # Empty job -> empty block, no crash.
+    job2 = WayfinderJob.new("substrate-empty", agent_mode="intervene")
+    store.save(job2)
+    assert _research_substrate_block(store.job_dir(job2.id)) == {}


### PR DESCRIPTION
Follow-up to #566 — this commit was pushed to that branch moments after it merged, so it never landed.

Three wakes after the derived columns were refreshed on majors-5m-lab, the agent was still citing "STALE since 2026-07-22" from its own agenda: dead-map entries are deliberately never re-explored, so a staleness claim written once outlives the fix with nothing in the context to contradict it.

The wake dynamic context now carries `research_substrate`, read from disk every wake: dataset `fetched_at`/`days`, newest derived-feature timestamp (tail-bounded scan), and the refresh stamp — with the directive that any agenda/dead-map entry blocked on staleness must be checked against these timestamps every wake and unblocked when current, plus the self-serve pointer (`job fetch-dataset` re-derives automatically since #566).

Tests: block reads disk (fresh timestamps + empty-job no-crash); worker cache eval still passes.