### PR TITLE
Mobile Agent - Task Spawn Deny

### DIFF
--- a/.opencode/agents/wayfinder-baseline.md
+++ b/.opencode/agents/wayfinder-baseline.md
@@ -11,6 +11,7 @@ permission:
     wayfinder-sports: deny
     scout: deny
     general: deny
+    wayfinder-mobile: deny
 
   write: allow
   wayfinder_*: deny

--- a/.opencode/agents/wayfinder-mobile.md
+++ b/.opencode/agents/wayfinder-mobile.md
@@ -13,6 +13,7 @@ permission:
     wayfinder-sports: allow
     scout: deny
     general: deny
+    wayfinder-mobile: deny
 
   write: allow
   wayfinder_*: deny

--- a/.opencode/agents/wayfinder.md
+++ b/.opencode/agents/wayfinder.md
@@ -13,6 +13,7 @@ permission:
     wayfinder-sports: allow
     scout: deny
     general: deny
+    wayfinder-mobile: deny
 
   write: allow
   wayfinder_*: deny


### PR DESCRIPTION
### Summary
Follow-up to #590: adds an explicit `wayfinder-mobile: deny` to the `permission.task` rulesets of the primary agents (`wayfinder`, `wayfinder-baseline`) and to `wayfinder-mobile` itself. The task tool doesn't advertise primary-mode agents, but an unlisted pattern resolves to `ask` rather than `deny` — this closes that path so the mobile agent can only be entered directly, never spawned as a subagent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)