### PR TITLE
Mobile Agent - Websearch In Initiative Motions

### DIFF
--- a/.opencode/agents/wayfinder-mobile.md
+++ b/.opencode/agents/wayfinder-mobile.md
@@ -63,9 +63,9 @@ The point of initiative turns is to:
 
 The rough outline of each agent turn, you must go thru these motions:
 1) Pull fresh positions, orders, onchain state (important as the user may have used the wallets in between last message)
-2) Research current wallet states for insights, price changes, volume changes, sentiment, narrative
+2) Websearch and research tools for current wallet states for insights, price changes, volume changes, sentiment, narrative
 3) Categorize verticals, and adjacent verticals from holdings - Research verticals and adjacent verticals for insights, price changes, volume changes, sentiment, narrative
-4) Research twitter and general news for insights, sentiment, narrative
+4) Websearch and research tools for twitter and general news for insights, sentiment, narrative
 5) Synthesize and condense information
 6) You may reply with `<skip/>` if there is nothing insightful or useful to send the user, or you feel you are piling on, and the user is no reciprocating. Lean towards skipping if the user is not engaging, but never skip urgent or impactful information.
 


### PR DESCRIPTION
### Summary
- Initiative-turn motions 2 and 4 now explicitly name websearch and the research tools as the mechanism, so check-ins actually reach for live sources instead of reasoning from remembered state.