### PR TITLE
runner: cap concurrent workers at 2 on constrained boxes

### DIFF
--- a/wayfinder_paths/jobs/runner_bridge.py
+++ b/wayfinder_paths/jobs/runner_bridge.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Any
 
 from wayfinder_paths.runner.client import RunnerControlClient
-from wayfinder_paths.runner.constants import JOB_TYPE_SCRIPT
+from wayfinder_paths.runner.constants import DEFAULT_MAX_WORKERS, JOB_TYPE_SCRIPT
 from wayfinder_paths.runner.lifecycle import ensure_daemon_started
 from wayfinder_paths.runner.paths import RunnerPaths, get_runner_paths
 from wayfinder_paths.runner.schedule import schedule_request_params
@@ -21,7 +21,7 @@ class RunnerBridge:
         started, info = ensure_daemon_started(
             paths=self.paths,
             tick_seconds=1.0,
-            max_workers=4,
+            max_workers=DEFAULT_MAX_WORKERS,
             max_failures=5,
             default_timeout_seconds=20 * 60,
             log_level="INFO",

--- a/wayfinder_paths/mcp/tools/runner.py
+++ b/wayfinder_paths/mcp/tools/runner.py
@@ -13,7 +13,11 @@ from wayfinder_paths.mcp.utils import (
     repo_root,
 )
 from wayfinder_paths.runner.client import RunnerControlClient
-from wayfinder_paths.runner.constants import JOB_TYPE_SCRIPT, JOB_TYPE_STRATEGY
+from wayfinder_paths.runner.constants import (
+    DEFAULT_MAX_WORKERS,
+    JOB_TYPE_SCRIPT,
+    JOB_TYPE_STRATEGY,
+)
 from wayfinder_paths.runner.lifecycle import ensure_daemon_started, try_status
 from wayfinder_paths.runner.paths import RunnerPaths, get_runner_paths
 from wayfinder_paths.runner.schedule import schedule_request_params
@@ -213,7 +217,9 @@ async def core_runner(
                     tick_seconds=float(tick_seconds)
                     if tick_seconds is not None
                     else 1.0,
-                    max_workers=int(max_workers) if max_workers is not None else 4,
+                    max_workers=int(max_workers)
+                    if max_workers is not None
+                    else DEFAULT_MAX_WORKERS,
                     max_failures=int(max_failures) if max_failures is not None else 5,
                     default_timeout_seconds=int(default_timeout_seconds)
                     if default_timeout_seconds is not None

--- a/wayfinder_paths/runner/cli.py
+++ b/wayfinder_paths/runner/cli.py
@@ -11,6 +11,7 @@ from loguru import logger
 from wayfinder_paths.runner.client import RunnerControlClient
 from wayfinder_paths.runner.constants import (
     ADD_JOB_CLI_VERB,
+    DEFAULT_MAX_WORKERS,
     JOB_TYPE_SCRIPT,
     JOB_TYPE_STRATEGY,
 )
@@ -35,7 +36,7 @@ def runner_cli() -> None:
 
 @runner_cli.command(name="start", help="Start the runner daemon (idempotent).")
 @click.option("--tick-seconds", type=float, default=1.0, show_default=True)
-@click.option("--max-workers", type=int, default=4, show_default=True)
+@click.option("--max-workers", type=int, default=DEFAULT_MAX_WORKERS, show_default=True)
 @click.option("--max-failures", type=int, default=5, show_default=True)
 @click.option("--default-timeout-seconds", type=int, default=20 * 60, show_default=True)
 @click.option(

--- a/wayfinder_paths/runner/constants.py
+++ b/wayfinder_paths/runner/constants.py
@@ -29,3 +29,11 @@ ADD_JOB_MCP_ACTION: Final[str] = "add_job"  # MCP action key (JSON identifier)
 
 # Control protocol limits
 MAX_LINE_BYTES: Final[int] = 1024 * 1024
+
+# Concurrent worker cap. Each worker is a full SDK Python (~170MB
+# baseline, several hundred MB during wake-path backtests/sims). On the
+# 2GB boxes, 4 concurrent workers atop opencode+MCP+runnerd blew through
+# memory during job-start bursts and the OOM killer took runnerd twice
+# (2026-07-27, 2026-07-31 — silent mid-line log stops). Two workers
+# halve the burst ceiling; ticks are seconds-long so queueing is cheap.
+DEFAULT_MAX_WORKERS = 2

--- a/wayfinder_paths/tests/test_wayfinder_jobs.py
+++ b/wayfinder_paths/tests/test_wayfinder_jobs.py
@@ -740,7 +740,9 @@ def test_runner_bridge_starts_daemon_with_defaults(tmp_path: Path, monkeypatch) 
     assert result["ok"] is True
     assert captured["paths"].repo_root == tmp_path.resolve()
     assert captured["tick_seconds"] == 1.0
-    assert captured["max_workers"] == 4
+    from wayfinder_paths.runner.constants import DEFAULT_MAX_WORKERS
+
+    assert captured["max_workers"] == DEFAULT_MAX_WORKERS
     assert captured["max_failures"] == 5
     assert captured["default_timeout_seconds"] == 20 * 60
     assert captured["log_level"] == "INFO"


### PR DESCRIPTION
Root-cause fix for the two runnerd deaths (Jul 27, Jul 31). The deaths are memory-pressure kills: each runner worker is a full SDK Python (~170MB baseline, several hundred MB while running the wake-path replication backtests / counterfactual sims over 120d datasets). With `--max-workers 4`, a job-start burst (the Jul 31 log shows **seven jobs starting within ten seconds, then a silent mid-line log stop** — the OOM-kill signature) stacks 4 ballooning workers on top of opencode (326MB) + MCP (169MB) + runnerd (168MB) and blows through the 2GB box.

`DEFAULT_MAX_WORKERS = 2` as one shared constant consumed by all three spawn paths (CLI default, jobs runner bridge, MCP ensure — previously three independent hardcoded 4s). Ticks are seconds-long so queueing is cheap; the burst ceiling halves. The now-deployed supervision (harness #152 — verified live with an unattended 40s kill-recovery drill) remains the safety net.

Runner suite passes; imports clean.