### PR TITLE
Hyperliquid Adapter - Clarify get_user_state is perp-only

### DIFF
--- a/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
+++ b/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
@@ -475,6 +475,14 @@ class HyperliquidAdapter(BaseAdapter):
     async def get_user_state(
         self, address: str
     ) -> tuple[Literal[True], dict[str, Any]] | tuple[Literal[False], str]:
+        """PERP STATE ONLY (clearinghouseState) — positions + perp margin
+        summary. This is NOT the account balance: on a UnifiedAccount, USDC
+        collateral lives in spot, so `marginSummary.accountValue` reads ~0 when
+        no perp positions are open. If you need collateral/balance and the
+        account is unified, you MUST also pull spot USDC via
+        `get_spot_user_state`.
+        """
+
         def _aggregate(results: list[dict[str, Any]]) -> dict[str, Any]:
             if not results:
                 return {}


### PR DESCRIPTION
### Summary

`get_user_state` (clearinghouseState) returns PERP state only — positions + perp margin summary — not the account balance. On a UnifiedAccount, USDC collateral lives in spot, so `marginSummary.accountValue` reads ~0 when no perp positions are open. Added a docstring making this explicit and pointing callers that need collateral/balance to also pull `get_spot_user_state`. This is the ad-hoc-script footgun behind agents reporting "$0 on Hyperliquid" while funds sit in spot.