### PR TITLE
Pattern Match - Restricted Region Market Data

### DIFF
--- a/wayfinder_paths/core/backtesting/data.py
+++ b/wayfinder_paths/core/backtesting/data.py
@@ -300,7 +300,13 @@ async def _fetch_prices_ccxt(
     symbols: list[str], start: datetime, end: datetime, interval: str
 ) -> pd.DataFrame:
     """Fetch prices from Binance spot via CCXT (multi-year history)."""
-    adapter = CCXTAdapter(exchanges={"binance": {}})
+    adapter = CCXTAdapter(
+        exchanges={
+            "binance": {
+                "options": {"fetchMarkets": {"types": ["spot"]}},
+            }
+        }
+    )
     # Binance's trading API is location-restricted on some cloud egress IPs.
     # This loader only reads public candles, so use Binance's official
     # market-data-only endpoint without changing any signed/private URLs.

--- a/wayfinder_paths/core/backtesting/data.py
+++ b/wayfinder_paths/core/backtesting/data.py
@@ -301,6 +301,10 @@ async def _fetch_prices_ccxt(
 ) -> pd.DataFrame:
     """Fetch prices from Binance spot via CCXT (multi-year history)."""
     adapter = CCXTAdapter(exchanges={"binance": {}})
+    # Binance's trading API is location-restricted on some cloud egress IPs.
+    # This loader only reads public candles, so use Binance's official
+    # market-data-only endpoint without changing any signed/private URLs.
+    adapter.binance.urls["api"]["public"] = "https://data-api.binance.vision/api/v3"
     try:
         start_ms = int(start.timestamp() * 1000)
         end_ms = int(end.timestamp() * 1000)

--- a/wayfinder_paths/core/backtesting/test_ccxt_market_data.py
+++ b/wayfinder_paths/core/backtesting/test_ccxt_market_data.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from wayfinder_paths.core.backtesting import data
+
+
+class _FakeBinance:
+    def __init__(self) -> None:
+        self.urls = {
+            "api": {
+                "public": "https://api.binance.com/api/v3",
+                "private": "https://api.binance.com/api/v3",
+            }
+        }
+        self.public_url_at_fetch: str | None = None
+
+    async def fetch_ohlcv(
+        self,
+        pair: str,
+        interval: str,
+        *,
+        since: int,
+        limit: int,
+    ) -> list[list[float]]:
+        self.public_url_at_fetch = self.urls["api"]["public"]
+        return [[since, 100.0, 101.0, 99.0, 100.5, 1.0]]
+
+
+class _FakeAdapter:
+    instance: _FakeAdapter | None = None
+
+    def __init__(self, **_: Any) -> None:
+        self.binance = _FakeBinance()
+        self.closed = False
+        type(self).instance = self
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_ccxt_prices_use_binance_market_data_endpoint(monkeypatch) -> None:
+    monkeypatch.setattr(data, "CCXTAdapter", _FakeAdapter)
+    start = datetime(2026, 8, 1, tzinfo=UTC)
+
+    result = await data._fetch_prices_ccxt(
+        ["BTC"],
+        start,
+        start + timedelta(minutes=5),
+        "5m",
+    )
+
+    adapter = _FakeAdapter.instance
+    assert adapter is not None
+    assert (
+        adapter.binance.public_url_at_fetch == "https://data-api.binance.vision/api/v3"
+    )
+    assert adapter.binance.urls["api"]["private"] == ("https://api.binance.com/api/v3")
+    assert adapter.closed is True
+    assert result.iloc[0]["BTC"] == 100.5

--- a/wayfinder_paths/core/backtesting/test_ccxt_market_data.py
+++ b/wayfinder_paths/core/backtesting/test_ccxt_market_data.py
@@ -33,8 +33,9 @@ class _FakeBinance:
 class _FakeAdapter:
     instance: _FakeAdapter | None = None
 
-    def __init__(self, **_: Any) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         self.binance = _FakeBinance()
+        self.exchanges = kwargs.get("exchanges")
         self.closed = False
         type(self).instance = self
 
@@ -56,6 +57,9 @@ async def test_ccxt_prices_use_binance_market_data_endpoint(monkeypatch) -> None
 
     adapter = _FakeAdapter.instance
     assert adapter is not None
+    assert adapter.exchanges == {
+        "binance": {"options": {"fetchMarkets": {"types": ["spot"]}}}
+    }
     assert (
         adapter.binance.public_url_at_fetch == "https://data-api.binance.vision/api/v3"
     )


### PR DESCRIPTION
### Summary

Routes Binance public candle reads through the official market-data-only endpoint and limits CCXT market discovery to spot, preventing restricted cloud regions from failing on Binance trading and futures metadata endpoints.