### PR TITLE
runner: ensure_daemon_started decides liveness on retries, not one shot

### DIFF
--- a/wayfinder_paths/runner/lifecycle.py
+++ b/wayfinder_paths/runner/lifecycle.py
@@ -121,7 +121,18 @@ def ensure_daemon_started(
     env: dict[str, str] | None = None,
 ) -> tuple[bool, dict[str, Any]]:
     client = RunnerControlClient(sock_path=paths.sock_path)
+    # Liveness is decided on RETRIES, never one shot: the control socket's
+    # accept backlog is small (5), so a status attempt that coincides with a
+    # burst of other clients can transiently fail against a HEALTHY daemon
+    # (measured on-box: 0-gap bursts 9/20, >=50ms spacing 20/20). A one-shot
+    # check here could then spawn a duplicate daemon — the new one steals
+    # the socket and the orphan keeps ticking the same schedule.
     started, status, err_obj = try_status(client)
+    for _ in range(4):
+        if started and status is not None:
+            break
+        time.sleep(0.3)
+        started, status, err_obj = try_status(client)
     if started and status is not None:
         return True, {
             "already_running": True,


### PR DESCRIPTION
Hardening found while drilling the supervision PR (harness #152) on the live box: the runner control socket's accept backlog (5) overflows under 0-gap connect bursts — measured 9/20 successes at 0-gap vs 20/20 at ≥50ms spacing against a **healthy** daemon. `ensure_daemon_started` decided liveness on a **one-shot** `try_status`, so any lazy caller whose check coincided with a burst could misread a live daemon as dead and spawn a duplicate — the new daemon unlinks and steals the socket while the orphan keeps ticking the same schedule (duplicate job executions from shared state.db). This race predates #152 and affects every ensure path.

Fix: retry status up to 5 times over ~1.2s before concluding dead. A genuinely dead daemon refuses instantly on every attempt (verified in the kill drill — recovery ~3s once escalation runs), so real-death latency is unchanged.

Pairs with harness #152's three-strike probe guard: entrypoint probes cheaply (30ms socket connect every 30s), escalates only after 3 failures 15s apart, and the starter itself now double-checks before spawning.