### PR TITLE
jobs: watchdog re-issues resumes that failed at apply completion

### DIFF
--- a/wayfinder_paths/jobs/watchdog.py
+++ b/wayfinder_paths/jobs/watchdog.py
@@ -267,6 +267,77 @@ def _recover_restage(
     return event
 
 
+def _recover_orphaned_pause(
+    store: JobStore,
+    job_id: str,
+    proposals: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Re-issue resumes that failed at apply completion.
+
+    Completion resumes the runner loops best-effort; when the daemon is
+    unresponsive (a gate backtest pinning the shared CPU), both resume calls
+    time out, the failure is RECORDED on the application — and the job stays
+    paused forever, because nothing watches "paused with no apply in
+    flight". Seen live: an apply finished `applied` at 18:35 and trading
+    stayed dark for 90 minutes. The watchdog now re-issues the recorded
+    failed resumes until they succeed; `resume_recovered` marks the terminal
+    success so an owner pausing the job later is never overridden.
+    """
+    in_flight = any(
+        p["application"].get("status") in {"queued", "applying"} for p in proposals
+    )
+    if in_flight:
+        return None  # the live apply owns the pause
+    candidates = []
+    for proposal in proposals:
+        application = proposal["application"]
+        if application.get("status") not in {"applied", "failed"}:
+            continue
+        if application.get("resume_recovered"):
+            continue
+        failed = [
+            entry
+            for entry in application.get("runner_responses") or []
+            if not (entry.get("response") or {}).get("ok")
+            and entry.get("runner_job_name")
+        ]
+        if failed:
+            candidates.append(
+                (str(application.get("finished_at") or ""), proposal, failed)
+            )
+    if not candidates:
+        return None
+    _, proposal, failed = max(candidates, key=lambda item: item[0])
+    proposal_id = str(proposal["proposal_id"])
+    bridge = RunnerBridge(repo_root=store.repo_root)
+    responses = []
+    all_ok = True
+    for entry in failed:
+        name = str(entry["runner_job_name"])
+        try:
+            response = bridge.resume(name)
+        except Exception as exc:  # noqa: BLE001 — retried next pass
+            response = {"ok": False, "error": str(exc)}
+        responses.append({"runner_job_name": name, "response": response})
+        if not (response or {}).get("ok"):
+            all_ok = False
+    if all_ok:
+        # Terminal: never re-resume this application again, so a LATER owner
+        # pause of the job is never fought by the watchdog.
+        proposal["application"]["resume_recovered"] = True
+        store.write_proposal(job_id, proposal)
+    event = {
+        "type": "application_watchdog_recovered",
+        "proposal_id": proposal_id,
+        "stalled_status": "orphaned_pause",
+        "action": "resume_orphaned_pause",
+        "outcome": "resumed" if all_ok else "resume_retry_pending",
+        "runner_responses": responses,
+    }
+    store.append_journal(job_id, event)
+    return event
+
+
 def recover_stalled_applications(
     *, store: JobStore | None = None, now: datetime | None = None
 ) -> dict[str, Any]:
@@ -322,6 +393,13 @@ def recover_stalled_applications(
                 continue
             if event is not None:
                 recovered.append({"job_id": job.id, **event})
+        try:
+            pause_event = _recover_orphaned_pause(store, job.id, proposals)
+        except Exception as exc:
+            errors.append({"job_id": job.id, "error": str(exc)})
+            pause_event = None
+        if pause_event is not None:
+            recovered.append({"job_id": job.id, **pause_event})
     return {"scanned": scanned, "recovered": recovered, "errors": errors}
 
 

--- a/wayfinder_paths/tests/test_jobs_apply_watchdog.py
+++ b/wayfinder_paths/tests/test_jobs_apply_watchdog.py
@@ -690,3 +690,111 @@ def test_watchdog_leaves_fresh_code_restage_to_the_agent(
     result = recover_stalled_applications(store=store)
     assert fired == []
     assert result["recovered"] == []
+
+
+def _write_resume_failed_proposal(
+    store: JobStore,
+    job_id: str,
+    proposal_id: str,
+    *,
+    ok: bool = False,
+    recovered: bool = False,
+    app_status: str = "applied",
+) -> None:
+    response = {"ok": True} if ok else {"ok": False, "error": "connect_failed"}
+    proposal = {
+        "proposal_id": proposal_id,
+        "job_id": job_id,
+        "status": "approved",
+        "proposed_change": {"summary": "Applied change"},
+        "intent_contract": _intent_contract(),
+        "scenario_plan": _scenario_plan(),
+        "application": {
+            "status": app_status,
+            "finished_at": _iso_ago(90),
+            "runner_responses": [
+                {
+                    "loop": "script",
+                    "runner_job_name": f"{job_id}-script",
+                    "response": response,
+                },
+                {
+                    "loop": "agent",
+                    "runner_job_name": f"{job_id}-agent",
+                    "response": response,
+                },
+            ],
+            **({"resume_recovered": True} if recovered else {}),
+        },
+    }
+    store.write_proposal(job_id, proposal)
+
+
+def test_watchdog_resumes_orphaned_pause(tmp_path: Path, monkeypatch) -> None:
+    """Resumes that timed out at apply completion are re-issued until they
+    succeed — a completed apply must never leave the lanes dark."""
+    calls = _patch_runner(monkeypatch)
+
+    # _recover_orphaned_pause constructs RunnerBridge directly — patch it there.
+    class RecordingBridge:
+        def __init__(self, *, repo_root=None):  # noqa: ANN001
+            self.repo_root = repo_root
+
+        def resume(self, name: str) -> dict:
+            calls.append(("resume", name))
+            return {"ok": True, "result": {"name": name, "status": "ACTIVE"}}
+
+    monkeypatch.setattr("wayfinder_paths.jobs.watchdog.RunnerBridge", RecordingBridge)
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "orphan-pause")
+    _write_resume_failed_proposal(store, job.id, "prop_orphan")
+
+    result = recover_stalled_applications(store=store)
+
+    resumed = [name for kind, name in calls if kind == "resume"]
+    assert sorted(resumed) == ["orphan-pause-agent", "orphan-pause-script"]
+    events = [e for e in result["recovered"] if e["action"] == "resume_orphaned_pause"]
+    assert len(events) == 1 and events[0]["outcome"] == "resumed"
+    reloaded = store.load_proposal(job.id, "prop_orphan")
+    assert reloaded["application"]["resume_recovered"] is True
+
+    # Terminal: second pass never re-resumes (owner pauses stay owned).
+    calls.clear()
+    second = recover_stalled_applications(store=store)
+    assert [name for kind, name in calls if kind == "resume"] == []
+    assert all(e["action"] != "resume_orphaned_pause" for e in second["recovered"])
+
+
+def test_watchdog_ignores_healthy_resumes_and_in_flight_applies(
+    tmp_path: Path, monkeypatch
+) -> None:
+    calls = _patch_runner(monkeypatch)
+
+    class RecordingBridge:
+        def __init__(self, *, repo_root=None):  # noqa: ANN001
+            self.repo_root = repo_root
+
+        def resume(self, name: str) -> dict:
+            calls.append(("resume", name))
+            return {"ok": True}
+
+    monkeypatch.setattr("wayfinder_paths.jobs.watchdog.RunnerBridge", RecordingBridge)
+    store = JobStore(repo_root=tmp_path)
+    # Healthy completion: resumes recorded ok — nothing to do.
+    job_a = _make_job(store, "orphan-healthy")
+    _write_resume_failed_proposal(store, job_a.id, "prop_ok", ok=True)
+    # Failed resume BUT another apply is queued — the live apply owns pausing.
+    job_b = _make_job(store, "orphan-inflight")
+    _write_resume_failed_proposal(store, job_b.id, "prop_bad")
+    _write_proposal(
+        store,
+        job_b.id,
+        "prop_live",
+        application={"status": "queued"},
+        candidate_report={"gate": "green"},
+    )
+
+    result = recover_stalled_applications(store=store)
+
+    assert [name for kind, name in calls if kind == "resume"] == []
+    assert all(e["action"] != "resume_orphaned_pause" for e in result["recovered"])


### PR DESCRIPTION
## Why

Found live during today's convergence test: #9's apply completed `applied` at 18:35, but **both loop-resume calls timed out** on the runner socket (daemon unresponsive under the gate backtest pinning the shared CPU). The failures were recorded on the application — and nothing acted on them. The job stayed paused for 90 minutes until an operator noticed. "Paused with no apply in flight" had no autonomous owner.

## What

New watchdog pass `_recover_orphaned_pause` (per job, each 5-min cycle):
- Finds the newest **terminal** application (applied/failed) whose recorded `runner_responses` contain failed resumes, skipping any job with an apply currently queued/applying (the live apply owns pausing).
- Re-issues exactly the recorded failed resumes via RunnerBridge, retrying each pass until they succeed.
- On success, stamps `resume_recovered` on the application — terminal, so a **later owner pause of the job is never fought by the watchdog**.
- Journals `application_watchdog_recovered` with action `resume_orphaned_pause` (renders in the decision log via the existing recovery mapping).

## Tests

- `test_watchdog_resumes_orphaned_pause` — re-issues both recorded lanes, stamps `resume_recovered`, second pass is a no-op.
- `test_watchdog_ignores_healthy_resumes_and_in_flight_applies` — ok-recorded resumes untouched; failed resumes ignored while another apply is in flight.
- 33 passed across watchdog + propose suites.