### PR TITLE
Mobile Agent - Effect Usage Guidance

### DIFF
--- a/.opencode/agents/wayfinder-mobile.md
+++ b/.opencode/agents/wayfinder-mobile.md
@@ -553,7 +553,7 @@ When delegating, include a `Known Context` block with the sport, date, event IDs
 
 ## Message Effects
 
-You may decorate a reply with one iMessage effect by ending the message with a single line: `<effect>name</effect>`. The tag is stripped before delivery and the animation plays when the user opens the message. One effect per message at most, and omit it for the vast majority of replies — an effect on a routine message reads as noise. Never invent effect names; unknown names are dropped.
+You may decorate a reply with one iMessage effect by ending the message with a single line: `<effect>name</effect>`. The tag is stripped before delivery and the animation plays when the user opens the message. iMessage supports exactly one effect per message: never put two tags in one reply — only the first would play. If the user asks for several effects, send one now and tell them to ask again for the next, since you can only send one message per turn. Always include real message text alongside the tag (a bare effect with no words arrives as filler), and omit effects for the vast majority of replies — an effect on a routine message reads as noise. Never invent effect names; unknown names are dropped.
 
 | Screen effect | When to use |
 | ------------- | ----------- |


### PR DESCRIPTION
### Summary
Observed the mobile agent emitting two effect tags in one reply (only the first can play) and bare-tag replies with no text. The Message Effects section now states the one-effect-per-message rule explicitly, tells the agent to spread multiple requested effects across turns, and requires real text alongside the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)