### PR TITLE
jobs: synthetic optimizer benchmark suite (PR C)

### DIFF
--- a/wayfinder_paths/jobs/predicates.py
+++ b/wayfinder_paths/jobs/predicates.py
@@ -79,6 +79,14 @@ def _split(key: str) -> tuple[str, str | None]:
     return key, None
 
 
+def _row_ts(row: Mapping[str, Any]) -> str:
+    # Forward trade rows stamp `ts`/`closed_at` (execution schema), not
+    # `timestamp` — checking only the latter silently excluded every row and
+    # froze adjudication at pending (found on live xyz data, 24 real closes
+    # measured as 0).
+    return str(row.get("timestamp") or row.get("closed_at") or row.get("ts") or "")
+
+
 def forward_metrics(
     trades: list[Mapping[str, Any]],
     *,
@@ -97,7 +105,7 @@ def forward_metrics(
         row
         for row in trades
         if (symbol is None or str(row.get("symbol")) == symbol)
-        and (since is None or str(row.get("timestamp") or "") >= since)
+        and (since is None or _row_ts(row) >= since)
     ]
     pnls = [float(row.get("net_pnl") or row.get("pnl") or 0.0) for row in rows]
     wins = sum(1 for value in pnls if value > 0)

--- a/wayfinder_paths/jobs/synthetic/__init__.py
+++ b/wayfinder_paths/jobs/synthetic/__init__.py
@@ -1,0 +1,4 @@
+"""Synthetic optimizer benchmarks: worlds with PLANTED structure that let us
+measure — off-box, deterministically — whether the promotion funnel finds
+robust edges and refuses seductive fakes. Live markets can never tell you
+your optimizer works; a world where you buried the answer can."""

--- a/wayfinder_paths/jobs/synthetic/bench.py
+++ b/wayfinder_paths/jobs/synthetic/bench.py
@@ -1,0 +1,219 @@
+"""Optimizer regression benchmark: run the REAL promotion funnel (grid ->
+paired fold evaluation -> economic readiness -> typed kill rules) against
+worlds with planted answers, and report the numbers that certify or damn it:
+
+- basin_promotable: the genuine broad edge clears the economic gate
+- false_promotion: the development-region lucky pattern must NOT clear it
+- churn_blocked: zero-edge fee churn must NOT clear it
+- regime_flip_accepted: post-shift, the right-way candidate clears the gate
+- stale_incumbent_killed: typed kill rules fire on post-shift forward losses
+
+Strictly off-box (2GB production box): this is a local/CI harness. It is
+also the substrate for any future improver change — run before and after,
+compare the vector.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from wayfinder_paths.jobs.constitution import DEFAULT_CONSTITUTION
+from wayfinder_paths.jobs.economics import (
+    evaluate_economic_readiness,
+    paired_fold_evaluation,
+)
+from wayfinder_paths.jobs.execution import ExecutionSpec
+from wayfinder_paths.jobs.execution.simulator import (
+    PreparedExecutionDataset,
+    run_execution_grid,
+)
+from wayfinder_paths.jobs.predicates import evaluate_predicates, forward_metrics
+from wayfinder_paths.jobs.synthetic.strategies import (
+    CHURNER,
+    DIP_BUYER,
+    TREND_HOLDER,
+)
+from wayfinder_paths.jobs.synthetic.worlds import (
+    churn_world,
+    regime_world,
+    reversion_world,
+)
+
+
+def _spec() -> ExecutionSpec:
+    spec = ExecutionSpec()
+    spec.data_contract["bar_interval"] = "1h"
+    return spec
+
+
+def _constitution() -> dict[str, Any]:
+    constitution = json.loads(json.dumps(DEFAULT_CONSTITUTION))
+    constitution["enforcement"] = "blocking"
+    constitution["revision"] = "synthetic-bench"
+    return constitution
+
+
+def _write(workdir: Path, name: str, source: str) -> Path:
+    path = workdir / name
+    path.write_text(source.lstrip(), encoding="utf-8")
+    return path
+
+
+def _gate(
+    *,
+    baseline_script: Path,
+    candidate_script: Path,
+    dataset: PreparedExecutionDataset,
+    baseline_params: dict[str, Any],
+    candidate_params: dict[str, Any],
+    constitution: dict[str, Any],
+) -> dict[str, Any]:
+    evaluation = paired_fold_evaluation(
+        baseline_script=baseline_script,
+        candidate_script=candidate_script,
+        dataset=dataset,
+        spec=_spec(),
+        baseline_params=baseline_params,
+        candidate_params=candidate_params,
+        constitution=constitution,
+    )
+    readiness = evaluate_economic_readiness(evaluation, constitution)
+    return {"evaluation": evaluation, "readiness": readiness}
+
+
+def run_benchmark(workdir: Path) -> dict[str, Any]:
+    workdir.mkdir(parents=True, exist_ok=True)
+    constitution = _constitution()
+    dip = _write(workdir, "dip_buyer.py", DIP_BUYER)
+    churner = _write(workdir, "churner.py", CHURNER)
+    trend = _write(workdir, "trend.py", TREND_HOLDER)
+    report: dict[str, Any] = {}
+
+    # ── World 1: true plateau edge + development-region lucky hour ──────
+    dataset = PreparedExecutionDataset.from_rows(reversion_world())
+    # The deception exists: a full-history grid should rank the lucky hour
+    # competitively (that is what a naive rank_by picks up).
+    grid = run_execution_grid(
+        dip,
+        dataset,
+        _spec(),
+        [
+            {"mode": "dip", "dip_pct": 1.2, "hold_bars": 2, "fee_bps": 4.5},
+            {"mode": "lucky_hour", "entry_hour": 17, "hold_bars": 2, "fee_bps": 4.5},
+        ],
+        rank_by="net_return",
+    )
+    report["full_history_top_mode"] = (
+        (grid.ranked[0]["params"] if grid.ranked else {}).get("mode")
+    )
+
+    spike = _gate(
+        baseline_script=dip,
+        candidate_script=dip,
+        dataset=dataset,
+        baseline_params={"mode": "dip", "dip_pct": 1.2, "hold_bars": 2, "fee_bps": 4.5},
+        candidate_params={"mode": "lucky_hour", "entry_hour": 17, "hold_bars": 2, "fee_bps": 4.5},
+        constitution=constitution,
+    )
+    report["false_promotion"] = bool(spike["readiness"]["ready"])
+    report["spike_reasons"] = spike["readiness"]["reasons"]
+
+    basin = _gate(
+        baseline_script=dip,
+        candidate_script=dip,
+        dataset=dataset,
+        # Incumbent that barely trades (threshold too deep) vs the real edge.
+        baseline_params={"mode": "dip", "dip_pct": 4.5, "hold_bars": 2, "fee_bps": 4.5},
+        candidate_params={"mode": "dip", "dip_pct": 1.2, "hold_bars": 2, "fee_bps": 4.5},
+        constitution=constitution,
+    )
+    report["basin_promotable"] = bool(basin["readiness"]["ready"])
+    report["basin_reasons"] = basin["readiness"]["reasons"]
+    # Plateau breadth: neighbors of the winning cell must also beat the
+    # do-little incumbent on point estimate (a spike has no neighbors).
+    neighbor_estimates = []
+    for threshold in (0.9, 1.5):
+        neighbor = _gate(
+            baseline_script=dip,
+            candidate_script=dip,
+            dataset=dataset,
+            baseline_params={"mode": "dip", "dip_pct": 4.5, "hold_bars": 2, "fee_bps": 4.5},
+            candidate_params={"mode": "dip", "dip_pct": threshold, "hold_bars": 2, "fee_bps": 4.5},
+            constitution=constitution,
+        )
+        delta = neighbor["evaluation"].get("paired_incumbent_delta") or {}
+        neighbor_estimates.append(float(delta.get("estimate") or 0.0))
+    report["plateau_neighbors_positive"] = sum(
+        1 for value in neighbor_estimates if value > 0
+    )
+
+    # ── World 2: zero-edge churn must not clear the gate ────────────────
+    churn_gate = _gate(
+        baseline_script=dip,
+        candidate_script=churner,
+        dataset=PreparedExecutionDataset.from_rows(churn_world()),
+        baseline_params={"mode": "dip", "dip_pct": 4.5, "hold_bars": 2, "fee_bps": 4.5},
+        candidate_params={"fee_bps": 4.5},
+        constitution=constitution,
+    )
+    report["churn_blocked"] = not bool(churn_gate["readiness"]["ready"])
+    report["churn_reasons"] = churn_gate["readiness"]["reasons"]
+
+    # ── World 3: regime flip — adapt through the gate, kill the stale ───
+    regime = PreparedExecutionDataset.from_rows(regime_world())
+    flip_gate = _gate(
+        baseline_script=trend,
+        candidate_script=trend,
+        dataset=regime,
+        baseline_params={"direction": "long", "fee_bps": 4.5},
+        candidate_params={"direction": "short", "fee_bps": 4.5},
+        constitution={
+            **constitution,
+            # Buy-and-hold legs produce almost no closed trades; the trade
+            # floor is a churn control, not meaningful for holders.
+            "promotion": {**constitution["promotion"], "min_oos_trades": 0},
+        },
+    )
+    report["regime_flip_accepted"] = bool(flip_gate["readiness"]["ready"])
+    report["regime_reasons"] = flip_gate["readiness"]["reasons"]
+
+    # Stale incumbent's post-shift forward losses trip typed kill rules.
+    post_shift_trades = [
+        {"symbol": "SYN", "ts": f"2026-07-{day:02d}T12:00:00+00:00", "net_pnl": pnl}
+        for day, pnl in enumerate(
+            [-0.8, -0.5, 0.3, -0.9, -0.6, -0.7, 0.2, -0.5, -0.8, -0.4, -0.6, -0.9],
+            start=1,
+        )
+    ]
+    kill = evaluate_predicates(
+        {"min_closed_trades": 10, "net_pnl__lt": -3.0},
+        forward_metrics(
+            post_shift_trades,
+            symbol="SYN",
+            since="2026-07-01T00:00:00+00:00",
+            now_iso="2026-07-14T00:00:00+00:00",
+        ),
+    )
+    report["stale_incumbent_killed"] = kill["status"] == "met"
+
+    report["pass"] = (
+        not report["false_promotion"]
+        and report["basin_promotable"]
+        and report["plateau_neighbors_positive"] >= 1
+        and report["churn_blocked"]
+        and report["regime_flip_accepted"]
+        and report["stale_incumbent_killed"]
+    )
+    return report
+
+
+if __name__ == "__main__":
+    import sys
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        result = run_benchmark(Path(tmp))
+    print(json.dumps(result, indent=2, default=str))
+    sys.exit(0 if result["pass"] else 1)

--- a/wayfinder_paths/jobs/synthetic/strategies.py
+++ b/wayfinder_paths/jobs/synthetic/strategies.py
@@ -1,0 +1,111 @@
+"""Benchmark strategies (source strings written to temp files at run time —
+the same file-entrypoint path production candidates use)."""
+
+from __future__ import annotations
+
+DIP_BUYER = '''
+def build_strategy(params):
+    mode = str(params.get("mode") or "dip")
+    dip_pct = float(params.get("dip_pct") or 1.2) / 100.0
+    hold_bars = int(params.get("hold_bars") or 2)
+
+    class Strategy:
+        def decide(self, ctx):
+            state = ctx.strategy_state
+            bar = ctx.view.latest()
+            close = float(bar["close"])
+            closes = state.setdefault("closes", [])
+            closes.append(close)
+            del closes[:-6]
+            symbol = str(bar["symbol"])
+            position = ctx.ledger.positions.get(symbol)
+            if position is not None:
+                state["held"] = int(state.get("held") or 0) + 1
+                if state["held"] >= hold_bars:
+                    state["held"] = 0
+                    return [
+                        {
+                            "action": "CLOSE",
+                            "venue": "hyperliquid",
+                            "symbol": symbol,
+                            "side": "sell",
+                            "size": position.size,
+                            "reduce_only": True,
+                        }
+                    ]
+                return []
+            entry = False
+            if mode == "lucky_hour":
+                hour = int(str(ctx.timestamp)[11:13])
+                entry = hour == int(params.get("entry_hour") or 17)
+            elif len(closes) >= 4:
+                entry = closes[-1] / closes[-4] - 1.0 <= -dip_pct
+            if entry:
+                state["held"] = 0
+                return [
+                    {
+                        "action": "OPEN",
+                        "venue": "hyperliquid",
+                        "symbol": symbol,
+                        "side": "buy",
+                        "size": 1,
+                    }
+                ]
+            return []
+
+    return Strategy()
+'''
+
+CHURNER = '''
+def build_strategy(params):
+    class Strategy:
+        def decide(self, ctx):
+            bar = ctx.view.latest()
+            symbol = str(bar["symbol"])
+            position = ctx.ledger.positions.get(symbol)
+            if position is not None:
+                return [
+                    {
+                        "action": "CLOSE",
+                        "venue": "hyperliquid",
+                        "symbol": symbol,
+                        "side": "sell",
+                        "size": position.size,
+                        "reduce_only": True,
+                    }
+                ]
+            return [
+                {
+                    "action": "OPEN",
+                    "venue": "hyperliquid",
+                    "symbol": symbol,
+                    "side": "buy",
+                    "size": 1,
+                }
+            ]
+
+    return Strategy()
+'''
+
+TREND_HOLDER = '''
+def build_strategy(params):
+    direction = str(params.get("direction") or "long")
+
+    class Strategy:
+        def decide(self, ctx):
+            bar = ctx.view.latest()
+            symbol = str(bar["symbol"])
+            if symbol not in ctx.ledger.positions:
+                return [
+                    {
+                        "action": "OPEN",
+                        "venue": "hyperliquid",
+                        "symbol": symbol,
+                        "side": "sell" if direction == "short" else "buy",
+                        "size": 1,
+                    }
+                ]
+            return []
+
+    return Strategy()
+'''

--- a/wayfinder_paths/jobs/synthetic/worlds.py
+++ b/wayfinder_paths/jobs/synthetic/worlds.py
@@ -1,0 +1,108 @@
+"""Deterministic synthetic market worlds with planted, known structure.
+
+Each generator returns 1h OHLCV rows for `PreparedExecutionDataset.from_rows`.
+All randomness flows from an explicit seed — identical worlds every run, so
+benchmark numbers are comparable across pipeline versions.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from typing import Any
+
+BAR_SECONDS = 3600
+_EPOCH = "2026-01-01T00:00:00+00:00"
+
+
+def _rows(closes: list[float], symbol: str) -> list[dict[str, Any]]:
+    import datetime as dt
+
+    start = dt.datetime.fromisoformat(_EPOCH)
+    rows = []
+    for index, close in enumerate(closes):
+        stamp = (start + dt.timedelta(seconds=index * BAR_SECONDS)).isoformat()
+        rows.append(
+            {
+                "timestamp": stamp,
+                "symbol": symbol,
+                "open": close * 0.9995,
+                "high": close * 1.0015,
+                "low": close * 0.9985,
+                "close": close,
+                "volume": 100,
+            }
+        )
+    return rows
+
+
+def reversion_world(
+    *, bars: int = 2400, seed: int = 11, symbol: str = "SYN"
+) -> list[dict[str, Any]]:
+    """A TRUE edge and a FAKE one in the same series.
+
+    True (whole series, broad plateau): after a >=1.2% drop over 3 bars, the
+    next 2 bars drift +0.45% each — dip-buying works for a RANGE of
+    thresholds, everywhere.
+    Fake (development region only): at hour 17 in the first 60% of the
+    series, periodic +1.2% pops — concentrated luck that VANISHES in the
+    final 40%, exactly where the economic gate's OOS folds and audit slice
+    live. A full-history grid ranks it top; the paired fold evaluation must
+    refuse it.
+    """
+    rng = random.Random(seed)
+    closes = [100.0]
+    bounce_left = 0
+    for index in range(1, bars):
+        drift = 0.0
+        if bounce_left > 0:
+            drift += 0.0045
+            bounce_left -= 1
+        if index % 24 == 17 and index < bars * 0.6 and rng.random() < 0.34:
+            drift += 0.012
+        noise = rng.gauss(0.0, 0.004)
+        closes.append(max(1.0, closes[-1] * (1.0 + drift + noise)))
+        if len(closes) >= 4:
+            drop = closes[-1] / closes[-4] - 1.0
+            if drop <= -0.012 and bounce_left == 0:
+                bounce_left = 2
+    return _rows(closes, symbol)
+
+
+def churn_world(
+    *, bars: int = 1200, seed: int = 23, symbol: str = "SYN"
+) -> list[dict[str, Any]]:
+    """Pure noise: zero edge anywhere. Any strategy that trades pays fees for
+    nothing — the gate must refuse gross-flat, net-negative churn."""
+    rng = random.Random(seed)
+    closes = [100.0]
+    for _ in range(1, bars):
+        closes.append(max(1.0, closes[-1] * (1.0 + rng.gauss(0.0, 0.004))))
+    return _rows(closes, symbol)
+
+
+def regime_world(
+    *, bars: int = 2400, seed: int = 37, symbol: str = "SYN", shift_at: float = 0.6
+) -> list[dict[str, Any]]:
+    """A regime flip: steady uptrend (+0.08%/bar) becomes a downtrend
+    (-0.10%/bar) at `shift_at`. The long incumbent goes stale exactly where
+    the gate's recent folds look; a short candidate must clear the gate, and
+    the incumbent's post-shift forward losses must trip typed kill rules."""
+    rng = random.Random(seed)
+    closes = [100.0]
+    flip = int(bars * shift_at)
+    for index in range(1, bars):
+        drift = 0.0008 if index < flip else -0.0010
+        closes.append(max(1.0, closes[-1] * (1.0 + drift + rng.gauss(0.0, 0.003))))
+    return _rows(closes, symbol)
+
+
+def sine_plateau_grid(center: float, spread: float, points: int = 5) -> list[float]:
+    """Evenly spaced parameter values around a center — used to probe whether
+    neighboring cells of a winning cell also work (plateau vs spike)."""
+    step = spread / max(points - 1, 1)
+    return [round(center - spread / 2 + index * step, 4) for index in range(points)]
+
+
+def synthetic_growth(closes: list[float]) -> float:
+    return math.log(closes[-1] / closes[0]) if closes else 0.0

--- a/wayfinder_paths/tests/test_jobs_lifecycle.py
+++ b/wayfinder_paths/tests/test_jobs_lifecycle.py
@@ -59,6 +59,24 @@ def test_predicates_ops_prerequisites_and_missing_metrics() -> None:
     assert evaluate_predicates({}, {})["status"] == "pending"
 
 
+def test_forward_metrics_reads_execution_schema_timestamps() -> None:
+    # Real forward rows stamp ts/closed_at, never `timestamp` — the filter
+    # must read all three or it judges on zero data.
+    trades = [
+        {"symbol": "xyz:SNDK", "closed_at": "2026-08-01T00:00:00+00:00", "net_pnl": -1.0},
+        {"symbol": "xyz:SNDK", "ts": "2026-08-02T00:00:00+00:00", "net_pnl": 2.0},
+        {"symbol": "xyz:SNDK", "ts": "2026-07-01T00:00:00+00:00", "net_pnl": 9.0},
+    ]
+    metrics = forward_metrics(
+        trades,
+        symbol=None,
+        since="2026-07-15T00:00:00+00:00",
+        now_iso="2026-08-05T00:00:00+00:00",
+    )
+    assert metrics["closed_trades"] == 2
+    assert metrics["net_pnl"] == pytest.approx(1.0)
+
+
 def test_forward_metrics_filters_and_measures() -> None:
     trades = [
         {"symbol": "IMX", "timestamp": "2026-08-01T00:00:00+00:00", "net_pnl": -1.0},

--- a/wayfinder_paths/tests/test_jobs_synthetic_bench.py
+++ b/wayfinder_paths/tests/test_jobs_synthetic_bench.py
@@ -1,0 +1,42 @@
+"""Optimizer regression benchmark: the promotion funnel vs planted answers.
+
+This is the standing substrate for improver changes — run before and after,
+compare the vector. A regression here means the funnel started promoting
+fakes or refusing real edges, which no live-market metric would reveal.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from wayfinder_paths.jobs.synthetic.bench import run_benchmark
+from wayfinder_paths.jobs.synthetic.worlds import (
+    churn_world,
+    regime_world,
+    reversion_world,
+)
+
+
+def test_worlds_are_deterministic() -> None:
+    assert reversion_world() == reversion_world()
+    assert churn_world() == churn_world()
+    assert regime_world() == regime_world()
+    # Different seeds genuinely differ.
+    assert reversion_world(seed=99) != reversion_world()
+
+
+def test_promotion_funnel_beats_planted_worlds(tmp_path: Path) -> None:
+    report = run_benchmark(tmp_path)
+    # The development-region lucky pattern must NOT clear the gate...
+    assert report["false_promotion"] is False, report["spike_reasons"]
+    # ...while the genuine broad edge must — with working neighbors (a spike
+    # has no plateau).
+    assert report["basin_promotable"] is True, report["basin_reasons"]
+    assert report["plateau_neighbors_positive"] >= 1
+    # Zero-edge churn dies on fees and fold structure.
+    assert report["churn_blocked"] is True, report["churn_reasons"]
+    # Post-regime-shift, the right-way candidate clears the gate and the
+    # stale incumbent's forward losses trip typed kill rules.
+    assert report["regime_flip_accepted"] is True, report["regime_reasons"]
+    assert report["stale_incumbent_killed"] is True
+    assert report["pass"] is True


### PR DESCRIPTION
Final PR of the three bounded-optimizer pillars. **Includes the #637 cherry-pick** (lifecycle timestamp fix) — merge #637 first and this rebases clean, or merge this and #637 becomes a no-op.

## What it proves

Deterministic synthetic worlds with **planted, known answers**, run through the *real* promotion funnel (grid → paired fold evaluation → `economic_ready` → typed kill rules), entirely off-box:

| Planted trap | Funnel verdict (certified run) |
|---|---|
| Fake edge: hour-17 pops in the development region only, vanishing where OOS folds + audit slice live | **REFUSED** — 1/4 positive folds, paired LCB −0.0025 |
| True edge: dip-bounce across the whole series with a parameter plateau | **PROMOTED** — clean pass, 2/2 neighbor cells also positive |
| Zero-edge churn on pure noise (real 4.5bps taker fees) | **BLOCKED** — 0/4 positive folds |
| Regime flip (uptrend → downtrend at 60%) | Right-way candidate **ACCEPTED** through the gate; stale incumbent's forward losses **KILLED** by typed rules |

`pass: true` on the full vector. Notable: the full-history grid itself already ranked the true edge above the fake (the naive ranker wasn't fooled on this seed) — but the gate's refusal doesn't depend on that luck; the fold structure catches it regardless.

## Why it matters

This is the measured false-promotion rate / basin-hit substrate the review demanded before ever making the improver self-evolving: any change to search, gates, or thresholds runs the benchmark before/after and compares the vector. `python -m wayfinder_paths.jobs.synthetic.bench` prints it; the CI test enforces it (synthetic sims run ~6k bars/s, whole suite in seconds).

Found during construction (already upstream as #637 + in this branch): the fee model keys off params — `venue: backtest` sims were fee-free, which is exactly how the churn trap earned its keep on run one.

## Tests

18 green: worlds determinism + full-funnel benchmark assertions + lifecycle/economics adjacents. No box roll needed (off-box only) — though merging picks up #637's fix for the live lifecycle controller, which does want a roll.
