### PR TITLE
jobs: lifecycle metrics read execution-schema timestamps (fix)

### DIFF
--- a/wayfinder_paths/jobs/predicates.py
+++ b/wayfinder_paths/jobs/predicates.py
@@ -79,6 +79,14 @@ def _split(key: str) -> tuple[str, str | None]:
     return key, None
 
 
+def _row_ts(row: Mapping[str, Any]) -> str:
+    # Forward trade rows stamp `ts`/`closed_at` (execution schema), not
+    # `timestamp` — checking only the latter silently excluded every row and
+    # froze adjudication at pending (found on live xyz data, 24 real closes
+    # measured as 0).
+    return str(row.get("timestamp") or row.get("closed_at") or row.get("ts") or "")
+
+
 def forward_metrics(
     trades: list[Mapping[str, Any]],
     *,
@@ -97,7 +105,7 @@ def forward_metrics(
         row
         for row in trades
         if (symbol is None or str(row.get("symbol")) == symbol)
-        and (since is None or str(row.get("timestamp") or "") >= since)
+        and (since is None or _row_ts(row) >= since)
     ]
     pnls = [float(row.get("net_pnl") or row.get("pnl") or 0.0) for row in rows]
     wins = sum(1 for value in pnls if value > 0)

--- a/wayfinder_paths/tests/test_jobs_lifecycle.py
+++ b/wayfinder_paths/tests/test_jobs_lifecycle.py
@@ -59,6 +59,24 @@ def test_predicates_ops_prerequisites_and_missing_metrics() -> None:
     assert evaluate_predicates({}, {})["status"] == "pending"
 
 
+def test_forward_metrics_reads_execution_schema_timestamps() -> None:
+    # Real forward rows stamp ts/closed_at, never `timestamp` — the filter
+    # must read all three or it judges on zero data.
+    trades = [
+        {"symbol": "xyz:SNDK", "closed_at": "2026-08-01T00:00:00+00:00", "net_pnl": -1.0},
+        {"symbol": "xyz:SNDK", "ts": "2026-08-02T00:00:00+00:00", "net_pnl": 2.0},
+        {"symbol": "xyz:SNDK", "ts": "2026-07-01T00:00:00+00:00", "net_pnl": 9.0},
+    ]
+    metrics = forward_metrics(
+        trades,
+        symbol=None,
+        since="2026-07-15T00:00:00+00:00",
+        now_iso="2026-08-05T00:00:00+00:00",
+    )
+    assert metrics["closed_trades"] == 2
+    assert metrics["net_pnl"] == pytest.approx(1.0)
+
+
 def test_forward_metrics_filters_and_measures() -> None:
     trades = [
         {"symbol": "IMX", "timestamp": "2026-08-01T00:00:00+00:00", "net_pnl": -1.0},


### PR DESCRIPTION
One-field fix found by live acceptance: forward trade rows stamp `ts`/`closed_at` (execution schema), never `timestamp`, so the lifecycle controller's since-filter measured **0 trades against xyz's 24 real closes** and froze adjudication at pending (fail-safe direction, but frozen). Fallback chain `timestamp → closed_at → ts` + regression test using the real row shape. 6 lifecycle tests green.