### PR TITLE
Alpha Lab - Sortable MCP search

### DIFF
--- a/.claude/skills/using-alpha-lab/SKILL.md
+++ b/.claude/skills/using-alpha-lab/SKILL.md
@@ -32,19 +32,21 @@ research_search_alpha(limit="20")                                               
 research_search_alpha(scan_type="twitter_post", limit="10")                        # Top 10 tweets
 research_search_alpha(query="ETH", limit="10")                                     # Search "ETH"
 research_search_alpha(created_after="2026-03-06T00:00:00Z", limit="20")            # Today's insights
+research_search_alpha(sort="-created", limit="20")                                 # Newest insights
 research_get_alpha_types()                                                         # List scan types
 ```
 
-Tool args: `research_search_alpha(query, scan_type, created_after, created_before, limit)`
+Tool args: `research_search_alpha(query, scan_type, created_after, created_before, sort, limit)`
 - `query`: text search, `_` for none (default `_`)
 - `scan_type`: filter by type, `all` for none (default `all`)
 - `created_after` / `created_before`: ISO 8601 datetime bounds, `_` to skip (default `_`)
+- `sort`: `-insightfulness_score` (default) or `-created` for newest first
 - `limit`: max results (default `"20"`, max `"200"`)
 
 **Critical gotchas:**
 - Client returns data directly (not tuples) — `data = await ALPHA_LAB_CLIENT.search()`
 - Scores are 0-1 floats (1 = most insightful)
-- MCP tool sorts by score descending (highest first); use Python client for custom sort/pagination
+- Default sort is score descending — all-time top scorers, NOT newest. For "latest/fresh alpha" pass `sort="-created"` (or a `created_after` bound), or recent items stay invisible unless they crack the all-time top N and the feed looks stale
 - Max 200 results per call; use `offset` for pagination (Python client only)
 
 ## When to use

--- a/.claude/skills/using-alpha-lab/rules/gotchas.md
+++ b/.claude/skills/using-alpha-lab/rules/gotchas.md
@@ -9,11 +9,11 @@
 | `sort="score"` | `sort="-insightfulness_score"` | Must use valid sort field with optional `-` prefix |
 | `limit=500` | `limit=200` | Max 200 per request; paginate with `offset` |
 
-## Valid Sort Fields (Python client only)
+## Valid Sort Fields
 
 `"insightfulness_score"`, `"-insightfulness_score"` (desc), `"created"`, `"-created"` (desc)
 
-MCP tool always sorts by `-insightfulness_score`.
+MCP tool defaults to `-insightfulness_score` — all-time top scorers, not newest. Pass `sort="-created"` when the user asks for latest/fresh insights.
 
 ## Valid Scan Types
 
@@ -24,12 +24,13 @@ MCP tool always sorts by `-insightfulness_score`.
 Use `_` for unused string params and `all` for no type filter.
 
 ```
-research_search_alpha(query, scan_type, created_after, created_before, limit)
+research_search_alpha(query, scan_type, created_after, created_before, sort, limit)
 ```
 
 Examples:
 ```
 research_search_alpha(limit="20")                                          # Top 20 insights
+research_search_alpha(sort="-created", limit="20")                         # Newest insights
 research_search_alpha(created_after="2026-03-06T00:00:00Z", limit="20")    # Today's insights
 research_search_alpha(query="ETH", scan_type="twitter_post", limit="10")   # ETH tweets
 ```

--- a/.claude/skills/using-alpha-lab/rules/high-value-reads.md
+++ b/.claude/skills/using-alpha-lab/rules/high-value-reads.md
@@ -5,6 +5,7 @@
 **User asks:** -> **Use this:**
 
 - "What's today's alpha?" -> `research_search_alpha(created_after="2026-03-06T00:00:00Z", limit="20")`
+- "What's the latest/freshest alpha?" -> `research_search_alpha(sort="-created", limit="20")`
 - "Any good tweets?" -> `research_search_alpha(scan_type="twitter_post", limit="20")`
 - "Chain flow activity?" -> `research_search_alpha(scan_type="defi_llama_chain_flow", limit="20")`
 - "Top APY signals" -> `research_search_alpha(scan_type="delta_lab_top_apy", limit="20")`
@@ -13,7 +14,7 @@
 
 ## MCP Tools
 
-Tool: `research_search_alpha(query, scan_type, created_after, created_before, limit)`
+Tool: `research_search_alpha(query, scan_type, created_after, created_before, sort, limit)`
 
 | Param | Values | Default |
 |-------|--------|---------|
@@ -21,9 +22,10 @@ Tool: `research_search_alpha(query, scan_type, created_after, created_before, li
 | `scan_type` | `all`, `twitter_post`, `defi_llama_chain_flow`, `defi_llama_overview`, `defi_llama_protocol`, `delta_lab_top_apy`, `delta_lab_best_delta_neutral` | `all` |
 | `created_after` | ISO 8601 datetime or `_` to skip | `_` |
 | `created_before` | ISO 8601 datetime or `_` to skip | `_` |
+| `sort` | `-insightfulness_score`, `insightfulness_score`, `-created`, `created` | `-insightfulness_score` |
 | `limit` | 1-200 | `"20"` |
 
-Results are always sorted by insightfulness score (highest first).
+Default sort is insightfulness score (highest first); use `sort="-created"` for newest first.
 
 ```python
 # Top 20 insights

--- a/wayfinder_paths/mcp/tools/alpha_lab.py
+++ b/wayfinder_paths/mcp/tools/alpha_lab.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from wayfinder_paths.core.clients.AlphaLabClient import ALPHA_LAB_CLIENT
+from wayfinder_paths.core.clients.AlphaLabClient import (
+    ALPHA_LAB_CLIENT,
+    VALID_SORT_FIELDS,
+)
 from wayfinder_paths.mcp.arg_validation import normalize_enum, normalize_int
 from wayfinder_paths.mcp.utils import catch_errors, ok
 
@@ -25,6 +28,7 @@ async def research_search_alpha(
     scan_type: str = "all",
     created_after: str = "_",
     created_before: str = "_",
+    sort: str = "-insightfulness_score",
     limit: str | int = "20",
 ) -> dict[str, Any]:
     """Search Alpha Lab insights. Sorted by insightfulness score (highest first).
@@ -36,10 +40,15 @@ async def research_search_alpha(
                   "delta_lab_best_delta_neutral", or "all".
         created_after: ISO 8601 datetime lower bound (e.g. "2026-03-06T00:00:00Z"). Use "_" to skip.
         created_before: ISO 8601 datetime upper bound. Use "_" to skip.
+        sort: "-insightfulness_score" (default, best first) or "-created" (newest
+              first — use this for fresh/latest insights; the score sort surfaces
+              all-time top scorers regardless of age).
         limit: Max results (default "20", max "200").
     """
     kwargs: dict[str, Any] = {
-        "sort": "-insightfulness_score",
+        "sort": normalize_enum(
+            sort, field_name="sort", allowed_values=VALID_SORT_FIELDS
+        ),
         "limit": min(200, normalize_int(limit, field_name="limit", min_value=1)),
     }
     type_value = normalize_enum(

--- a/wayfinder_paths/tests/test_mcp_argument_validation.py
+++ b/wayfinder_paths/tests/test_mcp_argument_validation.py
@@ -41,6 +41,16 @@ async def test_alpha_returns_allowed_values_for_bad_scan_type() -> None:
 
 
 @pytest.mark.asyncio
+async def test_alpha_returns_allowed_values_for_bad_sort() -> None:
+    result = await research_search_alpha(sort="score")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "invalid_argument"
+    assert result["error"]["details"]["field"] == "sort"
+    assert "-created" in result["error"]["details"]["allowed_values"]
+
+
+@pytest.mark.asyncio
 async def test_delta_lab_limit_type_errors_are_structured() -> None:
     result = await research_search_delta_lab_assets(query="ETH", limit="many")
 


### PR DESCRIPTION
### Summary
Expose a `sort` arg on the `research_search_alpha` MCP tool (default unchanged: `-insightfulness_score`), validated against the client's sort fields, so agents can fetch newest-first with `sort="-created"`. Previously the tool was hard-coded to score order, which surfaces all-time top scorers and makes the feed look stale when asked for recent insights. Skill docs updated with the freshness pattern; adds an invalid-sort validation test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)