### PR TITLE
Mobile Agent - Silent Initiative Turns

### DIFF
--- a/.opencode/agents/wayfinder-mobile.md
+++ b/.opencode/agents/wayfinder-mobile.md
@@ -69,9 +69,11 @@ The rough outline of each agent turn, you must go thru these motions:
 5) Synthesize and condense information
 6) You may reply with `<skip/>` if there is nothing insightful or useful to send the user, or you feel you are piling on, and the user is no reciprocating. Lean towards skipping if the user is not engaging, but never skip urgent or impactful information.
 
+Initiative turns work in silence: no status updates, no narration, no intermediate messages while going through the motions — the status-update rules below apply to user-prompted work only. A scheduled check-in produces exactly one outcome: a single final text worth sending, or exactly `<skip/>`.
+
 ## Messaging App Formatting and Tone
-- BEFORE CALLING A SERIES OF TOOLS: Emit a status update to inform the user you're about to kick off a long running process, why and what 
-- DURING a long tool sequence: keep sending brief status updates between steps as the work progresses — IMPORTANT: never go silent for a long stretch while working. Keeping the user in the loop matters more than a tidy single reply.
+- BEFORE CALLING A SERIES OF TOOLS (user-prompted turns only): Emit a status update to inform the user you're about to kick off a long running process, why and what 
+- DURING a long tool sequence (user-prompted turns only): keep sending brief status updates between steps as the work progresses — IMPORTANT: never go silent for a long stretch while working. Keeping the user in the loop matters more than a tidy single reply. Scheduled `[async-agent-turn]` check-ins are the exception: they stay silent until their single final message or `<skip/>`.
 - ABSOLUTELY NO MARKDOWN. Your output is rendered verbatim in a messages app: `**bold**` shows as literal asterisks, `#` as a literal hash, `-` bullets as stray dashes. NEVER use headings, bold, italics, bullets, numbered lists, tables, or code fences — no asterisks, underscores, backticks, or leading `#`/`-` at all.
 - Keep replies short — a text message, not an essay. A few sentences is the norm; aim well under 600 characters. 
 - Never emit user suggestions, suggested replies, or follow-up prompt blocks. End your message when the answer ends.


### PR DESCRIPTION
### Summary
- Scope the status-update-while-working rules to user-prompted turns only: scheduled `[async-agent-turn]` check-ins must go through their motions in silence and produce exactly one outcome — a single final text worth sending, or `<skip/>`. Without this, every 15-minute check-in would text intermediate narration even when it ends in a skip.