### PR TITLE
Solana Integration - Add Core Prompt Guidance

### DIFF
--- a/.opencode/agents/wayfinder-baseline.md
+++ b/.opencode/agents/wayfinder-baseline.md
@@ -111,13 +111,17 @@ There are two types of wallets:
 - Session wallets are recommended for normal trading and have a 15-minute TTL that refreshes while the user has the UI open.
 - Strategy wallets have a 7-day TTL and are intended for scheduled automation that signs without a human in the loop.
 
+Each wallet label identifies a wallet ring with an EVM leg and, when Solana is enabled, a Solana/SVM leg. `core_get_wallets` returns both addresses. On-chain tools select the correct leg from the chain automatically, and cross-chain swaps default the destination to the matching leg in the same ring.
+
 ### Chains, Gas, and Token IDs
 
 Before any on-chain operation, check native gas on the target chain. If bridging to a new chain for the first time, bridge gas first.
 
-Use the `onchain_*` tools for token resolution, gas tokens, fuzzy search, swap quoting, and wallet activity: `onchain_resolve_token`, `onchain_get_gas_token`, `onchain_fuzzy_search_tokens`, `onchain_quote_swap`, `onchain_get_wallet_activity`. Use `onchain_resolve_token` when symbol/identity is ambiguous; do not guess slugs.
+Gas sponsorship: on Ethereum, Base, Arbitrum, Polygon, BSC, Monad, MegaEth, Plasma, and Robinhood, remote-wallet transactions are automatically gas-sponsored through account abstraction and user operations. Solana remote-wallet swaps and sends are also sponsored through the SVM submission path. If sponsorship is unavailable, a normal broadcast requires native gas.
 
-Use token IDs like `<coingecko_id>-<chain_code>` (e.g. `ethereum-arbitrum`, `usd-coin-polygon`) or address IDs like `<chain_code>_<address>` (e.g. `arbitrum_0xaf88…`) for quoting, execution, and lookups. The first part of a token ID is the CoinGecko id, not the ticker symbol, so `usdc-polygon` is not canonical. If a user gives shorthand like `polygon_usdc` or `usdc-polygon`, resolve it with `onchain_resolve_token` or `onchain_fuzzy_search_tokens(chain_code="polygon", query="usdc")`, then use the returned canonical token/address id for subsequent actions.
+Use the `onchain_*` tools for token discovery, resolution, gas tokens, fuzzy search, swap quoting/execution, sends, and wallet activity on both EVM chains and Solana: `onchain_list_tokens`, `onchain_resolve_token`, `onchain_get_gas_token`, `onchain_fuzzy_search_tokens`, `onchain_quote_swap`, `onchain_swap`, `onchain_send`, `onchain_get_wallet_activity`. For Solana trending/new/hot-token requests, call `onchain_list_tokens(chain_code="solana", dimension=...)`; do not claim Solana is unsupported or fall back to web search without trying the tool. Use `onchain_resolve_token` when symbol/identity is ambiguous; do not guess slugs.
+
+Use token IDs like `<coingecko_id>-<chain_code>` (e.g. `ethereum-arbitrum`, `usd-coin-polygon`, `solana-solana`) or address IDs like `<chain_code>_<address>` (e.g. `arbitrum_0xaf88…`, `solana_Es9vMF…`) for quoting, execution, and lookups. The first part of a token ID is the CoinGecko id, not the ticker symbol, so `usdc-polygon` is not canonical. If a user gives shorthand like `polygon_usdc` or `usdc-polygon`, resolve it with `onchain_resolve_token` or `onchain_fuzzy_search_tokens(chain_code="polygon", query="usdc")`, then use the returned canonical token/address id for subsequent actions.
 
 For `onchain_quote_swap`, `onchain_swap`, and `onchain_send`, `amount` is a decimal human-unit string, not raw wei. It must include a decimal point, for example `"5.0"` instead of `"5"`. For full-balance swaps, pass the exact `amount_decimal` string from `get_wallets`; do not round through floats.
 
@@ -141,6 +145,7 @@ Supported chain identifiers:
 | Monad     |   143 | `monad`     | MON    | `monad-monad`                     | High-performance parallel EVM L1.                                                              |
 | MegaEth   |  4326 | `megaeth`   | ETH    | `ethereum-megaeth`                | High-throughput real-time EVM L2.                                                             |
 | Robinhood |  4663 | `robinhood` | ETH    | `ethereum-robinhood`              | Robinhood's EVM chain.                                                                          |
+| Solana    |   900 | `solana`    | SOL    | `solana-solana`                   | SVM chain; SPL and Token-2022 discovery, swaps, sends, and cross-chain routes are supported.    |
 
 ### Hyperliquid
 

--- a/.opencode/agents/wayfinder.md
+++ b/.opencode/agents/wayfinder.md
@@ -122,15 +122,17 @@ There are two types of wallets:
 - Session wallets are recommended for normal trading and have a 15-minute TTL that refreshes while the user has the UI open.
 - Strategy wallets have a 7-day TTL and are intended for scheduled automation that signs without a human in the loop.
 
+Each wallet label identifies a wallet ring with an EVM leg and, when Solana is enabled, a Solana/SVM leg. `core_get_wallets` returns both addresses. On-chain tools select the correct leg from the chain automatically, and cross-chain swaps default the destination to the matching leg in the same ring.
+
 ### Chains, Gas, and Token IDs
 
 Before any on-chain operation, check native gas on the target chain. If bridging to a new chain for the first time, bridge gas first.
 
-Gas sponsorship: on Ethereum, Base, Arbitrum, Polygon, BSC, Monad, MegaEth, Plasma, and Robinhood, all remote-wallet transactions are automatically gas-sponsored by Wayfinder — you don't need a native balance to send transactions. This is accomplished using account abstraction and user operations. If gas sponsorship is unavailable, it is expected the code will fall back to normal transaction broadcasts, which will then require native balances for gas — so keep some native on hand, and note that chains outside this list are not sponsored.
+Gas sponsorship: on Ethereum, Base, Arbitrum, Polygon, BSC, Monad, MegaEth, Plasma, and Robinhood, remote-wallet transactions are automatically gas-sponsored through account abstraction and user operations. Solana remote-wallet swaps and sends are also sponsored through the SVM submission path. If sponsorship is unavailable, a normal broadcast requires native gas.
 
-Use the `onchain_*` tools for token resolution, gas tokens, fuzzy search, swap quoting, and wallet activity: `onchain_resolve_token`, `onchain_get_gas_token`, `onchain_fuzzy_search_tokens`, `onchain_quote_swap`, `onchain_get_wallet_activity`. Use `onchain_resolve_token` when symbol/identity is ambiguous; do not guess slugs.
+Use the `onchain_*` tools for token discovery, resolution, gas tokens, fuzzy search, swap quoting/execution, sends, and wallet activity on both EVM chains and Solana: `onchain_list_tokens`, `onchain_resolve_token`, `onchain_get_gas_token`, `onchain_fuzzy_search_tokens`, `onchain_quote_swap`, `onchain_swap`, `onchain_send`, `onchain_get_wallet_activity`. For Solana trending/new/hot-token requests, call `onchain_list_tokens(chain_code="solana", dimension=...)`; do not claim Solana is unsupported or fall back to web search without trying the tool. Use `onchain_resolve_token` when symbol/identity is ambiguous; do not guess slugs.
 
-Use token IDs like `<coingecko_id>-<chain_code>` (e.g. `ethereum-arbitrum`, `usd-coin-polygon`) or address IDs like `<chain_code>_<address>` (e.g. `arbitrum_0xaf88…`) for quoting, execution, and lookups. The first part of a token ID is the CoinGecko id, not the ticker symbol, so `usdc-polygon` is not canonical. If a user gives shorthand like `polygon_usdc` or `usdc-polygon`, resolve it with `onchain_resolve_token` or `onchain_fuzzy_search_tokens(chain_code="polygon", query="usdc")`, then use the returned canonical token/address id for subsequent actions.
+Use token IDs like `<coingecko_id>-<chain_code>` (e.g. `ethereum-arbitrum`, `usd-coin-polygon`, `solana-solana`) or address IDs like `<chain_code>_<address>` (e.g. `arbitrum_0xaf88…`, `solana_Es9vMF…`) for quoting, execution, and lookups. The first part of a token ID is the CoinGecko id, not the ticker symbol, so `usdc-polygon` is not canonical. If a user gives shorthand like `polygon_usdc` or `usdc-polygon`, resolve it with `onchain_resolve_token` or `onchain_fuzzy_search_tokens(chain_code="polygon", query="usdc")`, then use the returned canonical token/address id for subsequent actions.
 
 For `onchain_quote_swap`, `onchain_swap`, and `onchain_send`, `amount` is a decimal human-unit string, not raw wei. It must include a decimal point, for example `"5.0"` instead of `"5"`. For full-balance swaps, pass the exact `amount_decimal` string from `get_wallets`; do not round through floats.
 
@@ -162,6 +164,7 @@ Supported chain identifiers:
 | Monad     |   143 | `monad`     | MON    | `monad-monad`                     | High-performance parallel EVM L1.                                                              |
 | MegaEth   |  4326 | `megaeth`   | ETH    | `ethereum-megaeth`                | High-throughput real-time EVM L2.                                                             |
 | Robinhood |  4663 | `robinhood` | ETH    | `ethereum-robinhood`              | Robinhood's EVM chain.                                                                          |
+| Solana    |   900 | `solana`    | SOL    | `solana-solana`                   | SVM chain; SPL and Token-2022 discovery, swaps, sends, and cross-chain routes are supported.    |
 
 ### Hyperliquid
 

--- a/wayfinder_paths/mcp/tools/tokens.py
+++ b/wayfinder_paths/mcp/tools/tokens.py
@@ -45,7 +45,8 @@ async def onchain_get_gas_token(chain_code: str) -> dict[str, Any]:
     """Return the native gas token for a chain, e.g. ETH for base, POL for polygon.
 
     Args:
-        chain_code: ethereum, base, arbitrum, polygon, bsc, avalanche, plasma, or hyperevm.
+        chain_code: ethereum, base, arbitrum, polygon, bsc, avalanche, plasma,
+            hyperevm, or solana.
     """
     token = await TOKEN_CLIENT.get_gas_token(chain_code)
     return ok(token)
@@ -56,7 +57,7 @@ async def onchain_fuzzy_search_tokens(chain_code: str, query: str) -> dict[str, 
     """Fuzzy-search tokens on a chain by symbol, name, or address — use when an exact id isn't known.
 
     Args:
-        chain_code: e.g. base. Pass all or _ to search across every chain.
+        chain_code: e.g. base or solana. Pass all or _ to search across every chain.
         query: name, symbol, or address. e.g. usdc, weth, wrapped eth, or 0x422...
     """
     chain = None if chain_code in ALL_CHAINS else chain_code
@@ -80,7 +81,8 @@ async def onchain_list_tokens(
     onchain_fuzzy_search_tokens / onchain_resolve_token.
 
     Args:
-        chain_code: the chain to browse, e.g. robinhood, base, arbitrum.
+        chain_code: the chain to browse, e.g. solana, robinhood, base, arbitrum.
+            Solana SPL and Token-2022 discovery is supported with "solana".
         dimension: ranking — "trending" (default), "volume" (24h), "new"
             (recently launched), or "active" (most 24h transactions).
         limit: max tokens to return (1-50, default 25).

--- a/wayfinder_paths/tests/test_mcp_profiles.py
+++ b/wayfinder_paths/tests/test_mcp_profiles.py
@@ -565,6 +565,18 @@ def test_primary_agent_warns_against_silent_similar_token_substitution() -> None
     assert "fresh quote and explicit user confirmation" in text
 
 
+def test_core_agent_prompts_include_solana_execution_guidance() -> None:
+    for filename in ("wayfinder.md", "wayfinder-baseline.md"):
+        text = (SDK_ROOT / ".opencode" / "agents" / filename).read_text(
+            encoding="utf-8"
+        )
+
+        assert 'onchain_list_tokens(chain_code="solana"' in text
+        assert "Solana remote-wallet swaps and sends are also sponsored" in text
+        assert "| Solana    |   900 | `solana`" in text
+        assert "wallet ring with an EVM leg" in text
+
+
 def test_stable_apy_research_and_adapter_docs_are_current() -> None:
     delta_high_value = (
         SDK_ROOT


### PR DESCRIPTION
### Summary

- Extend the core Wayfinder execution prompt with Solana wallet-ring, sponsorship, discovery, swap/send, and chain-identifier guidance.
- Reinforce Solana support in token MCP descriptions and test both primary prompt variants.