### PR TITLE
jobs: machine-wide heavy-compute lock — one big sim at a time

### DIFF
--- a/wayfinder_paths/jobs/compute_lock.py
+++ b/wayfinder_paths/jobs/compute_lock.py
@@ -1,0 +1,94 @@
+"""Machine-wide heavy-compute lock: one big simulation at a time.
+
+Measured on the 2GB boxes: a single 120d backtest peaks at ~336MB and runs
+~28s — it fits comfortably. Every OOM incident (runnerd deaths 2026-07-27
+and 2026-07-31; composition proposals blocked 2026-08-02 after three
+attempts) came from heavy computations OVERLAPPING: a wake-path replication
+run colliding with a candidate-validation backtest colliding with a scan.
+Serializing the heavies machine-wide turns a fatal burst into a few seconds
+of queueing.
+
+Cross-process via flock on `.wayfinder/compute.lock` under the repo root;
+reentrant within a process (replication -> backtest_execution_job must not
+self-deadlock). On timeout the caller gets a clear TimeoutError — agents
+see "another heavy computation is running, retry" instead of a silent
+OOM-kill, and the wake-path monitors already degrade gracefully on
+exceptions.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+LOCK_RELATIVE = ".wayfinder/compute.lock"
+DEFAULT_TIMEOUT_S = 600.0
+_POLL_S = 2.0
+_local = threading.local()
+
+
+class ComputeLockBusy(TimeoutError):
+    pass
+
+
+def _lock_path(repo_root: Path | None) -> Path:
+    if repo_root is None:
+        from wayfinder_paths.jobs.store import JobStore
+
+        repo_root = JobStore().repo_root
+    return Path(repo_root) / LOCK_RELATIVE
+
+
+@contextmanager
+def heavy_compute_lock(
+    *,
+    repo_root: Path | None = None,
+    label: str = "",
+    timeout_s: float = DEFAULT_TIMEOUT_S,
+) -> Iterator[None]:
+    if getattr(_local, "held", False):
+        # Reentrant: the outermost holder owns the flock.
+        yield
+        return
+    path = _lock_path(repo_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # "a+" — opening must NOT truncate: a contender that fails to acquire
+    # reads the current holder's pid/label out of this file for its error.
+    handle = path.open("a+")
+    deadline = time.monotonic() + float(timeout_s)
+    try:
+        while True:
+            try:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except OSError:
+                if time.monotonic() >= deadline:
+                    holder = ""
+                    try:
+                        holder = path.read_text(encoding="utf-8").strip()
+                    except OSError:
+                        pass
+                    raise ComputeLockBusy(
+                        "heavy-compute lock busy after "
+                        f"{timeout_s:.0f}s (held by: {holder or 'unknown'}) — "
+                        "another heavy computation is running on this box; "
+                        "retry when it finishes"
+                    ) from None
+                time.sleep(_POLL_S)
+        handle.seek(0)
+        handle.truncate()
+        handle.write(f"pid={os.getpid()} label={label}\n")
+        handle.flush()
+        _local.held = True
+        try:
+            yield
+        finally:
+            _local.held = False
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    finally:
+        handle.close()

--- a/wayfinder_paths/jobs/counterfactual.py
+++ b/wayfinder_paths/jobs/counterfactual.py
@@ -231,8 +231,11 @@ def _compute(
         warm_ready = warm_ready.tz_localize("UTC")
     effective_from = max(apply_ts, warm_ready)
 
+    from wayfinder_paths.jobs.compute_lock import heavy_compute_lock
+
     run = simulate or simulate_execution
-    result = run(script, dataset, spec, params)
+    with heavy_compute_lock(label=f"counterfactual:{job_id}"):
+        result = run(script, dataset, spec, params)
     shadow_rows = [dict(row) for row in result.trades]
 
     shadow_entries = _entries(shadow_rows, effective_from, interval_seconds)

--- a/wayfinder_paths/jobs/execution/job.py
+++ b/wayfinder_paths/jobs/execution/job.py
@@ -111,6 +111,37 @@ def backtest_execution_job(
     quick_bars: int | None = None,
     store: JobStore | None = None,
 ) -> dict[str, Any]:
+    from wayfinder_paths.jobs.compute_lock import heavy_compute_lock
+
+    store = store or JobStore()
+    with heavy_compute_lock(repo_root=store.repo_root, label=f"backtest:{job_id}"):
+        return _backtest_execution_job_locked(
+            job_id,
+            grid_path=grid_path,
+            workers=workers,
+            parallel=parallel,
+            rank_by=rank_by,
+            walk_forward=walk_forward,
+            optimizer=optimizer,
+            optuna_options=optuna_options,
+            quick_bars=quick_bars,
+            store=store,
+        )
+
+
+def _backtest_execution_job_locked(
+    job_id: str,
+    *,
+    grid_path: str | Path | None = None,
+    workers: int = 1,
+    parallel: str = "serial",
+    rank_by: str = "net_return",
+    walk_forward: Mapping[str, Any] | None = None,
+    optimizer: str = "grid",
+    optuna_options: Mapping[str, Any] | None = None,
+    quick_bars: int | None = None,
+    store: JobStore | None = None,
+) -> dict[str, Any]:
     store = store or JobStore()
     root = store.job_dir(job_id)
     job_data = _load_job_yaml(root)

--- a/wayfinder_paths/jobs/execution/simulator.py
+++ b/wayfinder_paths/jobs/execution/simulator.py
@@ -842,12 +842,21 @@ def write_backtest_artifacts(
         case _:
             latest = root / "latest.json"
             visualization = root / "visualization.json"
+            # Compact separators: indent=2 on multi-MB per-bar arrays doubles
+            # both the dump's transient memory and the disk footprint, and
+            # these files are machine-read only.
             latest.write_text(
-                json.dumps({**result.to_dict(), **stamp}, indent=2, default=str) + "\n",
+                json.dumps(
+                    {**result.to_dict(), **stamp},
+                    separators=(",", ":"),
+                    default=str,
+                )
+                + "\n",
                 encoding="utf-8",
             )
             visualization.write_text(
-                json.dumps(result.visualization, indent=2, default=str) + "\n",
+                json.dumps(result.visualization, separators=(",", ":"), default=str)
+                + "\n",
                 encoding="utf-8",
             )
             return {"latest": str(latest), "visualization": str(visualization)}

--- a/wayfinder_paths/jobs/universe.py
+++ b/wayfinder_paths/jobs/universe.py
@@ -93,13 +93,19 @@ def universe_scan_job(
                 {**entry, "scanned": False, "reason": "insufficient bars"}
             )
             continue
-        result = scan_signals(
-            frame,
-            bar_seconds=_BAR_SECONDS,
-            min_events=min_events,
-            condition_regime=True,
-            holdout_fraction=0.1,
-        )
+        from wayfinder_paths.jobs.compute_lock import heavy_compute_lock
+
+        # Per-symbol acquire: heavy scans serialize against other big sims
+        # while letting them interleave between symbols (fairness on the
+        # shared box).
+        with heavy_compute_lock(label=f"universe-scan:{symbol}"):
+            result = scan_signals(
+                frame,
+                bar_seconds=_BAR_SECONDS,
+                min_events=min_events,
+                condition_regime=True,
+                holdout_fraction=0.1,
+            )
         rows = [
             {**row, "universe_symbol": symbol} for row in result.get("_all_rows") or []
         ]

--- a/wayfinder_paths/jobs/validation.py
+++ b/wayfinder_paths/jobs/validation.py
@@ -124,9 +124,7 @@ def validate_candidate_application(
         }
     )
     if script_required:
-        checks.append(
-            entrypoint_inside_workspace_check(candidate_dir, script_path)
-        )
+        checks.append(entrypoint_inside_workspace_check(candidate_dir, script_path))
     if script_path and script_path.exists():
         if contract == "jobs_v1":
             checks.extend(_jobs_v1_script_checks(script_path))
@@ -305,12 +303,18 @@ def _candidate_behavior_checks(
             )
             return checks
     try:
-        result = simulate_execution(
-            script_path,
-            dataset,
-            spec,
-            params=dict(job_data.get("execution_params") or {}),
-        )
+        from wayfinder_paths.jobs.compute_lock import heavy_compute_lock
+
+        # Full-dataset candidate backtest (~336MB peak on 120d) — serialize
+        # machine-wide so it can never overlap another heavy sim (the OOM
+        # class that blocked composition proposals 2026-08-02).
+        with heavy_compute_lock(label=f"candidate-backtest:{job_dir.name}"):
+            result = simulate_execution(
+                script_path,
+                dataset,
+                spec,
+                params=dict(job_data.get("execution_params") or {}),
+            )
         # Persist the candidate backtest as a revision-stamped artifact inside
         # the candidate bundle (outside workspace/, so the candidate revision
         # is unchanged). Promotion copies it into the job's results/ — the

--- a/wayfinder_paths/tests/test_jobs_compute_lock.py
+++ b/wayfinder_paths/tests/test_jobs_compute_lock.py
@@ -1,0 +1,80 @@
+"""Machine-wide heavy-compute lock: cross-process exclusivity, in-process
+reentrancy, clear busy errors, and heavy entrypoints actually holding it."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from wayfinder_paths.jobs.compute_lock import (
+    ComputeLockBusy,
+    heavy_compute_lock,
+)
+
+
+def test_reentrant_within_process(tmp_path) -> None:
+    with heavy_compute_lock(repo_root=tmp_path, label="outer"):
+        with heavy_compute_lock(repo_root=tmp_path, label="inner"):
+            pass  # no self-deadlock
+
+
+def test_cross_process_exclusivity_and_busy_error(tmp_path) -> None:
+    import os
+
+    holder = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            textwrap.dedent(
+                f"""
+                import time
+                from wayfinder_paths.jobs.compute_lock import heavy_compute_lock
+                with heavy_compute_lock(repo_root={str(tmp_path)!r}, label="holder"):
+                    print("HELD", flush=True)
+                    time.sleep(8)
+                """
+            ),
+        ],
+        stdout=subprocess.PIPE,
+        text=True,
+        cwd=os.getcwd(),
+    )
+    try:
+        assert holder.stdout is not None
+        assert holder.stdout.readline().strip() == "HELD"
+        with pytest.raises(ComputeLockBusy, match="held by: pid="):
+            with heavy_compute_lock(
+                repo_root=tmp_path, label="contender", timeout_s=1.0
+            ):
+                pass
+    finally:
+        holder.kill()
+        holder.wait()
+    # After the holder dies, the lock is acquirable again.
+    with heavy_compute_lock(repo_root=tmp_path, label="after"):
+        pass
+
+
+def test_backtest_entrypoint_holds_lock(tmp_path, monkeypatch) -> None:
+    """backtest_execution_job must hold the lock while simulating."""
+    import wayfinder_paths.jobs.execution.job as job_mod
+    from wayfinder_paths.jobs import compute_lock
+
+    seen = {}
+
+    def fake_locked(job_id, **kwargs):
+        seen["held"] = getattr(compute_lock._local, "held", False)
+        return {"ok": True}
+
+    monkeypatch.setattr(job_mod, "_backtest_execution_job_locked", fake_locked)
+
+    class FakeStore:
+        repo_root = tmp_path
+
+    result = job_mod.backtest_execution_job("demo", store=FakeStore())
+    assert result == {"ok": True}
+    assert seen["held"] is True
+    assert not getattr(compute_lock._local, "held", False)  # released


### PR DESCRIPTION
The serialize-instead-of-scale answer to the OOM class. Measured on the box: a single 120d backtest peaks at **~336MB / 28s** — comfortably inside the ~940MB available. Every OOM incident (two runnerd deaths; composition hypotheses #7–9 currently stuck at 'Propose BLOCKED: OOM-kill on 120d backtest gate, 3 attempts') came from heavy computations **overlapping**, not from any single task.

**`heavy_compute_lock`** (`compute_lock.py`): flock on `.wayfinder/compute.lock`, machine-wide across the MCP server, runner workers, and agent CLI sessions; reentrant within a process (replication → backtest can't self-deadlock); waits up to 10 min then raises a clear `ComputeLockBusy` naming the holder's pid/label — agents get 'another heavy computation is running, retry' instead of a silent kill, and the wake-path monitors already degrade gracefully on exceptions.

Wrapped: `backtest_execution_job` (covers CLI backtests, replication, grids), the candidate-report full-dataset backtest, the counterfactual sim, universe scans (per-symbol acquire for fairness between symbols). Small scenario-fixture sims stay unwrapped. Bonus lean-out: `latest.json`/`visualization.json` dumps switch to compact separators — `indent=2` on multi-MB per-bar arrays doubled both transient dump memory and disk for machine-read files.

Tests: in-process reentrancy, cross-process exclusivity with busy-error naming the holder (this test caught a real bug — 'w'-mode open truncated the holder's diagnostic line), lock release after holder death, and the backtest entrypoint provably holding/releasing the lock. 57 tests across affected suites; ruff clean.

After merge+roll: the agent's queued composition hypotheses (#7–9) should re-propose cleanly.