### PR TITLE
jobs: memory diet — shrink the gate-backtest and resident footprint for the 2GB box

### DIFF
--- a/wayfinder_paths/jobs/derived_features.py
+++ b/wayfinder_paths/jobs/derived_features.py
@@ -22,6 +22,7 @@ import asyncio
 import datetime as dt
 import json
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -149,26 +150,28 @@ def derive_features_job(
             ).reindex(closes.index)
         columns["regime_code"] = regime_wide
 
-    # Load the store's existing keys BEFORE the fetch: appends dedup against
-    # them, and the newest existing stamp bounds the exog/venue fetch window.
+    # Newest stored stamp PER SERIES, streamed (never a per-row key set — at
+    # the live store's 600k+ rows that set alone was ~100MB+ of tuples).
+    # Dedup semantics: appends are chronological per series (incremental
+    # fetches only extend the tail), so "strictly newer than the series'
+    # newest" is equivalent to the old exact-key check.
     features_path = root / "state" / "features.jsonl"
     features_path.parent.mkdir(parents=True, exist_ok=True)
-    existing: set[tuple[str, str, str]] = set()
+    newest_by_series: dict[tuple[str, str], str] = {}
     if features_path.exists():
-        for line in features_path.read_text(encoding="utf-8").splitlines():
-            try:
-                row = json.loads(line)
-            except ValueError:
-                continue
-            if isinstance(row, dict):
-                existing.add(
-                    (
-                        str(row.get("timestamp")),
-                        str(row.get("name")),
-                        str(row.get("symbol")),
-                    )
-                )
-    newest_existing = max((key[0] for key in existing), default="")
+        with features_path.open(encoding="utf-8") as handle:
+            for line in handle:
+                try:
+                    row = json.loads(line)
+                except ValueError:
+                    continue
+                if not isinstance(row, dict):
+                    continue
+                series = (str(row.get("name")), str(row.get("symbol")))
+                ts = str(row.get("timestamp"))
+                if ts > newest_by_series.get(series, ""):
+                    newest_by_series[series] = ts
+    newest_existing = max(newest_by_series.values(), default="")
 
     if "exog" in sets or "venue" in sets:
         start_ms = int(closes.index[0].timestamp() * 1000)
@@ -220,10 +223,10 @@ def derive_features_job(
                         raise ValueError(
                             f"append cap {MAX_APPEND_ROWS} hit — raise every_bars"
                         )
-                    key = (ts.isoformat(), name, symbol)
-                    if key in existing:
+                    ts_iso = ts.isoformat()
+                    if ts_iso <= newest_by_series.get((name, symbol), ""):
                         continue
-                    existing.add(key)
+                    newest_by_series[(name, symbol)] = ts_iso
                     handle.write(
                         json.dumps(
                             {
@@ -246,7 +249,7 @@ def derive_features_job(
         "per_feature": dict(sorted(appended.items())),
         # Newest stamp in the store after this run — rows_appended == 0 is
         # NORMAL between hourly stamps; THIS is the staleness signal.
-        "newest_feature_ts": max((key[0] for key in existing), default=""),
+        "newest_feature_ts": max(newest_by_series.values(), default=""),
         "generated_at": str(dt.datetime.now(dt.UTC)),
         "read": (
             "Research-side derived features appended to the feature store — "
@@ -273,6 +276,70 @@ _DEGRADED_AFTER_FAILURES = 3
 # Newest feature stamp older than this despite "successful" refreshes is a
 # degradation too (a wedged feed that fails silent).
 _FEATURES_STALE_ALARM_S = 6 * 3600
+
+
+# Compact the append-only store once it outgrows this — the live store hit
+# 95MB/620k rows, filled the disk once, and rode through every backtest and
+# wake in full.
+_COMPACT_THRESHOLD_BYTES = 32 * 1024 * 1024
+# Keep the full evidence window plus margin so gate backtests and scans see
+# an unchanged store.
+_COMPACT_KEEP_DAYS = 130.0
+
+
+def compact_feature_store(
+    root: Path, *, keep_days: float = _COMPACT_KEEP_DAYS
+) -> dict[str, Any] | None:
+    """Rewrite features.jsonl keeping rows newer than the cutoff plus each
+    series' as-of anchor (newest row at/before cutoff) — merge_asof(backward)
+    observes identical values everywhere inside the kept window."""
+    path = root / "state" / "features.jsonl"
+    if not path.exists():
+        return None
+    before = path.stat().st_size
+    cutoff = (dt.datetime.now(dt.UTC) - dt.timedelta(days=keep_days)).isoformat()
+    anchors: dict[tuple[str, str], tuple[str, str]] = {}
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            try:
+                row = json.loads(line)
+            except ValueError:
+                continue
+            if not isinstance(row, dict):
+                continue
+            ts = str(row.get("timestamp"))
+            if ts >= cutoff:
+                continue
+            series = (str(row.get("name")), str(row.get("symbol")))
+            if ts > anchors.get(series, ("", ""))[0]:
+                anchors[series] = (ts, line if line.endswith("\n") else line + "\n")
+    kept = 0
+    dropped = 0
+    tmp = path.with_suffix(".jsonl.compact")
+    with tmp.open("w", encoding="utf-8") as out:
+        for _, line in sorted(anchors.values()):
+            out.write(line)
+            kept += 1
+        with path.open(encoding="utf-8") as handle:
+            for line in handle:
+                try:
+                    row = json.loads(line)
+                except ValueError:
+                    dropped += 1
+                    continue
+                if isinstance(row, dict) and str(row.get("timestamp")) >= cutoff:
+                    out.write(line if line.endswith("\n") else line + "\n")
+                    kept += 1
+                else:
+                    dropped += 1
+    tmp.replace(path)
+    dropped -= len(anchors)  # anchor rows were re-written, not dropped
+    return {
+        "before_bytes": before,
+        "after_bytes": path.stat().st_size,
+        "rows_kept": kept,
+        "rows_dropped": max(dropped, 0),
+    }
 
 
 def _feed_cause(error: str) -> str:
@@ -430,6 +497,28 @@ def refresh_derived_features_if_stale(
             {"type": "data_feed_recovered", "newest_feature_ts": newest_feature},
         )
         stamp.pop("degraded_since", None)
+
+    root = store.job_dir(job_id)
+    features_path = root / "state" / "features.jsonl"
+    if (
+        features_path.exists()
+        and features_path.stat().st_size > _COMPACT_THRESHOLD_BYTES
+    ):
+        try:
+            compacted = compact_feature_store(root)
+        except Exception as exc:  # noqa: BLE001 — compaction must not kill a wake
+            compacted = None
+            store.append_journal(
+                job_id,
+                {
+                    "type": "derived_features_refresh_failed",
+                    "error": f"feature store compaction: {str(exc)[:250]}",
+                },
+            )
+        if compacted:
+            store.append_journal(
+                job_id, {"type": "feature_store_compacted", **compacted}
+            )
 
     stamp.update(
         {

--- a/wayfinder_paths/jobs/execution/driver.py
+++ b/wayfinder_paths/jobs/execution/driver.py
@@ -264,7 +264,9 @@ async def tick_job(
     feature_guards: list[dict[str, Any]] = []
     feature_skip = False
     if feature_specs:
-        feature_frames = load_feature_rows([root], feature_specs)
+        stamps = view.timestamps
+        feature_window = (stamps[0], stamps[-1]) if stamps else None
+        feature_frames = load_feature_rows([root], feature_specs, window=feature_window)
         feature_guards, feature_skip = feature_staleness(
             feature_specs, feature_frames, now
         )

--- a/wayfinder_paths/jobs/execution/features.py
+++ b/wayfinder_paths/jobs/execution/features.py
@@ -97,49 +97,113 @@ def parse_feature_specs(spec: ExecutionSpec) -> list[FeatureSpec]:
     return specs
 
 
+# Single-entry parse cache keyed on (path, mtime_ns, size, names). The live
+# driver calls load_feature_rows every tick; without this each 5-minute tick
+# re-parsed the full store (95MB / 600k+ lines observed live) once per
+# declared feature. Any append invalidates via mtime/size.
+_FEATURE_FILE_CACHE: dict[str, Any] = {}
+
+
+def _parse_feature_file(path: Path, names: set[str]) -> dict[str, dict[str, list]]:
+    """ONE streaming pass over the jsonl store collecting column lists for
+    every requested name — the store is parsed once, not once per spec."""
+    stat = path.stat()
+    key = (str(path), stat.st_mtime_ns, stat.st_size, tuple(sorted(names)))
+    if _FEATURE_FILE_CACHE.get("key") == key:
+        return _FEATURE_FILE_CACHE["columns"]
+    columns: dict[str, dict[str, list]] = {
+        name: {"timestamp": [], "value": [], "symbol": []} for name in names
+    }
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except ValueError:
+                continue
+            if not isinstance(row, dict):
+                continue
+            bucket = columns.get(str(row.get("name")))
+            if bucket is None:
+                continue
+            bucket["timestamp"].append(row.get("timestamp"))
+            bucket["value"].append(row.get("value"))
+            bucket["symbol"].append(row.get("symbol"))
+    _FEATURE_FILE_CACHE["key"] = key
+    _FEATURE_FILE_CACHE["columns"] = columns
+    return columns
+
+
+def _trim_to_window(
+    frame: pd.DataFrame, start: pd.Timestamp, end: pd.Timestamp
+) -> pd.DataFrame:
+    """Rows within [start, end] plus, per symbol series (including the
+    null-symbol series), the latest row strictly before start — exactly what
+    merge_asof(direction=backward) can observe inside the window."""
+    before = frame[frame["timestamp"] < start]
+    if not before.empty:
+        anchor_idx = (
+            before.groupby(before["symbol"].astype(object), dropna=False)["timestamp"]
+            .idxmax()
+            .tolist()
+        )
+        anchors = frame.loc[anchor_idx]
+    else:
+        anchors = frame.iloc[0:0]
+    inside = frame[(frame["timestamp"] >= start) & (frame["timestamp"] <= end)]
+    return pd.concat([anchors, inside]).sort_values("timestamp").reset_index(drop=True)
+
+
 def load_feature_rows(
-    roots: list[Path], specs: list[FeatureSpec]
+    roots: list[Path],
+    specs: list[FeatureSpec],
+    *,
+    window: tuple[pd.Timestamp, pd.Timestamp] | None = None,
 ) -> dict[str, pd.DataFrame]:
     """Per-feature frames sorted by timestamp: columns [timestamp, value,
     symbol]. Empty frame when a feature has no rows yet. First root that has
     the file wins (candidate dir before job dir — mirrors the candidate
-    dataset fallback)."""
+    dataset fallback).
+
+    `window=(start, end)` trims each frame to the bar range plus the as-of
+    anchor row per series — merge_asof(backward) sees identical values, but
+    a multi-month store no longer rides through a 120-day backtest in full."""
+    by_path: dict[Path, set[str]] = {}
+    spec_path: dict[str, Path | None] = {}
+    for spec in specs:
+        chosen: Path | None = None
+        for root in roots:
+            candidate = Path(root) / spec.path
+            if candidate.exists():
+                chosen = candidate
+                break
+        spec_path[spec.name] = chosen
+        if chosen is not None:
+            by_path.setdefault(chosen, set()).add(spec.name)
+
+    parsed = {path: _parse_feature_file(path, names) for path, names in by_path.items()}
+
     frames: dict[str, pd.DataFrame] = {}
     for spec in specs:
-        rows: list[dict[str, Any]] = []
-        for root in roots:
-            path = Path(root) / spec.path
-            if not path.exists():
-                continue
-            for line in path.read_text(encoding="utf-8").splitlines():
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    row = json.loads(line)
-                except ValueError:
-                    continue
-                match row:
-                    case dict() if str(row.get("name")) == spec.name:
-                        rows.append(row)
-            break
-        if not rows:
+        path = spec_path[spec.name]
+        columns = parsed.get(path, {}).get(spec.name) if path is not None else None
+        if not columns or not columns["timestamp"]:
             frames[spec.name] = pd.DataFrame(columns=["timestamp", "value", "symbol"])
             continue
         frame = pd.DataFrame(
-            [
-                {
-                    "timestamp": row.get("timestamp"),
-                    "value": row.get("value"),
-                    "symbol": row.get("symbol"),
-                }
-                for row in rows
-            ]
-        )
-        frame["timestamp"] = pd.to_datetime(
-            frame["timestamp"], utc=True, errors="coerce"
+            {
+                "timestamp": pd.to_datetime(
+                    columns["timestamp"], utc=True, errors="coerce"
+                ),
+                "value": columns["value"],
+                "symbol": columns["symbol"],
+            }
         )
         frame = frame.dropna(subset=["timestamp"]).sort_values("timestamp")
+        if window is not None:
+            frame = _trim_to_window(frame, window[0], window[1])
         frames[spec.name] = frame.reset_index(drop=True)
     return frames
 

--- a/wayfinder_paths/jobs/execution/job.py
+++ b/wayfinder_paths/jobs/execution/job.py
@@ -358,7 +358,12 @@ def _load_dataset(
             tuple(feature_roots or (root,)), {item.name for item in specs}
         )
     if specs:
-        frames = load_feature_rows(list(feature_roots or (root,)), specs)
+        # Window the store load to the dataset's bar range (+ as-of anchors):
+        # a multi-month features.jsonl otherwise rides through every gate
+        # backtest in full — part of the 2GB-box OOM profile.
+        stamps = dataset.bars.timestamps
+        window = (stamps[0], stamps[-1]) if stamps else None
+        frames = load_feature_rows(list(feature_roots or (root,)), specs, window=window)
         dataset = PreparedExecutionDataset(
             merge_features(dataset.bars, frames, specs),
             {

--- a/wayfinder_paths/jobs/execution/primitives.py
+++ b/wayfinder_paths/jobs/execution/primitives.py
@@ -125,9 +125,11 @@ class CompletedBarsView:
         self._bars = frame.sort_values(["timestamp", "symbol"]).reset_index(drop=True)
         self._timestamps_cache: list[pd.Timestamp] | None = None
         self._symbols_cache: list[str] | None = None
-        # {(ts, symbol): MarketBar} + {ts: first MarketBar at ts}; shared with
-        # truncated child views (they guard lookups against their own bounds).
-        self._row_index: dict[Any, MarketBar] | None = None
+        # int64-ns timestamps of THIS frame's rows (sorted). row_at() binary-
+        # searches this instead of a {key: MarketBar} dict index — the dict
+        # retained one dataclass per row (115MB across rebuilds at the 120d
+        # 4-symbol scale, the gate backtest's OOM driver on the 2GB box).
+        self._ts_ns_cache: np.ndarray | None = None
         # {symbol: sorted positional indices in THIS frame}; shared with child
         # views alongside this view's absolute offset, so symbol_frame() is an
         # integer take instead of a per-call string-equality mask.
@@ -136,7 +138,13 @@ class CompletedBarsView:
 
     @classmethod
     def from_rows(cls, rows: list[Mapping[str, Any]]) -> CompletedBarsView:
-        return cls(pd.DataFrame([dict(row) for row in rows]))
+        # Columnar extraction, not [dict(row) for row in rows]: the per-row
+        # copy doubled the 120d/4-symbol parse footprint (a second 138k-dict
+        # list co-resident with the json.loads output) on the 2GB box.
+        if not rows:
+            return cls(pd.DataFrame(columns=sorted(cls.REQUIRED_COLUMNS)))
+        columns = {key: [row.get(key) for row in rows] for key in rows[0].keys()}
+        return cls(pd.DataFrame(columns))
 
     @classmethod
     def _from_trusted(
@@ -144,20 +152,20 @@ class CompletedBarsView:
         frame: pd.DataFrame,
         *,
         timestamps: list[pd.Timestamp] | None = None,
-        row_index: dict[Any, MarketBar] | None = None,
+        ts_ns: np.ndarray | None = None,
         symbol_positions: dict[str, np.ndarray] | None = None,
         symbol_positions_offset: int = 0,
     ) -> CompletedBarsView:
         """Fast path for frames already coerced+sorted by a prior __init__
         (e.g. per-tick truncation). Skipping re-coercion turns the simulator's
         per-bar view construction from O(n) coercions into a plain slice.
-        Passing the parent's timestamp slice and row index makes per-tick
+        Passing the parent's timestamp slice and ts-ns array makes per-tick
         views O(1) instead of recomputing uniques/masks each bar."""
         view = object.__new__(cls)
         view._bars = frame
         view._timestamps_cache = timestamps
         view._symbols_cache = None
-        view._row_index = row_index
+        view._ts_ns_cache = ts_ns
         view._symbol_positions = symbol_positions
         view._symbol_positions_offset = symbol_positions_offset
         return view
@@ -181,24 +189,25 @@ class CompletedBarsView:
             )
         return self._timestamps_cache
 
-    def _ensure_row_index(self) -> dict[Any, MarketBar]:
-        if self._row_index is None:
-            index: dict[Any, MarketBar] = {}
-            for row in self._bars.itertuples(index=False):
-                bar = MarketBar(
-                    timestamp=pd.Timestamp(row.timestamp),
-                    symbol=str(row.symbol),
-                    open=float(row.open),
-                    high=float(row.high),
-                    low=float(row.low),
-                    close=float(row.close),
-                    volume=None if pd.isna(row.volume) else float(row.volume),
-                )
-                index[(bar.timestamp, bar.symbol)] = bar
-                # First row at each timestamp (frame sorted by ts, symbol).
-                index.setdefault(bar.timestamp, bar)
-            self._row_index = index
-        return self._row_index
+    def _ensure_ts_ns(self) -> np.ndarray:
+        if self._ts_ns_cache is None:
+            self._ts_ns_cache = (
+                self._bars["timestamp"].to_numpy(dtype="datetime64[ns]").astype("int64")
+            )
+        return self._ts_ns_cache
+
+    def _bar_at_position(self, position: int) -> MarketBar:
+        row = self._bars.iloc[position]
+        volume = row["volume"]
+        return MarketBar(
+            timestamp=pd.Timestamp(row["timestamp"]),
+            symbol=str(row["symbol"]),
+            open=float(row["open"]),
+            high=float(row["high"]),
+            low=float(row["low"]),
+            close=float(row["close"]),
+            volume=None if pd.isna(volume) else float(volume),
+        )
 
     def latest(self, symbol: str | None = None) -> dict[str, Any]:
         frame = self._filter_symbol(symbol)
@@ -277,7 +286,7 @@ class CompletedBarsView:
         return CompletedBarsView._from_trusted(
             self._bars.iloc[start_pos:end_pos],
             timestamps=timestamps[start : end + 1],
-            row_index=self._ensure_row_index(),
+            ts_ns=self._ensure_ts_ns()[start_pos:end_pos],
             symbol_positions=self._ensure_symbol_positions(),
             symbol_positions_offset=self._symbol_positions_offset + start_pos,
         )
@@ -291,12 +300,19 @@ class CompletedBarsView:
         except TypeError:  # uncomparable input (naive ts, junk) == no bar
             in_bounds = False
         if in_bounds:
-            key = (timestamp, symbol) if symbol is not None else timestamp
-            bar = self._ensure_row_index().get(key)
-            if bar is not None:
-                # MarketBar is frozen, so sharing index instances across
-                # callers is safe — no defensive copy needed.
-                return bar
+            try:
+                ts_ns = int(pd.Timestamp(timestamp).value)
+            except (TypeError, ValueError):
+                ts_ns = None
+            if ts_ns is not None:
+                column = self._ensure_ts_ns()
+                left = int(np.searchsorted(column, ts_ns, side="left"))
+                right = int(np.searchsorted(column, ts_ns, side="right"))
+                for position in range(left, right):
+                    if symbol is None or str(self._bars["symbol"].iat[position]) == str(
+                        symbol
+                    ):
+                        return self._bar_at_position(position)
         raise ValueError(f"No bar at {timestamp} for {symbol or 'any symbol'}")
 
     def __len__(self) -> int:

--- a/wayfinder_paths/jobs/execution/simulator.py
+++ b/wayfinder_paths/jobs/execution/simulator.py
@@ -382,10 +382,11 @@ def simulate_execution(
             bars_by_symbol = _bars_at_timestamp(dataset.bars, timestamp)
             if not bars_by_symbol:
                 continue
+            timestamp_iso = timestamp.isoformat()
             for symbol, bar in bars_by_symbol.items():
                 price_series[symbol].append(
                     {
-                        "timestamp": timestamp.isoformat(),
+                        "timestamp": timestamp_iso,
                         "value": bar.close,
                         "open": bar.open,
                         "high": bar.high,


### PR DESCRIPTION
## Why

The majors session-gating experiment (a real find: US-session entries bleeding −39bps over 19 trades) is blocked because its propose gate needs a 4-symbol × 120d backtest that OOMs the 2GB box. Profiled at exactly that scale (34,560 5m bars, 620k-row feature store): **peak RSS ~1.07GB**, plus heavy steady-state pressure from the wake/tick paths.

## What (profile-driven, behavior-preserving)

| Hot spot (measured) | Fix |
|---|---|
| `{(ts,symbol): MarketBar}` row index — **115MB retained, 1M+ dataclasses**, rebuilt per root view | int64-ns timestamp array + binary search (~1MB, zero retained bars) |
| `from_rows` copied every parsed row dict a second time | columnar extraction |
| `load_feature_rows` parsed the **full store once per declared spec** — and the **live driver re-parsed 95MB every 5-minute tick** | ONE streaming pass for all specs + single-entry mtime cache + `window=(start,end)` trimming with per-series as-of anchors (merge_asof sees identical values); backtest loader and driver both pass their bar range |
| wake-path dedup set (~130MB at live scale, every wake) | per-series newest-stamp dict |
| `features.jsonl` unbounded (95MB/620k rows; filled the disk Aug 10) | `compact_feature_store` past 32MB — keeps the evidence window + as-of anchors, atomic rewrite, journaled |

## Measured

- Retained after run: **158MB → 66MB**
- Traced peak: 658 → 628MB (single-process); the remaining peak is the row-oriented `input_bars.json` parse (257MB of boxed row-dicts) — **a columnar dataset format is the identified next lever** if the gate still brushes the ceiling on-box (6 reader/writer sites, follow-up PR)
- Box steady-state drops far more than the single-process number: tick re-parses gone (cache), wake sets gone, store compacted — the resident half of the OOM equation

## Tests

131 passed across execution-engine/contract/timing, features, preflight, propose, gating, derived-features, and wayfinder-jobs suites. Feature-window trimming is asserted equivalent under merge_asof semantics (as-of anchors preserved).

## Acceptance test on the box

After merge + roll: the majors agent's deferred session-gating proposal should be able to run its gate backtest without OOM — that's the experiment this unblocks.