### PR TITLE
jobs: stale-baseline promotion refusal + approval-carryover auto re-stage

### DIFF
--- a/wayfinder_paths/jobs/application.py
+++ b/wayfinder_paths/jobs/application.py
@@ -29,6 +29,7 @@ class _ApplicationOutcome:
     promoted_revision: str | None = None
     compile_result: dict[str, Any] | None = None
     rollback: dict[str, Any] | None = None
+    restage_requested: bool = False
 
 
 def ensure_jobs_v1_contract(
@@ -224,6 +225,20 @@ def complete_application(
         promoted_revision=outcome.promoted_revision,
         rollback=outcome.rollback,
     )
+    if outcome.restage_requested:
+        # Approval carryover: the proposal stays approved; the flag marks it
+        # as awaiting an agent re-stage against the moved workspace. Wake the
+        # agent now (after loops resumed) instead of waiting out its interval.
+        proposal["application"]["restage_requested"] = True
+        store.write_proposal(job_id, proposal)
+        from wayfinder_paths.jobs.triggers import fire_triggers
+
+        fire_triggers(
+            store,
+            store.load(job_id),
+            ["proposal_restage_requested"],
+            source=f"apply:{proposal_id}",
+        )
     sync_all_jobs(store=store)
     return {
         "proposal": proposal,
@@ -260,8 +275,8 @@ def _complete_applied_application(
             f"baseline drift: candidate was staged against revision {base_revision} "
             f"but the active workspace is now {active_revision} (moved by an "
             "intervening apply). Promoting this candidate would revert those "
-            "changes. Re-propose against the current workspace to stage a fresh "
-            "candidate."
+            "changes. Approval carried over — the agent re-stages the change "
+            "against the current workspace and the apply re-queues automatically."
         )
         store.append_journal(
             job_id,
@@ -271,6 +286,7 @@ def _complete_applied_application(
                 "base_revision": base_revision,
                 "active_revision": active_revision,
                 "candidate_revision": candidate_revision,
+                "restage_requested": True,
             },
         )
         _write_apply_report(
@@ -278,7 +294,7 @@ def _complete_applied_application(
             job_id,
             proposal_id,
             status="red",
-            summary=f"Failed to apply approved proposal: {final_error}",
+            summary=f"Apply deferred: {final_error}",
             changed_files=changed_files or [],
             validation={"status": "failed", "checks": [], "error": final_error},
             error=final_error,
@@ -291,6 +307,7 @@ def _complete_applied_application(
                 "checks": [],
                 "error": final_error,
             },
+            restage_requested=True,
         )
     deterministic_validation = validate_candidate_application(
         repo_root=store.repo_root,

--- a/wayfinder_paths/jobs/application.py
+++ b/wayfinder_paths/jobs/application.py
@@ -245,6 +245,53 @@ def _complete_applied_application(
 ) -> _ApplicationOutcome:
     proposal = store.load_proposal(job_id, proposal_id)
     candidate_dir = _candidate_dir_from_proposal(store, job_id, proposal)
+    # A propose-time candidate is a full workspace snapshot and promotion is a
+    # wholesale replace — promoting a candidate whose base is no longer the
+    # active revision silently reverts every apply that landed in between.
+    # active == candidate revision is allowed: that is a crash-resume after the
+    # promotion itself completed, where finishing the bookkeeping is correct.
+    base_revision = str(proposal.get("base_revision") or "")
+    candidate_revision = str(
+        (proposal.get("candidate_report") or {}).get("revision") or ""
+    )
+    active_revision = compute_workspace_revision(store.job_dir(job_id))
+    if base_revision and active_revision not in (base_revision, candidate_revision):
+        final_error = (
+            f"baseline drift: candidate was staged against revision {base_revision} "
+            f"but the active workspace is now {active_revision} (moved by an "
+            "intervening apply). Promoting this candidate would revert those "
+            "changes. Re-propose against the current workspace to stage a fresh "
+            "candidate."
+        )
+        store.append_journal(
+            job_id,
+            {
+                "type": "stale_baseline_promotion_refused",
+                "proposal_id": proposal_id,
+                "base_revision": base_revision,
+                "active_revision": active_revision,
+                "candidate_revision": candidate_revision,
+            },
+        )
+        _write_apply_report(
+            store,
+            job_id,
+            proposal_id,
+            status="red",
+            summary=f"Failed to apply approved proposal: {final_error}",
+            changed_files=changed_files or [],
+            validation={"status": "failed", "checks": [], "error": final_error},
+            error=final_error,
+        )
+        return _ApplicationOutcome(
+            final_status="failed",
+            final_error=final_error,
+            deterministic_validation={
+                "status": "failed",
+                "checks": [],
+                "error": final_error,
+            },
+        )
     deterministic_validation = validate_candidate_application(
         repo_root=store.repo_root,
         job_dir=store.job_dir(job_id),

--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -50,7 +50,7 @@ from wayfinder_paths.jobs.models import (
     infer_job_kind,
     normalize_agent_mode,
 )
-from wayfinder_paths.jobs.proposals import propose_change
+from wayfinder_paths.jobs.proposals import propose_change, restage_proposal
 from wayfinder_paths.jobs.replication import replication_job
 from wayfinder_paths.jobs.research import (
     holdout_check_job,
@@ -1385,6 +1385,29 @@ def propose_cmd(
         scenario_plan=json.loads(scenario_json) if scenario_json else None,
         proposal_id=proposal_id,
         memo=memo,
+    )
+    _echo_json({"ok": True, "result": proposal})
+
+
+@job_cli.command(
+    name="restage",
+    help="Re-stage an approved proposal whose candidate went stale under an "
+    "intervening apply; re-runs the propose-time gates and auto-queues the "
+    "apply (approval carryover).",
+)
+@click.argument("job_id")
+@click.argument("proposal_id")
+@click.option(
+    "--candidate-dir",
+    default=None,
+    help="Re-authored change against the CURRENT workspace (bundle with "
+    "workspace/ or bare workspace). Required for code changes; params "
+    "updates re-stage mechanically.",
+)
+def restage_cmd(job_id: str, proposal_id: str, candidate_dir: str | None) -> None:
+    store = JobStore()
+    proposal = restage_proposal(
+        store, job_id, proposal_id, candidate_source=candidate_dir
     )
     _echo_json({"ok": True, "result": proposal})
 

--- a/wayfinder_paths/jobs/execution/validation.py
+++ b/wayfinder_paths/jobs/execution/validation.py
@@ -230,9 +230,11 @@ def _evidence_window_check(root: Path) -> list[dict[str, Any]]:
     if not bars_path.exists():
         return []  # fixture/scenario-driven validation contexts
     try:
-        metadata = json.loads(bars_path.read_text(encoding="utf-8")).get("metadata")
+        payload = json.loads(bars_path.read_text(encoding="utf-8"))
     except ValueError:
-        metadata = None
+        payload = None
+    # Legacy bars files are a bare list of rows with no metadata envelope.
+    metadata = payload.get("metadata") if isinstance(payload, dict) else None
     if not isinstance(metadata, dict) or metadata.get("days") is None:
         return [
             {

--- a/wayfinder_paths/jobs/proposals.py
+++ b/wayfinder_paths/jobs/proposals.py
@@ -83,28 +83,7 @@ def propose_change(
         store, job_id, pid, force_fresh=True
     )
     candidate_dir = store.repo_root / candidate_descriptor["candidate_dir"]
-    if candidate_source is not None:
-        source = Path(candidate_source)
-        if not source.exists():
-            raise FileNotFoundError(f"candidate_source not found: {source}")
-        if (source / "workspace").exists():
-            # Full bundle shape: workspace/ (+ optional job.yaml).
-            _replace_tree(source / "workspace", candidate_dir / "workspace")
-            if (source / "job.yaml").exists():
-                shutil.copy2(source / "job.yaml", candidate_dir / "job.yaml")
-        else:
-            # Bare workspace tree.
-            _replace_tree(source, candidate_dir / "workspace")
-    if params:
-        yaml_path = candidate_dir / "job.yaml"
-        job_yaml = yaml.safe_load(yaml_path.read_text(encoding="utf-8")) or {}
-        job_yaml["execution_params"] = {
-            **(job_yaml.get("execution_params") or {}),
-            **params,
-        }
-        yaml_path.write_text(
-            yaml.safe_dump(job_yaml, sort_keys=False), encoding="utf-8"
-        )
+    _overlay_change(candidate_dir, candidate_source=candidate_source, params=params)
     changed_files = _diff_workspaces(root, candidate_dir)
 
     job = store.load(job_id)
@@ -142,6 +121,82 @@ def propose_change(
         memo_path.parent.mkdir(parents=True, exist_ok=True)
         memo_path.write_text(memo.rstrip() + "\n", encoding="utf-8")
 
+    validation, candidate_report = _generate_candidate_report(
+        store, job_id, proposal, candidate_dir, base_revision=base_revision, pid=pid
+    )
+    proposal["candidate_report"] = candidate_report
+
+    store.write_proposal(job_id, proposal)
+    store.append_journal(
+        job_id,
+        {
+            "type": "proposal_created",
+            "proposal_id": pid,
+            "kind": kind,
+            "base_revision": base_revision,
+            "candidate_revision": candidate_report["revision"],
+            "validation_status": validation.get("status"),
+        },
+    )
+    store.refresh_scorecard(job_id)
+    sync_all_jobs(store=store)
+    # Surface a chat affordance (contract C5): the opencode harness turns this
+    # marker into a job_result part; the FE renders a review deep-link chip.
+    print(
+        JOB_RESULT_MARKER
+        + json.dumps(
+            {
+                "type": "job_result",
+                "severity": "info",
+                "summary": f"Proposal created: {summary}",
+                "job_id": job_id,
+                "proposal_id": pid,
+            }
+        )
+    )
+    return store.load_proposal(job_id, pid)
+
+
+def _overlay_change(
+    candidate_dir: Path,
+    *,
+    candidate_source: str | Path | None,
+    params: dict[str, Any] | None,
+) -> None:
+    """Apply the proposed change to a freshly staged candidate."""
+    if candidate_source is not None:
+        source = Path(candidate_source)
+        if not source.exists():
+            raise FileNotFoundError(f"candidate_source not found: {source}")
+        if (source / "workspace").exists():
+            # Full bundle shape: workspace/ (+ optional job.yaml).
+            _replace_tree(source / "workspace", candidate_dir / "workspace")
+            if (source / "job.yaml").exists():
+                shutil.copy2(source / "job.yaml", candidate_dir / "job.yaml")
+        else:
+            # Bare workspace tree.
+            _replace_tree(source, candidate_dir / "workspace")
+    if params:
+        yaml_path = candidate_dir / "job.yaml"
+        job_yaml = yaml.safe_load(yaml_path.read_text(encoding="utf-8")) or {}
+        job_yaml["execution_params"] = {
+            **(job_yaml.get("execution_params") or {}),
+            **params,
+        }
+        yaml_path.write_text(
+            yaml.safe_dump(job_yaml, sort_keys=False), encoding="utf-8"
+        )
+
+
+def _generate_candidate_report(
+    store: JobStore,
+    job_id: str,
+    proposal: dict[str, Any],
+    candidate_dir: Path,
+    *,
+    base_revision: str,
+    pid: str,
+) -> tuple[dict[str, Any], dict[str, Any]]:
     validation = validate_candidate_bundle(store, job_id, proposal, candidate_dir)
     candidate_revision = compute_workspace_revision(candidate_dir)
     comparison = _build_comparison(
@@ -163,7 +218,7 @@ def propose_change(
         }
         mode = "validation_only"
 
-    proposal["candidate_report"] = {
+    candidate_report = {
         "revision": candidate_revision,
         "base_revision": base_revision,
         "mode": mode,
@@ -182,36 +237,115 @@ def propose_change(
         ),
         "generated_at": utc_now_iso(),
     }
+    return validation, candidate_report
 
+
+def restage_proposal(
+    store: JobStore,
+    job_id: str,
+    proposal_id: str,
+    *,
+    candidate_source: str | Path | None = None,
+) -> dict[str, Any]:
+    """Re-stage an APPROVED proposal whose candidate went stale under it.
+
+    Approval carryover: the owner approved the proposal's intent; when an
+    intervening apply moves the workspace, the snapshot candidate can no
+    longer promote (stale-baseline refusal). This rebuilds the candidate
+    against the CURRENT workspace — mechanically for params updates, from an
+    agent-re-authored tree for code changes — re-runs the full propose-time
+    gates, and auto-queues the apply. The intent contract, summary, and kind
+    are carried over verbatim; a different change requires a fresh proposal
+    and a fresh approval.
+
+    If the re-staged candidate fails the approve-time gate on the new base,
+    the proposal is auto-rejected (housekeeping) — the world changed
+    materially, so the owner must review a fresh proposal instead.
+    """
+    proposal = store.load_proposal(job_id, proposal_id)
+    if proposal["status"] != "approved":
+        raise ValueError(f"Only approved proposals can be re-staged: {proposal_id}")
+    application = proposal["application"]
+    if application["status"] in {"applying", "applied"}:
+        raise ValueError(
+            f"Proposal application is {application['status']}; nothing to re-stage"
+        )
+    if not application.get("restage_requested"):
+        raise ValueError(
+            f"Proposal has no pending re-stage request: {proposal_id} "
+            "(re-stage is only for stale-baseline apply refusals)"
+        )
+    params = (proposal.get("proposed_change") or {}).get("execution_params")
+    if candidate_source is None and not params:
+        raise ValueError(
+            "code-change re-stage requires candidate_source (re-author the "
+            "change against the current workspace and pass the edited tree)"
+        )
+
+    root = store.job_dir(job_id)
+    old_base = str(proposal.get("base_revision") or "")
+    old_candidate = str((proposal.get("candidate_report") or {}).get("revision") or "")
+    base_revision = compute_workspace_revision(root)
+
+    candidate_descriptor = _prepare_candidate_workspace(
+        store, job_id, proposal_id, force_fresh=True
+    )
+    candidate_dir = store.repo_root / candidate_descriptor["candidate_dir"]
+    _overlay_change(candidate_dir, candidate_source=candidate_source, params=params)
+    changed_files = _diff_workspaces(root, candidate_dir)
+
+    proposal["base_revision"] = base_revision
+    proposal["changed_files"] = changed_files
+    application.update(candidate_descriptor)
+    application["restage_requested"] = False
+    application["error"] = None
+    _, candidate_report = _generate_candidate_report(
+        store,
+        job_id,
+        proposal,
+        candidate_dir,
+        base_revision=base_revision,
+        pid=proposal_id,
+    )
+    proposal["candidate_report"] = candidate_report
+    proposal["updated_at"] = utc_now_iso()
     store.write_proposal(job_id, proposal)
     store.append_journal(
         job_id,
         {
-            "type": "proposal_created",
-            "proposal_id": pid,
-            "kind": kind,
-            "base_revision": base_revision,
-            "candidate_revision": candidate_revision,
-            "validation_status": validation.get("status"),
+            "type": "proposal_restaged",
+            "proposal_id": proposal_id,
+            "old_base_revision": old_base,
+            "new_base_revision": base_revision,
+            "old_candidate_revision": old_candidate,
+            "new_candidate_revision": candidate_report["revision"],
+            "changed_files": changed_files,
         },
     )
-    store.refresh_scorecard(job_id)
-    sync_all_jobs(store=store)
-    # Surface a chat affordance (contract C5): the opencode harness turns this
-    # marker into a job_result part; the FE renders a review deep-link chip.
-    print(
-        JOB_RESULT_MARKER
-        + json.dumps(
-            {
-                "type": "job_result",
-                "severity": "info",
-                "summary": f"Proposal created: {summary}",
-                "job_id": job_id,
-                "proposal_id": pid,
-            }
+
+    try:
+        # Exact approve-time gate semantics (live-ready + candidate freshness).
+        store._ensure_candidate_report_gate(job_id, proposal, allow_ungated=False)
+    except ValueError as exc:
+        rejected = store.reject_proposal(
+            job_id,
+            proposal_id,
+            reason=(
+                f"re-stage gate failed on current base {base_revision}: {exc}. "
+                "The workspace changed materially since approval — propose the "
+                "change fresh so the owner can review it against the new base."
+            ),
+            rejected_by="agent",
         )
-    )
-    return store.load_proposal(job_id, pid)
+        sync_all_jobs(store=store)
+        return rejected
+
+    store.queue_proposal_application(job_id, proposal_id)
+    from wayfinder_paths.jobs.apply_launcher import launch_application
+
+    launch_application(store, job_id, proposal_id)
+    sync_all_jobs(store=store)
+    return store.load_proposal(job_id, proposal_id)
 
 
 def _replace_tree(source: Path, destination: Path) -> None:

--- a/wayfinder_paths/jobs/triggers.py
+++ b/wayfinder_paths/jobs/triggers.py
@@ -20,6 +20,11 @@ from wayfinder_paths.jobs.store import JobStore
 WAKE_STATE_PATH = "state/agent_wake_state.json"
 DEFAULT_DEBOUNCE_SECONDS = 600
 
+# Infrastructure events wake the agent regardless of the job's configured
+# trigger list: they represent work the pipeline is waiting on the agent for
+# (not market conditions the owner opted into watching).
+ALWAYS_WAKE_EVENTS = {"proposal_restage_requested"}
+
 
 def fire_triggers(
     store: JobStore,
@@ -55,7 +60,8 @@ def _fire_triggers(
     loop = job.agent_loop
     if not loop.enabled or loop.mode == "off":
         return None
-    matched = sorted(set(event_types) & set(loop.triggers))
+    events = set(event_types)
+    matched = sorted((events & set(loop.triggers)) | (events & ALWAYS_WAKE_EVENTS))
     if not matched:
         return None
 

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -200,6 +200,57 @@ def _research_substrate_block(root: Path) -> dict[str, Any]:
     return block
 
 
+def _restage_block(root: Path) -> list[dict[str, Any]]:
+    """Approved proposals awaiting re-stage after a stale-baseline refusal.
+
+    Approval carryover: the owner already approved these — the workspace moved
+    under the staged candidate, so the change must be re-authored against the
+    CURRENT workspace and re-staged. This is a top-priority mechanical task,
+    not a new decision."""
+    tasks: list[dict[str, Any]] = []
+    proposals_dir = root / "proposals"
+    if not proposals_dir.exists():
+        return tasks
+    for path in sorted(proposals_dir.glob("*.json")):
+        try:
+            proposal = json.loads(path.read_text(encoding="utf-8"))
+        except ValueError:
+            continue
+        application = proposal.get("application") or {}
+        if proposal.get("status") != "approved" or not application.get(
+            "restage_requested"
+        ):
+            continue
+        pid = str(proposal.get("proposal_id") or path.stem)
+        params = (proposal.get("proposed_change") or {}).get("execution_params")
+        if params:
+            instruction = (
+                f"Run `wayfinder job restage {root.name} {pid}` — params "
+                "updates re-stage mechanically from the recorded params."
+            )
+        else:
+            instruction = (
+                "Re-author this exact change against the CURRENT workspace: "
+                f"copy .wayfinder/jobs/{root.name}/workspace to a scratch dir, "
+                "apply the same change (the stale candidate at "
+                f"applications/{pid}/candidate shows what it looked like), then "
+                f"run `wayfinder job restage {root.name} {pid} "
+                "--candidate-dir <scratch>`. Do NOT alter the approved intent; "
+                "if the change no longer makes sense on the new base, reject "
+                "it (agent housekeeping) and propose fresh."
+            )
+        tasks.append(
+            {
+                "proposal_id": pid,
+                "summary": (proposal.get("proposed_change") or {}).get("summary"),
+                "base_revision": proposal.get("base_revision"),
+                "changed_files": proposal.get("changed_files") or [],
+                "instruction": instruction,
+            }
+        )
+    return tasks
+
+
 def _standing_checks_block(root: Path) -> dict[str, Any]:
     """Mechanical routine numbers, computed by the harness each wake.
 
@@ -408,6 +459,7 @@ def _build_worker_prompt_sections(
         "post_apply_shadow": _counterfactual_block(store, job_id),
         "research_substrate": _research_substrate_block(root),
         "standing_checks": _standing_checks_block(root),
+        "restage_tasks": _restage_block(root),
     }
 
     stable_prefix = (

--- a/wayfinder_paths/tests/test_jobs_apply_watchdog.py
+++ b/wayfinder_paths/tests/test_jobs_apply_watchdog.py
@@ -410,6 +410,100 @@ def test_torn_workspace_backup_preserved(tmp_path: Path, monkeypatch) -> None:
     assert (root / "workspace" / "src" / "fast_loop.py").exists()
 
 
+def _stamp_candidate_revisions(store: JobStore, job_id: str, proposal_id: str) -> None:
+    """Record base/candidate revisions the way the propose flow does."""
+    from wayfinder_paths.jobs.gating import compute_workspace_revision
+
+    proposal = store.load_proposal(job_id, proposal_id)
+    proposal["base_revision"] = compute_workspace_revision(store.job_dir(job_id))
+    candidate_dir = store.repo_root / proposal["application"]["candidate_dir"]
+    proposal["candidate_report"] = {
+        "revision": compute_workspace_revision(candidate_dir)
+    }
+    store.write_proposal(job_id, proposal)
+
+
+def test_complete_applied_refuses_stale_baseline(tmp_path: Path, monkeypatch) -> None:
+    """A candidate staged before an intervening apply must not promote: the
+    wholesale workspace replace would revert the intervening change."""
+    _patch_runner(monkeypatch)
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "drift-demo")
+    _write_proposal(store, job.id, "prop_drift")
+
+    claim_application(store, job.id, "prop_drift")
+    _prepare_candidate_script(
+        store,
+        job.id,
+        "prop_drift",
+        rearm_reason="rearm_guard: SNX still below SMA50.",
+    )
+    _stamp_candidate_revisions(store, job.id, "prop_drift")
+
+    # An intervening apply moves the active workspace past the staged base.
+    root = store.job_dir(job.id)
+    intervening = root / "workspace" / "src" / "graduated_sizing.py"
+    intervening.parent.mkdir(parents=True, exist_ok=True)
+    intervening.write_text("HYPE_FRACTION = 0.25\n", encoding="utf-8")
+
+    completed = complete_application(
+        store,
+        job.id,
+        "prop_drift",
+        status="applied",
+        allow_legacy=True,
+    )
+
+    application = completed["proposal"]["application"]
+    assert application["status"] == "failed"
+    assert "baseline drift" in str(application.get("error"))
+    # The intervening change survived — no wholesale revert.
+    assert intervening.read_text(encoding="utf-8") == "HYPE_FRACTION = 0.25\n"
+    assert "stale_baseline_promotion_refused" in _journal_types(store, job.id)
+
+
+def test_complete_applied_allows_crash_resume_after_promotion(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """If a completer crashed after the promotion itself, the active workspace
+    already equals the candidate — re-completion must finish, not refuse."""
+    import shutil
+
+    _patch_runner(monkeypatch)
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "resume-demo")
+    _write_proposal(store, job.id, "prop_resume")
+
+    claim_application(store, job.id, "prop_resume")
+    _prepare_candidate_script(
+        store,
+        job.id,
+        "prop_resume",
+        rearm_reason="rearm_guard: SNX still below SMA50.",
+    )
+    _stamp_candidate_revisions(store, job.id, "prop_resume")
+
+    # Simulate a crash after _promote_candidate: active == candidate content
+    # (promotion copies both the workspace and job.yaml).
+    root = store.job_dir(job.id)
+    proposal = store.load_proposal(job.id, "prop_resume")
+    candidate_dir = store.repo_root / proposal["application"]["candidate_dir"]
+    shutil.rmtree(root / "workspace")
+    shutil.copytree(candidate_dir / "workspace", root / "workspace")
+    shutil.copy2(candidate_dir / "job.yaml", root / "job.yaml")
+
+    completed = complete_application(
+        store,
+        job.id,
+        "prop_resume",
+        status="applied",
+        allow_legacy=True,
+    )
+
+    assert completed["proposal"]["application"]["status"] == "applied"
+    assert "stale_baseline_promotion_refused" not in _journal_types(store, job.id)
+
+
 def test_run_job_worker_apply_does_not_claim(tmp_path: Path, monkeypatch) -> None:
     calls = _patch_runner(monkeypatch)
 

--- a/wayfinder_paths/tests/test_jobs_propose.py
+++ b/wayfinder_paths/tests/test_jobs_propose.py
@@ -21,7 +21,7 @@ from wayfinder_paths.jobs.application import (
 from wayfinder_paths.jobs.backtest_artifacts import load_backtest_view
 from wayfinder_paths.jobs.gating import evaluate_live_gate
 from wayfinder_paths.jobs.models import WayfinderJob
-from wayfinder_paths.jobs.proposals import propose_change
+from wayfinder_paths.jobs.proposals import propose_change, restage_proposal
 from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.tests.test_jobs_application_gate import _patch_runner
 from wayfinder_paths.tests.test_jobs_gating import _make_job
@@ -314,3 +314,102 @@ def test_propose_fails_named_check_when_entrypoint_outside_workspace(
     summary = proposal["candidate_report"]["validation_summary"]
     assert summary["status"] == "failed"
     assert "entrypoint_inside_workspace" in summary["failed_checks"]
+
+
+def test_stale_baseline_apply_restages_with_approval_carryover(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The bulk-approve flow: an intervening apply moves the workspace, the
+    stale candidate's completion defers to a re-stage (approval carried over),
+    the mechanical params re-stage re-queues, and the second completion
+    promotes WITHOUT reverting the intervening change."""
+    _patch_runner(monkeypatch)
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.worker.run_job_worker",
+        lambda job_id, *, mode, **k: {"status": "queued"},
+    )
+    launches: list[str] = []
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.apply_launcher.launch_application",
+        lambda store, job_id, pid: launches.append(pid) or {"launched": pid},
+    )
+    store, job_id, root = _make_job(tmp_path)
+    proposal = _propose_params(store, job_id)
+    pid = proposal["proposal_id"]
+
+    # An intervening apply moves the active workspace after propose.
+    script = root / "workspace" / "src" / "strategy.py"
+    script.write_text(
+        script.read_text(encoding="utf-8") + "\n# graduated sizing\n",
+        encoding="utf-8",
+    )
+
+    store.approve_proposal(job_id, pid)
+    claim_application(store, job_id, pid)
+    completed = complete_application(store, job_id, pid, status="applied")
+
+    application = completed["proposal"]["application"]
+    assert application["status"] == "failed"
+    assert "baseline drift" in str(application.get("error"))
+    reloaded = store.load_proposal(job_id, pid)
+    assert reloaded["status"] == "approved", "approval must carry over"
+    assert reloaded["application"]["restage_requested"] is True
+    assert "# graduated sizing" in script.read_text(encoding="utf-8")
+
+    from wayfinder_paths.jobs.worker import _restage_block
+
+    assert [t["proposal_id"] for t in _restage_block(root)] == [pid]
+
+    restaged = restage_proposal(store, job_id, pid)
+
+    assert restaged["status"] == "approved"
+    assert restaged["application"]["status"] == "queued"
+    assert not restaged["application"].get("restage_requested")
+    assert launches == [pid]
+    journal = (root / "journal.jsonl").read_text(encoding="utf-8")
+    assert "proposal_restaged" in journal
+
+    # The re-staged candidate promotes cleanly on the moved base.
+    claim_application(store, job_id, pid)
+    completed = complete_application(store, job_id, pid, status="applied")
+    assert completed["proposal"]["application"]["status"] == "applied"
+    # Intervening change survived AND the approved change landed.
+    assert "# graduated sizing" in script.read_text(encoding="utf-8")
+    active_yaml = yaml.safe_load((root / "job.yaml").read_text(encoding="utf-8"))
+    assert active_yaml["execution_params"]["threshold"] == 10.7
+
+
+def test_restage_gate_failure_auto_rejects(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If the re-staged candidate cannot pass the approve-time gate on the new
+    base, the world changed materially — auto-reject so the owner reviews a
+    fresh proposal instead of silently applying a degraded change."""
+    _patch_runner(monkeypatch)
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.worker.run_job_worker",
+        lambda job_id, *, mode, **k: {"status": "queued"},
+    )
+    store, job_id, root = _make_job(tmp_path)
+    proposal = _propose_params(store, job_id)
+    pid = proposal["proposal_id"]
+
+    script = root / "workspace" / "src" / "strategy.py"
+    script.write_text(
+        script.read_text(encoding="utf-8") + "\n# drift\n", encoding="utf-8"
+    )
+    store.approve_proposal(job_id, pid)
+    claim_application(store, job_id, pid)
+    complete_application(store, job_id, pid, status="applied")
+    assert store.load_proposal(job_id, pid)["application"]["restage_requested"]
+
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.proposals.evaluate_live_gate",
+        lambda *a, **k: {"live_ready": False, "reasons": ["backtest regressed"]},
+    )
+
+    rejected = restage_proposal(store, job_id, pid)
+
+    assert rejected["status"] == "rejected"
+    assert rejected["rejection"]["by"] == "agent"
+    assert "re-stage gate failed" in str(rejected["rejection"]["reason"])

--- a/wayfinder_paths/tests/test_jobs_triggers.py
+++ b/wayfinder_paths/tests/test_jobs_triggers.py
@@ -134,3 +134,21 @@ def test_tick_trigger_event_derivation() -> None:
         {"ok": True, "guard_events": [{"kind": "risk_halt"}]}
     ) == ["risk_halt"]
     assert _tick_trigger_events({"ok": True, "snapshot": {"status": "valid"}}) == []
+
+
+def test_infrastructure_event_wakes_without_configured_trigger(
+    tmp_path: Path, wakes: list[dict[str, Any]]
+) -> None:
+    """Restage requests wake the agent even when the job never opted into any
+    trigger list — they are pipeline work, not market conditions."""
+    store, job = _make_job(tmp_path)
+    job.agent_loop.triggers = []
+    store.save(job)
+
+    fired = fire_triggers(
+        store, job, ["proposal_restage_requested"], source="apply:prop-x"
+    )
+
+    assert fired is not None
+    assert fired["triggers"] == ["proposal_restage_requested"]
+    assert len(wakes) == 1


### PR DESCRIPTION
## Why

Approving a proposal promotes its propose-time candidate — a full workspace snapshot — by wholesale replace. If other applies landed between propose and approve, the stale snapshot silently reverts them.

This happened live on majors-5m-lab: the composition-signal candidates were staged 08-03 against base `20ace6cd`; the HYPE graduation applied 08-05 (`7ca1b669`, sizing 0.125 → 0.25); approving #7/#8 on 08-06 promoted their stale snapshots back-to-back and reverted the graduation twice. The journal logged `candidate_baseline_drift` both times but nothing acted on it. (Live state repaired on-box from the pre-apply backup with an `owner_workspace_repair` journal record.)

## Commit 1 — refuse stale-baseline promotion (safety)

- `_complete_applied_application` refuses to promote when `base_revision` no longer matches the active workspace revision: journals `stale_baseline_promotion_refused`, writes a red apply report, completes the application as failed, resumes the loops.
- Crash-resume preserved: `active == candidate revision` means the promotion itself already completed, so finishing the bookkeeping is allowed. Legacy proposals without `base_revision` unaffected.
- Drive-by: `_evidence_window_check` no longer crashes (AttributeError) on legacy list-shaped `input_bars.json` — this was breaking two suites on the branch tip.

## Commit 2 — approval carryover: auto re-stage (bulk-approve UX)

Refusal alone would make bulk approvals cost a fresh propose + a fresh owner click each. Instead, one approval = approval of the *intent*:

- The refusal marks the application `restage_requested` (proposal stays **approved**) and fires an immediate agent wake — `proposal_restage_requested` is an infrastructure event that wakes regardless of the job's configured trigger list.
- Every wake surfaces pending re-stages via a `restage_tasks` block with exact instructions.
- New `wayfinder job restage <job> <proposal> [--candidate-dir …]`: rebuilds the candidate against the **current** workspace (mechanical for params updates from the recorded params; agent-re-authored tree for code changes), re-runs the full propose-time gates (validation + comparison backtest + live gate + candidate-freshness), journals `proposal_restaged`, and **auto-queues the apply** — no second owner click.
- Intent contract, summary, and kind carry over verbatim; a different change requires a fresh proposal.
- If the re-staged candidate fails the approve-time gate on the new base, the proposal is auto-rejected (agent housekeeping) — the world changed materially, so the owner reviews fresh.

Net: bulk-approve N proposals → the first applies immediately, the rest self-heal sequentially through re-stage cycles with zero further owner action.

## Tests

- `test_complete_applied_refuses_stale_baseline` / `test_complete_applied_allows_crash_resume_after_promotion` (commit 1)
- `test_stale_baseline_apply_restages_with_approval_carryover` — full end-to-end: drift → refusal → carryover → mechanical restage → re-queue → clean promote; asserts the intervening change survives AND the approved change lands.
- `test_restage_gate_failure_auto_rejects`, `test_infrastructure_event_wakes_without_configured_trigger`
- 94 passed across propose, triggers, apply-watchdog, application-gate, wayfinder-jobs, and evidence-window suites.