### PR TITLE
jobs: watchdog re-stamps revision-stale gates; red gates render as prompt text

### DIFF
--- a/wayfinder_paths/jobs/watchdog.py
+++ b/wayfinder_paths/jobs/watchdog.py
@@ -17,6 +17,7 @@ failed after a longer window; claim allows retry from "failed".
 from __future__ import annotations
 
 import os
+import re
 import signal
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -267,6 +268,107 @@ def _recover_restage(
     return event
 
 
+# Matches "backtest is for revision ab12cd34ef56, workspace is 0f1e2d3c4b5a" —
+# the gate reason shape for pure stamp staleness (evidence fine, fingerprint
+# old). Substantive failures (validation failed, contract, missing dataset)
+# do NOT match and are never auto-repaired.
+_REVISION_MISMATCH_RE = re.compile(
+    r"is for revision [0-9a-f]{6,}, workspace is [0-9a-f]{6,}"
+)
+_GATE_RESTAMP_MARKER = "state/gate_restamp.json"
+
+
+def _recover_stale_gate(
+    store: JobStore,
+    job_id: str,
+    proposals: list[dict[str, Any]],
+    *,
+    allow_restamp: bool = True,
+) -> dict[str, Any] | None:
+    """Re-stamp gate evidence when it is red PURELY from revision mismatch.
+
+    Config edits and (historically) agent memory writes move the workspace
+    revision without touching the stamped artifacts; the gate then blocks
+    approvals until someone re-runs backtest -> preflight -> validate. That
+    "someone" was a human three times in one week. Re-running the chain only
+    regenerates evidence at the current workspace — if the current code is
+    genuinely worse, the fresh artifacts say so and the gate stays red for
+    REAL reasons. A convergence marker stops the repair from looping: red at
+    a revision we already re-stamped escalates once instead of burning a
+    backtest every pass.
+    """
+    if any(p["application"].get("status") in {"queued", "applying"} for p in proposals):
+        return None  # promotion re-stamps as a side effect; let the apply run
+    # circular import: gating -> store; job/preflight/validation import deeply
+    from wayfinder_paths.jobs.gating import (
+        compute_workspace_revision,
+        evaluate_live_gate,
+    )
+
+    root = store.job_dir(job_id)
+    marker = store.read_json(job_id, _GATE_RESTAMP_MARKER) or {}
+    gate = evaluate_live_gate(job_id, store=store)
+    if gate.get("live_ready"):
+        if marker:
+            store.write_json(job_id, _GATE_RESTAMP_MARKER, {})
+        return None
+    reasons = [str(r) for r in gate.get("reasons") or []]
+    if not reasons or not all(_REVISION_MISMATCH_RE.search(r) for r in reasons):
+        return None  # substantive red — must stay visible, never masked
+    revision = compute_workspace_revision(root)
+    if str(marker.get("revision") or "") == revision:
+        # Already re-stamped at this exact revision and the gate is still
+        # red: repair does not converge — escalate once, then stand down.
+        if not marker.get("escalated"):
+            marker["escalated"] = True
+            store.write_json(job_id, _GATE_RESTAMP_MARKER, marker)
+            event = {
+                "type": "application_watchdog_recovered",
+                "stalled_status": "stale_gate",
+                "action": "gate_restamp_not_converging",
+                "outcome": "needs_attention",
+                "revision": revision,
+                "reasons": reasons[:4],
+            }
+            store.append_journal(job_id, event)
+            return event
+        return None
+    if not allow_restamp:
+        return None  # one re-stamp (a backtest) per pass; next pass retries
+
+    from wayfinder_paths.jobs.compute_lock import ComputeLockBusy
+    from wayfinder_paths.jobs.execution.job import backtest_execution_job
+    from wayfinder_paths.jobs.execution.preflight import run_preflight
+    from wayfinder_paths.jobs.execution.validation import validate_execution_job
+
+    try:
+        backtest_execution_job(job_id, store=store)
+        run_preflight(job_id, store=store)
+        validate_execution_job(job_id, store=store)
+    except ComputeLockBusy:
+        return None  # heavy compute in progress; retry next pass
+    except Exception as exc:
+        store.append_journal(
+            job_id,
+            {
+                "type": "application_watchdog_skipped",
+                "reason": f"gate restamp failed: {str(exc)[:250]}",
+            },
+        )
+        return None
+    after = evaluate_live_gate(job_id, store=store)
+    store.write_json(job_id, _GATE_RESTAMP_MARKER, {"revision": revision})
+    event = {
+        "type": "application_watchdog_recovered",
+        "stalled_status": "stale_gate",
+        "action": "gate_restamp",
+        "outcome": "green" if after.get("live_ready") else "still_red",
+        "revision": revision,
+    }
+    store.append_journal(job_id, event)
+    return event
+
+
 def _recover_orphaned_pause(
     store: JobStore,
     job_id: str,
@@ -354,6 +456,8 @@ def recover_stalled_applications(
     # each watchdog pass to one so the pass stays well inside its timeout;
     # the 5-minute cadence picks up the rest.
     restaged_this_pass = False
+    # A gate re-stamp runs a full backtest — same one-per-pass budget rule.
+    restamped_this_pass = False
     for job in store.list_jobs():
         try:
             proposals = store.proposals(job.id)
@@ -400,6 +504,17 @@ def recover_stalled_applications(
             pause_event = None
         if pause_event is not None:
             recovered.append({"job_id": job.id, **pause_event})
+        try:
+            gate_event = _recover_stale_gate(
+                store, job.id, proposals, allow_restamp=not restamped_this_pass
+            )
+        except Exception as exc:
+            errors.append({"job_id": job.id, "error": str(exc)})
+            gate_event = None
+        if gate_event is not None:
+            recovered.append({"job_id": job.id, **gate_event})
+            if gate_event.get("action") == "gate_restamp":
+                restamped_this_pass = True
     return {"scanned": scanned, "recovered": recovered, "errors": errors}
 
 

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -736,6 +736,21 @@ def _build_worker_prompt_sections(
     # a busy job can silently swallow a payload-only instruction — which is
     # exactly how an agent once missed a pending re-stage and burned the
     # owner's carried-over approval on a duplicate proposal.
+    # Gate state renders as prompt text too: a red gate buried in the
+    # truncated snapshot JSON let a wake report "gate green" while approvals
+    # were actually blocked for 28 hours (2026-08-12).
+    gate_alert = ""
+    gate_state = snapshot.get("gate") or {}
+    if gate_state and gate_state.get("live_ready") is False:
+        gate_reasons = "; ".join(str(r) for r in (gate_state.get("reasons") or [])[:4])
+        gate_alert = (
+            "GATE STATUS: RED — approvals and go-live are blocked.\n"
+            f"Reasons: {gate_reasons}\n"
+            "If every reason is a revision mismatch (stamps older than the "
+            "workspace), the watchdog re-stamps automatically — do not treat "
+            "it as a strategy failure, but DO NOT report the gate as green. "
+            "For any other reason, fixing the gate is a priority this wake.\n\n"
+        )
     restage_priority = ""
     restage_task_line = ""
     if restage_tasks:
@@ -762,6 +777,7 @@ def _build_worker_prompt_sections(
         )
     dynamic_context = (
         f"{DYNAMIC_CONTEXT_MARKER}\n"
+        f"{gate_alert}"
         f"{restage_priority}"
         "Current snapshot:\n"
         f"{_canonical_json(dynamic_payload, max_chars=12000)}\n\n"

--- a/wayfinder_paths/tests/test_jobs_apply_watchdog.py
+++ b/wayfinder_paths/tests/test_jobs_apply_watchdog.py
@@ -798,3 +798,109 @@ def test_watchdog_ignores_healthy_resumes_and_in_flight_applies(
 
     assert [name for kind, name in calls if kind == "resume"] == []
     assert all(e["action"] != "resume_orphaned_pause" for e in result["recovered"])
+
+
+def _gate(live_ready: bool, reasons: list[str]) -> dict:
+    return {"live_ready": live_ready, "reasons": reasons}
+
+
+_MISMATCH = "backtest is for revision aaaa11112222, workspace is bbbb33334444"
+
+
+def test_watchdog_restamps_revision_mismatch_gate(tmp_path: Path, monkeypatch) -> None:
+    """Gate red PURELY from revision mismatch → the watchdog re-runs the
+    stamp chain; substantive reds are never touched."""
+    _patch_runner(monkeypatch)
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "gate-stale")
+
+    gates = iter([_gate(False, [_MISMATCH]), _gate(True, [])])
+    chain: list[str] = []
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.gating.evaluate_live_gate",
+        lambda job_id, store=None, **k: next(gates),
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.gating.compute_workspace_revision",
+        lambda root: "bbbb33334444",
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.execution.job.backtest_execution_job",
+        lambda job_id, store=None, **k: chain.append("backtest"),
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.execution.preflight.run_preflight",
+        lambda job_id, store=None, **k: chain.append("preflight"),
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.execution.validation.validate_execution_job",
+        lambda job_id, store=None, **k: chain.append("validate"),
+    )
+
+    result = recover_stalled_applications(store=store)
+
+    assert chain == ["backtest", "preflight", "validate"]
+    events = [e for e in result["recovered"] if e["action"] == "gate_restamp"]
+    assert len(events) == 1 and events[0]["outcome"] == "green"
+    marker = store.read_json(job.id, "state/gate_restamp.json")
+    assert marker["revision"] == "bbbb33334444"
+
+
+def test_watchdog_never_touches_substantive_red_gate(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _patch_runner(monkeypatch)
+    store = JobStore(repo_root=tmp_path)
+    _make_job(store, "gate-real-red")
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.gating.evaluate_live_gate",
+        lambda job_id, store=None, **k: _gate(
+            False, [_MISMATCH, "candidate validation is not passed: failed"]
+        ),
+    )
+    chain: list[str] = []
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.execution.job.backtest_execution_job",
+        lambda job_id, store=None, **k: chain.append("backtest"),
+    )
+
+    result = recover_stalled_applications(store=store)
+
+    assert chain == []
+    assert all(e.get("stalled_status") != "stale_gate" for e in result["recovered"])
+
+
+def test_watchdog_gate_restamp_escalates_instead_of_looping(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Red at a revision we already re-stamped → one escalation event, then
+    stand down — never a backtest every 5 minutes."""
+    _patch_runner(monkeypatch)
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "gate-loop")
+    store.write_json(job.id, "state/gate_restamp.json", {"revision": "bbbb33334444"})
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.gating.evaluate_live_gate",
+        lambda job_id, store=None, **k: _gate(False, [_MISMATCH]),
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.gating.compute_workspace_revision",
+        lambda root: "bbbb33334444",
+    )
+    chain: list[str] = []
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.execution.job.backtest_execution_job",
+        lambda job_id, store=None, **k: chain.append("backtest"),
+    )
+
+    first = recover_stalled_applications(store=store)
+    second = recover_stalled_applications(store=store)
+
+    assert chain == []
+    escalations = [
+        e
+        for r in (first, second)
+        for e in r["recovered"]
+        if e["action"] == "gate_restamp_not_converging"
+    ]
+    assert len(escalations) == 1, "escalates once, then stands down"

--- a/wayfinder_paths/tests/test_wayfinder_jobs.py
+++ b/wayfinder_paths/tests/test_wayfinder_jobs.py
@@ -1286,3 +1286,50 @@ def test_worker_prompt_hoists_restage_tasks_out_of_snapshot(tmp_path: Path) -> N
     assert (
         "PRIORITY — approved changes awaiting re-stage" not in clean["dynamic_context"]
     )
+
+
+def test_worker_prompt_hoists_red_gate_out_of_snapshot(tmp_path: Path) -> None:
+    """A red gate must be PROMPT TEXT above the snapshot: buried in the
+    truncated JSON, a wake once reported "gate green" while approvals were
+    blocked for 28 hours."""
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        "gate-alert-demo",
+        goal="See the truth.",
+        script="workspace/src/loop.py",
+        agent_mode="intervene",
+    )
+    store.save(job)
+
+    red = _build_worker_prompt_sections(
+        store=store,
+        job_id=job.id,
+        mode="intervene",
+        snapshot=_worker_snapshot(
+            job,
+            scorecard={"health": "green"},
+            gate={
+                "live_ready": False,
+                "reasons": [
+                    "backtest is for revision aaaa11112222, workspace is bbbb33334444"
+                ],
+            },
+        ),
+    )
+    dynamic = red["dynamic_context"]
+    alert_at = dynamic.index("GATE STATUS: RED")
+    assert alert_at < dynamic.index("Current snapshot:")
+    assert "DO NOT report the gate as green" in dynamic
+    assert "revision aaaa11112222" in dynamic[: alert_at + 600]
+
+    green = _build_worker_prompt_sections(
+        store=store,
+        job_id=job.id,
+        mode="intervene",
+        snapshot=_worker_snapshot(
+            job,
+            scorecard={"health": "green"},
+            gate={"live_ready": True, "reasons": []},
+        ),
+    )
+    assert "GATE STATUS: RED" not in green["dynamic_context"]


### PR DESCRIPTION
## Why

Revision-stamp staleness is the last recurring manual-intervention class in the apply/evidence pipeline: config edits move the workspace hash without touching stamped artifacts → gate red → approvals blocked → a human re-runs backtest/preflight/validate. Three manual re-stamps in one week; live right now, majors has been red for 28+ hours while the agent's wake reported "gate green" (the red gate was buried in the truncated snapshot JSON — the same burial that caused the restage miss).

## What

**Watchdog — fourth recovery pass** (`_recover_stale_gate`, 5-min cycle):
- Eligible ONLY when **every** gate reason matches `"…is for revision A, workspace is B"` — substantive reds (validation failed, contract, missing dataset) are never auto-repaired or masked.
- Repair = re-run the exact human chain: `backtest_execution_job` → `run_preflight` → `validate_execution_job`. This regenerates evidence at the *current* workspace — truth-preserving: genuinely-worse code produces honestly-red fresh artifacts.
- Bounded: one re-stamp (a backtest) per pass; `ComputeLockBusy` → next pass; skipped when an apply is in flight (promotion re-stamps anyway).
- **Convergence guard**: red at a revision we already re-stamped → one `gate_restamp_not_converging` escalation, then stand down — never a backtest every 5 minutes. Marker clears when the gate goes green. (Ordering note: this layer is only viable *after* #627 — with memory edits still in the hash, re-stamps would never stick.)
- Journals `application_watchdog_recovered` with `action: gate_restamp` → renders in the decision log via the existing recovery mapping.

**Worker — the companion truth fix**: when the gate is red, it renders as prompt TEXT above the snapshot with reasons and an explicit "DO NOT report the gate as green", plus "the watchdog re-stamps revision mismatches automatically" so agents neither panic nor lie. Same hoisting lesson as `restage_tasks`: the 12k-truncated sort_keys JSON is not a place for load-bearing state.

## Acceptance test on the box

Majors' gate is red from pure revision mismatch right now. After merge + roll, the first watchdog pass should re-stamp it green autonomously — and unblock the agent re-proposing the session-gating experiment (#629's unlock).

## Tests

- `test_watchdog_restamps_revision_mismatch_gate` — full chain runs, gate green, marker written
- `test_watchdog_never_touches_substantive_red_gate` — mixed reasons untouched
- `test_watchdog_gate_restamp_escalates_instead_of_looping` — one escalation, no repeat backtests
- `test_worker_prompt_hoists_red_gate_out_of_snapshot` — alert above the snapshot, absent when green
- 79 passed across watchdog, wayfinder-jobs, propose, and gating suites.