### PR TITLE
jobs: probed ccxt unavailability is valid evidence-window proof

### DIFF
--- a/wayfinder_paths/jobs/execution/preflight.py
+++ b/wayfinder_paths/jobs/execution/preflight.py
@@ -166,6 +166,14 @@ def build_live_dataset(
             "days": days,
             "fetched_at": utc_now_iso(),
         }
+        # Probe the long-history source's market list so the evidence gate
+        # can distinguish "venue-capped but ccxt has years" (must refetch
+        # via ccxt) from "these symbols do not exist on ccxt at all" (HIP-3
+        # equity perps like xyz:MU) — the latter is legitimate proof of
+        # unavailability that a raising ccxt fetch can never leave behind.
+        missing = _ccxt_missing_markets(symbols, exchange=exchange, quote=quote)
+        if missing is not None:
+            metadata["ccxt_missing_markets"] = missing
     if not rows and not previous_rows:
         raise RuntimeError("no bars returned while building live dataset")
     if previous_rows:
@@ -657,6 +665,29 @@ def _write_report(
     return report
 
 
+def _ccxt_missing_markets(
+    symbols: list[str], *, exchange: str, quote: str
+) -> list[str] | None:
+    """Symbols with no swap OR spot market on the long-history exchange.
+    None = probe failed (network etc.) — record nothing so the evidence gate
+    stays conservative."""
+    try:
+        import ccxt
+
+        client = getattr(ccxt, exchange)()
+        markets = client.load_markets()
+        return [
+            coin
+            for coin in symbols
+            if not any(
+                (market := markets.get(pair)) and market.get("active")
+                for pair in (f"{coin}/{quote}:{quote}", f"{coin}/{quote}")
+            )
+        ]
+    except Exception:  # noqa: BLE001 — best-effort probe only
+        return None
+
+
 def _incremental_plan(
     root: Path,
     *,
@@ -717,9 +748,7 @@ def _merge_dataset_rows(
         merged[(str(row.get("timestamp")), str(row.get("symbol")))] = row
     for row in new_rows:
         merged[(str(row.get("timestamp")), str(row.get("symbol")))] = row
-    newest = max(
-        pd.Timestamp(str(row.get("timestamp"))) for row in merged.values()
-    )
+    newest = max(pd.Timestamp(str(row.get("timestamp"))) for row in merged.values())
     cutoff = newest - pd.Timedelta(days=days)
     kept = [
         row

--- a/wayfinder_paths/jobs/execution/validation.py
+++ b/wayfinder_paths/jobs/execution/validation.py
@@ -276,6 +276,38 @@ def _evidence_window_check(root: Path) -> list[dict[str, Any]]:
             }
         ]
     source = str(metadata.get("source") or "")
+    missing = metadata.get("ccxt_missing_markets")
+    if source != "ccxt" and isinstance(missing, list) and missing:
+        # The long-history source does not list these symbols at all (probed
+        # at fetch time) — a venue dataset is the only obtainable evidence.
+        if received >= EVIDENCE_FLOOR_DAYS:
+            return [
+                {
+                    "name": "evidence_window",
+                    "passed": True,
+                    "tier": "short_history_proven",
+                    "days_received": received,
+                    "note": (
+                        f"{received:g}d from the venue; symbols {missing} "
+                        "have no market on the long-history exchange (probed "
+                        "at fetch) — venue data is the only obtainable "
+                        "evidence. 30d floor applies; short-history caveats "
+                        "stand."
+                    ),
+                }
+            ]
+        return [
+            {
+                "name": "evidence_window",
+                "passed": False,
+                "days_received": received,
+                "error": (
+                    f"only {received:g}d of venue history and symbols "
+                    f"{missing} have no long-history market — below the "
+                    f"{EVIDENCE_FLOOR_DAYS:g}d floor; too new to validate."
+                ),
+            }
+        ]
     if source != "ccxt":
         # A VENUE shortfall proves nothing — venue feeds cap at days of
         # history while the ccxt path has years. This exact hole let an

--- a/wayfinder_paths/tests/test_jobs_evidence_window.py
+++ b/wayfinder_paths/tests/test_jobs_evidence_window.py
@@ -12,7 +12,7 @@ from wayfinder_paths.jobs.replication import replication_job
 from wayfinder_paths.jobs.store import JobStore
 
 
-def _root_with_dataset(tmp_path, *, days, days_received, source="ccxt"):
+def _root_with_dataset(tmp_path, *, days, days_received, source="ccxt", extra=None):
     root = tmp_path
     (root / "results" / "backtest").mkdir(parents=True, exist_ok=True)
     (root / "results" / "backtest" / "input_bars.json").write_text(
@@ -23,6 +23,7 @@ def _root_with_dataset(tmp_path, *, days, days_received, source="ccxt"):
                     "days": days,
                     "days_received": days_received,
                     "source": source,
+                    **(extra or {}),
                 },
             }
         ),
@@ -61,6 +62,44 @@ def test_evidence_window_policy_paths(tmp_path) -> None:
     )[0]
     assert not check["passed"]
     assert "NOT proof" in check["error"] and "--source ccxt" in check["error"]
+
+    # Venue data with PROBED ccxt unavailability (HIP-3 symbols) -> proven.
+    check = _evidence_window_check(
+        _root_with_dataset(
+            tmp_path / "h",
+            days=120,
+            days_received=52.0,
+            source="live_fetch",
+            extra={"ccxt_missing_markets": ["xyz:MU", "xyz:SNDK"]},
+        )
+    )[0]
+    assert check["passed"] and check["tier"] == "short_history_proven"
+    assert "no market on the long-history exchange" in check["note"]
+
+    # Probed-missing but below the floor -> still fails (too new).
+    check = _evidence_window_check(
+        _root_with_dataset(
+            tmp_path / "i",
+            days=120,
+            days_received=12.0,
+            source="live_fetch",
+            extra={"ccxt_missing_markets": ["NEWCOIN"]},
+        )
+    )[0]
+    assert not check["passed"] and "floor" in check["error"]
+
+    # Empty missing list (probe ran, all symbols exist on ccxt) -> venue
+    # shortfall still rejected.
+    check = _evidence_window_check(
+        _root_with_dataset(
+            tmp_path / "j",
+            days=120,
+            days_received=40.0,
+            source="live_fetch",
+            extra={"ccxt_missing_markets": []},
+        )
+    )[0]
+    assert not check["passed"] and "NOT proof" in check["error"]
 
     # Below the floor even with the target requested -> fail.
     check = _evidence_window_check(


### PR DESCRIPTION
Follow-up to #601, which over-corrected: xyz-scalp-lab's HIP-3 equity perps (`xyz:MU`, `xyz:SNDK`) have **no market on the long-history exchange at all** — the ccxt fetch raises `no active binance market` instead of returning short, so the source-proof gate demanded evidence that symbol class can never produce, and the job went validation-red on its only obtainable dataset.

Fix: venue fetches probe the long-history exchange's market list (best-effort, guarded — a failed probe records nothing and the gate stays conservative) and stamp `ccxt_missing_markets` into the dataset metadata. The gate then accepts a venue shortfall as `short_history_proven` when the symbols are provably unlisted, still enforces the 30d floor, and still rejects venue shortfalls when the probe shows the symbols DO exist on ccxt — the Aug 2 hole stays closed.

Tests: probed-unlisted passes with the note, probed-unlisted below floor still fails, probed-but-listed still rejects, all prior paths unchanged. 17 pass; ruff clean.

After merge+roll, xyz needs one dataset refetch to stamp the probe result and clear its validation.