### PR TITLE
jobs: economic promotion gate under an owner constitution + evolution ledger (PR A)

### DIFF
--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -981,6 +981,17 @@ def gate_cmd(job_id: str) -> None:
 
 
 @job_cli.command(
+    name="evolution",
+    help="Full update path + promotion reliability (evolution ledger).",
+)
+@click.argument("job_id")
+def evolution_cmd(job_id: str) -> None:
+    from wayfinder_paths.jobs.evolution_ledger import build_evolution_report
+
+    _echo_json({"ok": True, "result": build_evolution_report(JobStore(), job_id)})
+
+
+@job_cli.command(
     name="backtest-view", help="Read a bounded backtest visualization payload."
 )
 @click.argument("job_id")

--- a/wayfinder_paths/jobs/constitution.py
+++ b/wayfinder_paths/jobs/constitution.py
@@ -1,0 +1,90 @@
+"""Owner-owned optimization constitution: the protected economic standard a
+candidate must beat to be promoted.
+
+The file lives at the JOB ROOT (`constitution.yaml`), deliberately outside
+`workspace/` — it is not part of the workspace revision hash, is never staged
+into candidate workspaces, and agents read it but cannot activate changes to
+it. Agents may PROPOSE a new constitution as prose/diff for the owner; only a
+human editing the file changes the standard. This is the L4 boundary: the
+loop being judged must not be able to redefine what "better" means.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+CONSTITUTION_FILENAME = "constitution.yaml"
+
+# Applied when a job has no constitution.yaml yet: the economic gate still
+# computes and reports, but cannot block — existing jobs keep promoting under
+# the technical gate until the owner installs a constitution.
+DEFAULT_CONSTITUTION: dict[str, Any] = {
+    "version": 1,
+    "enforcement": "advisory",
+    "objective": {
+        # U = growth − λ·downside_deviation − κ·tail_loss − η·fee_load
+        "weights": {"downside": 0.5, "tail": 1.0, "turnover": 0.25},
+    },
+    "evaluation": {
+        "folds": 4,
+        "confidence": 0.90,
+        "bootstrap_iterations": 500,
+        "block_days": 5,
+        "audit_days": 7,
+    },
+    "promotion": {
+        "required_positive_folds": 2,
+        "min_oos_trades": 8,
+        "audit_min_delta_utility": -0.005,
+        # Probation-flagged proposals (reduced-size canary legs) clear on a
+        # positive point estimate instead of the LCB — small-sample jobs must
+        # stay movable; full-size promotion is where the LCB bites.
+        "probation_requires_lcb": False,
+    },
+    "hard_constraints": {
+        "max_drawdown_pct": 0.25,
+        "max_tail_loss": 0.15,
+    },
+}
+
+
+def load_constitution(root: Path) -> dict[str, Any]:
+    """Load the job's constitution, merged over defaults.
+
+    Returns the DEFAULT_CONSTITUTION (enforcement=advisory) when the file is
+    absent or unparseable — a broken constitution must degrade to advisory,
+    never brick promotion or silently enforce garbage.
+    """
+    path = root / CONSTITUTION_FILENAME
+    if not path.exists():
+        return {**DEFAULT_CONSTITUTION, "revision": None, "source": "defaults"}
+    try:
+        loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError:
+        loaded = None
+    if not isinstance(loaded, dict):
+        return {**DEFAULT_CONSTITUTION, "revision": None, "source": "defaults"}
+    merged = _merge(DEFAULT_CONSTITUTION, loaded)
+    merged["revision"] = constitution_revision(path)
+    merged["source"] = "file"
+    return merged
+
+
+def constitution_revision(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:12]
+
+
+def _merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            merged[key] = _merge(base[key], value)
+        else:
+            merged[key] = value
+    return merged

--- a/wayfinder_paths/jobs/counterfactual.py
+++ b/wayfinder_paths/jobs/counterfactual.py
@@ -132,7 +132,62 @@ def counterfactual_job(
         "actual_closes_total": actual_closes_total,
     }
     store.write_json(job_id, COUNTERFACTUAL_PATH, artifact)
+    _maybe_record_promotion_verdict(store, job_id, artifact)
     return artifact
+
+
+# Verdict maturity: enough forward window that beat/hurt is not one bar of
+# noise, sized to our jobs' trade cadence (days between closes).
+_VERDICT_MIN_DAYS = 3.0
+_VERDICT_MIN_CLOSES = 3
+_VERDICTS_PATH = "state/promotion_verdicts.json"
+
+
+def _maybe_record_promotion_verdict(
+    store: JobStore, job_id: str, artifact: dict[str, Any]
+) -> None:
+    """Once per promotion: classify the forward shadow comparison as
+    beat/neutral/hurt and persist it — the promotion-reliability datapoint
+    the evolution ledger aggregates. Never raises."""
+    try:
+        proposal_id = str(artifact.get("proposal_id") or "")
+        window = artifact.get("window") or {}
+        if not proposal_id or not artifact.get("available"):
+            return
+        closes = max(
+            int((artifact.get("actual") or {}).get("closes") or 0),
+            int((artifact.get("shadow") or {}).get("closes") or 0),
+        )
+        if float(window.get("days") or 0.0) < _VERDICT_MIN_DAYS:
+            return
+        if closes < _VERDICT_MIN_CLOSES:
+            return
+        verdicts = store.read_json(job_id, _VERDICTS_PATH) or {}
+        if proposal_id in verdicts:
+            return
+        delta = float(artifact.get("delta_net_pnl") or 0.0)
+        shadow_pnl = float((artifact.get("shadow") or {}).get("net_pnl") or 0.0)
+        threshold = max(0.25, 0.02 * abs(shadow_pnl))
+        verdict = "beat" if delta > threshold else "hurt" if delta < -threshold else "neutral"
+        record = {
+            "verdict": verdict,
+            "delta_net_pnl": delta,
+            "window_days": window.get("days"),
+            "closes": closes,
+            "recorded_at": utc_now_iso(),
+        }
+        verdicts[proposal_id] = record
+        store.write_json(job_id, _VERDICTS_PATH, verdicts)
+        store.append_journal(
+            job_id,
+            {
+                "type": "promotion_verdict",
+                "proposal_id": proposal_id,
+                **record,
+            },
+        )
+    except Exception:  # noqa: BLE001 — bookkeeping must not break the wake
+        return
 
 
 def _compute(

--- a/wayfinder_paths/jobs/decision_log.py
+++ b/wayfinder_paths/jobs/decision_log.py
@@ -221,6 +221,26 @@ def _journal_entries(
                     actor="system",
                 )
             )
+        elif kind == "promotion_verdict":
+            verdict = str(event.get("verdict") or "unknown")
+            delta = float(event.get("delta_net_pnl") or 0.0)
+            label = {
+                "beat": "beat the incumbent",
+                "neutral": "ran even with the incumbent",
+                "hurt": "underperformed the incumbent",
+            }.get(verdict, verdict)
+            entries.append(
+                _entry(
+                    ts,
+                    "proposal",
+                    f"Forward verdict: promoted change {label} ({delta:+.2f} USD)",
+                    f"{event.get('window_days')}d shadow window, "
+                    f"{event.get('closes')} closes",
+                    "info",
+                    actor="system",
+                    proposal_id=str(event.get("proposal_id") or "") or None,
+                )
+            )
         elif kind == "ideation_artifact":
             buckets = event.get("buckets") or {}
             bucket_desc = ", ".join(

--- a/wayfinder_paths/jobs/economics.py
+++ b/wayfinder_paths/jobs/economics.py
@@ -1,0 +1,368 @@
+"""Economic promotion evidence: objective vectors, the owner utility, and the
+paired candidate-vs-incumbent fold evaluation behind `economic_ready`.
+
+Design constraints this module encodes:
+- The gate replays BOTH param/code sets on the same outer OOS folds with the
+  same bars and costs — inner parameter selection already happened during
+  development, so no search runs here (K folds x 2 sides of test-window sims).
+- The confidence bound is on the GROWTH delta via a moving-block bootstrap of
+  paired daily log-return deltas; risk terms (downside, tail, fees) enter the
+  utility as point estimates. Conservative and small-sample-sane: at 24-160
+  trades a full multivariate bootstrap would be theater.
+- The terminal audit slice is excluded from the fold layout and evaluated
+  once, by this code, at decision time. Agents can technically backtest over
+  those bars during development, so this is freshness pressure rather than a
+  cryptographic seal — the honest 80% of a sealed-audit service.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from collections import defaultdict
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from wayfinder_paths.jobs.execution.primitives import ExecutionSpec
+from wayfinder_paths.jobs.execution.simulator import (
+    PreparedExecutionDataset,
+    simulate_execution,
+)
+from wayfinder_paths.jobs.execution.walk_forward import _slice
+
+
+def objective_vector(
+    equity_curve: list[Mapping[str, Any]],
+    trades: list[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Return/risk quantities the owner utility is defined over. Downside
+    deviation (not plain variance) so upside volatility is not penalized."""
+    daily = daily_log_returns(equity_curve)
+    returns = [value for _, value in daily]
+    growth = sum(returns)
+    negatives = [value for value in returns if value < 0]
+    downside = (
+        math.sqrt(sum(value * value for value in negatives) / len(returns))
+        if returns
+        else 0.0
+    )
+    base_equity = float(equity_curve[0]["equity"]) if equity_curve else 0.0
+    pnls = [float(row.get("pnl") or 0.0) for row in trades]
+    worst_k = max(1, len(pnls) // 10)
+    tail_loss = (
+        abs(sum(sorted(pnls)[:worst_k])) / base_equity if base_equity > 0 else 0.0
+    )
+    fees = sum(float(row.get("fee") or 0.0) for row in trades)
+    fee_load = fees / base_equity if base_equity > 0 else 0.0
+    max_dd = _max_drawdown(equity_curve)
+    return {
+        "net_log_growth": growth,
+        "downside_deviation": downside,
+        "tail_loss": tail_loss,
+        "fee_load": fee_load,
+        "max_drawdown_pct": max_dd,
+        "trade_count": len(trades),
+        "day_count": len(returns),
+    }
+
+
+def utility(vector: Mapping[str, Any], weights: Mapping[str, Any]) -> float:
+    return (
+        float(vector["net_log_growth"])
+        - float(weights.get("downside", 0.0)) * float(vector["downside_deviation"])
+        - float(weights.get("tail", 0.0)) * float(vector["tail_loss"])
+        - float(weights.get("turnover", 0.0)) * float(vector["fee_load"])
+    )
+
+
+def daily_log_returns(
+    equity_curve: list[Mapping[str, Any]],
+) -> list[tuple[str, float]]:
+    """Calendar-day log returns from an equity curve (last equity per day)."""
+    by_day: dict[str, float] = {}
+    for row in equity_curve:
+        day = str(pd.Timestamp(row["timestamp"]).date())
+        by_day[day] = float(row["equity"])
+    days = sorted(by_day)
+    returns: list[tuple[str, float]] = []
+    for prev, cur in zip(days, days[1:], strict=False):
+        if by_day[prev] > 0 and by_day[cur] > 0:
+            returns.append((cur, math.log(by_day[cur] / by_day[prev])))
+    return returns
+
+
+def paired_daily_deltas(
+    baseline: list[tuple[str, float]],
+    candidate: list[tuple[str, float]],
+) -> list[float]:
+    """Candidate-minus-baseline log return on the intersection of days —
+    paired so common market moves cancel out of the delta."""
+    base_map = dict(baseline)
+    return [value - base_map[day] for day, value in candidate if day in base_map]
+
+
+def block_bootstrap_lcb(
+    deltas: list[float],
+    *,
+    block_len: int,
+    iterations: int,
+    confidence: float,
+    seed: int = 7,
+) -> float | None:
+    """Lower confidence bound on the TOTAL growth delta via a circular
+    moving-block bootstrap. None when there is nothing to resample."""
+    n = len(deltas)
+    if n < 2:
+        return None
+    block = max(1, min(block_len, n))
+    rng = random.Random(seed)
+    blocks_needed = math.ceil(n / block)
+    totals: list[float] = []
+    for _ in range(iterations):
+        sample: list[float] = []
+        for _ in range(blocks_needed):
+            start = rng.randrange(n)
+            sample.extend(deltas[(start + offset) % n] for offset in range(block))
+        totals.append(sum(sample[:n]))
+    totals.sort()
+    index = int((1.0 - confidence) * (iterations - 1))
+    return totals[index]
+
+
+def paired_fold_evaluation(
+    *,
+    baseline_script: str | Path | Callable[..., Any],
+    candidate_script: str | Path | Callable[..., Any],
+    dataset: PreparedExecutionDataset,
+    spec: ExecutionSpec,
+    baseline_params: Mapping[str, Any],
+    candidate_params: Mapping[str, Any],
+    constitution: Mapping[str, Any],
+    warmup_bars: int = 60,
+) -> dict[str, Any]:
+    """Replay both sides on identical outer OOS folds + the terminal audit
+    slice; return the paired evidence the economic gate decides on."""
+    evaluation = constitution["evaluation"]
+    weights = constitution["objective"]["weights"]
+    folds = int(evaluation["folds"])
+    timestamps = dataset.bars.timestamps
+    total = len(timestamps)
+
+    bar_seconds = _bar_seconds(spec)
+    audit_bars = max(1, int(evaluation["audit_days"] * 86_400 // bar_seconds))
+    dev_total = total - audit_bars
+    # Fold the most recent THIRD of development history: recent regime is what
+    # promotion risks money on, and bounded test windows keep this affordable.
+    test_bars = max(1, min(dev_total // (folds * 3), dev_total // folds))
+    min_history = warmup_bars + folds * test_bars
+    if dev_total <= min_history or test_bars < 8:
+        return {
+            "status": "insufficient_history",
+            "detail": (
+                f"{total} bars with audit_bars={audit_bars} cannot fit "
+                f"{folds} folds (needs > {min_history + audit_bars})"
+            ),
+        }
+
+    fold_rows: list[dict[str, Any]] = []
+    baseline_daily: list[tuple[str, float]] = []
+    candidate_daily: list[tuple[str, float]] = []
+    baseline_pool: dict[str, list[Any]] = defaultdict(list)
+    candidate_pool: dict[str, list[Any]] = defaultdict(list)
+    for index in range(folds):
+        test_end = dev_total - (folds - 1 - index) * test_bars
+        test_start = test_end - test_bars
+        side_rows = {}
+        for side, script, params in (
+            ("baseline", baseline_script, baseline_params),
+            ("candidate", candidate_script, candidate_params),
+        ):
+            equity, trades = _oos_window(
+                script, dataset, spec, params, timestamps, test_start, test_end,
+                warmup_bars,
+            )
+            vector = objective_vector(equity, trades)
+            side_rows[side] = vector
+            pool = baseline_pool if side == "baseline" else candidate_pool
+            pool["equity"].extend(equity)
+            pool["trades"].extend(trades)
+            daily = daily_log_returns(equity)
+            (baseline_daily if side == "baseline" else candidate_daily).extend(daily)
+        fold_rows.append(
+            {
+                "fold": index,
+                "test": {
+                    "start": str(timestamps[test_start]),
+                    "end": str(timestamps[test_end - 1]),
+                    "bars": test_bars,
+                },
+                "baseline": side_rows["baseline"],
+                "candidate": side_rows["candidate"],
+                "delta_utility": utility(side_rows["candidate"], weights)
+                - utility(side_rows["baseline"], weights),
+            }
+        )
+
+    baseline_vector = objective_vector(
+        baseline_pool["equity"], baseline_pool["trades"]
+    )
+    candidate_vector = objective_vector(
+        candidate_pool["equity"], candidate_pool["trades"]
+    )
+    deltas = paired_daily_deltas(baseline_daily, candidate_daily)
+    growth_lcb = block_bootstrap_lcb(
+        deltas,
+        block_len=int(evaluation["block_days"]),
+        iterations=int(evaluation["bootstrap_iterations"]),
+        confidence=float(evaluation["confidence"]),
+    )
+    delta_estimate = utility(candidate_vector, weights) - utility(
+        baseline_vector, weights
+    )
+    # Conservative composite: growth term at its LCB, risk terms at their
+    # point estimates. See module docstring for why.
+    delta_lcb = None
+    if growth_lcb is not None:
+        risk_delta = delta_estimate - (
+            float(candidate_vector["net_log_growth"])
+            - float(baseline_vector["net_log_growth"])
+        )
+        delta_lcb = growth_lcb + risk_delta
+
+    audit_rows = {}
+    for side, script, params in (
+        ("baseline", baseline_script, baseline_params),
+        ("candidate", candidate_script, candidate_params),
+    ):
+        equity, trades = _oos_window(
+            script, dataset, spec, params, timestamps, dev_total, total, warmup_bars
+        )
+        audit_rows[side] = objective_vector(equity, trades)
+    audit_delta = utility(audit_rows["candidate"], weights) - utility(
+        audit_rows["baseline"], weights
+    )
+
+    return {
+        "status": "ok",
+        "folds": fold_rows,
+        "fold_count": folds,
+        "positive_folds": sum(1 for row in fold_rows if row["delta_utility"] > 0),
+        "objective": {"baseline": baseline_vector, "candidate": candidate_vector},
+        "paired_incumbent_delta": {
+            "estimate": delta_estimate,
+            "lcb": delta_lcb,
+            "confidence": float(evaluation["confidence"]),
+            "paired_days": len(deltas),
+        },
+        "audit_slice": {
+            "start": str(timestamps[dev_total]),
+            "end": str(timestamps[total - 1]),
+            "bars": audit_bars,
+            "baseline": audit_rows["baseline"],
+            "candidate": audit_rows["candidate"],
+            "delta_utility": audit_delta,
+        },
+    }
+
+
+def evaluate_economic_readiness(
+    report: Mapping[str, Any],
+    constitution: Mapping[str, Any],
+    *,
+    probation: bool = False,
+) -> dict[str, Any]:
+    """Map paired evidence to ready/reasons under the constitution. Pure
+    policy — no simulation — so enforcement stays trivially testable."""
+    promotion = constitution["promotion"]
+    hard = constitution["hard_constraints"]
+    reasons: list[str] = []
+    if report.get("status") != "ok":
+        reasons.append(f"economic evaluation unavailable: {report.get('detail')}")
+        return {"ready": False, "reasons": reasons, "probation": probation}
+
+    candidate = report["objective"]["candidate"]
+    if float(candidate["max_drawdown_pct"]) > float(hard["max_drawdown_pct"]):
+        reasons.append(
+            f"OOS max drawdown {candidate['max_drawdown_pct']:.3f} exceeds "
+            f"ceiling {hard['max_drawdown_pct']}"
+        )
+    if float(candidate["tail_loss"]) > float(hard["max_tail_loss"]):
+        reasons.append(
+            f"OOS tail loss {candidate['tail_loss']:.3f} exceeds ceiling "
+            f"{hard['max_tail_loss']}"
+        )
+    if int(candidate["trade_count"]) < int(promotion["min_oos_trades"]):
+        reasons.append(
+            f"OOS trade count {candidate['trade_count']} below minimum "
+            f"{promotion['min_oos_trades']}"
+        )
+    if int(report["positive_folds"]) < int(promotion["required_positive_folds"]):
+        reasons.append(
+            f"positive OOS folds {report['positive_folds']}/{report['fold_count']} "
+            f"below required {promotion['required_positive_folds']}"
+        )
+    delta = report["paired_incumbent_delta"]
+    require_lcb = not probation or bool(promotion["probation_requires_lcb"])
+    if require_lcb:
+        if delta["lcb"] is None:
+            reasons.append("paired delta LCB unavailable (too few paired days)")
+        elif float(delta["lcb"]) <= 0:
+            reasons.append(
+                f"paired utility delta LCB {delta['lcb']:.4f} not > 0 at "
+                f"{delta['confidence']:.0%} confidence"
+            )
+    elif float(delta["estimate"]) <= 0:
+        reasons.append(
+            f"paired utility delta estimate {delta['estimate']:.4f} not > 0 "
+            "(probation bar)"
+        )
+    audit_delta = float(report["audit_slice"]["delta_utility"])
+    if audit_delta < float(promotion["audit_min_delta_utility"]):
+        reasons.append(
+            f"audit-slice utility delta {audit_delta:.4f} below floor "
+            f"{promotion['audit_min_delta_utility']}"
+        )
+    return {"ready": not reasons, "reasons": reasons, "probation": probation}
+
+
+def _oos_window(
+    script: str | Path | Callable[..., Any],
+    dataset: PreparedExecutionDataset,
+    spec: ExecutionSpec,
+    params: Mapping[str, Any],
+    timestamps: list[pd.Timestamp],
+    test_start: int,
+    test_end: int,
+    warmup_bars: int,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    eval_start = max(0, test_start - warmup_bars)
+    window = _slice(dataset, timestamps, eval_start, test_end)
+    result = simulate_execution(script, window, spec, dict(params))
+    boundary = timestamps[test_start]
+    equity = [
+        row for row in result.equity_curve if pd.Timestamp(row["timestamp"]) >= boundary
+    ]
+    trades = [
+        row for row in result.trades if pd.Timestamp(row["timestamp"]) >= boundary
+    ]
+    return equity, trades
+
+
+def _bar_seconds(spec: ExecutionSpec) -> int:
+    from wayfinder_paths.jobs.execution.primitives import bar_interval_seconds
+
+    return bar_interval_seconds(spec.data_contract.get("bar_interval"))
+
+
+def _max_drawdown(equity_curve: list[Mapping[str, Any]]) -> float:
+    peak = 0.0
+    worst = 0.0
+    for row in equity_curve:
+        value = float(row["equity"])
+        peak = max(peak, value)
+        if peak > 0:
+            worst = max(worst, (peak - value) / peak)
+    return worst

--- a/wayfinder_paths/jobs/evolution_ledger.py
+++ b/wayfinder_paths/jobs/evolution_ledger.py
@@ -1,0 +1,158 @@
+"""Evolution ledger: the full update path of a job's self-improvement loop,
+derived from artifacts that already exist (proposals, journals, promotion
+verdicts, replication). A terminal score cannot distinguish retained
+improvement from temporary adaptation — this report can: it shows what was
+proposed, what survived which gate, what got promoted, and whether promoted
+changes actually beat the incumbent forward (promotion reliability)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from wayfinder_paths.jobs.models import utc_now_iso
+from wayfinder_paths.jobs.store import JobStore
+
+_VERDICTS_PATH = "state/promotion_verdicts.json"
+
+
+def build_evolution_report(store: JobStore, job_id: str) -> dict[str, Any]:
+    root = store.job_dir(job_id)
+    proposals = _load_proposals(root)
+    verdicts = store.read_json(job_id, _VERDICTS_PATH) or {}
+
+    by_family: dict[str, dict[str, int]] = {}
+    rows: list[dict[str, Any]] = []
+    for proposal in proposals:
+        family = _family(proposal)
+        outcome = _outcome(proposal)
+        bucket = by_family.setdefault(
+            family,
+            {
+                "proposed": 0,
+                "gate_rejected": 0,
+                "owner_rejected": 0,
+                "agent_rejected": 0,
+                "promoted": 0,
+                "pending": 0,
+            },
+        )
+        bucket["proposed"] += 1
+        bucket[outcome] += 1
+        pid = str(proposal.get("proposal_id") or "")
+        verdict = (verdicts.get(pid) or {}).get("verdict")
+        rows.append(
+            {
+                "proposal_id": pid,
+                "family": family,
+                "outcome": outcome,
+                "summary": str(
+                    (proposal.get("proposed_change") or {}).get("summary") or ""
+                )[:120],
+                "created_at": proposal.get("created_at"),
+                "forward_verdict": verdict,
+            }
+        )
+
+    verdict_counts = {"beat": 0, "neutral": 0, "hurt": 0}
+    for record in verdicts.values():
+        verdict = str(record.get("verdict") or "")
+        if verdict in verdict_counts:
+            verdict_counts[verdict] += 1
+    judged = sum(verdict_counts.values())
+
+    replication = _replication_summary(root)
+    return {
+        "job_id": job_id,
+        "proposals_total": len(proposals),
+        "by_family": by_family,
+        "promotion_reliability": {
+            **verdict_counts,
+            "judged": judged,
+            # Of promotions old enough to judge, how many actually beat the
+            # incumbent forward — the single trackable scalar for whether the
+            # improve loop is earning its keep.
+            "beat_rate": (verdict_counts["beat"] / judged) if judged else None,
+        },
+        "replication": replication,
+        "proposals": rows[-50:],
+        "generated_at": utc_now_iso(),
+    }
+
+
+def evolution_snapshot_block(store: JobStore, job_id: str) -> dict[str, Any]:
+    """Compact per-wake view: family scoreboard + reliability, no row list."""
+    report = build_evolution_report(store, job_id)
+    return {
+        "by_family": report["by_family"],
+        "promotion_reliability": report["promotion_reliability"],
+        "_basis": (
+            "Full update path + forward promotion verdicts. Low beat_rate in a "
+            "family means that family's evidence bar is too weak — raise your "
+            "own bar before re-proposing, do not re-litigate the gate."
+        ),
+    }
+
+
+def _load_proposals(root: Path) -> list[dict[str, Any]]:
+    proposals_dir = root / "proposals"
+    if not proposals_dir.is_dir():
+        return []
+    rows: list[dict[str, Any]] = []
+    for path in sorted(proposals_dir.glob("*.json")):
+        try:
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+        except ValueError:
+            continue
+        if isinstance(loaded, dict):
+            rows.append(loaded)
+    rows.sort(key=lambda row: str(row.get("created_at") or ""))
+    return rows
+
+
+def _family(proposal: dict[str, Any]) -> str:
+    change = proposal.get("proposed_change") or {}
+    if change.get("probation"):
+        return "probation"
+    if change.get("execution_params"):
+        return "params"
+    kind = str(proposal.get("kind") or change.get("kind") or "").strip()
+    if kind:
+        return kind
+    return "code"
+
+
+def _outcome(proposal: dict[str, Any]) -> str:
+    status = str(proposal.get("status") or "")
+    application = proposal.get("application") or {}
+    if application.get("status") == "applied":
+        return "promoted"
+    if status == "rejected":
+        rejected_by = str((proposal.get("rejection") or {}).get("by") or "")
+        if rejected_by == "agent":
+            return "agent_rejected"
+        if rejected_by in {"owner", "user", "human"}:
+            return "owner_rejected"
+        return "gate_rejected"
+    return "pending"
+
+
+def _replication_summary(root: Path) -> dict[str, Any] | None:
+    for relative in (
+        "reports/replication/latest.json",
+        "results/research/replication.json",
+    ):
+        path = root / relative
+        if not path.exists():
+            continue
+        try:
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+        except ValueError:
+            continue
+        if isinstance(loaded, dict):
+            return {
+                "decayed": loaded.get("decayed"),
+                "computed_at": loaded.get("computed_at") or loaded.get("generated_at"),
+            }
+    return None

--- a/wayfinder_paths/jobs/gating.py
+++ b/wayfinder_paths/jobs/gating.py
@@ -179,6 +179,97 @@ def evaluate_live_gate(
     }
 
 
+def evaluate_economic_gate(
+    job_id: str,
+    *,
+    candidate_dir: str | Path,
+    store: JobStore | None = None,
+    probation: bool = False,
+) -> dict[str, Any]:
+    """Independent economic acceptance: paired candidate-vs-incumbent replay
+    on identical OOS folds under the owner constitution. Computed by gate
+    code — the model cannot self-certify `economic_ready`."""
+    from wayfinder_paths.jobs.constitution import load_constitution
+    from wayfinder_paths.jobs.economics import (
+        evaluate_economic_readiness,
+        paired_fold_evaluation,
+    )
+    from wayfinder_paths.jobs.execution.job import _load_dataset, _load_job_yaml
+    from wayfinder_paths.jobs.execution.primitives import ExecutionSpec
+    from wayfinder_paths.jobs.execution.validation import resolve_execution_spec
+
+    store = store or JobStore()
+    root = store.job_dir(job_id)
+    candidate_root = Path(candidate_dir)
+    constitution = load_constitution(root)
+
+    baseline_yaml = _load_job_yaml(root)
+    candidate_yaml = _load_job_yaml(candidate_root)
+    spec_data, _ = resolve_execution_spec(candidate_root, candidate_yaml)
+    if not spec_data:
+        return _economic_unavailable(constitution, "no execution spec", probation)
+    spec = ExecutionSpec.from_dict(spec_data)
+    baseline_script = store.resolve_script_entrypoint(job_id, baseline_yaml)
+    candidate_script = store.resolve_script_entrypoint(
+        job_id, candidate_yaml, candidate_dir=candidate_root
+    )
+    if baseline_script is None or candidate_script is None:
+        return _economic_unavailable(constitution, "no script entrypoint", probation)
+    dataset = _load_dataset(candidate_root, spec, candidate_yaml)
+
+    evaluation = paired_fold_evaluation(
+        baseline_script=baseline_script,
+        candidate_script=candidate_script,
+        dataset=dataset,
+        spec=spec,
+        baseline_params=baseline_yaml.get("execution_params") or {},
+        candidate_params=candidate_yaml.get("execution_params") or {},
+        constitution=constitution,
+    )
+    readiness = evaluate_economic_readiness(
+        evaluation, constitution, probation=probation
+    )
+    return {
+        "ready": readiness["ready"],
+        "reasons": readiness["reasons"],
+        "probation": probation,
+        "enforcement": constitution["enforcement"],
+        "constitution_revision": constitution.get("revision"),
+        "objective": (evaluation.get("objective") if evaluation.get("status") == "ok" else None),
+        "paired_incumbent_delta": evaluation.get("paired_incumbent_delta"),
+        "positive_folds": evaluation.get("positive_folds"),
+        "fold_count": evaluation.get("fold_count"),
+        "audit_slice": _audit_summary(evaluation.get("audit_slice")),
+        "status": evaluation.get("status"),
+        "checked_at": utc_now_iso(),
+    }
+
+
+def _audit_summary(audit: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not audit:
+        return None
+    return {
+        "start": audit["start"],
+        "end": audit["end"],
+        "bars": audit["bars"],
+        "delta_utility": audit["delta_utility"],
+    }
+
+
+def _economic_unavailable(
+    constitution: dict[str, Any], reason: str, probation: bool
+) -> dict[str, Any]:
+    return {
+        "ready": None,
+        "reasons": [f"economic evaluation unavailable: {reason}"],
+        "probation": probation,
+        "enforcement": constitution["enforcement"],
+        "constitution_revision": constitution.get("revision"),
+        "status": "unavailable",
+        "checked_at": utc_now_iso(),
+    }
+
+
 def _read_json(path: Path) -> dict[str, Any] | None:
     if not path.exists():
         return None

--- a/wayfinder_paths/jobs/proposals.py
+++ b/wayfinder_paths/jobs/proposals.py
@@ -33,7 +33,7 @@ from wayfinder_paths.jobs.execution.job import (
     synthesize_scenario_plan,
 )
 from wayfinder_paths.jobs.execution.primitives import ExecutionSpec
-from wayfinder_paths.jobs.gating import compute_workspace_revision, evaluate_live_gate
+from wayfinder_paths.jobs.gating import compute_workspace_revision, evaluate_live_gate, evaluate_economic_gate
 from wayfinder_paths.jobs.models import utc_now_iso
 from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.jobs.sync import sync_all_jobs
@@ -209,6 +209,22 @@ def _generate_candidate_report(
             "reasons": gate.get("reasons") or [],
         }
         mode = "full"
+        probation = bool((proposal.get("proposed_change") or {}).get("probation"))
+        try:
+            economic = evaluate_economic_gate(
+                job_id,
+                candidate_dir=candidate_dir,
+                store=store,
+                probation=probation,
+            )
+        except Exception as exc:  # noqa: BLE001 — a crashed economic eval must
+            # degrade to advisory-unavailable, never break propose.
+            economic = {
+                "ready": None,
+                "reasons": [f"economic evaluation failed: {exc}"[:300]],
+                "enforcement": "advisory",
+                "status": "error",
+            }
     else:
         # Research-only / no-dataset jobs: nothing to backtest or gate — the
         # proposal is judged on validation alone (contract C1).
@@ -217,12 +233,14 @@ def _generate_candidate_report(
             "reasons": ["no execution backtest; validation-only proposal"],
         }
         mode = "validation_only"
+        economic = None
 
     candidate_report = {
         "revision": candidate_revision,
         "base_revision": base_revision,
         "mode": mode,
         "gate": gate_payload,
+        "economic": economic,
         "validation_summary": validation_summary(validation),
         # Stats/deltas only — never point series (sync payload discipline).
         "comparison": (

--- a/wayfinder_paths/jobs/store.py
+++ b/wayfinder_paths/jobs/store.py
@@ -372,6 +372,12 @@ class JobStore:
         if gate.get("live_ready") is not True:
             reasons = "; ".join(gate.get("reasons") or ["unknown"])
             raise ValueError(f"candidate gate is not live-ready: {reasons}")
+        economic = report.get("economic") or {}
+        # ready=None (advisory constitution, unavailable, or crashed eval)
+        # never blocks — only a computed False under a blocking constitution.
+        if economic.get("enforcement") == "blocking" and economic.get("ready") is False:
+            reasons = "; ".join(economic.get("reasons") or ["unknown"])
+            raise ValueError(f"candidate is not economic-ready: {reasons}")
         self._ensure_candidate_matches_report(job_id, proposal, report)
 
     def _ensure_candidate_matches_report(

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -329,6 +329,17 @@ def _restage_block(root: Path) -> list[dict[str, Any]]:
     return tasks
 
 
+def _evolution_block(store: JobStore, job_id: str) -> dict[str, Any]:
+    """Promotion-reliability scoreboard: the improver reads its own audited
+    outcomes instead of its memory of them. Never raises."""
+    try:
+        from wayfinder_paths.jobs.evolution_ledger import evolution_snapshot_block
+
+        return evolution_snapshot_block(store, job_id)
+    except Exception:  # noqa: BLE001
+        return {}
+
+
 def _standing_checks_block(root: Path) -> dict[str, Any]:
     """Mechanical routine numbers, computed by the harness each wake.
 
@@ -538,6 +549,7 @@ def _build_worker_prompt_sections(
         "post_apply_shadow": _counterfactual_block(store, job_id),
         "research_substrate": _research_substrate_block(root),
         "standing_checks": _standing_checks_block(root),
+        "evolution": _evolution_block(store, job_id),
         "restage_tasks": restage_tasks,
     }
 
@@ -802,6 +814,14 @@ def _build_worker_prompt_sections(
             "hypothesis requires NAMED new evidence. Keep the agenda compact "
             "(~150 lines): it is a curated map, not a log — compact it in "
             "place as part of updating it.\n"
+            "- Economic promotion gate: full-size promotion requires the "
+            "candidate to beat the incumbent on paired OOS folds under the "
+            "owner constitution (LCB > 0); it is computed by gate code and "
+            "you can NEVER claim or negotiate economic_ready yourself. "
+            "Weak-but-positive evidence: set proposed_change.probation=true "
+            "for a reduced-size canary leg (clears on point estimate). "
+            "Forward results ADJUDICATE changes — never fit parameters to "
+            "the forward stream.\n"
             "- If propose returns a failed validation, read ALL failed check "
             "names and fix them in ONE follow-up propose; after 2 failed propose "
             "attempts in a wake, stop and report the blocker instead of "

--- a/wayfinder_paths/tests/test_jobs_economics.py
+++ b/wayfinder_paths/tests/test_jobs_economics.py
@@ -1,0 +1,300 @@
+"""Economic promotion gate: objective math, readiness policy, constitution
+loading, enforcement, promotion verdicts, and the evolution ledger."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from wayfinder_paths.jobs.constitution import (
+    DEFAULT_CONSTITUTION,
+    load_constitution,
+)
+from wayfinder_paths.jobs.counterfactual import _maybe_record_promotion_verdict
+from wayfinder_paths.jobs.economics import (
+    block_bootstrap_lcb,
+    daily_log_returns,
+    evaluate_economic_readiness,
+    objective_vector,
+    paired_daily_deltas,
+    utility,
+)
+from wayfinder_paths.jobs.evolution_ledger import build_evolution_report
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.store import JobStore
+
+
+def _equity(values: list[float], start_day: int = 1) -> list[dict]:
+    return [
+        {"timestamp": f"2026-08-{start_day + i:02d}T00:00:00+00:00", "equity": value}
+        for i, value in enumerate(values)
+    ]
+
+
+def test_objective_vector_prefers_downside_over_variance() -> None:
+    # Upside volatility must not be punished: same growth, one path swings UP.
+    smooth = objective_vector(_equity([100, 101, 102, 103, 104]), trades=[])
+    spiky_up = objective_vector(_equity([100, 103, 102.5, 103.5, 104]), trades=[])
+    assert smooth["downside_deviation"] < 0.01
+    assert spiky_up["net_log_growth"] == pytest.approx(
+        smooth["net_log_growth"], abs=1e-9
+    )
+    # The up-spike path has one small down day; downside dev stays tiny.
+    assert spiky_up["downside_deviation"] < 0.01
+
+
+def test_objective_vector_tail_and_fees() -> None:
+    trades = [{"pnl": -5.0, "fee": 0.5}, {"pnl": 2.0, "fee": 0.5}, {"pnl": -1.0, "fee": 0.5}]
+    vector = objective_vector(_equity([100, 99, 98, 100]), trades)
+    assert vector["tail_loss"] == pytest.approx(5.0 / 100)
+    assert vector["fee_load"] == pytest.approx(1.5 / 100)
+    assert vector["max_drawdown_pct"] == pytest.approx(0.02)
+    assert vector["trade_count"] == 3
+
+
+def test_utility_applies_owner_weights() -> None:
+    vector = {
+        "net_log_growth": 0.10,
+        "downside_deviation": 0.02,
+        "tail_loss": 0.05,
+        "fee_load": 0.01,
+    }
+    weights = {"downside": 0.5, "tail": 1.0, "turnover": 0.25}
+    assert utility(vector, weights) == pytest.approx(0.10 - 0.01 - 0.05 - 0.0025)
+
+
+def test_paired_deltas_align_on_common_days() -> None:
+    baseline = daily_log_returns(_equity([100, 101, 102, 103]))
+    candidate = daily_log_returns(_equity([100, 102, 103, 105]))
+    deltas = paired_daily_deltas(baseline, candidate)
+    assert len(deltas) == 3
+    assert sum(deltas) > 0
+
+
+def test_block_bootstrap_lcb_is_deterministic_and_ordered() -> None:
+    up = [0.01] * 30
+    lcb_up = block_bootstrap_lcb(up, block_len=5, iterations=200, confidence=0.9)
+    assert lcb_up == pytest.approx(0.30, abs=1e-9)
+    mixed = [0.01, -0.012] * 15
+    lcb_mixed = block_bootstrap_lcb(mixed, block_len=5, iterations=200, confidence=0.9)
+    assert lcb_mixed is not None and lcb_mixed < lcb_up
+    again = block_bootstrap_lcb(mixed, block_len=5, iterations=200, confidence=0.9)
+    assert again == lcb_mixed
+    assert block_bootstrap_lcb([0.01], block_len=5, iterations=50, confidence=0.9) is None
+
+
+def _ok_report(**overrides) -> dict:
+    report = {
+        "status": "ok",
+        "objective": {
+            "candidate": {
+                "max_drawdown_pct": 0.05,
+                "tail_loss": 0.02,
+                "trade_count": 20,
+            },
+        },
+        "positive_folds": 3,
+        "fold_count": 4,
+        "paired_incumbent_delta": {"estimate": 0.02, "lcb": 0.005, "confidence": 0.9},
+        "audit_slice": {"delta_utility": 0.001},
+    }
+    report.update(overrides)
+    return report
+
+
+def test_readiness_passes_and_each_reason_blocks() -> None:
+    constitution = json.loads(json.dumps(DEFAULT_CONSTITUTION))
+    assert evaluate_economic_readiness(_ok_report(), constitution)["ready"] is True
+
+    weak_lcb = _ok_report(
+        paired_incumbent_delta={"estimate": 0.02, "lcb": -0.001, "confidence": 0.9}
+    )
+    result = evaluate_economic_readiness(weak_lcb, constitution)
+    assert result["ready"] is False and "LCB" in result["reasons"][0]
+
+    # Probation bar: LCB exempt, point estimate rules.
+    assert (
+        evaluate_economic_readiness(weak_lcb, constitution, probation=True)["ready"]
+        is True
+    )
+    negative = _ok_report(
+        paired_incumbent_delta={"estimate": -0.01, "lcb": -0.02, "confidence": 0.9}
+    )
+    assert (
+        evaluate_economic_readiness(negative, constitution, probation=True)["ready"]
+        is False
+    )
+
+    breach = _ok_report()
+    breach["objective"]["candidate"]["max_drawdown_pct"] = 0.60
+    assert evaluate_economic_readiness(breach, constitution)["ready"] is False
+
+    few_folds = _ok_report(positive_folds=1)
+    assert evaluate_economic_readiness(few_folds, constitution)["ready"] is False
+
+    bad_audit = _ok_report(audit_slice={"delta_utility": -0.5})
+    result = evaluate_economic_readiness(bad_audit, constitution)
+    assert result["ready"] is False and "audit-slice" in result["reasons"][0]
+
+    unavailable = {"status": "insufficient_history", "detail": "too few bars"}
+    assert evaluate_economic_readiness(unavailable, constitution)["ready"] is False
+
+
+def test_constitution_defaults_file_and_broken(tmp_path: Path) -> None:
+    defaults = load_constitution(tmp_path)
+    assert defaults["enforcement"] == "advisory" and defaults["source"] == "defaults"
+
+    (tmp_path / "constitution.yaml").write_text(
+        "enforcement: blocking\npromotion:\n  min_oos_trades: 30\n", encoding="utf-8"
+    )
+    loaded = load_constitution(tmp_path)
+    assert loaded["enforcement"] == "blocking"
+    assert loaded["promotion"]["min_oos_trades"] == 30
+    # Unspecified keys inherit defaults; revision is stamped.
+    assert loaded["promotion"]["required_positive_folds"] == 2
+    assert loaded["revision"]
+
+    (tmp_path / "constitution.yaml").write_text(":\n  - broken", encoding="utf-8")
+    assert load_constitution(tmp_path)["enforcement"] == "advisory"
+
+
+def _store_with_job(tmp_path: Path) -> tuple[JobStore, str]:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        "econ-gate-demo",
+        goal="Beat the incumbent honestly.",
+        script="workspace/src/loop.py",
+        agent_mode="intervene",
+        execution_contract="jobs_v1",
+    )
+    store.save(job)
+    return store, job.id
+
+
+def test_enforcement_blocks_only_computed_false_under_blocking(tmp_path: Path) -> None:
+    store, job_id = _store_with_job(tmp_path)
+    base = {
+        "revision": "cand111",
+        "validation_summary": {"status": "passed"},
+        "gate": {"live_ready": True, "reasons": []},
+        "mode": "full",
+    }
+
+    def proposal_with(economic) -> dict:
+        return {
+            "proposal_id": "prop-x",
+            "candidate_report": {**base, "economic": economic},
+            "application": {"status": "not_requested"},
+        }
+
+    blocking_false = {
+        "enforcement": "blocking",
+        "ready": False,
+        "reasons": ["paired utility delta LCB -0.0100 not > 0 at 90% confidence"],
+    }
+    with pytest.raises(ValueError, match="not economic-ready"):
+        store._ensure_candidate_report_gate(
+            job_id, proposal_with(blocking_false), allow_ungated=False
+        )
+
+    for economic in (
+        {"enforcement": "advisory", "ready": False, "reasons": ["weak"]},
+        {"enforcement": "blocking", "ready": None, "reasons": ["unavailable"]},
+        {"enforcement": "blocking", "ready": True, "reasons": []},
+        None,
+    ):
+        try:
+            store._ensure_candidate_report_gate(
+                job_id, proposal_with(economic), allow_ungated=False
+            )
+        except ValueError as exc:
+            # The freshness guard may complain about the missing candidate
+            # bundle in this fixture — economic enforcement must not.
+            assert "economic-ready" not in str(exc)
+
+
+def test_promotion_verdict_records_once_when_mature(tmp_path: Path) -> None:
+    store, job_id = _store_with_job(tmp_path)
+
+    immature = {
+        "available": True,
+        "proposal_id": "prop-young",
+        "window": {"days": 1.0},
+        "actual": {"closes": 5, "net_pnl": 1.0},
+        "shadow": {"closes": 5, "net_pnl": 0.0},
+        "delta_net_pnl": 1.0,
+    }
+    _maybe_record_promotion_verdict(store, job_id, immature)
+    assert store.read_json(job_id, "state/promotion_verdicts.json") is None
+
+    mature = {
+        "available": True,
+        "proposal_id": "prop-mature",
+        "window": {"days": 5.5},
+        "actual": {"closes": 8, "net_pnl": 3.0},
+        "shadow": {"closes": 7, "net_pnl": 1.0},
+        "delta_net_pnl": 2.0,
+    }
+    _maybe_record_promotion_verdict(store, job_id, mature)
+    _maybe_record_promotion_verdict(store, job_id, mature)
+    verdicts = store.read_json(job_id, "state/promotion_verdicts.json")
+    assert verdicts["prop-mature"]["verdict"] == "beat"
+    journal = (store.job_dir(job_id) / "journal.jsonl").read_text(encoding="utf-8")
+    assert journal.count("promotion_verdict") == 1
+
+    hurt = {**mature, "proposal_id": "prop-hurt", "delta_net_pnl": -2.0}
+    _maybe_record_promotion_verdict(store, job_id, hurt)
+    verdicts = store.read_json(job_id, "state/promotion_verdicts.json")
+    assert verdicts["prop-hurt"]["verdict"] == "hurt"
+
+
+def test_evolution_report_aggregates_path_and_reliability(tmp_path: Path) -> None:
+    store, job_id = _store_with_job(tmp_path)
+    proposals_dir = store.job_dir(job_id) / "proposals"
+    proposals_dir.mkdir(parents=True, exist_ok=True)
+    fixtures = [
+        {
+            "proposal_id": "prop-a",
+            "status": "approved",
+            "created_at": "2026-08-01T00:00:00+00:00",
+            "proposed_change": {"summary": "widen stop", "execution_params": {"x": 1}},
+            "application": {"status": "applied"},
+        },
+        {
+            "proposal_id": "prop-b",
+            "status": "rejected",
+            "created_at": "2026-08-02T00:00:00+00:00",
+            "proposed_change": {"summary": "bad idea", "execution_params": {"x": 2}},
+            "rejection": {"by": "agent", "reason": "gate failed"},
+            "application": {"status": "not_requested"},
+        },
+        {
+            "proposal_id": "prop-c",
+            "status": "rejected",
+            "created_at": "2026-08-03T00:00:00+00:00",
+            "proposed_change": {"summary": "owner said no"},
+            "rejection": {"by": "owner", "reason": "too risky"},
+            "application": {"status": "not_requested"},
+        },
+    ]
+    for fixture in fixtures:
+        (proposals_dir / f"{fixture['proposal_id']}.json").write_text(
+            json.dumps(fixture), encoding="utf-8"
+        )
+    store.write_json(
+        job_id,
+        "state/promotion_verdicts.json",
+        {"prop-a": {"verdict": "beat", "delta_net_pnl": 2.0}},
+    )
+
+    report = build_evolution_report(store, job_id)
+    assert report["proposals_total"] == 3
+    assert report["by_family"]["params"]["promoted"] == 1
+    assert report["by_family"]["params"]["agent_rejected"] == 1
+    assert report["by_family"]["code"]["owner_rejected"] == 1
+    reliability = report["promotion_reliability"]
+    assert reliability["beat"] == 1 and reliability["beat_rate"] == 1.0
+    promoted_row = next(r for r in report["proposals"] if r["proposal_id"] == "prop-a")
+    assert promoted_row["forward_verdict"] == "beat"


### PR DESCRIPTION
First of the three approved bounded-optimizer PRs (pillar 2 + tracking). PR B (archive + typed probation/lifecycle) and PR C (synthetic optimizer benchmarks) follow.

## Problem

The promotion gate answered "is this revision technically valid and evidenced enough to run?" — never "is it a statistically defensible economic improvement over the incumbent?". Walk-forward was report-only; a candidate with weak OOS could still promote. Per the self-evolution review: the loop being judged could influence the only evidence approving its own change.

## What this adds

**Owner constitution (the L4 anchor)** — `constitution.yaml` at the job ROOT: outside `workspace/`, outside the revision hash, never staged into candidates → structurally read-only to the propose/apply path. Objective weights, hard ceilings, fold/confidence/audit settings, `enforcement: blocking|advisory`. Missing or broken file degrades to advisory defaults — the roll cannot brick the three live jobs.

**Paired economic evaluation** (`economics.py`) — both incumbent and candidate replayed on identical outer OOS folds + a terminal audit slice, same bars and costs, no inner search (development already selected params; the gate certifies *benefit*, not the edit). Objective vector: net log growth, downside deviation (upside volatility is not punished), tail loss (worst-decile trade sum), fee load, max drawdown. Paired daily log-return deltas → circular moving-block bootstrap → LCB applied to the growth term with risk terms at point estimates — conservative and honest at 24–160-trade samples.

**`economic_ready`** — computed by gate code in `evaluate_economic_gate`; the model can never self-certify it. Requires: hard ceilings pass, ≥N positive OOS folds, `LCB(ΔU) > 0`, audit-slice ΔU above floor. Enforcement in `store._ensure_candidate_report_gate`: blocking constitution + computed `ready=False` refuses approval (auto mode included); advisory/unavailable never blocks. **Probation escape valve**: `proposed_change.probation=true` (reduced-size canary) clears on a positive point estimate instead of the LCB — small-sample jobs stay movable, full size pays the LCB bar.

**Promotion reliability tracking** — the counterfactual shadow now files a once-per-promotion verdict (beat/neutral/hurt) after a mature window; `evolution_ledger.py` aggregates the full update path by change family + `beat_rate`, surfaced via `wayfinder job evolution <id>`, decision-log entries, and a compact worker-snapshot block (the improver reads its own audited outcomes, not its memory of them). Worker contract adds: economic gate exists and is non-negotiable; forward results adjudicate, never fit.

Backend compat: `candidate_report.gate` untouched; `economic` is a sibling block.

## Honest limitations

The audit slice is freshness pressure, not a cryptographic seal (agents can technically backtest those bars during development) — the sealed-audit service stays deferred. Fold layout covers the most recent third of development history to bound cost; everything rides the existing propose-time compute lock (~K×2 test-window sims).

## Rollout

All jobs start on **advisory defaults** after the roll (no constitution files exist yet) — the gate computes and reports but does not block. I'll draft per-job `constitution.yaml` files (ceilings from each job's current risk config) for your approval, install them on the box, and only then does blocking enforcement go live per job.

## Tests

111 green across `test_jobs_economics` (new: objective math, bootstrap determinism, every readiness reason, constitution merge/broken-file, enforcement matrix, verdict maturity/dedup, ledger aggregation) + propose/worker/decision-log/counterfactual/watchdog/gating/application-gate/walk-forward regression suites. mypy clean on new modules (stub-noise only, repo-standard).
