### PR TITLE
jobs: forced daily ideation sessions with a mechanically checked research artifact

### DIFF
--- a/wayfinder_paths/jobs/decision_log.py
+++ b/wayfinder_paths/jobs/decision_log.py
@@ -221,6 +221,41 @@ def _journal_entries(
                     actor="system",
                 )
             )
+        elif kind == "ideation_artifact":
+            buckets = event.get("buckets") or {}
+            bucket_desc = ", ".join(
+                f"{buckets[name]} {name}"
+                for name in ("testable", "starved", "refuted")
+                if buckets.get(name)
+            )
+            entries.append(
+                _entry(
+                    ts,
+                    "research",
+                    f"Research expedition: {int(event.get('hypotheses') or 0)} "
+                    f"hypotheses from {int(event.get('sources') or 0)} external sources",
+                    bucket_desc,
+                    "info",
+                    actor="agent",
+                )
+            )
+        elif kind == "ideation_incomplete":
+            age_s = event.get("artifact_age_s")
+            detail = (
+                "no expedition artifact has ever been produced"
+                if age_s is None
+                else f"last artifact is {int(age_s) // 3600}h old"
+            )
+            entries.append(
+                _entry(
+                    ts,
+                    "research",
+                    "Research expedition overdue — daily ideation contract not met",
+                    detail,
+                    "info",
+                    actor="system",
+                )
+            )
         elif kind == "data_feed_recovered":
             entries.append(
                 _entry(

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import datetime as dt
 import json
 import os
 from pathlib import Path
@@ -198,6 +199,83 @@ def _research_substrate_block(root: Path) -> dict[str, Any]:
             "automatically as part of the build)."
         )
     return block
+
+
+_IDEATION_PATH = "research/ideation/latest.json"
+_IDEATION_SEEN_PATH = "research/ideation/last_seen.json"
+# Daily expedition, stamp-gated under the wake rhythm (20h, not 24h, so a
+# 30m cadence cannot alias it to every-other-day).
+_IDEATION_DUE_S = 20 * 3600
+_IDEATION_OVERDUE_S = 48 * 3600
+
+
+def _ideation_age_s(root: Path) -> float | None:
+    path = root / _IDEATION_PATH
+    if not path.exists():
+        return None
+    try:
+        doc = json.loads(path.read_text(encoding="utf-8"))
+        stamp = dt.datetime.fromisoformat(str(doc.get("generated_at")))
+    except (ValueError, TypeError):
+        return None
+    if stamp.tzinfo is None:
+        stamp = stamp.replace(tzinfo=dt.UTC)
+    return (dt.datetime.now(dt.UTC) - stamp).total_seconds()
+
+
+def _ideation_bookkeeping(store: JobStore, job_id: str) -> None:
+    """Mechanical accountability for the ideation contract.
+
+    Prose ideation degenerated into "nothing new, agenda stands" 130 wakes in
+    a row — no external tool was ever consulted. The contract is now an
+    ARTIFACT (research/ideation/latest.json); this journals each new artifact
+    into the decision log (owner-visible bucket counts) and escalates once
+    when the expedition is >48h overdue."""
+    root = store.job_dir(job_id)
+    path = root / _IDEATION_PATH
+    seen = store.read_json(job_id, _IDEATION_SEEN_PATH) or {}
+    doc = None
+    if path.exists():
+        try:
+            doc = json.loads(path.read_text(encoding="utf-8"))
+        except ValueError:
+            doc = None
+    generated_at = str((doc or {}).get("generated_at") or "")
+    if doc and generated_at and generated_at != str(seen.get("generated_at") or ""):
+        hypotheses = [h for h in doc.get("hypotheses") or [] if isinstance(h, dict)]
+        buckets: dict[str, int] = {}
+        for h in hypotheses:
+            bucket = str(h.get("bucket") or "unbucketed")
+            buckets[bucket] = buckets.get(bucket, 0) + 1
+        store.append_journal(
+            job_id,
+            {
+                "type": "ideation_artifact",
+                "generated_at": generated_at,
+                "sources": len(doc.get("sources_consulted") or []),
+                "hypotheses": len(hypotheses),
+                "buckets": buckets,
+            },
+        )
+        store.write_json(
+            job_id, _IDEATION_SEEN_PATH, {"generated_at": generated_at}
+        )
+        return
+    age = _ideation_age_s(root)
+    overdue = age is None or age > _IDEATION_OVERDUE_S
+    if overdue and seen.get("escalated_for") != generated_at:
+        store.append_journal(
+            job_id,
+            {
+                "type": "ideation_incomplete",
+                "artifact_age_s": None if age is None else int(age),
+            },
+        )
+        store.write_json(
+            job_id,
+            _IDEATION_SEEN_PATH,
+            {**seen, "escalated_for": generated_at},
+        )
 
 
 def _restage_block(root: Path) -> list[dict[str, Any]]:
@@ -710,18 +788,17 @@ def _build_worker_prompt_sections(
             "tools — no multiplicity control — so what they suggest becomes a "
             "workspace SignalDef or grid hypothesis for the scan/holdout "
             "gate, never direct evidence.\n"
-            "- Ideation cadence: research/agenda.md is the cumulative "
-            "research state — sections: Dead map (refuted, one line of "
-            "evidence each), Open hypotheses (ranked, each citing its "
-            "evidence), Starved (insufficient data, each with an explicit "
-            "unlock condition), and a Last-ideation timestamp. If that "
-            "timestamp is older than ~24h and operations are healthy, spend "
-            "THIS wake as an IDEATION session: start from the agenda plus "
-            "the durable-memory asset dossier, pull world context with the "
-            "research tools (what these assets ARE — sector links, earnings "
-            "calendar, market structure — is evidence), generate and RANK "
-            "structurally different hypotheses, append the best as Open "
-            "entries, and retire or starve stale ones. Reopening a refuted "
+            "- Ideation cadence: ideation is a FORCED session. Roughly daily "
+            "the harness marks a wake as an IDEATION SESSION via a block "
+            "above the snapshot — when present, execute it exactly: named "
+            "external research tools, ranked hypotheses, and the "
+            "research/ideation/latest.json artifact (mechanically checked; "
+            "buckets: testable / starved / refuted). Do NOT run ideation on "
+            "other wakes. research/agenda.md remains the cumulative research "
+            "state — sections: Dead map (refuted, one line of evidence "
+            "each), Open hypotheses (ranked, each citing its evidence), "
+            "Starved (insufficient data, each with an explicit unlock "
+            "condition), and a Last-ideation timestamp. Reopening a refuted "
             "hypothesis requires NAMED new evidence. Keep the agenda compact "
             "(~150 lines): it is a curated map, not a log — compact it in "
             "place as part of updating it.\n"
@@ -751,6 +828,66 @@ def _build_worker_prompt_sections(
             "it as a strategy failure, but DO NOT report the gate as green. "
             "For any other reason, fixing the gate is a priority this wake.\n\n"
         )
+    # Ideation is a FORCED session, not a prose suggestion: 130 consecutive
+    # "nothing new, agenda stands" wakes proved the agent never consults an
+    # external tool unless the wake's task IS the expedition. Stamp-gated on
+    # the artifact itself (~daily); skipped while ops need attention (red
+    # gate, pending re-stage, apply wake) so it lands on the next clean wake.
+    ideation_directive = ""
+    ideation_task_line = ""
+    ideation_age = _ideation_age_s(root)
+    ideation_due = ideation_age is None or ideation_age > _IDEATION_DUE_S
+    if (
+        ideation_due
+        and mode == "intervene"
+        and apply_proposal_id is None
+        and not restage_tasks
+        and not (gate_state and gate_state.get("live_ready") is False)
+    ):
+        age_desc = (
+            "missing (no expedition has ever produced one)"
+            if ideation_age is None
+            else f"{ideation_age / 3600:.0f}h old"
+        )
+        ideation_directive = (
+            "IDEATION SESSION — this wake is a research EXPEDITION, not a "
+            "routine review.\n"
+            f"The external-research artifact ({_IDEATION_PATH}) is {age_desc}; "
+            "the contract is one expedition per day.\n"
+            "Give routine ops ONE glance (act only if something is red), then:\n"
+            "1. Consult at least 3 DISTINCT external sources via named research "
+            "tool calls — research_search_alpha, research_crypto_sentiment, "
+            "research_social_x_search, research_search_perp, web search/fetch. "
+            "Re-reading the agenda, memory, or internal scan results does NOT "
+            "count as a source.\n"
+            "2. Look OUTWARD at the next 1-2 weeks for YOUR symbols and their "
+            "sector: scheduled events, token unlocks, listings, macro prints, "
+            "funding-regime shifts, narrative rotation.\n"
+            "3. Write research/ideation/latest.json with exactly this shape: "
+            '{"generated_at": "<UTC ISO8601>", "sources_consulted": [{"tool": '
+            '..., "query": ..., "takeaway": ...}], "hypotheses": [{"title": '
+            '..., "thesis": ..., "bucket": "testable"|"starved"|"refuted", '
+            '"next_step": ...}]} — hypotheses ranked best-first, at least 3, '
+            "every one bucketed honestly:\n"
+            "   - testable: next_step names the exact scan/SignalDef/feature "
+            "run to do NOW with data you already have.\n"
+            "   - starved: next_step names the unlock condition — the data or "
+            "feature that must exist first (e.g. an events/catalyst feed that "
+            "is not built yet). Naming missing data is a VALID and valuable "
+            "outcome, not a failure.\n"
+            "   - refuted: next_step names the disqualifying evidence.\n"
+            "4. Fold the artifact into research/agenda.md (curated + compact, "
+            "as usual).\n"
+            "A 'nothing actionable' expedition is valid ONLY if "
+            "sources_consulted proves you looked. The artifact is checked "
+            "mechanically each wake; a missing or stale artifact is journaled "
+            "as ideation_incomplete for the owner to see.\n\n"
+        )
+        ideation_task_line = (
+            "- This wake is an IDEATION SESSION: execute the IDEATION SESSION "
+            "block above the snapshot, including writing "
+            "research/ideation/latest.json.\n"
+        )
     restage_priority = ""
     restage_task_line = ""
     if restage_tasks:
@@ -779,6 +916,7 @@ def _build_worker_prompt_sections(
         f"{DYNAMIC_CONTEXT_MARKER}\n"
         f"{gate_alert}"
         f"{restage_priority}"
+        f"{ideation_directive}"
         "Current snapshot:\n"
         f"{_canonical_json(dynamic_payload, max_chars=12000)}\n\n"
         "Research agenda (research/agenda.md — cumulative exploration "
@@ -788,6 +926,7 @@ def _build_worker_prompt_sections(
         f"{recent_journal}\n\n"
         "Task:\n"
         f"{restage_task_line}"
+        f"{ideation_task_line}"
         f"{task_line}"
         "- Write the appropriate monitor/intervene/auto/apply report.\n"
         "- Emit a user-visible result only for meaningful state transitions, "
@@ -842,6 +981,11 @@ def prepare_job_worker_prompt(
     # merging cleanly into every scan frame). Stamp-gated hourly; never
     # raises.
     refresh_derived_features_if_stale(job.id, store=store)
+
+    # Ideation accountability: journal freshly produced expedition artifacts
+    # (owner-visible bucket counts) and escalate once when the daily research
+    # expedition is >48h overdue. Never raises.
+    _ideation_bookkeeping(store, job.id)
 
     prompt_sections = _build_worker_prompt_sections(
         store=store,

--- a/wayfinder_paths/tests/test_jobs_decision_log.py
+++ b/wayfinder_paths/tests/test_jobs_decision_log.py
@@ -288,3 +288,40 @@ def test_data_feed_events_reach_the_feed(tmp_path) -> None:
     assert "out_of_credits" in degraded
     assert "top up API credits" in degraded
     assert any(t == "Data feed recovered" for t in titles)
+
+
+def test_ideation_events_reach_the_feed(tmp_path) -> None:
+    """Research expeditions must be owner-visible: artifacts show ranked
+    bucket counts, and an overdue expedition names the broken contract."""
+    store, job_id = _mk(tmp_path)
+    root = store.job_dir(job_id)
+    journal = [
+        {
+            "ts": _ts(10),
+            "type": "ideation_artifact",
+            "generated_at": "2026-08-12T00:00:00+00:00",
+            "sources": 4,
+            "hypotheses": 5,
+            "buckets": {"testable": 1, "starved": 3, "refuted": 1},
+        },
+        {"ts": _ts(2), "type": "ideation_incomplete", "artifact_age_s": 180000},
+    ]
+    (root / "journal.jsonl").write_text(
+        "\n".join(json.dumps(row) for row in journal) + "\n", encoding="utf-8"
+    )
+
+    log = build_decision_log(store, job_id)
+    by_title = {entry["title"]: entry for entry in log["entries"]}
+    artifact = next(
+        entry
+        for title, entry in by_title.items()
+        if title.startswith("Research expedition: 5 hypotheses")
+    )
+    assert "4 external sources" in artifact["title"]
+    assert "1 testable, 3 starved, 1 refuted" in artifact["detail"]
+    overdue = next(
+        entry
+        for title, entry in by_title.items()
+        if title.startswith("Research expedition overdue")
+    )
+    assert "50h old" in overdue["detail"]

--- a/wayfinder_paths/tests/test_wayfinder_jobs.py
+++ b/wayfinder_paths/tests/test_wayfinder_jobs.py
@@ -19,6 +19,7 @@ from wayfinder_paths.jobs.worker import (
     DYNAMIC_CONTEXT_MARKER,
     STABLE_PREFIX_END_MARKER,
     _build_worker_prompt_sections,
+    _ideation_bookkeeping,
     run_job_worker,
 )
 
@@ -1333,3 +1334,188 @@ def test_worker_prompt_hoists_red_gate_out_of_snapshot(tmp_path: Path) -> None:
         ),
     )
     assert "GATE STATUS: RED" not in green["dynamic_context"]
+
+
+def _write_ideation_artifact(store: JobStore, job_id: str, *, age_hours: float) -> None:
+    import datetime as dt
+
+    path = store.job_dir(job_id) / "research" / "ideation" / "latest.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    stamp = dt.datetime.now(dt.UTC) - dt.timedelta(hours=age_hours)
+    path.write_text(
+        json.dumps(
+            {
+                "generated_at": stamp.isoformat(),
+                "sources_consulted": [
+                    {"tool": "research_search_alpha", "query": "sol unlocks", "takeaway": "none"},
+                    {"tool": "research_crypto_sentiment", "query": "SOL", "takeaway": "neutral"},
+                    {"tool": "research_social_x_search", "query": "solana catalyst", "takeaway": "fee vote"},
+                ],
+                "hypotheses": [
+                    {"title": "A", "thesis": "t", "bucket": "testable", "next_step": "scan"},
+                    {"title": "B", "thesis": "t", "bucket": "starved", "next_step": "needs events feed"},
+                    {"title": "C", "thesis": "t", "bucket": "refuted", "next_step": "no edge in 2024-2026"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_worker_prompt_forces_ideation_when_artifact_stale(tmp_path: Path) -> None:
+    """Ideation is a FORCED session: prose suggestions produced 130 straight
+    "nothing new" wakes with zero external tool calls. When the expedition
+    artifact is missing or >20h old, the wake's task IS the expedition."""
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        "ideation-demo",
+        goal="Find edges.",
+        script="workspace/src/loop.py",
+        agent_mode="intervene",
+    )
+    store.save(job)
+
+    forced = _build_worker_prompt_sections(
+        store=store,
+        job_id=job.id,
+        mode="intervene",
+        snapshot=_worker_snapshot(job, scorecard={"health": "green"}),
+    )
+    dynamic = forced["dynamic_context"]
+    at = dynamic.index("IDEATION SESSION — this wake is a research EXPEDITION")
+    assert at < dynamic.index("Current snapshot:")
+    assert "research/ideation/latest.json" in dynamic
+    assert '"testable"|"starved"|"refuted"' in dynamic
+    assert "This wake is an IDEATION SESSION" in dynamic
+    assert "at least 3 DISTINCT external sources" in dynamic
+
+    # Fresh artifact → back to routine wakes.
+    _write_ideation_artifact(store, job.id, age_hours=2)
+    routine = _build_worker_prompt_sections(
+        store=store,
+        job_id=job.id,
+        mode="intervene",
+        snapshot=_worker_snapshot(job, scorecard={"health": "green"}),
+    )
+    assert "IDEATION SESSION — this wake is a research EXPEDITION" not in routine["dynamic_context"]
+
+    # Stale again after ~a day.
+    _write_ideation_artifact(store, job.id, age_hours=26)
+    stale = _build_worker_prompt_sections(
+        store=store,
+        job_id=job.id,
+        mode="intervene",
+        snapshot=_worker_snapshot(job, scorecard={"health": "green"}),
+    )
+    assert "IDEATION SESSION — this wake is a research EXPEDITION" in stale["dynamic_context"]
+    assert "26h old" in stale["dynamic_context"]
+
+
+def test_ideation_defers_to_ops_priorities(tmp_path: Path) -> None:
+    """The expedition lands on the next CLEAN wake: red gates, pending
+    re-stages, apply wakes, and monitor mode all suppress it."""
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        "ideation-defer-demo",
+        goal="Ops first.",
+        script="workspace/src/loop.py",
+        agent_mode="intervene",
+    )
+    store.save(job)
+
+    red_gate = _build_worker_prompt_sections(
+        store=store,
+        job_id=job.id,
+        mode="intervene",
+        snapshot=_worker_snapshot(
+            job,
+            scorecard={"health": "green"},
+            gate={"live_ready": False, "reasons": ["backtest is stale"]},
+        ),
+    )
+    assert "IDEATION SESSION — this wake is a research EXPEDITION" not in red_gate["dynamic_context"]
+
+    monitor = _build_worker_prompt_sections(
+        store=store,
+        job_id=job.id,
+        mode="monitor",
+        snapshot=_worker_snapshot(job, scorecard={"health": "green"}),
+    )
+    assert "IDEATION SESSION — this wake is a research EXPEDITION" not in monitor["dynamic_context"]
+
+    apply_wake = _build_worker_prompt_sections(
+        store=store,
+        job_id=job.id,
+        mode="intervene",
+        snapshot=_worker_snapshot(job, scorecard={"health": "green"}),
+        apply_proposal_id="prop-params-update-aaaa1111",
+    )
+    assert "IDEATION SESSION — this wake is a research EXPEDITION" not in apply_wake["dynamic_context"]
+
+    proposals_dir = store.job_dir(job.id) / "proposals"
+    proposals_dir.mkdir(parents=True, exist_ok=True)
+    (proposals_dir / "prop-params-update-bbbb2222.json").write_text(
+        json.dumps(
+            {
+                "proposal_id": "prop-params-update-bbbb2222",
+                "status": "approved",
+                "proposed_change": {"summary": "s", "execution_params": {"x": 1}},
+                "application": {"status": "failed", "restage_requested": True},
+            }
+        ),
+        encoding="utf-8",
+    )
+    restage_wake = _build_worker_prompt_sections(
+        store=store,
+        job_id=job.id,
+        mode="intervene",
+        snapshot=_worker_snapshot(job, scorecard={"health": "green"}),
+    )
+    assert "IDEATION SESSION — this wake is a research EXPEDITION" not in restage_wake["dynamic_context"]
+
+
+def test_ideation_bookkeeping_journals_artifacts_and_overdue(tmp_path: Path) -> None:
+    """New artifacts journal once with bucket counts; a >48h-overdue
+    expedition escalates once per episode."""
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        "ideation-books-demo",
+        goal="Honest ledger.",
+        script="workspace/src/loop.py",
+        agent_mode="intervene",
+    )
+    store.save(job)
+    journal_path = store.job_dir(job.id) / "journal.jsonl"
+
+    def journal_types() -> list[str]:
+        if not journal_path.exists():
+            return []
+        return [
+            json.loads(line)["type"]
+            for line in journal_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+
+    # No artifact ever → escalate once, not every wake.
+    _ideation_bookkeeping(store, job.id)
+    _ideation_bookkeeping(store, job.id)
+    assert journal_types().count("ideation_incomplete") == 1
+
+    # Fresh artifact → journaled once with bucket counts, seen-stamped.
+    _write_ideation_artifact(store, job.id, age_hours=1)
+    _ideation_bookkeeping(store, job.id)
+    _ideation_bookkeeping(store, job.id)
+    assert journal_types().count("ideation_artifact") == 1
+    artifact_event = next(
+        json.loads(line)
+        for line in journal_path.read_text(encoding="utf-8").splitlines()
+        if json.loads(line)["type"] == "ideation_artifact"
+    )
+    assert artifact_event["hypotheses"] == 3
+    assert artifact_event["sources"] == 3
+    assert artifact_event["buckets"] == {"testable": 1, "starved": 1, "refuted": 1}
+
+    # A NEW expedition (different generated_at) journals again.
+    _write_ideation_artifact(store, job.id, age_hours=0)
+    _ideation_bookkeeping(store, job.id)
+    assert journal_types().count("ideation_artifact") == 2


### PR DESCRIPTION
## Problem

The majors agent logged 130 consecutive "Ideation session: nothing new, agenda stands" entries without a single external research tool call. `research/agenda.md` contains zero external content. The ideation instruction was aspirational prose with no forcing function — the same failure mode that verification bars fixed for evidence claims.

## What this does

**Forced expedition, stamp-gated (~daily):** when `research/ideation/latest.json` is missing or >20h old, the next clean intervene wake becomes an IDEATION SESSION via a hoisted block above the snapshot (prompt text — never payload-only JSON, per the restage/gate-alert lesson). The block requires:

1. ≥3 distinct **named** external research tool calls (`research_search_alpha`, `research_crypto_sentiment`, `research_social_x_search`, `research_search_perp`, web search/fetch) — internal re-reads don't count
2. An outward look at the next 1–2 weeks: events, unlocks, listings, macro prints, funding-regime shifts
3. `research/ideation/latest.json` — sources consulted + ≥3 ranked hypotheses, each in one honest bucket:
   - **testable** — exact scan/SignalDef next step with data we already have
   - **starved** — named unlock condition (e.g. the events/catalyst feed that isn't built yet); explicitly framed as a valid, valuable outcome
   - **refuted** — named disqualifying evidence
4. Fold into `agenda.md` as usual

"Nothing actionable" is valid only if `sources_consulted` proves the tools were tried.

**Defers to ops:** red gate, pending re-stage, apply wakes, and monitor mode all suppress the session; it lands on the next clean wake (cadence is 20h so 30-min slips don't matter).

**Mechanical accountability:** `_ideation_bookkeeping` (runs each wake prep, never raises) journals every new artifact (`ideation_artifact` with source/bucket counts) and escalates once per episode when the expedition is >48h overdue (`ideation_incomplete`). Both are mapped in the decision log so the owner sees "Research expedition: 5 hypotheses from 4 external sources — 1 testable, 3 starved, 1 refuted" in the Activity feed.

The stable-prefix ideation bullet is rewritten to defer to the forced block (no more self-timed ideation on other wakes).

## Deliberately out of scope

The events/catalyst **feature pipe** (making catalyst timing backtestable) — deferred by owner decision. Until it exists, catalyst hypotheses land in the *starved* bucket naming that missing feed, which doubles as demand signal for building it.

## Tests

- Forced when artifact missing / >20h old; released by a fresh artifact; age rendered in the block
- Suppressed on red gate, pending re-stage, apply wakes, monitor mode
- Bookkeeping: artifact journaled once with correct bucket counts, re-journaled on new `generated_at`, overdue escalation fires once per episode (incl. the never-produced case)
- Decision-log rendering for both events

104 tests green across the touched suites (`test_wayfinder_jobs`, `test_jobs_decision_log`, plus propose/triggers/watchdog/gating/derived-features regression). mypy clean on both touched files.
