### PR TITLE
jobs: candidate archive + typed lifecycle predicates + mechanical controller (PR B)

### DIFF
--- a/wayfinder_paths/jobs/application.py
+++ b/wayfinder_paths/jobs/application.py
@@ -610,6 +610,12 @@ def _record_promoted_revision(
             "validation_status": validation_status,
         },
     )
+    try:
+        from wayfinder_paths.jobs.archive import set_incumbent
+
+        set_incumbent(store, job_id, proposal_id)
+    except Exception:  # noqa: BLE001 — archive bookkeeping never breaks promotion
+        pass
     revisions_path = root / "versions" / "revisions.jsonl"
     revisions_path.parent.mkdir(parents=True, exist_ok=True)
     revisions_path.open("a", encoding="utf-8").write(

--- a/wayfinder_paths/jobs/archive.py
+++ b/wayfinder_paths/jobs/archive.py
@@ -1,0 +1,207 @@
+"""Candidate archive: branches, not just a champion.
+
+Every evaluated candidate is retained with its lineage, objective vector, and
+behavior descriptor — the Pareto frontier and refuted branches stay visible
+so exploration can revive an ancestor when the regime flips instead of
+re-deriving it, and duplicate-family proposals hit their own refutation.
+Entries are never silently deleted; status flips are the only mutation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from wayfinder_paths.jobs.models import utc_now_iso
+from wayfinder_paths.jobs.store import JobStore
+
+ARCHIVE_PATH = "state/archive.json"
+ARCHIVE_STATUSES = {
+    "incumbent",
+    "frontier",
+    "archived",
+    "probation",
+    "refuted",
+    "retired",
+}
+# Pareto axes over the objective vector: maximize growth, minimize the rest.
+_MAXIMIZE = ("net_log_growth",)
+_MINIMIZE = ("downside_deviation", "tail_loss", "max_drawdown_pct")
+
+
+def load_archive(store: JobStore, job_id: str) -> dict[str, Any]:
+    doc = store.read_json(job_id, ARCHIVE_PATH) or {}
+    if not isinstance(doc, dict) or not isinstance(doc.get("candidates"), list):
+        return {"candidates": []}
+    return doc
+
+
+def record_candidate(
+    store: JobStore,
+    job_id: str,
+    *,
+    candidate_id: str,
+    family: str,
+    summary: str,
+    status: str,
+    objective: dict[str, Any] | None,
+    revision: str | None = None,
+    parent_id: str | None = None,
+    behavior: dict[str, Any] | None = None,
+    evidence: str | None = None,
+) -> dict[str, Any]:
+    if status not in ARCHIVE_STATUSES:
+        raise ValueError(f"status must be one of {sorted(ARCHIVE_STATUSES)}")
+    doc = load_archive(store, job_id)
+    existing = _find(doc, candidate_id)
+    if existing is not None:
+        # Same candidate re-evaluated: update evidence/status, keep lineage.
+        existing.update(
+            {
+                "status": status,
+                "objective": objective or existing.get("objective"),
+                "evidence": evidence or existing.get("evidence"),
+                "updated_at": utc_now_iso(),
+            }
+        )
+        entry = existing
+    else:
+        entry = {
+            "candidate_id": candidate_id,
+            "family": family,
+            "summary": summary[:160],
+            "status": status,
+            "objective": objective,
+            "revision": revision,
+            "parent_id": parent_id,
+            "behavior": behavior or {},
+            "evidence": evidence,
+            "created_at": utc_now_iso(),
+        }
+        doc["candidates"].append(entry)
+    _refresh_frontier(doc)
+    store.write_json(job_id, ARCHIVE_PATH, doc)
+    return entry
+
+
+def set_candidate_status(
+    store: JobStore,
+    job_id: str,
+    candidate_id: str,
+    status: str,
+    *,
+    evidence: str | None = None,
+) -> dict[str, Any]:
+    if status not in ARCHIVE_STATUSES:
+        raise ValueError(f"status must be one of {sorted(ARCHIVE_STATUSES)}")
+    doc = load_archive(store, job_id)
+    entry = _find(doc, candidate_id)
+    if entry is None:
+        raise ValueError(f"unknown archive candidate {candidate_id!r}")
+    entry["status"] = status
+    if evidence:
+        entry["evidence"] = evidence
+    entry["updated_at"] = utc_now_iso()
+    _refresh_frontier(doc)
+    store.write_json(job_id, ARCHIVE_PATH, doc)
+    return entry
+
+
+def set_incumbent(store: JobStore, job_id: str, candidate_id: str) -> None:
+    """Promote one entry to incumbent; previous incumbents become archived
+    branches (still ranked on the frontier — that is the point)."""
+    doc = load_archive(store, job_id)
+    promoted = _find(doc, candidate_id)
+    if promoted is None:
+        return
+    for entry in doc.get("candidates") or []:
+        if entry.get("status") == "incumbent":
+            entry["status"] = "archived"
+            entry["updated_at"] = utc_now_iso()
+    promoted["status"] = "incumbent"
+    promoted["updated_at"] = utc_now_iso()
+    _refresh_frontier(doc)
+    store.write_json(job_id, ARCHIVE_PATH, doc)
+
+
+def archive_snapshot_block(store: JobStore, job_id: str) -> dict[str, Any]:
+    """Compact per-wake view: frontier + counts + refuted families, so
+    exploration cites archive state instead of memory."""
+    doc = load_archive(store, job_id)
+    candidates = doc.get("candidates") or []
+    counts: dict[str, int] = {}
+    for entry in candidates:
+        counts[entry.get("status", "?")] = counts.get(entry.get("status", "?"), 0) + 1
+    frontier = [
+        {
+            "candidate_id": entry["candidate_id"],
+            "family": entry["family"],
+            "summary": entry["summary"],
+            "objective": entry.get("objective"),
+            "status": entry["status"],
+        }
+        for entry in candidates
+        if entry.get("on_frontier")
+    ]
+    refuted = [
+        {
+            "candidate_id": entry["candidate_id"],
+            "family": entry["family"],
+            "evidence": (entry.get("evidence") or "")[:120],
+        }
+        for entry in candidates
+        if entry.get("status") == "refuted"
+    ][-10:]
+    return {
+        "counts": counts,
+        "frontier": frontier[:8],
+        "recent_refuted": refuted,
+        "_basis": (
+            "Candidate archive. Re-proposing a refuted family requires NAMED "
+            "new evidence; a frontier entry strong in the current regime is a "
+            "revival candidate before any novel divergent search."
+        ),
+    }
+
+
+def _find(doc: dict[str, Any], candidate_id: str) -> dict[str, Any] | None:
+    for entry in doc.get("candidates") or []:
+        if entry.get("candidate_id") == candidate_id:
+            return entry
+    return None
+
+
+def _refresh_frontier(doc: dict[str, Any]) -> None:
+    """Pareto frontier over candidates with objective vectors, excluding
+    refuted/retired branches (dead branches stay recorded, not ranked)."""
+    ranked = [
+        entry
+        for entry in doc.get("candidates") or []
+        if isinstance(entry.get("objective"), dict)
+        and entry.get("status") not in {"refuted", "retired"}
+    ]
+    for entry in doc.get("candidates") or []:
+        entry["on_frontier"] = False
+    for entry in ranked:
+        entry["on_frontier"] = not any(
+            _dominates(other, entry) for other in ranked if other is not entry
+        )
+
+
+def _dominates(a: dict[str, Any], b: dict[str, Any]) -> bool:
+    """True when a is at least as good on every axis and better on one."""
+    better_somewhere = False
+    for axis in _MAXIMIZE + _MINIMIZE:
+        a_value = a["objective"].get(axis)
+        b_value = b["objective"].get(axis)
+        if a_value is None or b_value is None:
+            return False
+        a_value, b_value = float(a_value), float(b_value)
+        if axis in _MAXIMIZE:
+            if a_value < b_value:
+                return False
+            better_somewhere = better_somewhere or a_value > b_value
+        else:
+            if a_value > b_value:
+                return False
+            better_somewhere = better_somewhere or a_value < b_value
+    return better_somewhere

--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -992,6 +992,17 @@ def evolution_cmd(job_id: str) -> None:
 
 
 @job_cli.command(
+    name="archive",
+    help="Candidate archive: Pareto frontier, branches, refuted lineage.",
+)
+@click.argument("job_id")
+def archive_cmd(job_id: str) -> None:
+    from wayfinder_paths.jobs.archive import load_archive
+
+    _echo_json({"ok": True, "result": load_archive(JobStore(), job_id)})
+
+
+@job_cli.command(
     name="backtest-view", help="Read a bounded backtest visualization payload."
 )
 @click.argument("job_id")

--- a/wayfinder_paths/jobs/decision_log.py
+++ b/wayfinder_paths/jobs/decision_log.py
@@ -221,6 +221,22 @@ def _journal_entries(
                     actor="system",
                 )
             )
+        elif kind == "lifecycle_decision":
+            decision = str(event.get("decision") or "")
+            metrics = event.get("metrics") or {}
+            entries.append(
+                _entry(
+                    ts,
+                    "proposal",
+                    f"Lifecycle controller {decision} probation leg "
+                    f"{event.get('leg')}",
+                    f"{metrics.get('closed_trades')} trades, "
+                    f"WR {metrics.get('win_rate')}, net {metrics.get('net_pnl')} USD "
+                    "— pre-registered rules, evaluated mechanically",
+                    "info",
+                    actor="system",
+                )
+            )
         elif kind == "promotion_verdict":
             verdict = str(event.get("verdict") or "unknown")
             delta = float(event.get("delta_net_pnl") or 0.0)

--- a/wayfinder_paths/jobs/predicates.py
+++ b/wayfinder_paths/jobs/predicates.py
@@ -1,0 +1,132 @@
+"""Typed lifecycle predicates: machine-evaluable graduate/kill rules.
+
+Prose criteria ("kill if WR<20% after 10 trades") depend on an agent reading
+and honoring them; a rule that fires only if someone re-reads it is not a
+rule. Predicates are data — {metric}{__op} thresholds evaluated by the
+deterministic lifecycle controller against measured forward metrics.
+
+Ops: __gte, __lte, __gt, __lt, __eq. Prerequisite keys (min_closed_trades,
+min_days) gate evaluation: until they are met the predicate set is PENDING,
+not failed — pre-registered sample-size gates, mechanically enforced.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+_OPS = {
+    "__gte": lambda value, limit: value >= limit,
+    "__lte": lambda value, limit: value <= limit,
+    "__gt": lambda value, limit: value > limit,
+    "__lt": lambda value, limit: value < limit,
+    "__eq": lambda value, limit: value == limit,
+}
+_PREREQUISITES = {"min_closed_trades": "closed_trades", "min_days": "days"}
+
+
+def evaluate_predicates(
+    rules: Mapping[str, Any] | None,
+    metrics: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return {status: pending|met|not_met, checks: [...], missing: [...]}.
+
+    `met` requires EVERY non-prerequisite rule to hold with all prerequisites
+    satisfied. A metric absent from `metrics` records as missing and the set
+    cannot be `met` — silence must never satisfy a rule.
+    """
+    if not rules:
+        return {"status": "pending", "checks": [], "missing": ["no rules registered"]}
+
+    checks: list[dict[str, Any]] = []
+    missing: list[str] = []
+    for key, limit in rules.items():
+        if key in _PREREQUISITES:
+            metric_name = _PREREQUISITES[key]
+            value = metrics.get(metric_name)
+            if value is None or float(value) < float(limit):
+                return {
+                    "status": "pending",
+                    "checks": checks,
+                    "missing": missing,
+                    "waiting_on": f"{metric_name} {value} < {limit}",
+                }
+            continue
+        metric_name, op = _split(key)
+        if op is None:
+            missing.append(f"unknown op in rule {key!r}")
+            continue
+        value = metrics.get(metric_name)
+        if value is None:
+            missing.append(f"metric {metric_name!r} unavailable")
+            continue
+        passed = _OPS[op](float(value), float(limit))
+        checks.append(
+            {"rule": key, "value": float(value), "limit": float(limit), "passed": passed}
+        )
+
+    if missing:
+        return {"status": "pending", "checks": checks, "missing": missing}
+    if checks and all(check["passed"] for check in checks):
+        return {"status": "met", "checks": checks, "missing": []}
+    return {"status": "not_met", "checks": checks, "missing": []}
+
+
+def _split(key: str) -> tuple[str, str | None]:
+    for op in _OPS:
+        if key.endswith(op):
+            return key[: -len(op)], op
+    return key, None
+
+
+def forward_metrics(
+    trades: list[Mapping[str, Any]],
+    *,
+    symbol: str | None = None,
+    since: str | None = None,
+    now_iso: str,
+) -> dict[str, Any]:
+    """Measured forward metrics for one leg/incumbent from closed-trade rows.
+
+    Filters by symbol and deployment time so a leg is judged only on its own
+    trades. Drawdown is computed on the cumulative net-pnl path (per-symbol
+    forward equity does not exist as an artifact)."""
+    import datetime as dt
+
+    rows = [
+        row
+        for row in trades
+        if (symbol is None or str(row.get("symbol")) == symbol)
+        and (since is None or str(row.get("timestamp") or "") >= since)
+    ]
+    pnls = [float(row.get("net_pnl") or row.get("pnl") or 0.0) for row in rows]
+    wins = sum(1 for value in pnls if value > 0)
+    peak = 0.0
+    trough_dd = 0.0
+    running = 0.0
+    for value in pnls:
+        running += value
+        peak = max(peak, running)
+        trough_dd = max(trough_dd, peak - running)
+    streak = 0
+    for value in reversed(pnls):
+        if value < 0:
+            streak += 1
+        else:
+            break
+    days = None
+    if since:
+        try:
+            start = dt.datetime.fromisoformat(since)
+            end = dt.datetime.fromisoformat(now_iso)
+            days = round((end - start).total_seconds() / 86_400.0, 2)
+        except ValueError:
+            days = None
+    return {
+        "closed_trades": len(rows),
+        "win_rate": (wins / len(rows)) if rows else None,
+        "net_pnl": round(sum(pnls), 4),
+        "drawdown_usd": round(trough_dd, 4),
+        "loss_streak": streak,
+        "days": days,
+    }

--- a/wayfinder_paths/jobs/probation.py
+++ b/wayfinder_paths/jobs/probation.py
@@ -31,6 +31,8 @@ def record_probation_leg(
     size_fraction: float,
     graduate_criterion: str,
     kill_criterion: str,
+    graduate_rules: dict[str, Any] | None = None,
+    kill_rules: dict[str, Any] | None = None,
     proposal_id: str | None = None,
     notes: str | None = None,
 ) -> dict[str, Any]:
@@ -52,8 +54,19 @@ def record_probation_leg(
         "deployed_at": utc_now_iso(),
         "size_fraction": float(size_fraction),
         "proposal_id": proposal_id,
-        "graduate": {"criterion": graduate_criterion, "progress": None},
-        "kill": {"criterion": kill_criterion, "status": None},
+        # criterion = human-readable rendering; rules = the machine-evaluable
+        # predicates the lifecycle controller actually enforces. A leg without
+        # rules is legacy: visible but never auto-graduated/killed.
+        "graduate": {
+            "criterion": graduate_criterion,
+            "rules": dict(graduate_rules or {}),
+            "progress": None,
+        },
+        "kill": {
+            "criterion": kill_criterion,
+            "rules": dict(kill_rules or {}),
+            "status": None,
+        },
         "notes": notes,
     }
     doc["legs"].append(leg)

--- a/wayfinder_paths/jobs/proposals.py
+++ b/wayfinder_paths/jobs/proposals.py
@@ -138,6 +138,28 @@ def propose_change(
             "validation_status": validation.get("status"),
         },
     )
+    try:
+        from wayfinder_paths.jobs.archive import record_candidate
+
+        change = proposal.get("proposed_change") or {}
+        economic = candidate_report.get("economic") or {}
+        record_candidate(
+            store,
+            job_id,
+            candidate_id=pid,
+            family=(
+                "probation" if change.get("probation")
+                else "params" if change.get("execution_params")
+                else str(kind or "code")
+            ),
+            summary=str(summary or ""),
+            status="probation" if change.get("probation") else "archived",
+            objective=(economic.get("objective") or {}).get("candidate"),
+            revision=candidate_report.get("revision"),
+            parent_id=base_revision,
+        )
+    except Exception:  # noqa: BLE001 — archive bookkeeping never breaks propose
+        pass
     store.refresh_scorecard(job_id)
     sync_all_jobs(store=store)
     # Surface a chat affordance (contract C5): the opencode harness turns this

--- a/wayfinder_paths/jobs/store.py
+++ b/wayfinder_paths/jobs/store.py
@@ -502,6 +502,18 @@ class JobStore:
             self._set_application_status(proposal, "canceled")
         proposal["updated_at"] = utc_now_iso()
         self.write_proposal(job_id, proposal)
+        try:
+            from wayfinder_paths.jobs.archive import set_candidate_status
+
+            set_candidate_status(
+                self,
+                job_id,
+                proposal_id,
+                "refuted",
+                evidence=f"rejected by {rejected_by or 'owner'}: {reason or ''}"[:160],
+            )
+        except Exception:  # noqa: BLE001 — archive bookkeeping never breaks reject
+            pass
         self.append_journal(
             job_id,
             {

--- a/wayfinder_paths/jobs/watchdog.py
+++ b/wayfinder_paths/jobs/watchdog.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import os
 import re
 import signal
+import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from textwrap import dedent
@@ -440,6 +441,94 @@ def _recover_orphaned_pause(
     return event
 
 
+# Lifecycle evaluation is cheap (json reads + arithmetic) but its decisions
+# are consequential — a 6h cadence matches the counterfactual cycle and keeps
+# kill/graduate flips out of the 5-minute noise floor.
+_LIFECYCLE_MARKER = "state/lifecycle_pass.json"
+_LIFECYCLE_INTERVAL_S = 6 * 3600
+
+
+def _run_lifecycle_pass(
+    store: JobStore, job_id: str, now: datetime
+) -> list[dict[str, Any]]:
+    """Deterministic demotion/retirement: evaluate typed probation predicates
+    against measured forward metrics and flip leg status mechanically. The
+    agent registers the rules; the controller enforces them — a rule that
+    fires only if someone re-reads it is not a rule."""
+    from wayfinder_paths.jobs.models import utc_now_iso
+    from wayfinder_paths.jobs.predicates import evaluate_predicates, forward_metrics
+    from wayfinder_paths.jobs.probation import load_probation, update_probation_leg
+
+    marker = store.read_json(job_id, _LIFECYCLE_MARKER) or {}
+    if _age(now, marker.get("ran_at")) < timedelta(seconds=_LIFECYCLE_INTERVAL_S):
+        return []
+    store.write_json(job_id, _LIFECYCLE_MARKER, {"ran_at": now.isoformat()})
+
+    doc = load_probation(store, job_id)
+    active = [leg for leg in doc.get("legs") or [] if leg.get("status") == "active"]
+    if not active:
+        return []
+    trades_path = store.job_dir(job_id) / "results" / "forward" / "trades.jsonl"
+    trades: list[dict[str, Any]] = []
+    if trades_path.exists():
+        for line in trades_path.read_text(encoding="utf-8").splitlines():
+            try:
+                row = json.loads(line)
+            except ValueError:
+                continue
+            if isinstance(row, dict):
+                trades.append(row)
+
+    events: list[dict[str, Any]] = []
+    for leg in active:
+        name = str(leg.get("name"))
+        metrics = forward_metrics(
+            trades,
+            symbol=str(leg.get("symbol")) or None,
+            since=str(leg.get("deployed_at") or "") or None,
+            now_iso=utc_now_iso(),
+        )
+        kill = evaluate_predicates((leg.get("kill") or {}).get("rules"), metrics)
+        graduate = evaluate_predicates(
+            (leg.get("graduate") or {}).get("rules"), metrics
+        )
+        update_probation_leg(
+            store,
+            job_id,
+            name,
+            progress=(
+                f"controller {now.date()}: kill={kill['status']} "
+                f"graduate={graduate['status']} "
+                f"trades={metrics['closed_trades']} pnl={metrics['net_pnl']}"
+            ),
+        )
+        # Kill outranks graduate: if both fire, the leg dies — pre-registered
+        # risk rules are senior to reward rules.
+        decision = (
+            ("killed", kill) if kill["status"] == "met"
+            else ("graduated", graduate) if graduate["status"] == "met"
+            else None
+        )
+        if decision is None:
+            continue
+        status, evaluation = decision
+        update_probation_leg(store, job_id, name, status=status)
+        store.append_journal(
+            job_id,
+            {
+                "type": "lifecycle_decision",
+                "leg": name,
+                "decision": status,
+                "metrics": metrics,
+                "checks": evaluation["checks"],
+            },
+        )
+        events.append(
+            {"action": f"lifecycle_{status}", "leg": name, "metrics": metrics}
+        )
+    return events
+
+
 def recover_stalled_applications(
     *, store: JobStore | None = None, now: datetime | None = None
 ) -> dict[str, Any]:
@@ -515,6 +604,11 @@ def recover_stalled_applications(
             recovered.append({"job_id": job.id, **gate_event})
             if gate_event.get("action") == "gate_restamp":
                 restamped_this_pass = True
+        try:
+            for lifecycle_event in _run_lifecycle_pass(store, job.id, now):
+                recovered.append({"job_id": job.id, **lifecycle_event})
+        except Exception as exc:
+            errors.append({"job_id": job.id, "error": f"lifecycle: {exc}"})
     return {"scanned": scanned, "recovered": recovered, "errors": errors}
 
 

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -329,6 +329,17 @@ def _restage_block(root: Path) -> list[dict[str, Any]]:
     return tasks
 
 
+def _archive_block(store: JobStore, job_id: str) -> dict[str, Any]:
+    """Frontier + refuted branches: exploration cites archive state, not
+    memory. Never raises."""
+    try:
+        from wayfinder_paths.jobs.archive import archive_snapshot_block
+
+        return archive_snapshot_block(store, job_id)
+    except Exception:  # noqa: BLE001
+        return {}
+
+
 def _evolution_block(store: JobStore, job_id: str) -> dict[str, Any]:
     """Promotion-reliability scoreboard: the improver reads its own audited
     outcomes instead of its memory of them. Never raises."""
@@ -550,6 +561,7 @@ def _build_worker_prompt_sections(
         "research_substrate": _research_substrate_block(root),
         "standing_checks": _standing_checks_block(root),
         "evolution": _evolution_block(store, job_id),
+        "archive": _archive_block(store, job_id),
         "restage_tasks": restage_tasks,
     }
 
@@ -814,6 +826,12 @@ def _build_worker_prompt_sections(
             "hypothesis requires NAMED new evidence. Keep the agenda compact "
             "(~150 lines): it is a curated map, not a log — compact it in "
             "place as part of updating it.\n"
+            "- Probation legs carry TYPED graduate/kill rules "
+            "(graduate_rules/kill_rules predicate dicts, e.g. "
+            "win_rate__lt: 0.2 with min_closed_trades: 10). The lifecycle "
+            "controller evaluates them mechanically every ~6h and flips leg "
+            "status itself — register honest rules at leg creation; do not "
+            "hand-adjudicate outcomes the controller owns.\n"
             "- Economic promotion gate: full-size promotion requires the "
             "candidate to beat the incumbent on paired OOS folds under the "
             "owner constitution (LCB > 0); it is computed by gate code and "

--- a/wayfinder_paths/tests/test_jobs_lifecycle.py
+++ b/wayfinder_paths/tests/test_jobs_lifecycle.py
@@ -1,0 +1,215 @@
+"""PR B: typed predicates, candidate archive + Pareto frontier, and the
+mechanical lifecycle controller."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from wayfinder_paths.jobs.archive import (
+    archive_snapshot_block,
+    load_archive,
+    record_candidate,
+    set_candidate_status,
+    set_incumbent,
+)
+from wayfinder_paths.jobs.models import WayfinderJob, utc_now_iso
+from wayfinder_paths.jobs.predicates import evaluate_predicates, forward_metrics
+from wayfinder_paths.jobs.probation import load_probation, record_probation_leg
+from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.jobs.watchdog import _run_lifecycle_pass
+
+
+def _store(tmp_path: Path) -> tuple[JobStore, str]:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        "lifecycle-demo",
+        goal="Mechanical rules.",
+        script="workspace/src/loop.py",
+        agent_mode="intervene",
+        execution_contract="jobs_v1",
+    )
+    store.save(job)
+    return store, job.id
+
+
+def test_predicates_ops_prerequisites_and_missing_metrics() -> None:
+    rules = {"min_closed_trades": 10, "win_rate__lt": 0.2, "drawdown_usd__gte": 5.0}
+    # Prerequisite unmet → pending, never met/not_met.
+    pending = evaluate_predicates(rules, {"closed_trades": 4, "win_rate": 0.1})
+    assert pending["status"] == "pending" and "closed_trades" in pending["waiting_on"]
+    # Both conditions hold → met.
+    met = evaluate_predicates(
+        rules, {"closed_trades": 12, "win_rate": 0.15, "drawdown_usd": 6.0}
+    )
+    assert met["status"] == "met"
+    # One fails → not_met.
+    not_met = evaluate_predicates(
+        rules, {"closed_trades": 12, "win_rate": 0.5, "drawdown_usd": 6.0}
+    )
+    assert not_met["status"] == "not_met"
+    # Missing metric → pending: silence never satisfies a rule.
+    missing = evaluate_predicates(rules, {"closed_trades": 12, "win_rate": 0.1})
+    assert missing["status"] == "pending" and missing["missing"]
+    # No rules registered → pending (legacy prose leg).
+    assert evaluate_predicates(None, {})["status"] == "pending"
+    assert evaluate_predicates({}, {})["status"] == "pending"
+
+
+def test_forward_metrics_filters_and_measures() -> None:
+    trades = [
+        {"symbol": "IMX", "timestamp": "2026-08-01T00:00:00+00:00", "net_pnl": -1.0},
+        {"symbol": "IMX", "timestamp": "2026-08-02T00:00:00+00:00", "net_pnl": 2.0},
+        {"symbol": "OP", "timestamp": "2026-08-03T00:00:00+00:00", "net_pnl": -3.0},
+        {"symbol": "IMX", "timestamp": "2026-08-04T00:00:00+00:00", "net_pnl": -0.5},
+        # Before the leg deployed — must be excluded.
+        {"symbol": "IMX", "timestamp": "2026-07-01T00:00:00+00:00", "net_pnl": 9.0},
+    ]
+    metrics = forward_metrics(
+        trades,
+        symbol="IMX",
+        since="2026-07-15T00:00:00+00:00",
+        now_iso="2026-08-05T00:00:00+00:00",
+    )
+    assert metrics["closed_trades"] == 3
+    assert metrics["win_rate"] == pytest.approx(1 / 3)
+    assert metrics["net_pnl"] == pytest.approx(0.5)
+    assert metrics["loss_streak"] == 1
+    assert metrics["days"] == pytest.approx(21.0)
+    assert metrics["drawdown_usd"] == pytest.approx(1.0)
+
+
+def test_archive_frontier_and_status_flow(tmp_path: Path) -> None:
+    store, job_id = _store(tmp_path)
+    vec = lambda g, d, t_, dd: {  # noqa: E731
+        "net_log_growth": g,
+        "downside_deviation": d,
+        "tail_loss": t_,
+        "max_drawdown_pct": dd,
+    }
+    record_candidate(
+        store, job_id, candidate_id="c-strong", family="params",
+        summary="high growth low risk", status="archived",
+        objective=vec(0.10, 0.01, 0.02, 0.05),
+    )
+    record_candidate(
+        store, job_id, candidate_id="c-dominated", family="params",
+        summary="worse everywhere", status="archived",
+        objective=vec(0.05, 0.02, 0.03, 0.08),
+    )
+    record_candidate(
+        store, job_id, candidate_id="c-tradeoff", family="code",
+        summary="less growth, less risk", status="archived",
+        objective=vec(0.06, 0.005, 0.01, 0.03),
+    )
+    doc = load_archive(store, job_id)
+    frontier = {e["candidate_id"] for e in doc["candidates"] if e["on_frontier"]}
+    assert frontier == {"c-strong", "c-tradeoff"}
+
+    # Refuted entries leave the frontier but never the archive; c-dominated
+    # stays off it because c-strong beats it on every axis.
+    set_candidate_status(store, job_id, "c-tradeoff", "refuted", evidence="0/3 folds")
+    doc = load_archive(store, job_id)
+    frontier = {e["candidate_id"] for e in doc["candidates"] if e["on_frontier"]}
+    assert frontier == {"c-strong"}
+    assert len(doc["candidates"]) == 3
+
+    set_incumbent(store, job_id, "c-strong")
+    doc = load_archive(store, job_id)
+    assert next(
+        e for e in doc["candidates"] if e["candidate_id"] == "c-strong"
+    )["status"] == "incumbent"
+
+    # Promoting another demotes the previous incumbent to an archived branch.
+    set_incumbent(store, job_id, "c-dominated")
+    doc = load_archive(store, job_id)
+    statuses = {e["candidate_id"]: e["status"] for e in doc["candidates"]}
+    assert statuses["c-strong"] == "archived"
+    assert statuses["c-dominated"] == "incumbent"
+
+    block = archive_snapshot_block(store, job_id)
+    assert block["counts"]["refuted"] == 1
+    assert any(r["candidate_id"] == "c-tradeoff" for r in block["recent_refuted"])
+    with pytest.raises(ValueError):
+        set_candidate_status(store, job_id, "c-strong", "bogus-status")
+
+
+def _write_trades(store: JobStore, job_id: str, rows: list[dict]) -> None:
+    path = store.job_dir(job_id) / "results" / "forward" / "trades.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8"
+    )
+
+
+def test_lifecycle_controller_kills_on_typed_rules(tmp_path: Path) -> None:
+    store, job_id = _store(tmp_path)
+    record_probation_leg(
+        store,
+        job_id,
+        name="op-leg",
+        symbol="OP",
+        size_fraction=0.25,
+        graduate_criterion="Sharpe > 1 after 20 trades",
+        kill_criterion="WR < 20% after 10 trades",
+        graduate_rules={"min_closed_trades": 20, "win_rate__gte": 0.5},
+        kill_rules={"min_closed_trades": 10, "win_rate__lt": 0.2},
+    )
+    deployed = (datetime.now(UTC) - timedelta(days=10)).isoformat()
+    doc = load_probation(store, job_id)
+    doc["legs"][0]["deployed_at"] = deployed
+    store.write_json(job_id, "probation.json", doc)
+
+    losing = [
+        {
+            "symbol": "OP",
+            "timestamp": (
+                datetime.now(UTC) - timedelta(days=9) + timedelta(hours=i)
+            ).isoformat(),
+            "net_pnl": -1.0 if i % 10 else 1.0,
+        }
+        for i in range(12)
+    ]
+    _write_trades(store, job_id, losing)
+
+    events = _run_lifecycle_pass(store, job_id, datetime.now(UTC))
+    assert events and events[0]["action"] == "lifecycle_killed"
+    doc = load_probation(store, job_id)
+    assert doc["legs"][0]["status"] == "killed"
+    journal = (store.job_dir(job_id) / "journal.jsonl").read_text(encoding="utf-8")
+    assert "lifecycle_decision" in journal
+
+    # Stamp-gated: an immediate second pass does nothing.
+    assert _run_lifecycle_pass(store, job_id, datetime.now(UTC)) == []
+
+
+def test_lifecycle_controller_pending_below_sample_gate(tmp_path: Path) -> None:
+    store, job_id = _store(tmp_path)
+    record_probation_leg(
+        store,
+        job_id,
+        name="young-leg",
+        symbol="OP",
+        size_fraction=0.25,
+        graduate_criterion="prose",
+        kill_criterion="prose",
+        kill_rules={"min_closed_trades": 10, "win_rate__lt": 0.2},
+    )
+    _write_trades(
+        store,
+        job_id,
+        [
+            {"symbol": "OP", "timestamp": utc_now_iso(), "net_pnl": -1.0}
+            for _ in range(3)
+        ],
+    )
+    events = _run_lifecycle_pass(store, job_id, datetime.now(UTC))
+    assert events == []
+    doc = load_probation(store, job_id)
+    leg = doc["legs"][0]
+    assert leg["status"] == "active"
+    # But the controller left visible progress on the leg.
+    assert "kill=pending" in (leg["graduate"]["progress"] or "")


### PR DESCRIPTION
Second of the three bounded-optimizer PRs (pillars 1 + 3). Builds on the economic gate (#635).

## Branches, not just a champion

`state/archive.json` per job: every proposed candidate is retained with lineage (parent revision), its objective vector (from the economic gate's paired evaluation), and a status — `incumbent / archived / probation / refuted / retired`. The Pareto frontier (growth vs downside vs tail vs drawdown) excludes dead branches but **nothing is ever deleted** — a refuted family keeps its disqualifying evidence, and an archived ex-champion stays ranked for revival when the regime flips.

Wired into the real flow, not a side registry: `propose` records the candidate, `reject` flips it to refuted with the rejection as evidence, promotion flips it to incumbent and demotes the previous incumbent to an archived branch. The worker's snapshot now carries the frontier + recent refutations with contract language: re-proposing a refuted family requires named new evidence; frontier ancestors are revival candidates before novel divergent search. `wayfinder job archive <id>` reads the whole tree.

## Mechanical demotion/retirement (typed predicates)

Prose criteria ("kill if WR<20% after 10 trades") only fire if an agent re-reads and honors them. Now: probation legs carry `graduate_rules` / `kill_rules` as machine-evaluable predicates (`win_rate__lt: 0.2` with `min_closed_trades: 10`). The **lifecycle controller** (stamp-gated 6h pass inside the existing watchdog) computes each leg's measured forward metrics (symbol- and deployment-time-filtered) and flips status itself:

- Prerequisites unmet → **pending**, never failed — pre-registered sample-size gates, mechanically enforced
- Missing metrics → pending — silence never satisfies a rule
- Kill outranks graduate when both fire — risk rules are senior to reward rules
- Every decision journals with metrics + per-rule checks and renders in the decision log

Legacy prose-only legs stay visible but are never auto-adjudicated.

## Post-merge (on-box, with owner visibility)

Register the xyz kill/continue criteria as the pilot typed-rule set (its adjudication has been overdue with prose-only criteria), and imx's OP leg gets its existing prose rules ("kill: WR<20% after 10 trades; graduate: Sharpe>1 after 20") converted to predicates.

## Tests

102 green: new `test_jobs_lifecycle` (predicate ops/prerequisites/missing-metric honesty, forward-metric filtering, frontier math incl. domination + refutation flow, incumbent handoff, controller kill on typed rules, sample-gate pending, stamp-gating) + economics/propose/watchdog/worker/decision-log/counterfactual/gating/application-gate/triggers regression. mypy clean on new modules.
