### PR TITLE
jobs: dataset file metadata rides into dataset.metadata — window labels need it

### DIFF
--- a/wayfinder_paths/jobs/execution/job.py
+++ b/wayfinder_paths/jobs/execution/job.py
@@ -376,8 +376,21 @@ def _resolve_dataset(
     for path in candidate_paths:
         if path.exists():
             # Agent-written files: accept a bare row list or {"bars": [...]}.
+            # The file's own metadata block (days/interval/fetched_at from
+            # fetch-dataset) rides along — dropping it here left the proposal
+            # comparison's dataset window empty, so the UI could not label
+            # "window return (Nd)".
             match json.loads(path.read_text(encoding="utf-8")):
-                case {"bars": list() as rows} | [*rows]:
+                case {"bars": list() as rows, **rest}:
+                    file_meta = rest.get("metadata")
+                    return PreparedExecutionDataset.from_rows(
+                        rows,
+                        {
+                            **(file_meta if isinstance(file_meta, dict) else {}),
+                            "source": str(path),
+                        },
+                    )
+                case [*rows]:
                     return PreparedExecutionDataset.from_rows(
                         rows, {"source": str(path)}
                     )

--- a/wayfinder_paths/tests/test_jobs_universe.py
+++ b/wayfinder_paths/tests/test_jobs_universe.py
@@ -102,3 +102,39 @@ def test_universe_scan_filters_pools_and_persists(tmp_path) -> None:
         encoding="utf-8"
     )
     assert "universe-scan-" in ledger
+
+
+def test_resolve_dataset_keeps_file_metadata(tmp_path) -> None:
+    """input_bars.json metadata (days/fetched_at) must survive into dataset
+    metadata — it is the only source for the UI's window labels."""
+    import json as _json
+
+    from wayfinder_paths.jobs.execution.job import _load_dataset
+    from wayfinder_paths.jobs.execution.primitives import ExecutionSpec
+
+    root = tmp_path
+    (root / "results" / "backtest").mkdir(parents=True)
+    bars = [
+        {
+            "timestamp": f"2026-07-01T00:{m:02d}:00+00:00",
+            "symbol": "LIT",
+            "open": 1.0,
+            "high": 1.1,
+            "low": 0.9,
+            "close": 1.0,
+            "volume": 2.0,
+        }
+        for m in range(10)
+    ]
+    (root / "results" / "backtest" / "input_bars.json").write_text(
+        _json.dumps(
+            {"bars": bars, "metadata": {"days": 14, "fetched_at": "2026-07-27"}}
+        ),
+        encoding="utf-8",
+    )
+    spec = ExecutionSpec()
+    spec.data_contract["bar_interval"] = "5m"
+    dataset = _load_dataset(root, spec, {})
+    assert dataset.metadata["days"] == 14
+    assert dataset.metadata["fetched_at"] == "2026-07-27"
+    assert "input_bars.json" in dataset.metadata["source"]


### PR DESCRIPTION
Companion to vault-frontend #1897 (basis labels + annualized backtest returns). `_resolve_dataset` read `input_bars.json` and **discarded the file's metadata block** (`days`/`interval`/`fetched_at` written by `fetch-dataset`), stamping only the source path — so `comparison.dataset` reached the backend/UI empty and the FE cannot label "window return (14d)".

Fix: merge the file's metadata under the source stamp (`{**file_meta, "source": path}`); bare row-list files behave exactly as before. The backend's slim projection already forwards non-series dataset keys, and `cagr` already rides `stats` whole — so with this, both fields #1897 consumes leniently are populated.

Test: file metadata (days/fetched_at) survives `_load_dataset`; 18 adjacent tests pass; ruff clean.