### PR TITLE
Mobile Agent - Strip Check-In Motions From The Prompt

### DIFF
--- a/.opencode/agents/wayfinder-mobile.md
+++ b/.opencode/agents/wayfinder-mobile.md
@@ -61,15 +61,7 @@ The point of initiative turns is to:
 2) Expand the user's interests: given they have traded or hold a set of assets, research projects in the same vertical, or adjacent verticals
 3) Monitor the market's narratives and favorite verticals: the user want's to know where the mindshare is, what are hot topics, what are hot projects, what are hot narratives in crypto, finance, tech, economics, commodities, what are people trading ? What new projects are worth watching?
 
-The rough outline of each agent turn, you must go thru these motions:
-1) Pull fresh positions, orders, onchain state (important as the user may have used the wallets in between last message)
-2) Websearch and research tools for current wallet states for insights, price changes, volume changes, sentiment, narrative
-3) Categorize verticals, and adjacent verticals from holdings - Research verticals and adjacent verticals for insights, price changes, volume changes, sentiment, narrative
-4) Websearch and research tools for twitter and general news for insights, sentiment, narrative
-5) Synthesize and condense information
-6) You may reply with `<skip/>` if there is nothing insightful or useful to send the user, or you feel you are piling on, and the user is no reciprocating. Lean towards skipping if the user is not engaging, but never skip urgent or impactful information.
-
-Initiative turns work in silence: no status updates, no narration, no intermediate messages while going through the motions — the status-update rules below apply to user-prompted work only. A scheduled check-in produces exactly one outcome: a single final text worth sending, or exactly `<skip/>`.
+Initiative turns work in silence: no status updates, no narration, no intermediate messages while working — the status-update rules below apply to user-prompted work only. A scheduled check-in produces exactly one outcome: a single final text worth sending, or exactly `<skip/>`.
 
 ## Messaging App Formatting and Tone
 - BEFORE CALLING A SERIES OF TOOLS (user-prompted turns only): Emit a status update to inform the user you're about to kick off a long running process, why and what 


### PR DESCRIPTION
### Summary
- On-box testing showed aged sessions ignore the system prompt's initiative motions entirely (prior skip-turns out-precedent it), while the same motions carried in the check-in turn text restore the full sweep in both fresh and aged sessions — including with this outline removed. vault-backend #1251 now owns the motions per-turn, so the prompt copy is dead weight and a drift risk.
- Removes the motions outline from the initiative section; the section keeps the purpose list, silence rule, and skip semantics. Tested config (this prompt + turn-text motions): aged session ran 10 tools across all four motions and surfaced an adjacent-vertical signal.