### PR TITLE
jobs: exclude agent memory.md from the workspace revision hash

### DIFF
--- a/wayfinder_paths/jobs/gating.py
+++ b/wayfinder_paths/jobs/gating.py
@@ -30,6 +30,12 @@ def compute_workspace_revision(root: Path) -> str:
             # (py_compile, module loading) and must not perturb the revision.
             if "__pycache__" in path.parts or path.suffix == ".pyc":
                 continue
+            # Agent-writable diary state, read by nothing in the execution
+            # path (durable memory lives at the JOB root). Hashing it turned
+            # every routine memory update into a phantom strategy change:
+            # stale gate stamps + baseline drift on staged candidates.
+            if path.relative_to(workspace) == Path("memory.md"):
+                continue
             if path.is_file():
                 digest.update(str(path.relative_to(root)).encode("utf-8"))
                 digest.update(path.read_bytes())

--- a/wayfinder_paths/tests/test_jobs_gating.py
+++ b/wayfinder_paths/tests/test_jobs_gating.py
@@ -142,3 +142,36 @@ def test_validation_report_is_revision_stamped(tmp_path: Path) -> None:
     report = validate_execution_job(job_id, store=store)
 
     assert report["revision"] == compute_workspace_revision(root)
+
+
+def test_agent_memory_edits_do_not_move_the_revision(tmp_path: Path) -> None:
+    """workspace/memory.md is agent diary state, read by nothing in the
+    execution path — hashing it turned every routine memory update into a
+    phantom strategy change (stale gate stamps + baseline drift on staged
+    candidates, seen live 2026-08-11)."""
+    store, job_id, root = _make_job(tmp_path)
+    baseline = compute_workspace_revision(root)
+
+    memory = root / "workspace" / "memory.md"
+    memory.write_text("# Durable memory\n- one more thought\n", encoding="utf-8")
+    assert compute_workspace_revision(root) == baseline
+
+    memory.write_text("# Durable memory\n- yet another thought\n", encoding="utf-8")
+    assert compute_workspace_revision(root) == baseline
+
+    # Strategy content and execution config still move the revision.
+    script = next((root / "workspace").rglob("*.py"))
+    script.write_text(
+        script.read_text(encoding="utf-8") + "\n# edit\n", encoding="utf-8"
+    )
+    after_code = compute_workspace_revision(root)
+    assert after_code != baseline
+
+    job_yaml = root / "job.yaml"
+    job_yaml.write_text(
+        job_yaml.read_text(encoding="utf-8").replace(
+            "goal:", "goal_note: tweaked\ngoal:", 1
+        ),
+        encoding="utf-8",
+    )
+    assert compute_workspace_revision(root) != after_code


### PR DESCRIPTION
## Why

Root cause of the "out-of-band workspace move" mystery from the Aug 11 postmortem: `workspace/memory.md` — the agent's diary, which it updates on routine wakes — is inside `compute_workspace_revision`. Every memory update silently moved the revision, invalidating gate stamps ("preflight is for revision `ed42f8bd`, workspace is `6370b681`") and drifting every staged candidate. Verified live: hashing the pre-apply backup reproduces the mystery revision exactly, and a memory.md edit alone moves it. Nothing in the execution path reads `workspace/memory.md` (durable memory lives at the job root).

## What

`compute_workspace_revision` skips `workspace/memory.md` alongside `__pycache__`/`.pyc`. Diary entries stop being fingerprinted as strategy changes.

## One-time deploy consequence (no migration code needed)

Every job's computed revision shifts once: candidate-reuse checks + gate stamps go stale once, replication baselines re-pin. All of it is absorbed autonomously by the restage-carryover + watchdog machinery (#613/#624/#626) — expect one noisy watchdog pass after the roll.

## Tests

`test_agent_memory_edits_do_not_move_the_revision` — repeated memory edits leave the revision fixed; code and job.yaml edits still move it. 41 passed across gating, propose, and apply-watchdog suites.

Part 1/2 of the postmortem fixes (feed-resilience bundle follows).