### PR TITLE
Give the backend-sync thread its own DB connection; surface side-effect crashes

### DIFF
--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -342,10 +342,8 @@ class RunnerDaemon:
             try:
                 callback()
             except Exception:  # noqa: BLE001
-                # WARNING, not debug: a silently dying side effect is how the
-                # backend job mirror went stale for a week — the sync thread
-                # crashed on every run and nothing surfaced at the daemon's
-                # INFO log level.
+                # Warning, not debug: crashes here are invisible at the
+                # daemon's INFO log level otherwise.
                 logger.opt(exception=True).warning(f"Runner side effect {label} failed")
 
         thread = threading.Thread(
@@ -409,12 +407,9 @@ class RunnerDaemon:
         db_path = self._paths.db_path
 
         def _sync() -> None:
-            # Read through a private connection. self._db is one shared sqlite
-            # connection used concurrently by the scheduler tick loop and the
-            # control server; using it from this thread as well killed the
-            # sync mid-read — before bulk_sync could POST or log — so the
-            # backend job mirror went permanently stale while report_run
-            # 404-warned about jobs the backend had never seen.
+            # Private connection: self._db is shared with the scheduler loop
+            # and control server, and cross-thread use kills this thread
+            # mid-read before the POST.
             db = RunnerDB(db_path)
             try:
                 jobs = []

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -341,8 +341,12 @@ class RunnerDaemon:
         def _target() -> None:
             try:
                 callback()
-            except Exception as exc:  # noqa: BLE001
-                logger.debug(f"Runner side effect {label} failed: {exc}")
+            except Exception:  # noqa: BLE001
+                # WARNING, not debug: a silently dying side effect is how the
+                # backend job mirror went stale for a week — the sync thread
+                # crashed on every run and nothing surfaced at the daemon's
+                # INFO log level.
+                logger.opt(exception=True).warning(f"Runner side effect {label} failed")
 
         thread = threading.Thread(
             target=_target,
@@ -402,26 +406,37 @@ class RunnerDaemon:
     def _sync_to_backend_async(self) -> None:
         if not is_opencode_instance():
             return
+        db_path = self._paths.db_path
 
         def _sync() -> None:
-            jobs = []
-            for j in self._db.list_jobs():
-                result = self._db.get_job(name=j["name"])
-                if not result:
-                    continue
-                job, state = result
-                jobs.append(
-                    {
-                        "job_name": job.name,
-                        "job_type": job.type,
-                        "status": state.status,
-                        "interval_seconds": job.interval_seconds,
-                        "schedule_kind": job.schedule_kind,
-                        "cron_expr": job.cron_expr,
-                        "timezone": job.timezone,
-                        "payload": job.payload,
-                    }
-                )
+            # Read through a private connection. self._db is one shared sqlite
+            # connection used concurrently by the scheduler tick loop and the
+            # control server; using it from this thread as well killed the
+            # sync mid-read — before bulk_sync could POST or log — so the
+            # backend job mirror went permanently stale while report_run
+            # 404-warned about jobs the backend had never seen.
+            db = RunnerDB(db_path)
+            try:
+                jobs = []
+                for j in db.list_jobs():
+                    result = db.get_job(name=j["name"])
+                    if not result:
+                        continue
+                    job, state = result
+                    jobs.append(
+                        {
+                            "job_name": job.name,
+                            "job_type": job.type,
+                            "status": state.status,
+                            "interval_seconds": job.interval_seconds,
+                            "schedule_kind": job.schedule_kind,
+                            "cron_expr": job.cron_expr,
+                            "timezone": job.timezone,
+                            "payload": job.payload,
+                        }
+                    )
+            finally:
+                db.close()
             SCHEDULED_JOBS_CLIENT.bulk_sync(jobs)
 
         self._run_side_effect("bulk-sync", _sync)

--- a/wayfinder_paths/runner/db.py
+++ b/wayfinder_paths/runner/db.py
@@ -49,9 +49,6 @@ class RunnerDB:
         self._init_schema()
 
     def close(self) -> None:
-        """Close the underlying connection. For short-lived private
-        connections (e.g. the backend-sync thread) — the daemon's main
-        RunnerDB lives for the process lifetime and never calls this."""
         self._conn.close()
 
     def _init_schema(self) -> None:

--- a/wayfinder_paths/runner/db.py
+++ b/wayfinder_paths/runner/db.py
@@ -48,6 +48,12 @@ class RunnerDB:
         self._conn.row_factory = sqlite3.Row
         self._init_schema()
 
+    def close(self) -> None:
+        """Close the underlying connection. For short-lived private
+        connections (e.g. the backend-sync thread) — the daemon's main
+        RunnerDB lives for the process lifetime and never calls this."""
+        self._conn.close()
+
     def _init_schema(self) -> None:
         cur = self._conn.cursor()
         cur.execute("PRAGMA journal_mode=WAL;")

--- a/wayfinder_paths/tests/test_runner_reconcile.py
+++ b/wayfinder_paths/tests/test_runner_reconcile.py
@@ -133,8 +133,7 @@ def _wait_for(predicate, timeout_s: float = 5.0) -> bool:
 def test_sync_to_backend_delivers_full_registry(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """End-to-end through _sync_to_backend_async (the earlier tests hand-built
-    the payload and never exercised the async path that was silently dying)."""
+    """Exercises _sync_to_backend_async end-to-end, not a hand-built payload."""
     monkeypatch.setenv("OPENCODE_INSTANCE_ID", "inst-xyz")
 
     daemon = RunnerDaemon(paths=_paths(tmp_path))
@@ -160,11 +159,8 @@ def test_sync_to_backend_delivers_full_registry(
 def test_sync_does_not_use_the_daemons_shared_connection(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Regression: the sync thread used self._db — one sqlite connection
-    shared with the 1s scheduler loop and the control server — and died
-    mid-read on every sync, before bulk_sync could POST or log. The backend
-    mirror froze for a week on a production box. The sync must read through
-    a private connection, so poisoning the shared one must not matter."""
+    """The sync thread must read through its own connection: poisoning the
+    daemon's shared one must not affect delivery."""
     monkeypatch.setenv("OPENCODE_INSTANCE_ID", "inst-xyz")
 
     daemon = RunnerDaemon(paths=_paths(tmp_path))
@@ -190,8 +186,7 @@ def test_sync_does_not_use_the_daemons_shared_connection(
 def test_side_effect_failure_logs_at_warning(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Regression: side-effect crashes were logged at DEBUG — invisible at the
-    daemon's INFO level — which is how the dying sync went unnoticed."""
+    """Side-effect crashes must surface at WARNING, not debug."""
     from loguru import logger
 
     daemon = RunnerDaemon(paths=_paths(tmp_path))

--- a/wayfinder_paths/tests/test_runner_reconcile.py
+++ b/wayfinder_paths/tests/test_runner_reconcile.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -116,3 +117,92 @@ def test_bulk_sync_empty_when_no_jobs(
 
     assert len(synced) == 1
     assert synced[0] == []
+
+
+def _wait_for(predicate, timeout_s: float = 5.0) -> bool:
+    import time
+
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.02)
+    return False
+
+
+def test_sync_to_backend_delivers_full_registry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end through _sync_to_backend_async (the earlier tests hand-built
+    the payload and never exercised the async path that was silently dying)."""
+    monkeypatch.setenv("OPENCODE_INSTANCE_ID", "inst-xyz")
+
+    daemon = RunnerDaemon(paths=_paths(tmp_path))
+    _add_local(daemon, "job-a")
+    _add_local(daemon, "job-b")
+
+    synced: list[list[dict]] = []
+    monkeypatch.setattr(
+        SCHEDULED_JOBS_CLIENT, "bulk_sync", lambda jobs: synced.append(jobs)
+    )
+
+    daemon._sync_to_backend_async()
+
+    assert _wait_for(lambda: len(synced) == 1)
+    names = {j["job_name"] for j in synced[0]}
+    assert names == {"job-a", "job-b"}
+    row = next(j for j in synced[0] if j["job_name"] == "job-a")
+    assert row["status"] == JobStatus.ACTIVE
+    assert row["interval_seconds"] == 60
+    assert row["payload"] == {"script_path": "x.py"}
+
+
+def test_sync_does_not_use_the_daemons_shared_connection(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression: the sync thread used self._db — one sqlite connection
+    shared with the 1s scheduler loop and the control server — and died
+    mid-read on every sync, before bulk_sync could POST or log. The backend
+    mirror froze for a week on a production box. The sync must read through
+    a private connection, so poisoning the shared one must not matter."""
+    monkeypatch.setenv("OPENCODE_INSTANCE_ID", "inst-xyz")
+
+    daemon = RunnerDaemon(paths=_paths(tmp_path))
+    _add_local(daemon, "job-a")
+
+    def _poisoned(*args, **kwargs):
+        raise sqlite3.ProgrammingError("shared connection used across threads")
+
+    monkeypatch.setattr(daemon._db, "list_jobs", _poisoned)
+    monkeypatch.setattr(daemon._db, "get_job", _poisoned)
+
+    synced: list[list[dict]] = []
+    monkeypatch.setattr(
+        SCHEDULED_JOBS_CLIENT, "bulk_sync", lambda jobs: synced.append(jobs)
+    )
+
+    daemon._sync_to_backend_async()
+
+    assert _wait_for(lambda: len(synced) == 1)
+    assert {j["job_name"] for j in synced[0]} == {"job-a"}
+
+
+def test_side_effect_failure_logs_at_warning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression: side-effect crashes were logged at DEBUG — invisible at the
+    daemon's INFO level — which is how the dying sync went unnoticed."""
+    from loguru import logger
+
+    daemon = RunnerDaemon(paths=_paths(tmp_path))
+
+    records: list[str] = []
+    sink_id = logger.add(lambda message: records.append(str(message)), level="WARNING")
+    try:
+        daemon._run_side_effect(
+            "explode", lambda: (_ for _ in ()).throw(RuntimeError("boom"))
+        )
+        assert _wait_for(lambda: any("explode" in r for r in records))
+    finally:
+        logger.remove(sink_id)
+    assert any("Runner side effect explode failed" in r for r in records)


### PR DESCRIPTION
## Problem

The runner daemon's backend job sync (`bulk_sync`) **silently did nothing on a production box for a week**. The backend's job mirror froze on Aug 6 while the box created and ran new trading jobs the platform never learned about — their per-run reports 404-warned **1,263 times** ("jobs the backend has never seen") while the sync that should have registered them never landed.

Two defects compounded:

1. **The sync thread died before the POST, inside its DB reads.** The evidence is diagnostic but the exact mechanism is unproven: `ScheduledJobsClient.bulk_sync` logs a WARNING on any failure and **zero** were ever emitted across a week of syncs, while `report_run` (whose thread does no DB access before the client call) logged its failures loudly — 1,263 times. So the death happened between thread start and the client call, i.e. in the `self._db` reads on the connection shared with the 1s scheduler loop and the control server. A concurrent-write stress test (60 syncs under ~17k writes on the shared connection) did *not* reproduce the failure on the old code, so the trigger is something narrower than plain contention — a private connection removes the whole class regardless, and the logging fix below guarantees any recurrence is visible with a traceback instead of silent.
2. **Silent death.** `_run_side_effect` caught the crash at `logger.debug` — invisible at the daemon's `INFO` log level — so whatever the exception was, it surfaced nothing. This is the part that made the incident undiagnosable, and the WARNING+traceback change is the part that makes any recurrence diagnosable.

## Fix

- `_sync_to_backend_async` reads through a **private `RunnerDB` connection** opened in the sync thread and closed when done (new `RunnerDB.close()`).
- `_run_side_effect` logs failures at **WARNING with the traceback**.

Once deployed, the next daemon boot heals every stale mirror (boot sync pushes the full registry), and any residual failure is visible in `runnerd.log`.

## Why it matters

The stale mirror is the missing half of the legacy-job off-switch: WayfinderFoundation/vault-backend#1312 adds a durable pause/resume/delete write API for runner jobs and WayfinderFoundation/vault-frontend#2063 wires the UI to it — but the UI can only control jobs the mirror knows about. On the incident box, 4 of 6 live trading jobs were invisible to the platform because of this bug.

## Tests

- `test_sync_to_backend_delivers_full_registry` — end-to-end through `_sync_to_backend_async` (prior tests hand-built the payload and never exercised the async path that was dying).
- `test_sync_does_not_use_the_daemons_shared_connection` — poisons `self._db` and asserts the sync still delivers. **Fails on the old code.**
- `test_side_effect_failure_logs_at_warning` — **fails on the old code** (message emitted at DEBUG).

Runner suite: **35 passed**. ruff check/format clean.

