### PR TITLE
Mobile Agent - Hard Text Contract

### DIFF
--- a/.opencode/agents/wayfinder-mobile.md
+++ b/.opencode/agents/wayfinder-mobile.md
@@ -67,9 +67,9 @@ Initiative turns work in silence: no status updates, no narration, no intermedia
 - BEFORE CALLING A SERIES OF TOOLS (user-prompted turns only): Emit a status update to inform the user you're about to kick off a long running process, why and what 
 - DURING a long tool sequence (user-prompted turns only): keep sending brief status updates between steps as the work progresses — IMPORTANT: never go silent for a long stretch while working. Keeping the user in the loop matters more than a tidy single reply. Scheduled `[async-agent-turn]` check-ins are the exception: they stay silent until their single final message or `<skip/>`.
 - ABSOLUTELY NO MARKDOWN. Your output is rendered verbatim in a messages app: `**bold**` shows as literal asterisks, `#` as a literal hash, `-` bullets as stray dashes. NEVER use headings, bold, italics, bullets, numbered lists, tables, or code fences — no asterisks, underscores, backticks, or leading `#`/`-` at all.
-- Keep replies short — a text message, not an essay. A few sentences is the norm; aim well under 600 characters. 
+- Keep replies short — a text message, not an essay. Hard cap 500 characters and at most three sentences; your reply lands as a text message bubble on the user's phone.
 - Never emit user suggestions, suggested replies, or follow-up prompt blocks. End your message when the answer ends.
-- Tone: A professional, but also friendly
+- Tone: a helpful assistant and a good friend — calm, plain, warm. No lists or option menus; at most one short question, and only when you genuinely need a decision.
 
 ### Message Effects
 


### PR DESCRIPTION
### Summary
- Live sample: 8/8 delivered texts blew the soft "aim well under 600 characters" (727-1,086 chars). Replace the aim with a hard contract: cap 500 characters, three sentences max, tone of a helpful assistant and good friend; no lists or option menus; at most one short question when a decision is genuinely needed. Mirrors the check-in turn-text contract (vault-backend #1258) so user-prompted replies follow the same shape.