### PR TITLE
jobs: ledger hygiene + standing checks — process out of research context

### DIFF
--- a/scripts/eval_wayfinder_jobs.py
+++ b/scripts/eval_wayfinder_jobs.py
@@ -1574,7 +1574,6 @@ def build_application_prompt(workspace: Path, case: WorkerCase) -> str:
         job_id=case.job_id,
         mode="intervene",
         apply_proposal_id=SCRIPT_AGENT_PROPOSAL_ID,
-        claim_application_before_prompt=True,
     )
     return str(sections["prompt"])
 

--- a/wayfinder_paths/jobs/ledger.py
+++ b/wayfinder_paths/jobs/ledger.py
@@ -29,6 +29,30 @@ from wayfinder_paths.jobs.store import JobStore
 LEDGER_DIR = "ledgers"
 _NAME_RE = re.compile(r"^[a-z0-9_-]+$")
 
+# Housekeeping families never belong in the research ledger: the candidates
+# tail rides the wake prompt, so process rows crowd research history out of
+# the agent's context (audit 2026-07-27: operations/monitoring/maintenance
+# were the TOP candidates families on both labs). Rows in these families are
+# rerouted to the `ops` ledger, which does not ride the research context.
+PROCESS_FAMILIES = {
+    "operations",
+    "operational",
+    "ops",
+    "monitoring",
+    "maintenance",
+    "infrastructure",
+    "housekeeping",
+    "health",
+    "no_change",
+    "status_quo",
+}
+OPS_LEDGER = "ops"
+RESEARCH_LEDGER = "candidates"
+
+
+def _family(row: dict[str, Any]) -> str:
+    return str(row.get("family") or "").strip().lower()
+
 
 def _ledger_path(store: JobStore, job_id: str, name: str):
     if not _NAME_RE.match(name or ""):
@@ -41,6 +65,9 @@ def append_ledger_row(
 ) -> dict[str, Any]:
     if not row:
         raise ValueError("ledger row must be a non-empty object")
+    if name == RESEARCH_LEDGER and _family(row) in PROCESS_FAMILIES:
+        name = OPS_LEDGER
+        row = {**row, "rerouted_from": RESEARCH_LEDGER}
     payload = {"ts": utc_now_iso(), **row}
     target = _ledger_path(store, job_id, name)
     target.parent.mkdir(parents=True, exist_ok=True)
@@ -67,4 +94,8 @@ def tail_ledger(
         match row:
             case dict():
                 rows.append(row)
+    if name == RESEARCH_LEDGER:
+        # Filter BEFORE slicing so process rows already in old files (written
+        # before rerouting existed) cannot eat the research tail budget.
+        rows = [row for row in rows if _family(row) not in PROCESS_FAMILIES]
     return rows[-max(int(limit), 1) :]

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -200,6 +200,101 @@ def _research_substrate_block(root: Path) -> dict[str, Any]:
     return block
 
 
+def _standing_checks_block(root: Path) -> dict[str, Any]:
+    """Mechanical routine numbers, computed by the harness each wake.
+
+    The audit found ~30 ledger entries re-deriving `funding_mean > 0` in LLM
+    sessions — threshold arithmetic done by the most expensive component in
+    the system. This block does the arithmetic mechanically; a wake READS the
+    numbers and compares them to its gates."""
+    block: dict[str, Any] = {}
+    trades_path = root / "results" / "forward" / "trades.jsonl"
+    if trades_path.exists():
+        per_symbol: dict[str, int] = {}
+        last_close = ""
+        for line in trades_path.read_text(encoding="utf-8").splitlines():
+            try:
+                row = json.loads(line)
+            except ValueError:
+                continue
+            symbol = str(row.get("symbol") or "?")
+            per_symbol[symbol] = per_symbol.get(symbol, 0) + 1
+            last_close = max(last_close, str(row.get("closed_at") or ""))
+        if per_symbol:
+            block["closed_trades"] = {
+                "total": sum(per_symbol.values()),
+                "per_symbol": dict(sorted(per_symbol.items())),
+                "last_close_ts": last_close,
+            }
+    feats = root / "state" / "features.jsonl"
+    if feats.exists():
+        from wayfinder_paths.jobs.indicators import REGIME_LABELS
+
+        regime_newest: dict[str, tuple[str, float]] = {}
+        funding: dict[str, list[tuple[str, float]]] = {}
+        # Reverse scan with early exit: newest regime per symbol + a week of
+        # funding rows, without parsing the whole multi-MB store.
+        scanned = 0
+        for line in reversed(feats.read_text(encoding="utf-8").splitlines()):
+            scanned += 1
+            if scanned > 30_000:
+                break
+            try:
+                row = json.loads(line)
+            except ValueError:
+                continue
+            name = str(row.get("name") or "")
+            symbol = str(row.get("symbol") or "")
+            ts = str(row.get("timestamp") or "")
+            if name == "regime_code":
+                if symbol not in regime_newest or ts > regime_newest[symbol][0]:
+                    try:
+                        regime_newest[symbol] = (ts, float(row.get("value")))
+                    except (TypeError, ValueError):
+                        pass
+            elif name == "funding":
+                rows = funding.setdefault(symbol, [])
+                if len(rows) < 42:  # ~7d of 4h readings
+                    try:
+                        rows.append((ts, float(row.get("value"))))
+                    except (TypeError, ValueError):
+                        pass
+        if regime_newest:
+            block["regime_now"] = {
+                symbol: {
+                    "label": REGIME_LABELS[int(code)]
+                    if 0 <= int(code) < len(REGIME_LABELS)
+                    else "unknown",
+                    "as_of": ts,
+                }
+                for symbol, (ts, code) in sorted(regime_newest.items())
+            }
+        if funding:
+            block["funding_recent"] = {
+                symbol: {
+                    "mean_1d": round(
+                        sum(v for _, v in rows[:6]) / max(len(rows[:6]), 1), 9
+                    ),
+                    "mean_7d": round(sum(v for _, v in rows) / len(rows), 9),
+                    "n": len(rows),
+                    "newest_ts": max(ts for ts, _ in rows),
+                }
+                for symbol, rows in sorted(funding.items())
+                if rows
+            }
+    if block:
+        block["_basis"] = (
+            "Routine numbers computed mechanically THIS wake — never re-fetch "
+            "or re-derive them in-session; compare them to your gates and "
+            "cite them. A pure status observation (runner healthy, gate "
+            "still closed, no new trades) is an ops note, NOT research: "
+            "write it with family operations/monitoring/no_change and it "
+            "lands in the ops ledger automatically. The candidates ledger "
+            "is for research verdicts only."
+        )
+    return block
+
+
 def _drop_volatile_stable_keys(value: Any) -> Any:
     match value:
         case dict():
@@ -290,6 +385,7 @@ def _build_worker_prompt_sections(
         "attribution": _attribution_block(root),
         "post_apply_shadow": _counterfactual_block(store, job_id),
         "research_substrate": _research_substrate_block(root),
+        "standing_checks": _standing_checks_block(root),
     }
 
     stable_prefix = (

--- a/wayfinder_paths/tests/test_eval_wayfinder_jobs.py
+++ b/wayfinder_paths/tests/test_eval_wayfinder_jobs.py
@@ -389,7 +389,10 @@ def test_wayfinder_jobs_worker_prompts_scope_bash_fallback(tmp_path: Path) -> No
                 case.job_id,
                 module.SCRIPT_AGENT_PROPOSAL_ID,
             )
-            assert proposal["application"]["status"] == "applying"
+            # Post-#542 contract: preparing the prompt NEVER claims (a
+            # dropped prompt after a claim stalls the job) — the claim
+            # happens inside the live session, so it is still queued here.
+            assert proposal["application"]["status"] == "queued"
             assert "validate_application" in apply_prompt
             assert "failed checks" in apply_prompt
             assert "candidate workspace" in apply_prompt

--- a/wayfinder_paths/tests/test_jobs_forward_view.py
+++ b/wayfinder_paths/tests/test_jobs_forward_view.py
@@ -153,8 +153,9 @@ def test_markers_carry_mode_and_kind(tmp_path: Path) -> None:
         ("entry", "live"),
         ("exit", "live"),
     ]
-    assert markers[0]["label"] == "paper entry: new_low_5"
-    assert markers[1]["label"] == "paper exit: sma50_floor"
+    assert markers[0]["label"] == "paper short entry: new_low_5"
+    assert markers[1]["label"] == "paper short exit: sma50_floor"
+    assert markers[0]["direction"] == "short"
 
 
 def test_pnl_by_mode_splits_paper_and_live(tmp_path: Path) -> None:

--- a/wayfinder_paths/tests/test_jobs_ledger_hygiene.py
+++ b/wayfinder_paths/tests/test_jobs_ledger_hygiene.py
@@ -1,0 +1,106 @@
+"""Ledger hygiene + standing checks: process rows reroute to the ops ledger,
+the research tail stays clean even over legacy files, and routine numbers
+are computed mechanically for the wake context."""
+
+from __future__ import annotations
+
+import json
+
+from wayfinder_paths.jobs.ledger import append_ledger_row, tail_ledger
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.jobs.worker import _standing_checks_block
+
+
+def _mk(tmp_path):
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("hygiene-demo", agent_mode="intervene")
+    store.save(job)
+    return store, job.id
+
+
+def test_process_families_reroute_to_ops(tmp_path) -> None:
+    store, job_id = _mk(tmp_path)
+    kept = append_ledger_row(
+        store, job_id, "candidates", {"family": "breakout", "name": "donch_up"}
+    )
+    moved = append_ledger_row(
+        store, job_id, "candidates", {"family": "operations", "name": "runner ok"}
+    )
+    assert kept["family"] == "breakout"
+    assert moved["rerouted_from"] == "candidates"
+    root = store.job_dir(job_id)
+    assert not any(
+        "operations" in line
+        for line in (root / "ledgers" / "candidates.jsonl").read_text().splitlines()
+    )
+    ops = (root / "ledgers" / "ops.jsonl").read_text()
+    assert "runner ok" in ops
+
+
+def test_candidates_tail_filters_legacy_process_rows(tmp_path) -> None:
+    store, job_id = _mk(tmp_path)
+    path = store.job_dir(job_id) / "ledgers" / "candidates.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    rows = [{"family": "monitoring", "name": f"noise-{i}"} for i in range(30)]
+    rows.append({"family": "trend", "name": "real-idea", "verdict": "candidate"})
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+    tail = tail_ledger(store, job_id, "candidates", limit=5)
+    # 30 legacy process rows cannot eat the tail budget: the one research row
+    # survives the 5-row limit.
+    assert [r["name"] for r in tail] == ["real-idea"]
+    # Other ledgers are untouched by the filter.
+    append_ledger_row(store, job_id, "decisions", {"family": "monitoring", "d": 1})
+    assert len(tail_ledger(store, job_id, "decisions", limit=5)) == 1
+
+
+def test_standing_checks_block(tmp_path) -> None:
+    store, job_id = _mk(tmp_path)
+    root = store.job_dir(job_id)
+    forward = root / "results" / "forward"
+    forward.mkdir(parents=True, exist_ok=True)
+    trades = [
+        {"symbol": "LIT", "net_pnl": -0.1, "closed_at": "2026-07-26T10:00:00+00:00"},
+        {"symbol": "LIT", "net_pnl": 0.2, "closed_at": "2026-07-27T01:00:00+00:00"},
+        {"symbol": "XRP", "net_pnl": 0.0, "closed_at": "2026-07-25T09:00:00+00:00"},
+    ]
+    (forward / "trades.jsonl").write_text(
+        "\n".join(json.dumps(t) for t in trades) + "\n", encoding="utf-8"
+    )
+    (root / "state").mkdir(exist_ok=True)
+    feats = [
+        {
+            "timestamp": "2026-07-27T00:50:00+00:00",
+            "name": "regime_code",
+            "symbol": "LIT",
+            "value": 2.0,
+        },
+        {
+            "timestamp": "2026-07-27T00:00:00+00:00",
+            "name": "funding",
+            "symbol": "POL",
+            "value": -2e-05,
+        },
+        {
+            "timestamp": "2026-07-27T04:00:00+00:00",
+            "name": "funding",
+            "symbol": "POL",
+            "value": -1e-05,
+        },
+    ]
+    (root / "state" / "features.jsonl").write_text(
+        "\n".join(json.dumps(f) for f in feats) + "\n", encoding="utf-8"
+    )
+    block = _standing_checks_block(root)
+    assert block["closed_trades"]["total"] == 3
+    assert block["closed_trades"]["per_symbol"] == {"LIT": 2, "XRP": 1}
+    assert block["regime_now"]["LIT"]["label"] == "down_lowvol"
+    pol = block["funding_recent"]["POL"]
+    assert pol["n"] == 2 and pol["mean_7d"] == -1.5e-05
+    assert pol["newest_ts"] == "2026-07-27T04:00:00+00:00"
+    assert "ops ledger" in block["_basis"]
+
+    # Empty job -> empty block.
+    job2 = WayfinderJob.new("hygiene-empty", agent_mode="intervene")
+    store.save(job2)
+    assert _standing_checks_block(store.job_dir(job2.id)) == {}


### PR DESCRIPTION
First of the wake-economy fixes from the audit ('are they trending or spinning'). Two findings this addresses directly: the top `candidates` ledger families on both labs were **operations/monitoring/maintenance** — a process diary crowding actual research out of the prompt tail — and **~30 entries re-derived `funding_mean > 0` in LLM sessions**.

1. **Ledger rerouting** — `candidates` rows in process families (`operations`, `monitoring`, `maintenance`, `infrastructure`, `no_change`, `status_quo`, …) are mechanically rerouted to a new `ops` ledger that never rides the research context (row echoes `rerouted_from`). Enforcement in the writer, not guidance.
2. **Defensive tail filter** — the candidates tail drops process families *before* the limit slice, so the legacy polluted files on the boxes stop eating the research tail budget immediately, no migration needed.
3. **`standing_checks` wake block** — harness-computed routine numbers: closed trades per symbol, current regime per symbol (newest `regime_code`), funding 1d/7d means (bounded reverse scan of the feature store). The `_basis` directs the agent: compare your gates to these numbers, never re-fetch/re-derive them in-session, and pure status observations belong in ops families.

Tests: rerouting, legacy-tail filtering (30 noise rows can't displace 1 research row at limit 5), decisions ledger untouched, standing-checks numbers + regime label mapping + empty-job no-crash. Worker cache eval passes; ruff clean.