### PR TITLE
Pattern Match - Compact Overlay Handoff

### DIFF
--- a/.claude/skills/pattern-match/SKILL.md
+++ b/.claude/skills/pattern-match/SKILL.md
@@ -71,15 +71,17 @@ and never invent missing candles or outcomes.
 
 ## Utility views
 
-Pattern Match tool results include a bounded `visual_spec`. Return the most
-complete one unchanged as `visualSpec` (the proxy result supersedes the exact
-one when present). It targets the existing chart with an outcome fan and top
-analogues; do not replace it with a newly generated chart spec.
+Pattern Match tool results include a `visual_match_id` pointer to a cached,
+bounded chart overlay. Return it as `visualMatchId`; never request, reconstruct,
+or inline the dense overlay. The proxy call updates the same pointer with the
+most complete exact-plus-proxy view.
 
 Carry `market_id`, `chart_id`, `match_id`, analyzed interval, selected perp
-venue, and sample counts in `contextForNextAgent`. The primary agent will
-delegate the spec to `wayfinder-visual`; do not call visual tools directly.
+venue, and sample counts in `contextForNextAgent`. The primary agent will apply
+the pointer directly; do not call visual tools yourself.
 
 Return the standard quant JSON contract with a concise `analysisSummary`,
 metrics, confidence, warnings, `contextForNextAgent`, and optional
-`visualSpec`.
+`visualMatchId`. Tool responses intentionally include only the five strongest
+match rows; aggregate distributions and evidence counts still cover the full
+sample.

--- a/.opencode/agents/wayfinder-quant.md
+++ b/.opencode/agents/wayfinder-quant.md
@@ -67,9 +67,9 @@ baseline is weak, choose any additional comparisons yourself from the market
 context and fetch only their histories. Prefer
 `wayfinder_quant_pattern_match_ccxt_proxy` for a defensible same-asset
 perpetual comparison. It uses strict perp markets and returns the chosen venue;
-do not replace it with spot. Return the most complete tool-provided
-`visual_spec` unchanged as `visualSpec`, but never repeat the exact candle pull
-or present proxy matches as exact evidence.
+do not replace it with spot. Return the tool-provided `visual_match_id` as
+`visualMatchId`; never reconstruct or inline its cached overlay, repeat the
+exact candle pull, or present proxy matches as exact evidence.
 
 Return a detailed but structured technical read: selected-pattern range and
 realized volatility; strongest match dates and shape/magnitude/volatility

--- a/.opencode/agents/wayfinder-visual.md
+++ b/.opencode/agents/wayfinder-visual.md
@@ -44,6 +44,9 @@ If the primary or quant agent passes a `Known Context` block with exact market I
 
 Pattern Match overlay fast path:
 
+- When the primary passes a `visualMatchId`, call
+  `visual_add_workspace_chart_overlay(match_id=visualMatchId)` once. Do not
+  request or reconstruct the cached overlay.
 - When `visualSpec.operation` is `upsert_overlay`, call
   `visual_add_workspace_chart_overlay` once with its exact `chart_id` and
   `overlay`.

--- a/.opencode/agents/wayfinder.md
+++ b/.opencode/agents/wayfinder.md
@@ -101,11 +101,11 @@ Inside a Shells instance, you operate very permissively on a Debian box: you hav
 When a completed `wayfinder-quant` subtask returns a Pattern Match result, do not
 re-fetch candles, re-run the match, or delegate another quant task. Preserve its
 exact-versus-fuzzy provenance, sample-size, coverage, and confidence warnings.
-If it includes a useful `visualSpec`, pass that exact bounded spec to
-`wayfinder-visual` before answering; otherwise answer directly.
-For `operation="upsert_overlay"`, instruct the visual worker to apply the raw
-overlay to `chart_id` with `visual_add_workspace_chart_overlay`. It must update
-the existing live chart, not create or activate a workspace chart.
+If it includes `visualMatchId`, call
+`visual_add_workspace_chart_overlay(match_id=visualMatchId)` once before
+answering. Apply this pointer directly instead of delegating to
+`wayfinder-visual` or copying chart paths through model context. It updates the
+existing live chart and returns a compact acknowledgement.
 
 This Wayfinder Shells instance includes tools (MCP), protocol interfaces (adapters) and custom scripting (.wayfinder_runs/).
 

--- a/wayfinder_paths/mcp/tools/instance_state.py
+++ b/wayfinder_paths/mcp/tools/instance_state.py
@@ -9,6 +9,9 @@ import httpx
 from wayfinder_paths.core.clients.InstanceStateClient import INSTANCE_STATE_CLIENT
 from wayfinder_paths.core.config import is_opencode_instance
 from wayfinder_paths.mcp.utils import catch_errors, err, ok, repo_root
+from wayfinder_paths.quant.pattern_match_pipeline import (
+    get_pattern_match_visual_spec,
+)
 
 _NOT_OPENCODE_ERR = ("not_opencode_instance", "Not running on an OpenCode instance")
 _VISUAL_SPEC_DIR = Path(".wayfinder_runs") / "visual_specs"
@@ -680,14 +683,19 @@ async def visual_add_workspace_chart_annotation(
 
 @catch_errors
 async def visual_add_workspace_chart_overlay(
-    chart_id: str,
-    overlay: dict[str, Any],
+    chart_id: str | None = None,
+    overlay: dict[str, Any] | None = None,
+    match_id: str | None = None,
 ) -> dict[str, Any]:
     """Upsert a raw overlay or event marker set on a workspace or default chart.
 
+    For Pattern Match, pass only ``match_id`` from the quant result. The dense
+    overlay is resolved from the short-lived cache and never enters model
+    context. A successful pointer application returns a compact acknowledgement.
+
     Overlays with an ``id`` replace the prior overlay with that id; overlays
-    without one append. Pattern Match uses ``type=pattern_match_distribution``
-    with the bounded spec returned by the quant tool.
+    without one append. Raw ``chart_id`` plus ``overlay`` remains available for
+    other bounded overlays.
 
     For event marker sets, use overlay = {"type": "event_markers", "data": [...]}
     with each event using {time, price?, label?/text?, color?}. The legacy
@@ -695,10 +703,32 @@ async def visual_add_workspace_chart_overlay(
     """
     if not is_opencode_instance():
         return err(*_NOT_OPENCODE_ERR)
-    try:
-        return ok(
-            await INSTANCE_STATE_CLIENT.add_workspace_chart_overlay(chart_id, overlay)
+    pointer_result: dict[str, Any] | None = None
+    if match_id is not None:
+        if chart_id is not None or overlay is not None:
+            return err(
+                "invalid_argument",
+                "Pass match_id alone, or pass chart_id with overlay",
+            )
+        visual_spec = get_pattern_match_visual_spec(match_id)
+        chart_id = str(visual_spec["chart_id"])
+        overlay = visual_spec["overlay"]
+        pointer_result = {
+            "applied": True,
+            "match_id": match_id,
+            "chart_id": chart_id,
+            "overlay_id": overlay.get("id"),
+        }
+    if chart_id is None or overlay is None:
+        return err(
+            "invalid_argument",
+            "Pass match_id alone, or pass chart_id with overlay",
         )
+    try:
+        result = await INSTANCE_STATE_CLIENT.add_workspace_chart_overlay(
+            chart_id, overlay
+        )
+        return ok(pointer_result or result)
     except httpx.HTTPStatusError as exc:
         return err("chart_workspace_http_error", f"HTTP {exc.response.status_code}")
     except Exception as exc:  # noqa: BLE001

--- a/wayfinder_paths/mcp/tools/pattern_match.py
+++ b/wayfinder_paths/mcp/tools/pattern_match.py
@@ -7,6 +7,7 @@ from typing import Any, Literal
 from wayfinder_paths.mcp.utils import catch_errors, ok
 from wayfinder_paths.quant.pattern_match_context import create_pattern_match_request
 from wayfinder_paths.quant.pattern_match_pipeline import (
+    compact_pattern_match_result,
     run_pattern_match,
     run_pattern_match_ccxt_proxy,
 )
@@ -49,7 +50,8 @@ async def quant_pattern_match(
         chain_id=chain_id,
         token_address=token_address,
     )
-    return ok(await run_pattern_match(request=request))
+    result = await run_pattern_match(request=request)
+    return ok(compact_pattern_match_result(result))
 
 
 @catch_errors
@@ -64,4 +66,5 @@ async def quant_pattern_match_ccxt_proxy(
     healthy supported perp venue is used; spot is never substituted. Proxy
     evidence remains separate from the exact-market baseline.
     """
-    return ok(await run_pattern_match_ccxt_proxy(match_id=match_id, symbol=symbol))
+    result = await run_pattern_match_ccxt_proxy(match_id=match_id, symbol=symbol)
+    return ok(compact_pattern_match_result(result))

--- a/wayfinder_paths/quant/pattern_match_pipeline.py
+++ b/wayfinder_paths/quant/pattern_match_pipeline.py
@@ -8,6 +8,7 @@ import math
 import time
 from collections import OrderedDict
 from collections.abc import Mapping, Sequence
+from copy import deepcopy
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from typing import Any, TypedDict
@@ -37,6 +38,7 @@ MAX_ONCHAIN_HISTORY_PAGES = math.ceil(
 )
 MAX_HISTORY_DAYS = 3 * 366
 TOP_MATCHES = 15
+AGENT_MATCH_LIMIT = 5
 MATCH_CACHE_TTL_SECONDS = 15 * 60
 MATCH_CACHE_MAX_ENTRIES = 32
 FORWARD_HORIZONS_MS = {
@@ -68,6 +70,7 @@ class _MatchWindow:
 @dataclass
 class _CachedMatch:
     result: dict[str, Any]
+    visual_spec: dict[str, Any]
     created_at: float = field(default_factory=time.monotonic)
 
 
@@ -286,11 +289,53 @@ async def run_pattern_match_ccxt_proxy(
                 result,
                 label=f"{perp_history.exchange_id.upper()} perpetual",
                 scope="same_asset_proxy",
+                include_band=False,
+                analogue_limit=0,
             ),
         ],
     )
     _cache_match(cache_key, result)
+    _set_cached_visual_spec(match_id, result["visual_spec"])
     return result
+
+
+def compact_pattern_match_result(result: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the analytic fields an agent needs without dense chart paths."""
+
+    compact = {
+        key: deepcopy(value)
+        for key, value in result.items()
+        if key not in {"visual_spec", "forward_path_distribution", "matches"}
+    }
+    compact["visual_match_id"] = str(result["match_id"])
+
+    matches = result.get("matches")
+    match_rows = matches if isinstance(matches, list) else []
+    compact_matches: list[dict[str, Any]] = []
+    for match in match_rows[:AGENT_MATCH_LIMIT]:
+        if not isinstance(match, Mapping):
+            continue
+        summary = deepcopy(dict(match))
+        summary.pop("shape_path_bps", None)
+        summary.pop("forward_path_bps", None)
+        compact_matches.append(summary)
+    compact["matches"] = compact_matches
+
+    evidence = compact.get("evidence")
+    if isinstance(evidence, dict):
+        evidence["top_matches_returned"] = len(compact_matches)
+    return compact
+
+
+def get_pattern_match_visual_spec(match_id: str) -> dict[str, Any]:
+    """Resolve the most complete cached overlay for a Pattern Match run."""
+
+    _evict_expired_matches()
+    cached = _MATCH_CACHE.get(match_id)
+    if cached is None:
+        raise ValueError("match_id is unknown or expired; run Pattern Match again")
+    _MATCH_CACHE.move_to_end(match_id)
+    return deepcopy(cached.visual_spec)
 
 
 def _match_identity(request: PatternMatchRequest) -> str:
@@ -501,7 +546,12 @@ def _analyze_history(
 
 
 def _distribution_series(
-    result: Mapping[str, Any], *, label: str, scope: str
+    result: Mapping[str, Any],
+    *,
+    label: str,
+    scope: str,
+    include_band: bool = True,
+    analogue_limit: int = 1,
 ) -> dict[str, Any]:
     matches = result.get("matches")
     match_rows = matches if isinstance(matches, list) else []
@@ -514,7 +564,7 @@ def _distribution_series(
         }
         for match in match_rows
         if isinstance(match, Mapping) and "forward_path_bps" in match
-    ][:3]
+    ][:analogue_limit]
     distribution = result["forward_path_distribution"]
     proxy = result.get("proxy")
     coverage = result.get("coverage")
@@ -528,8 +578,8 @@ def _distribution_series(
         else None,
         "sample_count": distribution["samples"],
         "median_bps": distribution["median_bps"],
-        "q25_bps": distribution["q25_bps"],
-        "q75_bps": distribution["q75_bps"],
+        "q25_bps": distribution["q25_bps"] if include_band else [],
+        "q75_bps": distribution["q75_bps"] if include_band else [],
         "hit_rate_up": distribution["hit_rate_up"],
         "analogues": analogues,
     }
@@ -610,10 +660,21 @@ def _cached_match(match_id: str) -> dict[str, Any] | None:
 
 
 def _cache_match(match_id: str, result: dict[str, Any]) -> None:
-    _MATCH_CACHE[match_id] = _CachedMatch(result)
+    _MATCH_CACHE[match_id] = _CachedMatch(
+        result=result,
+        visual_spec=result["visual_spec"],
+    )
     _MATCH_CACHE.move_to_end(match_id)
     while len(_MATCH_CACHE) > MATCH_CACHE_MAX_ENTRIES:
         _MATCH_CACHE.popitem(last=False)
+
+
+def _set_cached_visual_spec(match_id: str, visual_spec: dict[str, Any]) -> None:
+    cached = _MATCH_CACHE.get(match_id)
+    if cached is None:
+        raise ValueError("match_id is unknown or expired; run Pattern Match again")
+    cached.visual_spec = visual_spec
+    _MATCH_CACHE.move_to_end(match_id)
 
 
 def _evict_expired_matches() -> None:

--- a/wayfinder_paths/tests/test_instance_state_tools.py
+++ b/wayfinder_paths/tests/test_instance_state_tools.py
@@ -9,6 +9,59 @@ from wayfinder_paths.mcp.tools import instance_state
 
 
 @pytest.mark.asyncio
+async def test_pattern_match_overlay_resolves_compact_pointer(monkeypatch) -> None:
+    monkeypatch.setattr(instance_state, "is_opencode_instance", lambda: True)
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        instance_state,
+        "get_pattern_match_visual_spec",
+        lambda match_id: {
+            "operation": "upsert_overlay",
+            "chart_id": "hl-perp-aero",
+            "overlay": {
+                "id": f"pattern-match-{match_id}",
+                "type": "pattern_match_distribution",
+            },
+        },
+    )
+
+    async def fake_add_overlay(
+        chart_id: str, overlay: dict[str, object]
+    ) -> dict[str, object]:
+        captured["chart_id"] = chart_id
+        captured["overlay"] = overlay
+        return {"large_frontend_state": "not returned to the agent"}
+
+    monkeypatch.setattr(
+        instance_state.INSTANCE_STATE_CLIENT,
+        "add_workspace_chart_overlay",
+        fake_add_overlay,
+    )
+
+    result = await instance_state.visual_add_workspace_chart_overlay(
+        match_id="match-123"
+    )
+
+    assert result == {
+        "ok": True,
+        "result": {
+            "applied": True,
+            "match_id": "match-123",
+            "chart_id": "hl-perp-aero",
+            "overlay_id": "pattern-match-match-123",
+        },
+    }
+    assert captured == {
+        "chart_id": "hl-perp-aero",
+        "overlay": {
+            "id": "pattern-match-match-123",
+            "type": "pattern_match_distribution",
+        },
+    }
+
+
+@pytest.mark.asyncio
 async def test_visual_get_frontend_context_passes_include_health(monkeypatch) -> None:
     monkeypatch.setattr(instance_state, "is_opencode_instance", lambda: True)
 

--- a/wayfinder_paths/tests/test_pattern_match_pipeline.py
+++ b/wayfinder_paths/tests/test_pattern_match_pipeline.py
@@ -366,7 +366,26 @@ async def test_ccxt_proxy_reuses_exact_match_at_selected_timeframe(
     assert proxy["forward_path_distribution"]["samples"] == len(proxy["matches"])
     assert proxy["visual_spec"]["operation"] == "upsert_overlay"
     assert len(proxy["visual_spec"]["overlay"]["series"]) == 2
+    exact_series, proxy_series = proxy["visual_spec"]["overlay"]["series"]
+    assert len(exact_series["analogues"]) == 1
+    assert proxy_series["analogues"] == []
+    assert proxy_series["q25_bps"] == []
+    assert proxy_series["q75_bps"] == []
+    assert (
+        pipeline.get_pattern_match_visual_spec(exact["match_id"])
+        == proxy["visual_spec"]
+    )
     assert cached_proxy == proxy
+
+    compact = pipeline.compact_pattern_match_result(proxy)
+    assert compact["visual_match_id"] == exact["match_id"]
+    assert "visual_spec" not in compact
+    assert "forward_path_distribution" not in compact
+    assert len(compact["matches"]) == pipeline.AGENT_MATCH_LIMIT
+    assert compact["evidence"]["top_matches_returned"] == pipeline.AGENT_MATCH_LIMIT
+    assert all("shape_path_bps" not in match for match in compact["matches"])
+    assert all("forward_path_bps" not in match for match in compact["matches"])
+    assert "forward_path_bps" in proxy["matches"][0]
 
 
 def test_request_requires_exact_market_identity() -> None:


### PR DESCRIPTION
### Summary

- Applies cached Pattern Match overlays by `match_id` instead of passing dense chart paths through agent contexts.
- Keeps quant responses focused on aggregate evidence and the five strongest matches.
- Simplifies the chart to one same-market analogue and band plus a proxy median comparison.