### PR TITLE
jobs: rank-IC fails loud on undefined inputs + basket-relative ratioz column

### DIFF
--- a/wayfinder_paths/jobs/derived_features.py
+++ b/wayfinder_paths/jobs/derived_features.py
@@ -96,6 +96,17 @@ def derive_features_job(
 
     if "cross" in sets:
         returns = closes.pct_change()
+        # Basket-relative dislocation: each symbol's log price vs the
+        # equal-weight (geometric) basket, z-scored — varies cross-
+        # sectionally by construction, so it is the natural rank-IC input
+        # (pair-wise ratioz_<sym> columns have a self-hole and panel-wide
+        # exog columns are cross-sectionally constant; neither can rank).
+        log_closes = np.log(closes)
+        basket_spread = log_closes.sub(log_closes.mean(axis=1), axis=0)
+        basket_z = (
+            basket_spread - basket_spread.rolling(RATIO_Z_BARS).mean()
+        ) / basket_spread.rolling(RATIO_Z_BARS).std()
+        _add(f"ratioz_basket{RATIO_Z_BARS}", basket_z)
         for symbol in symbols:
             for sibling in symbols:
                 if sibling == symbol:

--- a/wayfinder_paths/jobs/research.py
+++ b/wayfinder_paths/jobs/research.py
@@ -1181,6 +1181,30 @@ def rank_ic(
         sub = frame[["timestamp", column, "close"]].copy()
         sub["close"] = sub["close"].astype(float)
         aligned[symbol] = sub.set_index("timestamp")
+    # Fail loud on inputs where rank-IC is undefined by construction —
+    # the silent alternative is n=0 "no periods" that reads like a data
+    # problem and wedges lanes (2026-07-27: btc_trend is panel-wide, so
+    # three agent wakes chased a phantom merge bug).
+    all_nan = sorted(
+        symbol for symbol, sub in aligned.items() if sub[column].isna().all()
+    )
+    if all_nan:
+        raise ValueError(
+            f"column {column!r} is entirely NaN for {all_nan} — pair-wise "
+            "columns (ratioz_<sym>, corr_<sym>) have no self-value, so the "
+            "full cross-section can never rank. Use the basket-relative "
+            "column (ratioz_basket*) for rank-IC instead."
+        )
+    wide = pd.DataFrame({symbol: sub[column] for symbol, sub in aligned.items()})
+    varying = (wide.nunique(axis=1, dropna=True) > 1).sum()
+    if len(wide) > 0 and varying < max(4, 0.05 * len(wide)):
+        raise ValueError(
+            f"column {column!r} is cross-sectionally constant (same value "
+            "for every symbol per bar — a panel-wide/exogenous series like "
+            "btc_trend or breadth). Rank-IC is undefined for it. Test it as "
+            "a CONDITIONING variable instead: signal-scan --condition-regime "
+            "or event-study conditioned on its level."
+        )
     per_horizon = []
     any_edge = False
     for h in sorted({int(h) for h in horizons}):

--- a/wayfinder_paths/tests/test_jobs_rank_check_diagnosis.py
+++ b/wayfinder_paths/tests/test_jobs_rank_check_diagnosis.py
@@ -1,0 +1,100 @@
+"""rank_ic fails loud on inputs where rank-IC is undefined by construction —
+panel-wide (cross-sectionally constant) columns and pair-wise columns with a
+self-hole — instead of the silent n=0 that wedged the BTC-exog lane."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from wayfinder_paths.jobs.research import rank_ic
+
+_N = 120
+
+
+def _frame(values: np.ndarray) -> pd.DataFrame:
+    ts = pd.date_range("2026-06-01", periods=_N, freq="5min", tz="UTC")
+    return pd.DataFrame(
+        {"timestamp": ts, "col": values, "close": 100 + np.arange(_N) * 0.1}
+    )
+
+
+def test_panel_wide_column_fails_loud() -> None:
+    shared = np.sin(np.arange(_N))  # varies in time, constant across symbols
+    frames = {s: _frame(shared.copy()) for s in ("A", "B", "C", "D")}
+    with pytest.raises(ValueError, match="cross-sectionally constant"):
+        rank_ic(frames, "col")
+
+
+def test_self_hole_column_fails_loud() -> None:
+    rng = np.random.default_rng(3)
+    frames = {s: _frame(rng.normal(size=_N)) for s in ("A", "B", "C", "D")}
+    frames["A"]["col"] = np.nan  # pair-wise column's self-symbol hole
+    with pytest.raises(ValueError, match="entirely NaN for \\['A'\\]"):
+        rank_ic(frames, "col")
+
+
+def test_varying_column_still_ranks() -> None:
+    rng = np.random.default_rng(7)
+    frames = {s: _frame(rng.normal(size=_N)) for s in ("A", "B", "C", "D")}
+    result = rank_ic(frames, "col")
+    assert result["horizons"][0]["n"] > 0
+
+
+def test_basket_relative_column_derives_cross_sectionally(tmp_path) -> None:
+    """The basket z-column must vary ACROSS symbols per bar (rankable)."""
+    import json
+
+    import yaml
+
+    from wayfinder_paths.jobs.derived_features import derive_features_job
+    from wayfinder_paths.jobs.models import WayfinderJob
+    from wayfinder_paths.jobs.store import JobStore
+
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("basket-demo", agent_mode="intervene")
+    store.save(job)
+    root = store.job_dir(job.id)
+    symbols = ["A", "B", "C", "D"]
+    job_yaml = {
+        "id": job.id,
+        "execution_spec": {"data_contract": {"bar_interval": "5m", "symbols": symbols}},
+        "execution_params": {"symbols": symbols},
+    }
+    (root / "job.yaml").write_text(yaml.safe_dump(job_yaml), encoding="utf-8")
+    ts = pd.date_range("2026-06-01", periods=200, freq="5min", tz="UTC")
+    rng = np.random.default_rng(11)
+    bars = []
+    for i, symbol in enumerate(symbols):
+        prices = 50 * (i + 1) + np.cumsum(rng.normal(0, 0.3, len(ts)))
+        for t, price in zip(ts, prices, strict=True):
+            bars.append(
+                {
+                    "timestamp": t.isoformat(),
+                    "symbol": symbol,
+                    "open": price,
+                    "high": price + 0.1,
+                    "low": price - 0.1,
+                    "close": price,
+                    "volume": 5.0,
+                }
+            )
+    (root / "results" / "backtest").mkdir(parents=True, exist_ok=True)
+    (root / "results" / "backtest" / "input_bars.json").write_text(
+        json.dumps({"bars": bars}), encoding="utf-8"
+    )
+    result = derive_features_job(job.id, sets=("cross",), store=store)
+    assert "ratioz_basket96" in result["features"]
+    rows = [
+        json.loads(line)
+        for line in (root / "state" / "features.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    basket = [r for r in rows if r["name"] == "ratioz_basket96"]
+    by_ts: dict[str, set[float]] = {}
+    for r in basket:
+        by_ts.setdefault(r["timestamp"], set()).add(round(float(r["value"]), 6))
+    varying = [ts for ts, vals in by_ts.items() if len(vals) > 1]
+    assert varying, "basket z must differ across symbols at the same bar"

--- a/wayfinder_paths/tests/test_jobs_rank_check_diagnosis.py
+++ b/wayfinder_paths/tests/test_jobs_rank_check_diagnosis.py
@@ -13,23 +13,31 @@ from wayfinder_paths.jobs.research import rank_ic
 _N = 120
 
 
-def _frame(values: np.ndarray) -> pd.DataFrame:
+def _frame(values: np.ndarray, *, seed: int = 0) -> pd.DataFrame:
     ts = pd.date_range("2026-06-01", periods=_N, freq="5min", tz="UTC")
-    return pd.DataFrame(
-        {"timestamp": ts, "col": values, "close": 100 + np.arange(_N) * 0.1}
-    )
+    # Per-symbol random-walk closes: identical close paths make forward-
+    # return ranks constant (degenerate IC), which is not what these tests
+    # probe.
+    walk = np.random.default_rng(seed).normal(0, 0.2, _N).cumsum()
+    return pd.DataFrame({"timestamp": ts, "col": values, "close": 100 + walk})
 
 
 def test_panel_wide_column_fails_loud() -> None:
     shared = np.sin(np.arange(_N))  # varies in time, constant across symbols
-    frames = {s: _frame(shared.copy()) for s in ("A", "B", "C", "D")}
+    frames = {
+        s: _frame(shared.copy(), seed=i)
+        for i, s in enumerate(("A", "B", "C", "D"))
+    }
     with pytest.raises(ValueError, match="cross-sectionally constant"):
         rank_ic(frames, "col")
 
 
 def test_self_hole_column_fails_loud() -> None:
     rng = np.random.default_rng(3)
-    frames = {s: _frame(rng.normal(size=_N)) for s in ("A", "B", "C", "D")}
+    frames = {
+        s: _frame(rng.normal(size=_N), seed=i)
+        for i, s in enumerate(("A", "B", "C", "D"))
+    }
     frames["A"]["col"] = np.nan  # pair-wise column's self-symbol hole
     with pytest.raises(ValueError, match="entirely NaN for \\['A'\\]"):
         rank_ic(frames, "col")
@@ -37,7 +45,10 @@ def test_self_hole_column_fails_loud() -> None:
 
 def test_varying_column_still_ranks() -> None:
     rng = np.random.default_rng(7)
-    frames = {s: _frame(rng.normal(size=_N)) for s in ("A", "B", "C", "D")}
+    frames = {
+        s: _frame(rng.normal(size=_N), seed=i)
+        for i, s in enumerate(("A", "B", "C", "D"))
+    }
     result = rank_ic(frames, "col")
     assert result["horizons"][0]["n"] > 0
 


### PR DESCRIPTION
Fixes the rank-check dead end from the audit: `btc_trend` is panel-wide (same value for every symbol per bar), so rank-IC is undefined for it by construction — but `rank_ic` silently reported `n=0 "no periods"`, which reads like a data problem. Three agent wakes chased a phantom merge bug.

1. **Fail loud with a route**: `rank_ic` now raises for the two undefined input shapes — cross-sectionally constant columns (→ "test it as a CONDITIONING variable: `signal-scan --condition-regime` or conditioned event-study") and pair-wise columns whose self-symbol hole leaves a symbol entirely NaN (→ "use the basket-relative column").
2. **A column that genuinely ranks**: the derived `cross` set gains `ratioz_basket96` — each symbol's log price vs the equal-weight geometric basket, z-scored. Varies across symbols per bar by construction: the natural rank-IC input, with no self-hole.

Tests: both loud-failure paths, a varying column still ranks, and the basket column derives with genuine cross-sectional variation. Ruff clean.