### PR TITLE
jobs: wake-path monitors give up on the compute lock fast

### DIFF
--- a/wayfinder_paths/jobs/counterfactual.py
+++ b/wayfinder_paths/jobs/counterfactual.py
@@ -33,6 +33,8 @@ _WARMUP_BARS = 720
 _MAX_FETCH_BARS = 4500
 _MIN_WINDOW_BARS = 12
 _RECOMPUTE_AFTER_S = 6 * 3600
+# Worker-safety: give up on the compute lock quickly (see _compute).
+_LOCK_TIMEOUT_S = 60.0
 _EXAMPLE_LIMIT = 5
 
 BASIS_NOTE = (
@@ -234,7 +236,16 @@ def _compute(
     from wayfinder_paths.jobs.compute_lock import heavy_compute_lock
 
     run = simulate or simulate_execution
-    with heavy_compute_lock(label=f"counterfactual:{job_id}"):
+    # Short lock wait: this monitor runs inside a runner WORKER (cap 2) on
+    # the wake path — waiting minutes for the lock would hold a worker and
+    # delay script ticks. It is stamp-gated; skipping a cycle is free, and
+    # ComputeLockBusy degrades to the journaled-unavailable path like any
+    # other failure.
+    with heavy_compute_lock(
+        repo_root=store.repo_root,
+        label=f"counterfactual:{job_id}",
+        timeout_s=_LOCK_TIMEOUT_S,
+    ):
         result = run(script, dataset, spec, params)
     shadow_rows = [dict(row) for row in result.trades]
 

--- a/wayfinder_paths/jobs/replication.py
+++ b/wayfinder_paths/jobs/replication.py
@@ -23,6 +23,8 @@ from wayfinder_paths.jobs.store import JobStore
 
 REPLICATION_PATH = "results/backtest/replication.json"
 _RECOMPUTE_AFTER_S = 24 * 3600
+# Worker-safety: give up on the compute lock quickly (see _compute).
+_LOCK_TIMEOUT_S = 60.0
 # Relative collapse of net return vs the revision's own baseline that flags
 # decay (sign flips always flag).
 _DECAY_RELATIVE = 0.5
@@ -56,9 +58,15 @@ def replication_job(
 def _compute(
     store: JobStore, job_id: str, cached: dict[str, Any] | None
 ) -> dict[str, Any]:
+    from wayfinder_paths.jobs.compute_lock import heavy_compute_lock
     from wayfinder_paths.jobs.execution.job import backtest_execution_job
 
-    payload = backtest_execution_job(job_id, store=store)
+    # Short lock wait for the same reason as the counterfactual monitor:
+    # this runs in a runner worker on the wake path — skip the cycle rather
+    # than hold a worker behind a long-running sim. The inner acquire in
+    # backtest_execution_job is reentrant and free once we hold it here.
+    with heavy_compute_lock(label=f"replication:{job_id}", timeout_s=_LOCK_TIMEOUT_S):
+        payload = backtest_execution_job(job_id, store=store)
     result = payload.get("result") or {}
     stats = result.get("stats") or {}
     revision = str(payload.get("revision") or "")

--- a/wayfinder_paths/jobs/replication.py
+++ b/wayfinder_paths/jobs/replication.py
@@ -65,7 +65,11 @@ def _compute(
     # this runs in a runner worker on the wake path — skip the cycle rather
     # than hold a worker behind a long-running sim. The inner acquire in
     # backtest_execution_job is reentrant and free once we hold it here.
-    with heavy_compute_lock(label=f"replication:{job_id}", timeout_s=_LOCK_TIMEOUT_S):
+    with heavy_compute_lock(
+        repo_root=store.repo_root,
+        label=f"replication:{job_id}",
+        timeout_s=_LOCK_TIMEOUT_S,
+    ):
         payload = backtest_execution_job(job_id, store=store)
     result = payload.get("result") or {}
     stats = result.get("stats") or {}

--- a/wayfinder_paths/tests/test_jobs_compute_lock.py
+++ b/wayfinder_paths/tests/test_jobs_compute_lock.py
@@ -78,3 +78,60 @@ def test_backtest_entrypoint_holds_lock(tmp_path, monkeypatch) -> None:
     assert result == {"ok": True}
     assert seen["held"] is True
     assert not getattr(compute_lock._local, "held", False)  # released
+
+
+def test_wake_monitors_skip_fast_when_lock_held(tmp_path, monkeypatch) -> None:
+    """Replication/counterfactual run in runner workers — when the lock is
+    held elsewhere they must give up quickly (journaled skip), never hold a
+    worker for the full default wait."""
+    import subprocess
+    import textwrap
+    import time as _time
+
+    from wayfinder_paths.jobs import counterfactual as cf
+    from wayfinder_paths.jobs import replication as rep
+    from wayfinder_paths.jobs.models import WayfinderJob
+    from wayfinder_paths.jobs.store import JobStore
+
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("locked-demo", agent_mode="intervene")
+    store.save(job)
+
+    monkeypatch.setattr(rep, "_LOCK_TIMEOUT_S", 1.0)
+    monkeypatch.setattr(cf, "_LOCK_TIMEOUT_S", 1.0)
+
+    import os
+
+    holder = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            textwrap.dedent(
+                f"""
+                import time
+                from wayfinder_paths.jobs.compute_lock import heavy_compute_lock
+                with heavy_compute_lock(repo_root={str(tmp_path)!r}, label="grid"):
+                    print("HELD", flush=True)
+                    time.sleep(15)
+                """
+            ),
+        ],
+        stdout=subprocess.PIPE,
+        text=True,
+        cwd=os.getcwd(),
+    )
+    try:
+        assert holder.stdout is not None
+        assert holder.stdout.readline().strip() == "HELD"
+
+        t0 = _time.monotonic()
+        doc = rep.replication_job(job.id, store=store)
+        elapsed = _time.monotonic() - t0
+        assert doc["available"] is False
+        assert "lock busy" in doc["reason"]
+        assert elapsed < 8  # gave up fast, did not hold a worker
+        journal = (store.job_dir(job.id) / "journal.jsonl").read_text()
+        assert "replication_failed" in journal
+    finally:
+        holder.kill()
+        holder.wait()


### PR DESCRIPTION
Closes the one indirect coupling between the compute lock (#597) and the execution lane. Direct coupling is zero — verified the tick driver/engine/forward loop never acquire the lock, so trading ticks are structurally unaffected. But replication and counterfactual run inside runner **workers** (cap 2) on the wake path: with the default 10-minute lock wait, a worker could sit blocked behind a long grid run, and two blocked wake-preps would delay script ticks.

Both monitors are stamp-gated — skipping a cycle is free — so they now wait **60s max** then take the existing journaled-degraded path (`ComputeLockBusy` → `replication_failed`/`counterfactual_failed` → retry next wake). Worker occupancy from lock contention is now bounded at a minute.

Also fixes a latent wiring bug the new test caught: the monitors locked the *default* store's lock path instead of the job store's `repo_root` — coincidentally identical on the box, but wrong. Test: subprocess holds the lock, replication gives up in <8s with the busy reason journaled. 12 tests pass across the lock suites; ruff clean.