### PR TITLE
jobs: decision-log glance stats compute before the display cap

### DIFF
--- a/wayfinder_paths/jobs/decision_log.py
+++ b/wayfinder_paths/jobs/decision_log.py
@@ -45,10 +45,14 @@ def build_decision_log(
     entries.extend(_shadow_entries(root))
     entries.sort(key=lambda entry: str(entry.get("ts") or ""), reverse=True)
     _assign_threads(entries)
-    entries = entries[: max(int(limit), 1)]
+    # Stats over the FULL set BEFORE the display cap — a busy week must not
+    # undercount, and a small --limit must not produce nonsense glance
+    # numbers (caught live: --limit 5 reported self_culled=0 for a week
+    # that had them).
+    stats = _glance_stats(entries)
     return {
-        "entries": entries,
-        "stats": _glance_stats(entries),
+        "entries": entries[: max(int(limit), 1)],
+        "stats": stats,
         "generated_at": _now_iso(),
     }
 

--- a/wayfinder_paths/tests/test_jobs_decision_log.py
+++ b/wayfinder_paths/tests/test_jobs_decision_log.py
@@ -182,3 +182,5 @@ def test_caps_and_empty_job(tmp_path) -> None:
     )
     log = build_decision_log(store, job_id, limit=25)
     assert len(log["entries"]) == 25
+    # Stats see past the display cap: all 80 pending proposals counted.
+    assert log["stats"]["proposals_created"] == 80


### PR DESCRIPTION
Live-box catch after the roll: `wayfinder job decision-log --limit 5` reported `self_culled=0` for a week that had self-culls — `_glance_stats` ran over the already-capped entry list, so small limits (or any week with >50 entries) undercount the glance line the UI leads with. One-line reorder: stats over the full set, cap applies to the displayed entries only. Test extended to pin it.