### PR TITLE
jobs: postmortem fixes — revision-hash hygiene + data-feed resilience

### DIFF
--- a/wayfinder_paths/core/clients/HyperliquidDataClient.py
+++ b/wayfinder_paths/core/clients/HyperliquidDataClient.py
@@ -3,8 +3,35 @@ from __future__ import annotations
 import time
 from typing import NotRequired, Required, TypedDict
 
+import httpx
+
 from wayfinder_paths.core.clients.WayfinderClient import WayfinderClient
 from wayfinder_paths.core.config import get_api_base_url
+
+
+class DataFeedError(RuntimeError):
+    """A data-feed request failed for a reason the owner or agent can act on.
+
+    `cause` is machine-readable: "out_of_credits" (owner action: top up API
+    credits), "rate_limited" (transient: back off), or "http_<status>".
+    Journal payloads stringify exceptions, so the cause rides the message
+    too — downstream escalation can grep it from either place.
+    """
+
+    def __init__(self, cause: str, detail: str) -> None:
+        super().__init__(f"{cause}: {detail}")
+        self.cause = cause
+
+
+def _feed_error(exc: httpx.HTTPStatusError) -> DataFeedError:
+    status = exc.response.status_code
+    if status == 402:
+        cause = "out_of_credits"
+    elif status == 429:
+        cause = "rate_limited"
+    else:
+        cause = f"http_{status}"
+    return DataFeedError(cause, str(exc)[:200])
 
 
 class FundingHistoryEntry(TypedDict):
@@ -39,8 +66,10 @@ class HyperliquidDataClient(WayfinderClient):
     ) -> dict:
         url = f"{self.api_base_url}/funding/"
         params = {"coin": coin, "start_ms": start_ms, "end_ms": end_ms}
-        resp = await self._authed_request("GET", url, params=params)
-        resp.raise_for_status()
+        try:
+            resp = await self._authed_request("GET", url, params=params)
+        except httpx.HTTPStatusError as exc:
+            raise _feed_error(exc) from exc
         return resp.json()
 
     async def get_candles(
@@ -84,8 +113,10 @@ class HyperliquidDataClient(WayfinderClient):
             "end_ms": end_ms,
             "interval": interval,
         }
-        resp = await self._authed_request("GET", url, params=params)
-        resp.raise_for_status()
+        try:
+            resp = await self._authed_request("GET", url, params=params)
+        except httpx.HTTPStatusError as exc:
+            raise _feed_error(exc) from exc
         return resp.json()
 
 

--- a/wayfinder_paths/core/clients/WayfinderClient.py
+++ b/wayfinder_paths/core/clients/WayfinderClient.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 from typing import Any
 
@@ -47,6 +48,22 @@ class WayfinderClient:
         if headers:
             merged_headers.update(headers)
         resp = await self.client.request(method, url, headers=merged_headers, **kwargs)
+
+        if resp.status_code == 429:
+            # One polite retry honoring Retry-After (capped), then surface the
+            # error. Instant hammer-retries are what turned a credit blip into
+            # an hours-long 429 storm across every job on the box.
+            try:
+                delay = min(float(resp.headers.get("Retry-After") or 5.0), 30.0)
+            except ValueError:
+                delay = 5.0
+            logger.warning(
+                f"HTTP 429 for {method} {url} — retrying once in {delay:.0f}s"
+            )
+            await asyncio.sleep(delay)
+            resp = await self.client.request(
+                method, url, headers=merged_headers, **kwargs
+            )
 
         elapsed = time.time() - start_time
         if resp.status_code >= 400:

--- a/wayfinder_paths/jobs/decision_log.py
+++ b/wayfinder_paths/jobs/decision_log.py
@@ -204,6 +204,34 @@ def _journal_entries(
                     actor="owner",
                 )
             )
+        elif kind == "data_feed_degraded":
+            cause = str(event.get("cause") or "unknown")
+            hint = {
+                "out_of_credits": " — top up API credits to restore data",
+                "rate_limited": " — backing off; recovers on its own",
+                "features_stale": " — research features are not advancing",
+            }.get(cause, "")
+            entries.append(
+                _entry(
+                    ts,
+                    "halt",
+                    f"Data feed degraded ({cause}){hint}",
+                    str(event.get("error") or ""),
+                    "info",
+                    actor="system",
+                )
+            )
+        elif kind == "data_feed_recovered":
+            entries.append(
+                _entry(
+                    ts,
+                    "halt",
+                    "Data feed recovered",
+                    "",
+                    "info",
+                    actor="system",
+                )
+            )
         elif kind in ("halt_requested", "halt_flattened"):
             entries.append(
                 _entry(

--- a/wayfinder_paths/jobs/derived_features.py
+++ b/wayfinder_paths/jobs/derived_features.py
@@ -39,6 +39,9 @@ BREADTH_SMA = 50
 EXOG_TREND_SMA = 50
 DEFAULT_EVERY_BARS = 12
 MAX_APPEND_ROWS = 200_000
+# Incremental exog/venue fetches reach back far enough for the widest rolling
+# window used on fetched series, plus margin.
+_FETCH_WARMUP_BARS = max(CORR_BARS, EXOG_TREND_SMA) * 2
 
 
 def _native_hl_closes(coin: str, start_ms: int, end_ms: int) -> pd.Series:
@@ -146,24 +149,8 @@ def derive_features_job(
             ).reindex(closes.index)
         columns["regime_code"] = regime_wide
 
-    if "exog" in sets or "venue" in sets:
-        start_ms = int(closes.index[0].timestamp() * 1000)
-        end_ms = int(closes.index[-1].timestamp() * 1000) + 300_000
-        if "exog" in sets:
-            for coin in exog_symbols:
-                exog = fetch(coin, start_ms, end_ms).reindex(closes.index).ffill()
-                _add(f"{coin.lower()}_ret{CORR_BARS}", exog.pct_change(CORR_BARS))
-                _add(
-                    f"{coin.lower()}_trend",
-                    (exog > exog.rolling(EXOG_TREND_SMA).mean()).astype(float),
-                )
-        if "venue" in sets:
-            for symbol in symbols:
-                hl = fetch(symbol, start_ms, end_ms).reindex(closes.index).ffill()
-                basis = (hl / closes[symbol] - 1) * 1e4
-                columns.setdefault("venue_basis_bps", pd.DataFrame())[symbol] = basis
-
-    # Serialize at the coarse cadence with the fetch-funding dedup semantics.
+    # Load the store's existing keys BEFORE the fetch: appends dedup against
+    # them, and the newest existing stamp bounds the exog/venue fetch window.
     features_path = root / "state" / "features.jsonl"
     features_path.parent.mkdir(parents=True, exist_ok=True)
     existing: set[tuple[str, str, str]] = set()
@@ -181,6 +168,43 @@ def derive_features_job(
                         str(row.get("symbol")),
                     )
                 )
+    newest_existing = max((key[0] for key in existing), default="")
+
+    if "exog" in sets or "venue" in sets:
+        start_ms = int(closes.index[0].timestamp() * 1000)
+        end_ms = int(closes.index[-1].timestamp() * 1000) + 300_000
+        if newest_existing:
+            # Incremental: rows before the newest stored stamp are dedup'd
+            # away anyway, so fetch only the tail plus rolling-window warmup.
+            # The full-span fetch (120d of 5m bars, paginated, every ~30min,
+            # per job) was the request storm behind the 429/credit burn.
+            try:
+                bar_step = (
+                    closes.index[1] - closes.index[0]
+                    if len(closes.index) > 1
+                    else pd.Timedelta(minutes=5)
+                )
+                warm_start = pd.Timestamp(newest_existing) - bar_step * (
+                    _FETCH_WARMUP_BARS
+                )
+                start_ms = max(start_ms, int(warm_start.timestamp() * 1000))
+            except (ValueError, TypeError):
+                pass  # unparseable stamp → keep the full window
+        if "exog" in sets:
+            for coin in exog_symbols:
+                exog = fetch(coin, start_ms, end_ms).reindex(closes.index).ffill()
+                _add(f"{coin.lower()}_ret{CORR_BARS}", exog.pct_change(CORR_BARS))
+                _add(
+                    f"{coin.lower()}_trend",
+                    (exog > exog.rolling(EXOG_TREND_SMA).mean()).astype(float),
+                )
+        if "venue" in sets:
+            for symbol in symbols:
+                hl = fetch(symbol, start_ms, end_ms).reindex(closes.index).ffill()
+                basis = (hl / closes[symbol] - 1) * 1e4
+                columns.setdefault("venue_basis_bps", pd.DataFrame())[symbol] = basis
+
+    # Serialize at the coarse cadence with the fetch-funding dedup semantics.
     written_at = utc_now_iso()
     stamps = closes.index[::every_bars]
     appended: dict[str, int] = {}
@@ -220,6 +244,9 @@ def derive_features_job(
         "features": sorted(columns),
         "rows_appended": total,
         "per_feature": dict(sorted(appended.items())),
+        # Newest stamp in the store after this run — rows_appended == 0 is
+        # NORMAL between hourly stamps; THIS is the staleness signal.
+        "newest_feature_ts": max((key[0] for key in existing), default=""),
         "generated_at": str(dt.datetime.now(dt.UTC)),
         "read": (
             "Research-side derived features appended to the feature store — "
@@ -236,6 +263,66 @@ REFRESH_STAMP_PATH = "results/research/derived_refresh.json"
 # other wake instead of aliasing to 90m.
 REFRESH_MAX_AGE_S = 3300
 _REFRESH_SETS = ("cross", "exog", "venue", "regime")
+# Features derive over the job DATASET, so they can never advance past its
+# newest bar. The dataset historically refreshed only as a side effect of
+# applies/validations — features froze for 15h+ between agent activity.
+DATASET_STALE_S = 2 * 3600
+# Consecutive refresh failures before the degradation escalates to the
+# decision log (owner-visible) instead of only journal noise.
+_DEGRADED_AFTER_FAILURES = 3
+# Newest feature stamp older than this despite "successful" refreshes is a
+# degradation too (a wedged feed that fails silent).
+_FEATURES_STALE_ALARM_S = 6 * 3600
+
+
+def _feed_cause(error: str) -> str:
+    for cause in ("out_of_credits", "rate_limited"):
+        if cause in error:
+            return cause
+    return "unknown"
+
+
+def _refresh_dataset_if_stale(job_id: str, store: JobStore, root: Any) -> str | None:
+    """Extend the job dataset's tail when its newest bar has aged out.
+
+    Reuses build_live_dataset's incremental path with the dataset's OWN
+    recorded provenance so only the tail is fetched. Returns a note string
+    for the caller's result payload, or None when nothing was needed."""
+    path = root / "results" / "backtest" / "input_bars.json"
+    if not path.exists():
+        return None
+    try:
+        doc = json.loads(path.read_text(encoding="utf-8"))
+    except ValueError:
+        return None
+    meta = doc.get("metadata") if isinstance(doc, dict) else None
+    rows = doc.get("bars") if isinstance(doc, dict) else None
+    if not isinstance(meta, dict) or not isinstance(rows, list) or not rows:
+        return None
+    days = int(float(meta.get("days") or 0))
+    if not days:
+        return None
+    newest = max((str(row.get("timestamp") or "") for row in rows[-500:]), default="")
+    try:
+        age = (
+            dt.datetime.now(dt.UTC) - dt.datetime.fromisoformat(newest)
+        ).total_seconds()
+    except (ValueError, TypeError):
+        return None
+    if age < DATASET_STALE_S:
+        return None
+    # circular import: preflight chains back into this module's refresh
+    from wayfinder_paths.jobs.execution.preflight import build_live_dataset
+
+    if str(meta.get("source") or "") == "ccxt":
+        kwargs: dict[str, Any] = {
+            "source": "ccxt",
+            "exchange": str(meta.get("exchange") or "binance"),
+        }
+    else:
+        kwargs = {"source": "venues"}
+    build_live_dataset(job_id, days=days, store=store, **kwargs)
+    return f"dataset tail refreshed (was {int(age)}s stale)"
 
 
 def refresh_derived_features_if_stale(
@@ -244,6 +331,7 @@ def refresh_derived_features_if_stale(
     store: JobStore | None = None,
     max_age_seconds: int = REFRESH_MAX_AGE_S,
     derive: Callable[..., dict[str, Any]] | None = None,
+    refresh_dataset: bool = True,
 ) -> dict[str, Any]:
     """Keep research-side derived features live from the wake path.
 
@@ -252,7 +340,12 @@ def refresh_derived_features_if_stale(
     values). The consumer of these columns is the agent wake's research, so
     the wake is the refresh point — stamp-gated to the design's hourly
     cadence, and NEVER raising: a broken exog fetch degrades to a journaled
-    skip, not a dead wake."""
+    skip, not a dead wake.
+
+    Degradations escalate: >=3 consecutive failures, or features stale past
+    the alarm window despite successful refreshes, journal a single
+    `data_feed_degraded` event (owner-visible via the decision log) carrying
+    the structured cause; recovery journals `data_feed_recovered` once."""
     store = store or JobStore()
     stamp = store.read_json(job_id, REFRESH_STAMP_PATH) or {}
     refreshed_at = str(stamp.get("refreshed_at") or "")
@@ -262,22 +355,98 @@ def refresh_derived_features_if_stale(
         ).total_seconds()
         if age < max_age_seconds:
             return {"refreshed": False, "reason": f"fresh ({int(age)}s old)"}
+
+    dataset_note: str | None = None
+    if refresh_dataset:
+        try:
+            dataset_note = _refresh_dataset_if_stale(
+                job_id, store, store.job_dir(job_id)
+            )
+        except Exception as exc:  # noqa: BLE001 — derive over the old dataset instead
+            store.append_journal(
+                job_id,
+                {
+                    "type": "derived_features_refresh_failed",
+                    "error": f"dataset refresh: {str(exc)[:280]}",
+                },
+            )
+            dataset_note = f"dataset refresh failed: {str(exc)[:120]}"
+
     run = derive or derive_features_job
     try:
         result = run(job_id, sets=_REFRESH_SETS, store=store)
     except Exception as exc:  # noqa: BLE001 — wake must not die on research prep
+        error = str(exc)[:300]
         store.append_journal(
             job_id,
-            {"type": "derived_features_refresh_failed", "error": str(exc)[:300]},
+            {"type": "derived_features_refresh_failed", "error": error},
         )
+        failures = int(stamp.get("consecutive_failures") or 0) + 1
+        stamp["consecutive_failures"] = failures
+        if failures >= _DEGRADED_AFTER_FAILURES and not stamp.get("degraded_since"):
+            stamp["degraded_since"] = str(dt.datetime.now(dt.UTC))
+            store.append_journal(
+                job_id,
+                {
+                    "type": "data_feed_degraded",
+                    "cause": _feed_cause(error),
+                    "consecutive_failures": failures,
+                    "error": error,
+                },
+            )
+        store.write_json(job_id, REFRESH_STAMP_PATH, stamp)
         return {"refreshed": False, "reason": f"failed: {exc}"}
-    store.write_json(
-        job_id,
-        REFRESH_STAMP_PATH,
+
+    newest_feature = str(result.get("newest_feature_ts") or "")
+    feature_age: float | None = None
+    if newest_feature:
+        try:
+            feature_age = (
+                dt.datetime.now(dt.UTC) - dt.datetime.fromisoformat(newest_feature)
+            ).total_seconds()
+        except (ValueError, TypeError):
+            feature_age = None
+    if (
+        feature_age is not None
+        and feature_age > _FEATURES_STALE_ALARM_S
+        and not stamp.get("degraded_since")
+    ):
+        stamp["degraded_since"] = str(dt.datetime.now(dt.UTC))
+        store.append_journal(
+            job_id,
+            {
+                "type": "data_feed_degraded",
+                "cause": "features_stale",
+                "newest_feature_ts": newest_feature,
+                "error": f"newest feature {int(feature_age)}s old after a "
+                "successful refresh",
+            },
+        )
+    elif stamp.get("degraded_since") and (
+        feature_age is None or feature_age <= _FEATURES_STALE_ALARM_S
+    ):
+        store.append_journal(
+            job_id,
+            {"type": "data_feed_recovered", "newest_feature_ts": newest_feature},
+        )
+        stamp.pop("degraded_since", None)
+
+    stamp.update(
         {
             "refreshed_at": str(dt.datetime.now(dt.UTC)),
             "rows_appended": result.get("rows_appended"),
+            "newest_feature_ts": newest_feature,
             "sets": result.get("sets"),
-        },
+            "consecutive_failures": 0,
+        }
     )
-    return {"refreshed": True, "rows_appended": result.get("rows_appended")}
+    if dataset_note:
+        stamp["dataset_note"] = dataset_note
+    else:
+        stamp.pop("dataset_note", None)
+    store.write_json(job_id, REFRESH_STAMP_PATH, stamp)
+    return {
+        "refreshed": True,
+        "rows_appended": result.get("rows_appended"),
+        **({"dataset": dataset_note} if dataset_note else {}),
+    }

--- a/wayfinder_paths/jobs/execution/preflight.py
+++ b/wayfinder_paths/jobs/execution/preflight.py
@@ -228,8 +228,11 @@ def build_live_dataset(
         refresh_derived_features_if_stale,
     )
 
+    # refresh_dataset=False: this call runs INSIDE the dataset build — the
+    # helper's own dataset-staleness hook calling back into build_live_dataset
+    # would recurse.
     result["derived_features"] = refresh_derived_features_if_stale(
-        job_id, store=store, max_age_seconds=0
+        job_id, store=store, max_age_seconds=0, refresh_dataset=False
     )
     return result
 

--- a/wayfinder_paths/jobs/gating.py
+++ b/wayfinder_paths/jobs/gating.py
@@ -30,6 +30,12 @@ def compute_workspace_revision(root: Path) -> str:
             # (py_compile, module loading) and must not perturb the revision.
             if "__pycache__" in path.parts or path.suffix == ".pyc":
                 continue
+            # Agent-writable diary state, read by nothing in the execution
+            # path (durable memory lives at the JOB root). Hashing it turned
+            # every routine memory update into a phantom strategy change:
+            # stale gate stamps + baseline drift on staged candidates.
+            if path.relative_to(workspace) == Path("memory.md"):
+                continue
             if path.is_file():
                 digest.update(str(path.relative_to(root)).encode("utf-8"))
                 digest.update(path.read_bytes())

--- a/wayfinder_paths/runner/constants.py
+++ b/wayfinder_paths/runner/constants.py
@@ -22,6 +22,10 @@ class RunStatus(StrEnum):
 JOB_TYPE_STRATEGY: Final[str] = "strategy"
 JOB_TYPE_SCRIPT: Final[str] = "script"
 
+# ERROR lanes retry after max(4 * interval, this floor) instead of parking
+# until a human resumes them — ERROR means "backing off", not "dead".
+ERROR_RETRY_COOLDOWN_SECONDS: Final[int] = 1800
+
 # How the "add job" action appears on each surface. Both forms are used by
 # session-message discovery to find the chat that registered a job.
 ADD_JOB_CLI_VERB: Final[str] = "add-job"  # CLI command name (Click convention)

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -956,7 +956,9 @@ class RunnerDaemon:
         if not result:
             return {"ok": False, "error": f"Job not found: {name}"}
         job, state = result
-        if state.status != JobStatus.ACTIVE:
+        if state.status == JobStatus.PAUSED:
+            # ERROR is allowed: run-once is exactly how an operator (or the
+            # cooldown retry) probes whether the upstream failure cleared.
             return {"ok": False, "error": f"job is not ACTIVE (status={state.status})"}
 
         job_dict: dict[str, Any] = {

--- a/wayfinder_paths/runner/db.py
+++ b/wayfinder_paths/runner/db.py
@@ -7,7 +7,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from wayfinder_paths.runner.constants import JobStatus, RunStatus
+from wayfinder_paths.runner.constants import (
+    ERROR_RETRY_COOLDOWN_SECONDS,
+    JobStatus,
+    RunStatus,
+)
 
 
 @dataclass(frozen=True)
@@ -326,13 +330,16 @@ class RunnerDB:
         )
 
     def record_job_success(self, *, job_id: int, ok_at: int) -> None:
+        # A success also clears ERROR: with the cooldown retry in due_jobs,
+        # ERROR means "backing off", not "dead" — recovery must be automatic.
         self._conn.cursor().execute(
             """
             UPDATE job_state
-            SET last_ok_at = ?, consecutive_failures = 0, last_error = NULL
+            SET last_ok_at = ?, consecutive_failures = 0, last_error = NULL,
+                status = CASE WHEN status = ? THEN ? ELSE status END
             WHERE job_id = ?
             """,
-            (ok_at, job_id),
+            (ok_at, JobStatus.ERROR, JobStatus.ACTIVE, job_id),
         )
 
     def record_job_failure(
@@ -368,6 +375,10 @@ class RunnerDB:
 
     def due_jobs(self, *, now: int) -> list[dict[str, Any]]:
         cur = self._conn.cursor()
+        # ERROR jobs retry after a cooldown instead of parking forever: a
+        # transient upstream failure (a 429 burst) once ERROR'd a lane that
+        # then sat dead 12 hours until a human resumed it. ERROR stays
+        # visible in the UI between retries; PAUSED alone never runs.
         cur.execute(
             """
             SELECT d.id, d.name, d.type, d.payload_json, d.interval_seconds,
@@ -376,10 +387,21 @@ class RunnerDB:
                    s.consecutive_failures, s.last_error
             FROM job_defs d
             JOIN job_state s ON s.job_id = d.id
-            WHERE s.status = ? AND s.next_run_at <= ?
+            WHERE (s.status = ? AND s.next_run_at <= ?)
+               OR (
+                    s.status = ?
+                    AND COALESCE(s.last_run_at, 0) <=
+                        ? - MAX(COALESCE(d.interval_seconds, 0) * 4, ?)
+                  )
             ORDER BY s.next_run_at ASC, d.id ASC
             """,
-            (JobStatus.ACTIVE, now),
+            (
+                JobStatus.ACTIVE,
+                now,
+                JobStatus.ERROR,
+                now,
+                ERROR_RETRY_COOLDOWN_SECONDS,
+            ),
         )
         return [
             {

--- a/wayfinder_paths/tests/test_data_feed_errors.py
+++ b/wayfinder_paths/tests/test_data_feed_errors.py
@@ -1,0 +1,60 @@
+"""Data-feed failure surface: one polite 429 retry at the client, and
+structured out_of_credits / rate_limited causes so journals and the decision
+log say the actionable truth instead of a generic exception string."""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from wayfinder_paths.core.clients.HyperliquidDataClient import (
+    DataFeedError,
+    HyperliquidDataClient,
+)
+
+
+def _client_with_responses(responses: list[httpx.Response]) -> HyperliquidDataClient:
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        resp = responses[min(calls["n"], len(responses) - 1)]
+        calls["n"] += 1
+        return resp
+
+    client = HyperliquidDataClient()
+    client.client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    client._calls = calls  # type: ignore[attr-defined]
+    return client
+
+
+def test_429_retries_once_after_retry_after() -> None:
+    client = _client_with_responses(
+        [
+            httpx.Response(429, headers={"Retry-After": "0"}),
+            httpx.Response(200, json={"rows": [{"t": 1, "c": "1.0"}]}),
+        ]
+    )
+    rows = asyncio.run(client.get_candles("BTC", start_ms=0, end_ms=1))
+    assert rows == [{"t": 1, "c": "1.0"}]
+    assert client._calls["n"] == 2  # type: ignore[attr-defined]
+
+
+def test_429_exhausted_surfaces_rate_limited() -> None:
+    client = _client_with_responses([httpx.Response(429, headers={"Retry-After": "0"})])
+    with pytest.raises(DataFeedError) as err:
+        asyncio.run(client.get_candles("BTC", start_ms=0, end_ms=1))
+    assert err.value.cause == "rate_limited"
+    assert "rate_limited" in str(err.value)
+    # One original + exactly one retry — no hammering.
+    assert client._calls["n"] == 2  # type: ignore[attr-defined]
+
+
+def test_402_surfaces_out_of_credits() -> None:
+    client = _client_with_responses([httpx.Response(402)])
+    with pytest.raises(DataFeedError) as err:
+        asyncio.run(client.get_candles("BTC", start_ms=0, end_ms=1))
+    assert err.value.cause == "out_of_credits"
+    assert "out_of_credits" in str(err.value)
+    assert client._calls["n"] == 1  # type: ignore[attr-defined]

--- a/wayfinder_paths/tests/test_jobs_decision_log.py
+++ b/wayfinder_paths/tests/test_jobs_decision_log.py
@@ -262,3 +262,29 @@ def test_apply_lifecycle_events(tmp_path) -> None:
         entry for entry in log["entries"] if entry["title"].startswith("Apply deferred")
     )
     assert deferred["proposal_id"] == "prop-aaaaaaaa"
+
+
+def test_data_feed_events_reach_the_feed(tmp_path) -> None:
+    """Feed degradations must be owner-visible: out_of_credits names the
+    owner action, and recovery closes the episode."""
+    store, job_id = _mk(tmp_path)
+    root = store.job_dir(job_id)
+    journal = [
+        {
+            "ts": _ts(10),
+            "type": "data_feed_degraded",
+            "cause": "out_of_credits",
+            "error": "out_of_credits: HTTP 402 for candles",
+        },
+        {"ts": _ts(2), "type": "data_feed_recovered"},
+    ]
+    (root / "journal.jsonl").write_text(
+        "\n".join(json.dumps(row) for row in journal) + "\n", encoding="utf-8"
+    )
+
+    log = build_decision_log(store, job_id)
+    titles = [entry["title"] for entry in log["entries"]]
+    degraded = next(t for t in titles if t.startswith("Data feed degraded"))
+    assert "out_of_credits" in degraded
+    assert "top up API credits" in degraded
+    assert any(t == "Data feed recovered" for t in titles)

--- a/wayfinder_paths/tests/test_jobs_derived_features.py
+++ b/wayfinder_paths/tests/test_jobs_derived_features.py
@@ -223,3 +223,168 @@ def test_research_substrate_block_reads_disk(tmp_path) -> None:
     job2 = WayfinderJob.new("substrate-empty", agent_mode="intervene")
     store.save(job2)
     assert _research_substrate_block(store.job_dir(job2.id)) == {}
+
+
+def test_exog_fetch_is_incremental_after_backfill(tmp_path: Path) -> None:
+    """First run backfills the dataset span; later runs fetch only the tail
+    plus rolling warmup — the full-span fetch every 30 minutes was the
+    request storm behind the 429/credit burn."""
+    store, job_id = _make_job(tmp_path)
+    windows: list[tuple[int, int]] = []
+
+    def recording_fetch(coin: str, start_ms: int, end_ms: int) -> pd.Series:
+        windows.append((start_ms, end_ms))
+        return _fake_fetch(coin, start_ms, end_ms)
+
+    derive_features_job(
+        job_id, sets=("exog",), store=store, fetch_closes=recording_fetch
+    )
+    first_start, first_end = windows[0]
+
+    derive_features_job(
+        job_id, sets=("exog",), store=store, fetch_closes=recording_fetch
+    )
+    second_start, _ = windows[-1]
+
+    # The dataset spans 400 bars; the incremental window must skip most of it
+    # (tail + warmup only), never re-request the full span.
+    assert second_start > first_start
+    span = first_end - first_start
+    assert (first_end - second_start) < span / 2
+
+
+def test_refresh_escalates_after_consecutive_failures_and_recovers(tmp_path) -> None:
+    from wayfinder_paths.jobs.derived_features import (
+        REFRESH_STAMP_PATH,
+        refresh_derived_features_if_stale,
+    )
+    from wayfinder_paths.jobs.models import WayfinderJob
+    from wayfinder_paths.jobs.store import JobStore
+
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("degrade-demo", agent_mode="intervene")
+    store.save(job)
+
+    def boom(job_id, **kwargs):
+        raise RuntimeError("rate_limited: HTTP 429 from candles endpoint")
+
+    for _ in range(4):
+        refresh_derived_features_if_stale(
+            job.id, store=store, derive=boom, refresh_dataset=False
+        )
+
+    journal = (store.job_dir(job.id) / "journal.jsonl").read_text(encoding="utf-8")
+    degraded = [line for line in journal.splitlines() if "data_feed_degraded" in line]
+    assert len(degraded) == 1, "escalates once per episode, not per failure"
+    assert "rate_limited" in degraded[0]
+    stamp = store.read_json(job.id, REFRESH_STAMP_PATH)
+    assert stamp["consecutive_failures"] == 4
+    assert stamp.get("degraded_since")
+
+    def healthy(job_id, **kwargs):
+        return {
+            "rows_appended": 3,
+            "sets": list(kwargs["sets"]),
+            "newest_feature_ts": pd.Timestamp.now(tz="UTC").isoformat(),
+        }
+
+    result = refresh_derived_features_if_stale(
+        job.id, store=store, derive=healthy, refresh_dataset=False
+    )
+    assert result["refreshed"] is True
+    journal = (store.job_dir(job.id) / "journal.jsonl").read_text(encoding="utf-8")
+    assert "data_feed_recovered" in journal
+    stamp = store.read_json(job.id, REFRESH_STAMP_PATH)
+    assert stamp["consecutive_failures"] == 0
+    assert not stamp.get("degraded_since")
+
+
+def test_refresh_alarms_on_stale_features_despite_success(tmp_path) -> None:
+    """A refresh that 'succeeds' while the newest feature is hours old is a
+    degradation too — the silent-wedge mode seen live (rows_appended: 0,
+    features 15h stale)."""
+    from wayfinder_paths.jobs.derived_features import (
+        refresh_derived_features_if_stale,
+    )
+    from wayfinder_paths.jobs.models import WayfinderJob
+    from wayfinder_paths.jobs.store import JobStore
+
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("stale-demo", agent_mode="intervene")
+    store.save(job)
+
+    stale_ts = (pd.Timestamp.now(tz="UTC") - pd.Timedelta(hours=15)).isoformat()
+
+    def wedged(job_id, **kwargs):
+        return {
+            "rows_appended": 0,
+            "sets": list(kwargs["sets"]),
+            "newest_feature_ts": stale_ts,
+        }
+
+    refresh_derived_features_if_stale(
+        job.id, store=store, derive=wedged, refresh_dataset=False
+    )
+    journal = (store.job_dir(job.id) / "journal.jsonl").read_text(encoding="utf-8")
+    assert "data_feed_degraded" in journal
+    assert "features_stale" in journal
+
+
+def test_refresh_extends_stale_dataset_with_recorded_provenance(
+    tmp_path, monkeypatch
+) -> None:
+    from wayfinder_paths.jobs.derived_features import (
+        refresh_derived_features_if_stale,
+    )
+    from wayfinder_paths.jobs.models import WayfinderJob
+    from wayfinder_paths.jobs.store import JobStore
+
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("dataset-demo", agent_mode="intervene")
+    store.save(job)
+    root = store.job_dir(job.id)
+    bars_path = root / "results" / "backtest" / "input_bars.json"
+    bars_path.parent.mkdir(parents=True, exist_ok=True)
+    old = (pd.Timestamp.now(tz="UTC") - pd.Timedelta(hours=20)).isoformat()
+    bars_path.write_text(
+        json.dumps(
+            {
+                "bars": [{"timestamp": old, "symbol": "LIT", "close": 1.0}],
+                "metadata": {
+                    "days": 120,
+                    "source": "ccxt",
+                    "exchange": "binance",
+                    "interval": "5m",
+                    "symbols": ["LIT"],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    fetches: list[dict] = []
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.execution.preflight.build_live_dataset",
+        lambda job_id, **kwargs: fetches.append({"job_id": job_id, **kwargs}),
+    )
+
+    def healthy(job_id, **kwargs):
+        return {
+            "rows_appended": 1,
+            "sets": list(kwargs["sets"]),
+            "newest_feature_ts": pd.Timestamp.now(tz="UTC").isoformat(),
+        }
+
+    result = refresh_derived_features_if_stale(job.id, store=store, derive=healthy)
+    assert result["refreshed"] is True
+    assert len(fetches) == 1
+    assert fetches[0]["days"] == 120
+    assert fetches[0]["source"] == "ccxt"
+    assert fetches[0]["exchange"] == "binance"
+
+    # refresh_dataset=False (the in-dataset-build call) never re-fetches.
+    store.write_json(job.id, "results/research/derived_refresh.json", {})
+    refresh_derived_features_if_stale(
+        job.id, store=store, derive=healthy, refresh_dataset=False
+    )
+    assert len(fetches) == 1

--- a/wayfinder_paths/tests/test_jobs_gating.py
+++ b/wayfinder_paths/tests/test_jobs_gating.py
@@ -142,3 +142,36 @@ def test_validation_report_is_revision_stamped(tmp_path: Path) -> None:
     report = validate_execution_job(job_id, store=store)
 
     assert report["revision"] == compute_workspace_revision(root)
+
+
+def test_agent_memory_edits_do_not_move_the_revision(tmp_path: Path) -> None:
+    """workspace/memory.md is agent diary state, read by nothing in the
+    execution path — hashing it turned every routine memory update into a
+    phantom strategy change (stale gate stamps + baseline drift on staged
+    candidates, seen live 2026-08-11)."""
+    store, job_id, root = _make_job(tmp_path)
+    baseline = compute_workspace_revision(root)
+
+    memory = root / "workspace" / "memory.md"
+    memory.write_text("# Durable memory\n- one more thought\n", encoding="utf-8")
+    assert compute_workspace_revision(root) == baseline
+
+    memory.write_text("# Durable memory\n- yet another thought\n", encoding="utf-8")
+    assert compute_workspace_revision(root) == baseline
+
+    # Strategy content and execution config still move the revision.
+    script = next((root / "workspace").rglob("*.py"))
+    script.write_text(
+        script.read_text(encoding="utf-8") + "\n# edit\n", encoding="utf-8"
+    )
+    after_code = compute_workspace_revision(root)
+    assert after_code != baseline
+
+    job_yaml = root / "job.yaml"
+    job_yaml.write_text(
+        job_yaml.read_text(encoding="utf-8").replace(
+            "goal:", "goal_note: tweaked\ngoal:", 1
+        ),
+        encoding="utf-8",
+    )
+    assert compute_workspace_revision(root) != after_code

--- a/wayfinder_paths/tests/test_runner_db.py
+++ b/wayfinder_paths/tests/test_runner_db.py
@@ -223,3 +223,51 @@ def test_runner_db_reserve_run_advances_schedule_atomically(tmp_path: Path) -> N
     assert run is not None
     assert run["reason"] == "schedule"
     assert run["scheduled_for"] == 100
+
+
+def test_error_jobs_retry_after_cooldown_and_self_heal(tmp_path: Path) -> None:
+    """ERROR means "backing off", not "dead": a transient upstream 429 burst
+    once ERROR'd a lane that then sat dark 12 hours until a human resumed
+    it. ERROR lanes come due again after max(4x interval, floor) and a
+    success flips them back to ACTIVE."""
+    from wayfinder_paths.runner.constants import ERROR_RETRY_COOLDOWN_SECONDS
+
+    db = RunnerDB(tmp_path / "state.db")
+    now = int(time.time())
+    job_id = db.add_job(
+        name="flaky-feed",
+        job_type=JOB_TYPE_STRATEGY,
+        payload={"strategy": "s"},
+        interval_seconds=60,
+        status=JobStatus.ACTIVE,
+        next_run_at=now - 1,
+    )
+    db.record_job_failure(job_id=job_id, error_text="429", max_failures=1)
+    assert db.list_jobs()[0]["status"] == JobStatus.ERROR
+
+    # Freshly failed: inside the cooldown, not due.
+    db.set_job_last_run(job_id=job_id, last_run_at=now)
+    assert db.due_jobs(now=now + 60) == []
+
+    # Past the cooldown: due again despite ERROR status.
+    cooldown = max(4 * 60, ERROR_RETRY_COOLDOWN_SECONDS)
+    due = db.due_jobs(now=now + cooldown + 1)
+    assert [j["id"] for j in due] == [job_id]
+
+    # A success self-heals the status back to ACTIVE.
+    db.record_job_success(job_id=job_id, ok_at=now + cooldown + 2)
+    assert db.list_jobs()[0]["status"] == JobStatus.ACTIVE
+
+
+def test_paused_jobs_never_come_due(tmp_path: Path) -> None:
+    db = RunnerDB(tmp_path / "state.db")
+    now = int(time.time())
+    db.add_job(
+        name="parked",
+        job_type=JOB_TYPE_STRATEGY,
+        payload={"strategy": "s"},
+        interval_seconds=60,
+        status=JobStatus.PAUSED,
+        next_run_at=now - 10_000,
+    )
+    assert db.due_jobs(now=now + 1_000_000) == []


### PR DESCRIPTION
## Why

The two root-caused fixes from the Aug 11 postmortem, combined into one PR (one merge, one bake+roll).

## Part 1 — agent memory is not a strategy change (was #627)

`workspace/memory.md` — the agent's diary, updated on routine wakes — was inside `compute_workspace_revision`. Every memory update silently moved the revision: stale gate stamps ("preflight is for revision `ed42f8bd`, workspace is `6370b681`") and baseline drift on every staged candidate. Verified live: hashing the pre-apply backup reproduces the mystery revision exactly. Now excluded alongside `__pycache__`. **One-time deploy consequence**: every job's revision shifts once — candidate-reuse/gate stamps go stale once, replication baselines re-pin; all absorbed autonomously by the restage/watchdog machinery (#613/#624/#626). Expect one noisy watchdog pass post-roll.

## Part 2 — data-feed resilience

Root cause of `derived_features_refresh_failed` (×10/×12/×6) + `counterfactual_failed` (×4): the **429 burst Aug 10 22:34 → Aug 11 02:53** (credits dry). And the kicker: our refresh loop was re-fetching the **full 120-day dataset span every 30 min per job** — the very load that burns credits.

| Gap | Fix |
|---|---|
| Hammer retries into the rate limit | ONE polite retry honoring `Retry-After` (cap 30s), then surface |
| 402 vs 429 indistinguishable | structured `DataFeedError`: `out_of_credits` / `rate_limited` |
| ERROR lanes park forever (imx: 12h dead) | ERROR = backing off — due after `max(4× interval, 30 min)`, success auto-resets ACTIVE, run-once may probe |
| Full-span exog fetch every 30 min | incremental tail + rolling warmup (~99% volume cut) |
| Features frozen at dataset end (`rows_appended: 0`, 15h stale) | refresh extends the dataset tail (>2h stale) via `build_live_dataset`'s incremental path with recorded provenance; `refresh_dataset=False` guards in-build recursion |
| 3 days of silent failures | ≥3 consecutive failures or >6h stale-despite-success → ONE `data_feed_degraded` per episode with structured cause; `data_feed_recovered` closes it; both in the decision log — **out_of_credits names the owner action** |

## Tests

78 passed across gating, runner (db/daemon/e2e/control/script-jobs), derived-features, decision-log, evidence-window suites + new `test_data_feed_errors.py`.