### PR TITLE
jobs: narrate the apply pipeline in the decision log

### DIFF
--- a/wayfinder_paths/jobs/decision_log.py
+++ b/wayfinder_paths/jobs/decision_log.py
@@ -141,6 +141,69 @@ def _journal_entries(
                     actor="watchdog",
                 )
             )
+        elif kind == "stale_baseline_promotion_refused":
+            entries.append(
+                _entry(
+                    ts,
+                    "proposal",
+                    (
+                        f"Apply deferred: {title}"
+                        if title
+                        else "Apply deferred — stale baseline"
+                    ),
+                    "Candidate was staged before an earlier change applied; "
+                    "promoting it would revert that change. Re-stage requested "
+                    "— approval carries over, no action needed.",
+                    "info",
+                    actor="system",
+                    proposal_id=pid,
+                )
+            )
+        elif kind == "proposal_restaged":
+            entries.append(
+                _entry(
+                    ts,
+                    "proposal",
+                    (
+                        f"Re-staged against current strategy: {title}"
+                        if title
+                        else "Change re-staged against current strategy"
+                    ),
+                    f"new base revision {event.get('new_base_revision')}; "
+                    "apply re-queued automatically",
+                    "info",
+                    actor="agent",
+                    proposal_id=pid,
+                )
+            )
+        elif kind == "proposal_apply_finished":
+            status = str(event.get("application_status") or "")
+            error = str(event.get("error") or "")
+            # Applied is already narrated by proposal_promoted; deferrals by
+            # stale_baseline_promotion_refused. Only genuine failures add news.
+            if status == "failed" and "baseline drift" not in error:
+                entries.append(
+                    _entry(
+                        ts,
+                        "proposal",
+                        f"Apply failed: {title}" if title else "Apply failed",
+                        error or "no error recorded",
+                        "info",
+                        actor="system",
+                        proposal_id=pid,
+                    )
+                )
+        elif kind == "owner_workspace_repair":
+            entries.append(
+                _entry(
+                    ts,
+                    "recovery",
+                    "Owner repaired the strategy workspace",
+                    str(event.get("reason") or ""),
+                    "info",
+                    actor="owner",
+                )
+            )
         elif kind in ("halt_requested", "halt_flattened"):
             entries.append(
                 _entry(

--- a/wayfinder_paths/tests/test_jobs_decision_log.py
+++ b/wayfinder_paths/tests/test_jobs_decision_log.py
@@ -184,3 +184,81 @@ def test_caps_and_empty_job(tmp_path) -> None:
     assert len(log["entries"]) == 25
     # Stats see past the display cap: all 80 pending proposals counted.
     assert log["stats"]["proposals_created"] == 80
+
+
+def test_apply_lifecycle_events(tmp_path) -> None:
+    """The apply pipeline narrates itself: stale-baseline deferral, re-stage,
+    genuine apply failure, and owner repair each become feed entries; applied
+    and deferral outcomes are not double-reported via proposal_apply_finished."""
+    store, job_id = _mk(tmp_path)
+    root = store.job_dir(job_id)
+    _write_proposal(root, "prop-aaaaaaaa", "Add vol_surge SignalDef")
+    _write_proposal(root, "prop-bbbbbbbb", "Bump stop_pct")
+
+    journal = [
+        {
+            "ts": _ts(10),
+            "type": "stale_baseline_promotion_refused",
+            "proposal_id": "prop-aaaaaaaa",
+            "base_revision": "aaaa11112222",
+            "active_revision": "bbbb33334444",
+        },
+        {
+            "ts": _ts(9),
+            "type": "proposal_apply_finished",
+            "proposal_id": "prop-aaaaaaaa",
+            "application_status": "failed",
+            "error": "baseline drift: candidate was staged against revision …",
+        },
+        {
+            "ts": _ts(8),
+            "type": "proposal_restaged",
+            "proposal_id": "prop-aaaaaaaa",
+            "new_base_revision": "bbbb33334444",
+        },
+        {
+            "ts": _ts(7),
+            "type": "proposal_apply_finished",
+            "proposal_id": "prop-bbbbbbbb",
+            "application_status": "failed",
+            "error": "Candidate validation failed: entrypoint missing",
+        },
+        {
+            "ts": _ts(6),
+            "type": "proposal_apply_finished",
+            "proposal_id": "prop-bbbbbbbb",
+            "application_status": "applied",
+            "error": None,
+        },
+        {
+            "ts": _ts(5),
+            "type": "owner_workspace_repair",
+            "reason": "Applies reverted the HYPE graduation; restored from backup.",
+        },
+    ]
+    (root / "journal.jsonl").write_text(
+        "\n".join(json.dumps(row) for row in journal) + "\n", encoding="utf-8"
+    )
+
+    log = build_decision_log(store, job_id)
+    titles = [entry["title"] for entry in log["entries"]]
+
+    assert any(t.startswith("Apply deferred") for t in titles)
+    assert any(t.startswith("Re-staged against current strategy") for t in titles)
+    # Genuine failure reported once; baseline-drift failure NOT double-reported.
+    failures = [t for t in titles if t.startswith("Apply failed")]
+    assert failures == ["Apply failed: Bump stop_pct"]
+    # Applied completions are narrated by proposal_promoted, not apply_finished.
+    assert not any("applied" in t.lower() for t in titles)
+    repair = next(
+        entry
+        for entry in log["entries"]
+        if entry["title"] == "Owner repaired the strategy workspace"
+    )
+    assert repair["actor"] == "owner"
+    assert "HYPE graduation" in repair["detail"]
+    # Deferral + re-stage thread with the proposal they belong to.
+    deferred = next(
+        entry for entry in log["entries"] if entry["title"].startswith("Apply deferred")
+    )
+    assert deferred["proposal_id"] == "prop-aaaaaaaa"


### PR DESCRIPTION
## Why

Yesterday's apply saga (stale-baseline deferral → re-stage → owner repair) was invisible in the Activity feed — the owner saw a paused job with no story. With #613's approval-carryover flow there are new lifecycle events the feed must narrate.

## What

`build_decision_log` maps four more journal events into feed entries:

| Journal event | Feed entry | Outcome |
|---|---|---|
| `stale_baseline_promotion_refused` | "Apply deferred: {summary}" + why + "approval carries over, no action needed" | info |
| `proposal_restaged` | "Re-staged against current strategy: {summary}" + new base revision | info |
| `proposal_apply_finished` (failed, non-drift) | "Apply failed: {summary}" + error | info |
| `owner_workspace_repair` | "Owner repaired the strategy workspace" + reason | info (actor: owner) |

De-duplication: baseline-drift failures are narrated only by the deferral entry, applied completions only by `proposal_promoted` — `proposal_apply_finished` adds an entry solely for genuine failures.

Part 1/3 of the apply-lifecycle UX arc (backend serializer + FE to follow).

## Tests

`test_apply_lifecycle_events` — fixture journal with the full arc; asserts each entry, the de-dup rules, actor/threading. 3 passed in the suite.