### PR TITLE
jobs: venue shortfalls are not proof; window changes re-pin replication

### DIFF
--- a/wayfinder_paths/jobs/execution/validation.py
+++ b/wayfinder_paths/jobs/execution/validation.py
@@ -275,6 +275,26 @@ def _evidence_window_check(root: Path) -> list[dict[str, Any]]:
                 ),
             }
         ]
+    source = str(metadata.get("source") or "")
+    if source != "ccxt":
+        # A VENUE shortfall proves nothing — venue feeds cap at days of
+        # history while the ccxt path has years. This exact hole let an
+        # Aug 2 default-source refetch replace the 120d ccxt dataset with
+        # 40d of venue data and still pass the gate as "proven".
+        return [
+            {
+                "name": "evidence_window",
+                "passed": False,
+                "days_received": received,
+                "error": (
+                    f"dataset spans {received:g}d from source {source!r} — a "
+                    "venue-capped shortfall is NOT proof of unavailability. "
+                    f"Refetch via the long-history path: fetch-dataset --days "
+                    f"{EVIDENCE_TARGET_DAYS:g} --source ccxt. Only a ccxt "
+                    "shortfall counts as proven (new listing)."
+                ),
+            }
+        ]
     if received >= EVIDENCE_FLOOR_DAYS:
         return [
             {
@@ -284,9 +304,10 @@ def _evidence_window_check(root: Path) -> list[dict[str, Any]]:
                 "days_received": received,
                 "note": (
                     f"{received:g}d received of {requested:g}d requested — the "
-                    "source could not supply the target (new symbol); the 30d "
-                    "floor applies. Evidence from this window is short-history: "
-                    "prefer probation sizing and re-validate as history grows."
+                    "long-history source could not supply the target (new "
+                    "symbol); the 30d floor applies. Evidence from this window "
+                    "is short-history: prefer probation sizing and re-validate "
+                    "as history grows."
                 ),
             }
         ]

--- a/wayfinder_paths/jobs/replication.py
+++ b/wayfinder_paths/jobs/replication.py
@@ -83,9 +83,20 @@ def _compute(
         "run_at": utc_now_iso(),
     }
 
+    current["dataset_days"] = (
+        dataset_meta.get("days_received") or dataset_meta.get("days")
+        if isinstance(dataset_meta, dict)
+        else None
+    )
     baseline = None
     if cached and cached.get("revision") == revision:
         baseline = cached.get("baseline")
+    if baseline and _window_changed(baseline, current):
+        # Different dataset window => not comparable. A 120d baseline vs a
+        # 40d rerun reads as "decay" when only the window shrank (Aug 4
+        # false positive). Re-pin and note it — the evidence_window gate
+        # separately polices whether the window itself is acceptable.
+        baseline = None
     if not baseline:
         # First run for this revision pins its baseline — subsequent runs
         # measure drift against it. A new revision resets the baseline (its
@@ -114,6 +125,17 @@ def _compute(
         ),
         "computed_at": utc_now_iso(),
     }
+
+
+def _window_changed(baseline: dict[str, Any], current: dict[str, Any]) -> bool:
+    try:
+        base_days = float(baseline.get("dataset_days") or 0.0)
+        now_days = float(current.get("dataset_days") or 0.0)
+    except (TypeError, ValueError):
+        return False
+    if not base_days or not now_days:
+        return False
+    return abs(now_days - base_days) / base_days > 0.2
 
 
 def _decayed(baseline: dict[str, Any], current: dict[str, Any]) -> bool:

--- a/wayfinder_paths/tests/test_jobs_evidence_window.py
+++ b/wayfinder_paths/tests/test_jobs_evidence_window.py
@@ -12,14 +12,18 @@ from wayfinder_paths.jobs.replication import replication_job
 from wayfinder_paths.jobs.store import JobStore
 
 
-def _root_with_dataset(tmp_path, *, days, days_received):
+def _root_with_dataset(tmp_path, *, days, days_received, source="ccxt"):
     root = tmp_path
     (root / "results" / "backtest").mkdir(parents=True, exist_ok=True)
     (root / "results" / "backtest" / "input_bars.json").write_text(
         json.dumps(
             {
                 "bars": [],
-                "metadata": {"days": days, "days_received": days_received},
+                "metadata": {
+                    "days": days,
+                    "days_received": days_received,
+                    "source": source,
+                },
             }
         ),
         encoding="utf-8",
@@ -47,6 +51,16 @@ def test_evidence_window_policy_paths(tmp_path) -> None:
     )[0]
     assert not check["passed"]
     assert "--source ccxt" in check["error"]
+
+    # VENUE shortfall is NOT proof — ccxt has the history (the Aug 2 hole:
+    # a default-source refetch got 40d from the venue and passed as proven).
+    check = _evidence_window_check(
+        _root_with_dataset(
+            tmp_path / "g", days=120, days_received=40.4, source="live_fetch"
+        )
+    )[0]
+    assert not check["passed"]
+    assert "NOT proof" in check["error"] and "--source ccxt" in check["error"]
 
     # Below the floor even with the target requested -> fail.
     check = _evidence_window_check(
@@ -266,3 +280,50 @@ def test_incremental_provenance_mismatch_forces_full(tmp_path) -> None:
     path.write_text(_json.dumps(doc), encoding="utf-8")
     build_live_dataset(job_id, days=5, store=store, source="ccxt", feed=feed)
     assert feed.lookbacks[1] == 120  # full 5d again
+
+
+def test_replication_window_change_repins_not_decays(tmp_path, monkeypatch) -> None:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("rep-window", agent_mode="intervene")
+    store.save(job)
+    runs = [
+        {  # 120d baseline, strong
+            "revision": "rev-a",
+            "dataset": {"days": 120, "days_received": 119.0, "source": "ccxt"},
+            "result": {
+                "stats": {
+                    "net_return": 0.20,
+                    "avg_trade_pnl": 0.006,
+                    "total_trades": 1300,
+                    "win_rate": 0.51,
+                }
+            },
+        },
+        {  # window collapsed to 40d — NOT decay; re-pin
+            "revision": "rev-a",
+            "dataset": {"days": 120, "days_received": 40.0, "source": "live_fetch"},
+            "result": {
+                "stats": {
+                    "net_return": 0.008,
+                    "avg_trade_pnl": 0.007,
+                    "total_trades": 226,
+                    "win_rate": 0.52,
+                }
+            },
+        },
+    ]
+    calls = {"n": 0}
+
+    def fake_backtest(job_id, **kwargs):
+        payload = runs[min(calls["n"], len(runs) - 1)]
+        calls["n"] += 1
+        return payload
+
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.execution.job.backtest_execution_job", fake_backtest
+    )
+    first = replication_job(job.id, store=store)
+    assert first["baseline"]["dataset_days"] == 119.0
+    second = replication_job(job.id, store=store, force=True)
+    assert second["decayed"] is False  # window change, not edge decay
+    assert second["baseline"]["dataset_days"] == 40.0  # re-pinned


### PR DESCRIPTION
Fixes a real evidence-policy loophole surfaced live (Aug 2–4): the agent refetched with `--days 120` but default source, the venue capped it at 40d and **replaced** the 120d ccxt dataset, and the gate granted `short_history_proven` — treating a venue cap as proof of unavailability when ccxt has years of history. The replication monitor then flagged `decayed` that was purely the window shrinking (trade count 1300 → 226; per-trade economics actually improved).

1. **Gate**: a shortfall only counts as proven when the request went through the long-history source (`metadata.source == "ccxt"`). Venue-sourced short datasets fail loud with the exact refetch command.
2. **Replication**: baselines record `dataset_days`; a >20% window change **re-pins** the baseline instead of reporting decay. The gate polices window acceptability; the monitor polices edge persistence; neither lies about the other's domain.

Tests: venue-shortfall rejection, ccxt-shortfall still proven, window-collapse re-pins without decay. 10+ pass across the affected suites; ruff clean.

Box follow-up (separate): restore majors' 120d ccxt dataset.