### PR TITLE
jobs: make approval-carryover re-stages converge without owner touches

### DIFF
--- a/wayfinder_paths/jobs/watchdog.py
+++ b/wayfinder_paths/jobs/watchdog.py
@@ -43,6 +43,10 @@ QUEUED_TIMEOUT = timedelta(minutes=10)
 # A completer pid that is still alive but has made no progress for this long
 # is wedged: kill its process group, then recover.
 HARD_KILL_TIMEOUT = timedelta(minutes=45)
+# A code-change re-stage the agent has not resolved past this age gets the
+# restage wake re-fired (once per window) — one truncated prompt or dead
+# session must not strand an owner-approved change.
+RESTAGE_NAG_TIMEOUT = timedelta(minutes=30)
 
 
 def _pid_alive(pid: int) -> bool:
@@ -178,6 +182,91 @@ def _recover_queued(
     return event
 
 
+def _recover_restage(
+    store: JobStore,
+    job_id: str,
+    proposal: dict[str, Any],
+    now: datetime,
+    *,
+    allow_mechanical: bool = True,
+) -> dict[str, Any] | None:
+    """Autonomous recovery for approval-carryover re-stages.
+
+    Params updates need no authoring — the change is the stored params dict —
+    so the watchdog re-stages them mechanically (full gate re-run + auto
+    queue) instead of waiting on an agent session. Code changes must be
+    re-authored by the agent; if one sits unresolved past the nag window
+    (a truncated prompt, a dead session, a wrong turn into propose), the
+    watchdog re-fires the restage wake so the pipeline converges without an
+    owner touch.
+    """
+    application = proposal["application"]
+    if proposal.get("status") != "approved":
+        return None
+    if not application.get("restage_requested"):
+        return None
+    if application.get("status") in {"queued", "applying", "applied"}:
+        return None
+    proposal_id = str(proposal["proposal_id"])
+    params = (proposal.get("proposed_change") or {}).get("execution_params")
+
+    if params:
+        if not allow_mechanical:
+            return None  # next pass, 5 minutes out
+        # circular import: proposals → worker → …driver → triggers → watchdog
+        from wayfinder_paths.jobs.proposals import restage_proposal
+
+        try:
+            result = restage_proposal(store, job_id, proposal_id)
+        except Exception as exc:
+            store.append_journal(
+                job_id,
+                {
+                    "type": "application_watchdog_skipped",
+                    "proposal_id": proposal_id,
+                    "reason": f"mechanical restage failed: {exc}",
+                },
+            )
+            return None
+        event = {
+            "type": "application_watchdog_recovered",
+            "proposal_id": proposal_id,
+            "stalled_status": "restage_requested",
+            "action": "mechanical_restage",
+            "outcome": result.get("application", {}).get("status")
+            or result.get("status"),
+        }
+        store.append_journal(job_id, event)
+        return event
+
+    age = _age(now, application.get("finished_at") or proposal.get("updated_at"))
+    if age < RESTAGE_NAG_TIMEOUT:
+        return None
+    last_nag = application.get("restage_nag_ts")
+    if last_nag and _age(now, last_nag) < RESTAGE_NAG_TIMEOUT:
+        return None
+    from wayfinder_paths.jobs.triggers import fire_triggers
+
+    fire_triggers(
+        store,
+        store.load(job_id),
+        ["proposal_restage_requested"],
+        source=f"watchdog-nag:{proposal_id}",
+    )
+    application["restage_nag_ts"] = now.isoformat()
+    store.write_proposal(job_id, proposal)
+    event = {
+        "type": "application_watchdog_recovered",
+        "proposal_id": proposal_id,
+        "stalled_status": "restage_requested",
+        "age_seconds": int(age.total_seconds()) if age != timedelta.max else None,
+        "action": "restage_wake_nag",
+        "outcome": "agent_renotified",
+    }
+    store.append_journal(job_id, event)
+    return event
+
+
 def recover_stalled_applications(
     *, store: JobStore | None = None, now: datetime | None = None
 ) -> dict[str, Any]:
@@ -190,6 +279,10 @@ def recover_stalled_applications(
     scanned = 0
     recovered: list[dict[str, Any]] = []
     errors: list[dict[str, Any]] = []
+    # A mechanical restage re-runs the full gate suite (a backtest) — bound
+    # each watchdog pass to one so the pass stays well inside its timeout;
+    # the 5-minute cadence picks up the rest.
+    restaged_this_pass = False
     for job in store.list_jobs():
         try:
             proposals = store.proposals(job.id)
@@ -204,6 +297,18 @@ def recover_stalled_applications(
                     event = _recover_applying(store, job.id, proposal, now)
                 elif status == "queued":
                     event = _recover_queued(store, job.id, proposal, now)
+                elif proposal["application"].get("restage_requested"):
+                    event = _recover_restage(
+                        store,
+                        job.id,
+                        proposal,
+                        now,
+                        allow_mechanical=not restaged_this_pass,
+                    )
+                    if event is not None and event.get("action") == (
+                        "mechanical_restage"
+                    ):
+                        restaged_this_pass = True
                 else:
                     event = None
             except Exception as exc:

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -438,6 +438,7 @@ def _build_worker_prompt_sections(
             "PnL, or trade count as a forward result."
         )
 
+    restage_tasks = _restage_block(root)
     dynamic_payload = {
         "scorecard": snapshot.get("scorecard") or {},
         "forward": forward_block,
@@ -459,7 +460,7 @@ def _build_worker_prompt_sections(
         "post_apply_shadow": _counterfactual_block(store, job_id),
         "research_substrate": _research_substrate_block(root),
         "standing_checks": _standing_checks_block(root),
-        "restage_tasks": _restage_block(root),
+        "restage_tasks": restage_tasks,
     }
 
     stable_prefix = (
@@ -730,8 +731,38 @@ def _build_worker_prompt_sections(
             "retrying.\n"
         )
     )
+    # Re-stage tasks are rendered as prompt text, never only inside the JSON
+    # snapshot: the snapshot is truncated at 12k chars with sort_keys=True, so
+    # a busy job can silently swallow a payload-only instruction — which is
+    # exactly how an agent once missed a pending re-stage and burned the
+    # owner's carried-over approval on a duplicate proposal.
+    restage_priority = ""
+    restage_task_line = ""
+    if restage_tasks:
+        restage_task_line = (
+            "- FIRST: complete the PRIORITY re-stage tasks listed above the snapshot.\n"
+        )
+        items = "".join(
+            f"  - {task['proposal_id']}: {task['instruction']}\n"
+            for task in restage_tasks
+        )
+        restage_priority = (
+            "PRIORITY — approved changes awaiting re-stage (do this FIRST):\n"
+            "The owner already approved these; an intervening apply moved the "
+            "workspace, so each candidate must be rebuilt against the CURRENT "
+            "workspace and re-staged.\n"
+            f"{items}"
+            "Use `wayfinder job restage` exactly as instructed per task. Do "
+            "NOT create a new proposal for these and do NOT use propose — a "
+            "new proposal discards the owner's approval and forces a "
+            "duplicate review. Re-staging re-runs every gate and re-queues "
+            "the apply automatically; if the change no longer makes sense on "
+            "the new base, reject it (agent housekeeping) and only then "
+            "propose fresh.\n\n"
+        )
     dynamic_context = (
         f"{DYNAMIC_CONTEXT_MARKER}\n"
+        f"{restage_priority}"
         "Current snapshot:\n"
         f"{_canonical_json(dynamic_payload, max_chars=12000)}\n\n"
         "Research agenda (research/agenda.md — cumulative exploration "
@@ -740,6 +771,7 @@ def _build_worker_prompt_sections(
         "Recent journal:\n"
         f"{recent_journal}\n\n"
         "Task:\n"
+        f"{restage_task_line}"
         f"{task_line}"
         "- Write the appropriate monitor/intervene/auto/apply report.\n"
         "- Emit a user-visible result only for meaningful state transitions, "

--- a/wayfinder_paths/tests/test_jobs_apply_watchdog.py
+++ b/wayfinder_paths/tests/test_jobs_apply_watchdog.py
@@ -582,3 +582,111 @@ def test_claim_survives_sync_failure(tmp_path: Path, monkeypatch) -> None:
     assert claimed["proposal"]["application"]["status"] == "applying"
     assert ("pause", "sync-fail-demo-script") in calls
     assert "claim_sync_failed" in _journal_types(store, job.id)
+
+
+def _write_restage_proposal(
+    store: JobStore,
+    job_id: str,
+    proposal_id: str,
+    *,
+    params: dict | None,
+    finished_minutes_ago: float = 45,
+) -> None:
+    proposal = {
+        "proposal_id": proposal_id,
+        "job_id": job_id,
+        "status": "approved",
+        "proposed_change": {
+            "summary": "Approved change awaiting re-stage",
+            **({"execution_params": params} if params else {}),
+        },
+        "intent_contract": _intent_contract(),
+        "scenario_plan": _scenario_plan(),
+        "candidate_report": {"revision": "abc123def456"},
+        "application": {
+            "status": "failed",
+            "restage_requested": True,
+            "finished_at": _iso_ago(finished_minutes_ago),
+        },
+    }
+    store.write_proposal(job_id, proposal)
+
+
+def test_watchdog_mechanically_restages_params_carryover(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A params re-stage needs no authoring: the watchdog re-stages it
+    directly instead of waiting on an agent session — bounded to one
+    mechanical re-stage per pass (each re-runs the gate backtest)."""
+    _patch_runner(monkeypatch)
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "restage-mech")
+    _write_restage_proposal(store, job.id, "prop_params_a", params={"stop_pct": 0.01})
+    _write_restage_proposal(store, job.id, "prop_params_b", params={"tp_pct": 0.05})
+
+    restaged: list[str] = []
+
+    def fake_restage(store_, job_id, proposal_id):  # noqa: ANN001
+        restaged.append(proposal_id)
+        return {"status": "approved", "application": {"status": "queued"}}
+
+    monkeypatch.setattr("wayfinder_paths.jobs.proposals.restage_proposal", fake_restage)
+
+    result = recover_stalled_applications(store=store)
+
+    assert len(restaged) == 1, "one mechanical restage per watchdog pass"
+    actions = [event["action"] for event in result["recovered"]]
+    assert actions == ["mechanical_restage"]
+    assert "application_watchdog_recovered" in _journal_types(store, job.id)
+
+    # Next pass picks up the second one.
+    restaged.clear()
+    recover_stalled_applications(store=store)
+    assert len(restaged) == 1
+
+
+def test_watchdog_renags_code_change_restage(tmp_path: Path, monkeypatch) -> None:
+    """A code-change re-stage the agent has not resolved gets the wake
+    re-fired after the nag window — once per window, not every pass."""
+    _patch_runner(monkeypatch)
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "restage-nag")
+    _write_restage_proposal(store, job.id, "prop_code_x", params=None)
+
+    fired: list[str] = []
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.triggers.fire_triggers",
+        lambda store_, job_, events, *, source: fired.append(source) or {"ok": True},
+    )
+
+    result = recover_stalled_applications(store=store)
+    assert fired == ["watchdog-nag:prop_code_x"]
+    assert [e["action"] for e in result["recovered"]] == ["restage_wake_nag"]
+
+    # Within the nag window: no re-fire.
+    second = recover_stalled_applications(store=store)
+    assert fired == ["watchdog-nag:prop_code_x"]
+    assert second["recovered"] == []
+
+
+def test_watchdog_leaves_fresh_code_restage_to_the_agent(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Inside the nag window the agent still owns the task — no watchdog
+    action, no duplicate wake."""
+    _patch_runner(monkeypatch)
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "restage-fresh")
+    _write_restage_proposal(
+        store, job.id, "prop_code_y", params=None, finished_minutes_ago=5
+    )
+
+    fired: list[str] = []
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.triggers.fire_triggers",
+        lambda *a, **k: fired.append(1),
+    )
+
+    result = recover_stalled_applications(store=store)
+    assert fired == []
+    assert result["recovered"] == []

--- a/wayfinder_paths/tests/test_wayfinder_jobs.py
+++ b/wayfinder_paths/tests/test_wayfinder_jobs.py
@@ -1228,3 +1228,61 @@ def test_reject_proposal_records_provenance(tmp_path: Path) -> None:
     journal = (store.job_dir(job.id) / "journal.jsonl").read_text()
     assert '"rejected_by": "owner"' in journal
     assert '"rejected_by": "agent"' in journal
+
+
+def test_worker_prompt_hoists_restage_tasks_out_of_snapshot(tmp_path: Path) -> None:
+    """Pending re-stages must be PROMPT TEXT, not payload-only: the snapshot
+    JSON truncates at 12k chars (sort_keys), which once swallowed the
+    instruction and the agent burned a carried-over approval on a duplicate
+    proposal."""
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        "restage-prompt-demo",
+        goal="Carry approvals over.",
+        script="workspace/src/loop.py",
+        agent_mode="intervene",
+    )
+    store.save(job)
+    proposals_dir = store.job_dir(job.id) / "proposals"
+    proposals_dir.mkdir(parents=True, exist_ok=True)
+    (proposals_dir / "prop-params-update-aaaa1111.json").write_text(
+        json.dumps(
+            {
+                "proposal_id": "prop-params-update-aaaa1111",
+                "status": "approved",
+                "proposed_change": {
+                    "summary": "Tighten stop",
+                    "execution_params": {"stop_pct": 0.01},
+                },
+                "application": {"status": "failed", "restage_requested": True},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    sections = _build_worker_prompt_sections(
+        store=store,
+        job_id=job.id,
+        mode="intervene",
+        snapshot=_worker_snapshot(job, scorecard={"health": "green"}),
+    )
+
+    dynamic = sections["dynamic_context"]
+    priority_at = dynamic.index("PRIORITY — approved changes awaiting re-stage")
+    assert priority_at < dynamic.index("Current snapshot:")
+    assert "Do NOT create a new proposal" in dynamic
+    assert "wayfinder job restage" in dynamic
+    assert "prop-params-update-aaaa1111" in dynamic[: priority_at + 2000]
+    assert "FIRST: complete the PRIORITY re-stage tasks" in dynamic
+
+    # No pending re-stage → no priority section.
+    (proposals_dir / "prop-params-update-aaaa1111.json").unlink()
+    clean = _build_worker_prompt_sections(
+        store=store,
+        job_id=job.id,
+        mode="intervene",
+        snapshot=_worker_snapshot(job, scorecard={"health": "green"}),
+    )
+    assert (
+        "PRIORITY — approved changes awaiting re-stage" not in clean["dynamic_context"]
+    )


### PR DESCRIPTION
## Why

Today's live test of the carryover flow (#613) worked through refusal → carryover → wake, then stalled at the last mile: the agent **created a duplicate pending proposal** instead of running `wayfinder job restage`, burning the carried-over approval.

Root cause, two reinforcing factors:
1. The `restage_tasks` instruction lived only inside the dynamic snapshot JSON — which is **truncated at 12k chars with `sort_keys=True`**, so on a busy job the block silently vanished.
2. The agent's durable memory still carried the pre-restage lesson ("stale baseline → re-propose"), so with no visible instruction it did the previously-correct thing.

## What — three layers, so a stranded re-stage is impossible by construction

1. **Prompt hoist** (`worker.py`): pending re-stages render as a PRIORITY section in prompt text *above* the snapshot (truncation-immune), plus a `FIRST:` task-line directive, with an explicit "do NOT create a new proposal / do NOT use propose" instruction and the reject-then-propose-fresh escape hatch.
2. **Watchdog mechanical restage** (`watchdog.py`): `params_update` re-stages need no authoring — the change IS the stored params dict — so the watchdog re-stages them directly (full gate re-run + auto-queue) on its 5-minute cycle. Bounded to one per pass (each runs a gate backtest).
3. **Watchdog nag**: a code-change re-stage unresolved past 30 minutes gets the restage wake re-fired, once per window — a truncated prompt or dead session gets retried instead of relying on one shot.

The live stranded state on the box (params proposal `8b03aa48`, code proposal `4e24b85c`, both `restage_requested`) is the acceptance test: after bake+roll, the watchdog should mechanically restage the params one within minutes and re-nag the agent for the code one — zero manual intervention.

## Tests

- `test_worker_prompt_hoists_restage_tasks_out_of_snapshot` — priority section renders above the snapshot, correct instruction text, absent when nothing pending.
- `test_watchdog_mechanically_restages_params_carryover` — one per pass, second picked up next pass.
- `test_watchdog_renags_code_change_restage` / `test_watchdog_leaves_fresh_code_restage_to_the_agent` — nag fires once per window, fresh tasks left to the agent.
- 78 passed across worker, watchdog, propose, triggers, and application-gate suites.