### PR TITLE
Shells Linq - Notification Delivery

### DIFF
--- a/wayfinder_paths/core/clients/NotifyClient.py
+++ b/wayfinder_paths/core/clients/NotifyClient.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
+from uuid import uuid4
 
 from wayfinder_paths.core.clients.WayfinderClient import WayfinderClient
 from wayfinder_paths.core.config import get_api_base_url
@@ -10,8 +11,8 @@ def normalize_notify_delivery(delivery: str | None) -> str:
     value = str(delivery or "email").strip().lower()
     if value == "text":
         value = "sms"
-    if value not in {"email", "sms"}:
-        raise ValueError("delivery must be one of: email, sms, text")
+    if value not in {"email", "sms", "linq"}:
+        raise ValueError("delivery must be one of: email, sms, text, linq")
     return value
 
 
@@ -22,12 +23,15 @@ class NotifyClient(WayfinderClient):
         message: str,
         *,
         delivery: str = "email",
+        idempotency_key: str | None = None,
     ) -> dict[str, Any]:
         url = f"{get_api_base_url()}/opencode/notify/"
         delivery_normalized = normalize_notify_delivery(delivery)
-        payload = {"title": title, "message": message}
+        payload: dict[str, str] = {"title": title, "message": message}
         if delivery_normalized != "email":
             payload["delivery"] = delivery_normalized
+        if delivery_normalized == "linq":
+            payload["idempotency_key"] = idempotency_key or str(uuid4())
         response = await self._authed_request("POST", url, json=payload)
         return response.json()
 

--- a/wayfinder_paths/mcp/tools/notify.py
+++ b/wayfinder_paths/mcp/tools/notify.py
@@ -14,15 +14,17 @@ MESSAGE_MAX = 20_000
 
 @catch_errors
 async def notification_send(title: str, message: str, delivery: str = "email") -> dict:
-    """Notify the OpenCode instance owner by email or SMS.
+    """Notify the OpenCode instance owner by email, SMS, or linked iMessage.
 
     Email requires a verified email address and renders Markdown into a themed
-    HTML email. SMS requires a verified phone number and sends plain text.
+    HTML email. SMS requires a verified phone number and sends plain text. Linq
+    sends an iMessage to the owner only when that channel is linked in Shells.
+    Sensitive approvals still happen in Shells, never through iMessage.
 
     Args:
         title: Short subject line (<= 200 chars).
         message: Markdown body (<= 20 000 chars).
-        delivery: "email" (default), "sms", or "text".
+        delivery: "email" (default), "sms", "text", or "linq".
     """
     title_s = throw_if_empty_str("title is required", title)
     if len(title_s) > TITLE_MAX:

--- a/wayfinder_paths/tests/test_notify_client.py
+++ b/wayfinder_paths/tests/test_notify_client.py
@@ -67,6 +67,37 @@ async def test_notify_client_text_alias_requests_sms(
     }
 
 
+@pytest.mark.asyncio
+async def test_notify_client_linq_adds_stable_request_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        notify_client_module,
+        "get_api_base_url",
+        lambda: "https://example.com/api/v1",
+    )
+    client = NotifyClient()
+    client._authed_request = AsyncMock(return_value=_Response({"sent": True}))  # type: ignore[method-assign]
+
+    await client.notify(
+        title="Alert",
+        message="Body",
+        delivery="linq",
+        idempotency_key="job:monitor:123",
+    )
+
+    assert client._authed_request.await_args.kwargs["json"] == {
+        "title": "Alert",
+        "message": "Body",
+        "delivery": "linq",
+        "idempotency_key": "job:monitor:123",
+    }
+
+
+def test_normalize_notify_delivery_accepts_linq() -> None:
+    assert normalize_notify_delivery(" LINQ ") == "linq"
+
+
 def test_normalize_notify_delivery_rejects_unknown_delivery() -> None:
     with pytest.raises(ValueError):
         normalize_notify_delivery("fax")
@@ -87,6 +118,24 @@ async def test_notification_send_passes_sms_delivery(
         title="Alert",
         message="Body",
         delivery="sms",
+    )
+
+
+@pytest.mark.asyncio
+async def test_notification_send_passes_linq_delivery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_client = AsyncMock()
+    fake_client.notify.return_value = {"sent": True, "delivery": "linq"}
+    monkeypatch.setattr(notify_tool_module, "NOTIFY_CLIENT", fake_client)
+
+    out = await notify_tool_module.notification_send("Alert", "Body", delivery="linq")
+
+    assert out == {"ok": True, "result": {"sent": True, "delivery": "linq"}}
+    fake_client.notify.assert_awaited_once_with(
+        title="Alert",
+        message="Body",
+        delivery="linq",
     )
 
 


### PR DESCRIPTION
### Summary

- add Linq as a supported OpenCode notification delivery mode
- attach idempotency keys for Linq sends and expose the mode through the notification MCP tool
- document that sensitive approvals remain in Shells