### PR TITLE
WOB PR I: exact known-optimum benchmark kernel + published exact-v0 dataset

### DIFF
--- a/scripts/benchmark_wayfinder_optimizer.py
+++ b/scripts/benchmark_wayfinder_optimizer.py
@@ -1,0 +1,93 @@
+"""Wayfinder Optimizer Benchmark CLI.
+
+Examples:
+    # Fast smoke (CI shape): 1 seed x 3 archetypes, tiny budgets
+    python scripts/benchmark_wayfinder_optimizer.py --suite smoke
+
+    # Public half of exact-v0 (anyone can regenerate this)
+    python scripts/benchmark_wayfinder_optimizer.py --suite exact-v0-public \
+        --out .wayfinder_runs/benchmarks/exact-v0
+
+    # Full exact-v0 incl. sealed worlds (requires WOB_PRIVATE_SEEDS)
+    python scripts/benchmark_wayfinder_optimizer.py --suite exact-v0 \
+        --out .wayfinder_runs/benchmarks/exact-v0 \
+        --sealed-out ~/wob-sealed/exact-v0 --workers 6
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from wayfinder_paths.jobs.benchmarks.manifest import (  # noqa: E402
+    load_private_seeds,
+    suite_split,
+)
+from wayfinder_paths.jobs.benchmarks.runner import run_suite  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Wayfinder Optimizer Benchmark")
+    parser.add_argument(
+        "--suite",
+        default="smoke",
+        choices=["smoke", "exact-v0-public", "exact-v0"],
+    )
+    parser.add_argument("--out", default=".wayfinder_runs/benchmarks/latest")
+    parser.add_argument("--sealed-out", default=None)
+    parser.add_argument(
+        "--optimizers", default="random,grid,tpe,funnel",
+        help="comma-separated lane names",
+    )
+    parser.add_argument("--budgets", default="25,50,100")
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--workers", type=int, default=1)
+    parser.add_argument("--oracle-paths", type=int, default=64)
+    args = parser.parse_args()
+
+    if args.suite == "smoke":
+        plan = {
+            "public": {
+                "smooth_optimum": [1000],
+                "deceptive_multi_peak": [1100],
+                "null_world": [1900],
+            }
+        }
+        budgets = [25]
+        repeats = 1
+        oracle_paths = min(args.oracle_paths, 16)
+    else:
+        private = load_private_seeds() if args.suite == "exact-v0" else {}
+        plan = suite_split(private_seeds=private)
+        if args.suite == "exact-v0-public":
+            plan = {"public": plan["public"]}
+        elif not plan["sealed"]:
+            raise SystemExit(
+                "exact-v0 requires sealed seeds: set WOB_PRIVATE_SEEDS to the "
+                "owner-held registry (or run exact-v0-public)"
+            )
+        budgets = [int(b) for b in args.budgets.split(",")]
+        repeats = args.repeats
+        oracle_paths = args.oracle_paths
+
+    report = run_suite(
+        plan,
+        out_dir=Path(args.out),
+        sealed_dir=Path(args.sealed_out) if args.sealed_out else None,
+        optimizers=[name.strip() for name in args.optimizers.split(",")],
+        budgets=budgets,
+        repeats=repeats,
+        oracle_paths=oracle_paths,
+        workers=args.workers,
+    )
+    print(json.dumps(report["by_optimizer"], indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/wayfinder_paths/jobs/benchmarks/__init__.py
+++ b/wayfinder_paths/jobs/benchmarks/__init__.py
@@ -1,0 +1,6 @@
+"""Wayfinder Optimizer Benchmark (WOB): exact known-optimum worlds, an
+exhaustive oracle over a finite Strategy Genome, and matched-budget optimizer
+lanes — the instrument that answers "did the stack find the global region or
+merely improve the local incumbent," with regret decomposed into search
+(never found it), selection (found it, picked wrong), and execution
+(picked right, couldn't realize it)."""

--- a/wayfinder_paths/jobs/benchmarks/adapters.py
+++ b/wayfinder_paths/jobs/benchmarks/adapters.py
@@ -1,0 +1,173 @@
+"""Matched-budget optimizer lanes.
+
+Every adapter sees ONLY development paths and a candidate-evaluation budget;
+it returns its full evaluated lineage (every genome it scored, in order) and
+its selected genome (None = abstain). The oracle never enters an adapter —
+selection regret is measurable only because lineage is complete.
+
+`funnel_search` is the production stack's shape without the LLM: propose on
+a train path, hold out a second path, refuse candidates that fail holdout —
+abstention on null worlds is exactly what the false-promotion metric scores.
+"""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Sequence
+from typing import Any
+
+from wayfinder_paths.jobs.benchmarks.grammar import Genome
+from wayfinder_paths.jobs.benchmarks.oracle import (
+    ContinuationSeries,
+    evaluate_genome,
+    utility_from_trades,
+)
+
+_WEIGHTS = {"downside": 0.5, "tail": 1.0, "turnover": 0.25}
+
+
+def dev_score(
+    genome: Genome, dev_series: Sequence[ContinuationSeries], *, fee_bps: float
+) -> float:
+    utilities = [
+        utility_from_trades(
+            evaluate_genome(genome, series, fee_bps=fee_bps)["pnls"],
+            weights=_WEIGHTS,
+        )
+        for series in dev_series
+    ]
+    return sum(utilities) / len(utilities)
+
+
+def random_search(
+    genomes: Sequence[Genome],
+    dev_series: Sequence[ContinuationSeries],
+    *,
+    budget: int,
+    fee_bps: float,
+    seed: int,
+) -> dict[str, Any]:
+    rng = random.Random(seed)
+    picks = rng.sample(list(genomes), min(budget, len(genomes)))
+    lineage = [(g, dev_score(g, dev_series, fee_bps=fee_bps)) for g in picks]
+    selected = max(lineage, key=lambda pair: pair[1])[0]
+    return {"lineage": lineage, "selected": selected, "optimizer": "random"}
+
+
+def grid_search(
+    genomes: Sequence[Genome],
+    dev_series: Sequence[ContinuationSeries],
+    *,
+    budget: int,
+    fee_bps: float,
+    seed: int = 0,
+) -> dict[str, Any]:
+    """Deterministic coarse lattice: stride the enumeration order so every
+    structural region gets touched at any budget."""
+    stride = max(1, len(genomes) // budget)
+    picks = list(genomes)[::stride][:budget]
+    lineage = [(g, dev_score(g, dev_series, fee_bps=fee_bps)) for g in picks]
+    selected = max(lineage, key=lambda pair: pair[1])[0]
+    return {"lineage": lineage, "selected": selected, "optimizer": "grid"}
+
+
+def tpe_search(
+    genomes: Sequence[Genome],
+    dev_series: Sequence[ContinuationSeries],
+    *,
+    budget: int,
+    fee_bps: float,
+    seed: int,
+) -> dict[str, Any]:
+    import optuna
+
+    optuna.logging.set_verbosity(optuna.logging.WARNING)
+    index: dict[tuple[str, str, str, int, str], Genome] = {}
+    exits: list[tuple[str, tuple]] = []
+    for genome in genomes:
+        exit_key = (genome.exit_family, genome.exit_params)
+        if exit_key not in exits:
+            exits.append(exit_key)
+        index[
+            (
+                genome.signal,
+                genome.direction,
+                genome.confirm_filter,
+                exits.index(exit_key),
+                genome.sizing_family,
+            )
+        ] = genome
+    signals = sorted({g.signal for g in genomes})
+    filters = sorted({g.confirm_filter for g in genomes})
+    sizings = sorted({g.sizing_family for g in genomes})
+    lineage: list[tuple[Genome, float]] = []
+
+    def objective(trial: Any) -> float:
+        key = (
+            trial.suggest_categorical("signal", signals),
+            trial.suggest_categorical("direction", ["long", "short"]),
+            trial.suggest_categorical("filter", filters),
+            trial.suggest_int("exit_index", 0, len(exits) - 1),
+            trial.suggest_categorical("sizing", sizings),
+        )
+        genome = index.get(key)
+        if genome is None:
+            return -1.0
+        score = dev_score(genome, dev_series, fee_bps=fee_bps)
+        lineage.append((genome, score))
+        return score
+
+    study = optuna.create_study(
+        direction="maximize",
+        sampler=optuna.samplers.TPESampler(seed=seed),
+    )
+    study.optimize(objective, n_trials=budget)
+    if not lineage:
+        return {"lineage": [], "selected": None, "optimizer": "tpe"}
+    selected = max(lineage, key=lambda pair: pair[1])[0]
+    return {"lineage": lineage, "selected": selected, "optimizer": "tpe"}
+
+
+def funnel_search(
+    genomes: Sequence[Genome],
+    dev_series: Sequence[ContinuationSeries],
+    *,
+    budget: int,
+    fee_bps: float,
+    seed: int,
+    holdout_top_k: int = 5,
+) -> dict[str, Any]:
+    """The production funnel's shape: search on the TRAIN path only, then an
+    independent holdout adjudicates the top-k. No candidate clears on train
+    evidence alone; nothing positive on holdout → ABSTAIN (the incumbent
+    stays). This is the lane that must refuse null worlds."""
+    if len(dev_series) < 2:
+        raise ValueError("funnel_search requires train + holdout dev paths")
+    train, holdout = dev_series[0], dev_series[1]
+    proposal = tpe_search(
+        genomes, [train], budget=budget, fee_bps=fee_bps, seed=seed
+    )
+    lineage = proposal["lineage"]
+    ranked = sorted(lineage, key=lambda pair: pair[1], reverse=True)
+    top = [genome for genome, score in ranked[:holdout_top_k] if score > 0]
+    best_genome, best_holdout = None, 0.0
+    holdout_scores: list[tuple[str, float]] = []
+    for genome in top:
+        score = dev_score(genome, [holdout], fee_bps=fee_bps)
+        holdout_scores.append((genome.genome_id, score))
+        if score > best_holdout:
+            best_genome, best_holdout = genome, score
+    return {
+        "lineage": lineage,
+        "selected": best_genome,  # None = abstain
+        "optimizer": "funnel",
+        "holdout_scores": holdout_scores,
+    }
+
+
+ADAPTERS = {
+    "random": random_search,
+    "grid": grid_search,
+    "tpe": tpe_search,
+    "funnel": funnel_search,
+}

--- a/wayfinder_paths/jobs/benchmarks/agent_adapter.py
+++ b/wayfinder_paths/jobs/benchmarks/agent_adapter.py
@@ -1,0 +1,208 @@
+"""Agent lane: the full production stack as an optimizer, through the REAL
+OpenCode harness — `opencode run --agent wayfinder-job-worker` with the same
+agent definition, tool permissions, MCP toolset, and prompt path as live
+wakes. This is the whole-stack measurement; everything else in ADAPTERS is a
+baseline.
+
+Per world: a sandbox job bundle is built with the world's development data
+planted as the job's backtest dataset and the genome interpreter installed
+as the workspace strategy (genome fields in execution_params — the agent's
+normal propose flow mutates exactly the benchmark's search space). The agent
+gets N intervene wakes; every candidate it evaluates or proposes is
+harvested as lineage; its final applied/approved genome is the selection.
+Tokens and calls are metered from the opencode session DB.
+
+Run manually (never CI): model spend is real. Results feed the same
+score_run/aggregate pipeline as every other lane.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sqlite3
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from wayfinder_paths.jobs.benchmarks.compiler import write_interpreter
+from wayfinder_paths.jobs.benchmarks.grammar import Genome
+
+DEFAULT_OPENCODE = Path.home() / ".opencode" / "bin" / "opencode"
+DEFAULT_SESSION_DB = Path.home() / ".local" / "share" / "opencode" / "opencode.db"
+DEFAULT_AGENT = "wayfinder-job-worker"
+
+
+def build_world_bundle(
+    world: Any,
+    *,
+    sandbox: Path,
+    repo_root: Path,
+    initial_genome: Genome,
+) -> str:
+    """Sandbox job bundle: SDK-visible workspace + the world's dev data as
+    the job dataset + the interpreter as the strategy. Hidden rows and the
+    mechanism NEVER enter the sandbox (audit isolation)."""
+    from wayfinder_paths.jobs.models import WayfinderJob
+    from wayfinder_paths.jobs.store import JobStore
+
+    sandbox.mkdir(parents=True, exist_ok=True)
+    # Agent definitions + MCP config: the sandbox must BE an opencode-able
+    # workspace with the production agent available.
+    for name in (".opencode", ".mcp.json"):
+        source = repo_root / name
+        target = sandbox / name
+        if source.exists() and not target.exists():
+            if source.is_dir():
+                shutil.copytree(source, target)
+            else:
+                shutil.copy(source, target)
+
+    store = JobStore(repo_root=sandbox)
+    job = WayfinderJob.new(
+        f"wob-{world.world_id}",
+        goal=(
+            "Maximize risk-adjusted return of this strategy by improving its "
+            "genome parameters (signal/filter/exit/sizing in "
+            "execution_params.genome_spec). The dataset is fixed; there is "
+            "no live venue."
+        ),
+        script="workspace/src/strategy.py",
+        agent_mode="intervene",
+        execution_contract="jobs_v1",
+    )
+    store.save(job)
+    root = store.job_dir(job.id)
+    src_dir = root / "workspace" / "src"
+    src_dir.mkdir(parents=True, exist_ok=True)
+    interpreter = write_interpreter(src_dir)
+    interpreter.rename(src_dir / "strategy.py")
+
+    import yaml
+
+    job_yaml_path = root / "job.yaml"
+    job_yaml = yaml.safe_load(job_yaml_path.read_text()) or {}
+    job_yaml["execution_params"] = {
+        "genome_spec": initial_genome.to_dict(),
+        "fee_bps": world.mechanism.fee_bps,
+    }
+    job_yaml["script_loop"] = {"enabled": True, "entrypoint": "workspace/src/strategy.py"}
+    job_yaml_path.write_text(yaml.safe_dump(job_yaml, sort_keys=False))
+
+    dataset_dir = root / "results" / "backtest"
+    dataset_dir.mkdir(parents=True, exist_ok=True)
+    rows = [row for path_rows in world.dev_rows for row in path_rows]
+    (dataset_dir / "input_bars.json").write_text(
+        json.dumps(rows, default=str)
+    )
+    return job.id
+
+
+def run_agent_wakes(
+    *,
+    sandbox: Path,
+    job_id: str,
+    wakes: int,
+    model: str,
+    opencode: Path = DEFAULT_OPENCODE,
+    agent: str = DEFAULT_AGENT,
+    timeout_s: int = 1800,
+) -> list[dict[str, Any]]:
+    """Drive N intervene wakes through the production harness. Each wake:
+    build the REAL worker prompt, hand it to `opencode run --agent`, record
+    the session title for token metering."""
+    from wayfinder_paths.jobs.store import JobStore
+    from wayfinder_paths.jobs.worker import prepare_job_worker_prompt
+
+    store = JobStore(repo_root=sandbox)
+    sessions: list[dict[str, Any]] = []
+    for wake in range(wakes):
+        prepared = prepare_job_worker_prompt(job_id, mode="intervene", store=store)
+        title = f"wob-{job_id}-wake-{wake}"
+        command = [
+            str(opencode), "run", "--agent", agent, "-m", model,
+            "--dir", str(sandbox), "--title", title, prepared["prompt"],
+        ]
+        result = subprocess.run(
+            command, capture_output=True, text=True, timeout=timeout_s,
+            cwd=sandbox, check=False,
+        )
+        sessions.append(
+            {
+                "wake": wake,
+                "title": title,
+                "exit_code": result.returncode,
+                "stderr_tail": result.stderr[-500:],
+            }
+        )
+    return sessions
+
+
+def meter_sessions(
+    sessions: list[dict[str, Any]],
+    *,
+    session_db: Path = DEFAULT_SESSION_DB,
+) -> dict[str, Any]:
+    """Token/call accounting from the opencode session DB (same query seam
+    as the eval harness)."""
+    totals = {"sessions": 0, "messages": 0, "tokens_in": 0, "tokens_out": 0}
+    if not session_db.exists():
+        return {**totals, "note": "session db not found"}
+    connection = sqlite3.connect(str(session_db))
+    try:
+        for session in sessions:
+            row = connection.execute(
+                "SELECT id FROM session WHERE title=? "
+                "ORDER BY time_updated DESC LIMIT 1",
+                (session["title"],),
+            ).fetchone()
+            if not row:
+                continue
+            totals["sessions"] += 1
+            for tokens_in, tokens_out in connection.execute(
+                "SELECT json_extract(data,'$.tokens.input'), "
+                "json_extract(data,'$.tokens.output') FROM message "
+                "WHERE session_id=?",
+                (row[0],),
+            ):
+                totals["messages"] += 1
+                totals["tokens_in"] += int(tokens_in or 0)
+                totals["tokens_out"] += int(tokens_out or 0)
+    finally:
+        connection.close()
+    return totals
+
+
+def harvest_lineage(*, sandbox: Path, job_id: str) -> dict[str, Any]:
+    """Candidates the agent evaluated/proposed → lineage genomes; the
+    currently applied genome → selection. Non-genome proposals are recorded
+    but score as no-ops (the grammar lane only credits in-space moves)."""
+    import yaml
+
+    from wayfinder_paths.jobs.store import JobStore
+
+    store = JobStore(repo_root=sandbox)
+    root = store.job_dir(job_id)
+    lineage: list[Genome] = []
+    for path in sorted((root / "proposals").glob("*.json")):
+        try:
+            proposal = json.loads(path.read_text())
+        except ValueError:
+            continue
+        params = (proposal.get("proposed_change") or {}).get("execution_params") or {}
+        spec = params.get("genome_spec")
+        if isinstance(spec, dict) and spec.get("genome"):
+            try:
+                lineage.append(Genome.from_dict(spec))
+            except (KeyError, TypeError):
+                continue
+    job_yaml = yaml.safe_load((root / "job.yaml").read_text()) or {}
+    active_spec = (job_yaml.get("execution_params") or {}).get("genome_spec")
+    selected = None
+    if isinstance(active_spec, dict) and active_spec.get("genome"):
+        try:
+            selected = Genome.from_dict(active_spec)
+        except (KeyError, TypeError):
+            selected = None
+    return {"lineage": [(g, 0.0) for g in lineage], "selected": selected,
+            "optimizer": "agent"}

--- a/wayfinder_paths/jobs/benchmarks/agent_adapter.py
+++ b/wayfinder_paths/jobs/benchmarks/agent_adapter.py
@@ -93,7 +93,17 @@ def build_world_bundle(
     dataset_dir.mkdir(parents=True, exist_ok=True)
     rows = [row for path_rows in world.dev_rows for row in path_rows]
     (dataset_dir / "input_bars.json").write_text(
-        json.dumps(rows, default=str)
+        json.dumps(
+            {
+                "bars": rows,
+                "metadata": {
+                    "source": "wob-benchmark",
+                    "world_id": world.world_id,
+                    "interval": "1h",
+                },
+            },
+            default=str,
+        )
     )
     return job.id
 
@@ -117,7 +127,9 @@ def run_agent_wakes(
     store = JobStore(repo_root=sandbox)
     sessions: list[dict[str, Any]] = []
     for wake in range(wakes):
-        prepared = prepare_job_worker_prompt(job_id, mode="intervene", store=store)
+        prepared = prepare_job_worker_prompt(
+            store=store, job_id=job_id, mode="intervene"
+        )
         title = f"wob-{job_id}-wake-{wake}"
         command = [
             str(opencode), "run", "--agent", agent, "-m", model,

--- a/wayfinder_paths/jobs/benchmarks/agent_adapter.py
+++ b/wayfinder_paths/jobs/benchmarks/agent_adapter.py
@@ -31,6 +31,15 @@ from wayfinder_paths.jobs.benchmarks.grammar import Genome
 DEFAULT_OPENCODE = Path.home() / ".opencode" / "bin" / "opencode"
 DEFAULT_SESSION_DB = Path.home() / ".local" / "share" / "opencode" / "opencode.db"
 DEFAULT_AGENT = "wayfinder-job-worker"
+# opencode.json (provider config) is untracked; worktrees lack it. Fall back
+# to the primary checkout when the given repo_root is a bare worktree.
+PRIMARY_CHECKOUT = Path("/Users/adrianhaldenby/Documents/wayfinder-paths-sdk")
+
+
+def _config_source(repo_root: Path) -> Path:
+    if (repo_root / ".opencode" / "opencode.json").exists():
+        return repo_root
+    return PRIMARY_CHECKOUT
 
 
 def build_world_bundle(
@@ -47,16 +56,42 @@ def build_world_bundle(
     from wayfinder_paths.jobs.store import JobStore
 
     sandbox.mkdir(parents=True, exist_ok=True)
-    # Agent definitions + MCP config: the sandbox must BE an opencode-able
-    # workspace with the production agent available.
-    for name in (".opencode", ".mcp.json"):
-        source = repo_root / name
-        target = sandbox / name
-        if source.exists() and not target.exists():
-            if source.is_dir():
-                shutil.copytree(source, target)
-            else:
-                shutil.copy(source, target)
+    # The sandbox must BE an opencode-able SDK workspace: agent definitions
+    # + provider config (opencode.json is UNTRACKED — source it from a real
+    # checkout, not a bare worktree), the venv + package symlinked so the
+    # `wayfinder job` CLI works, and MCP servers disabled (file-based
+    # worlds; the worker falls back to the CLI — eval-harness pattern).
+    config_source = _config_source(repo_root)
+    target = sandbox / ".opencode"
+    if not target.exists():
+        shutil.copytree(
+            config_source / ".opencode", target,
+            ignore=shutil.ignore_patterns("node_modules"),
+            symlinks=False,
+        )
+    opencode_json = target / "opencode.json"
+    if opencode_json.exists():
+        config = json.loads(opencode_json.read_text())
+        for server in (config.get("mcp") or {}).values():
+            if isinstance(server, dict):
+                server["enabled"] = False
+        opencode_json.write_text(json.dumps(config, indent=2) + "\n")
+    # Code must be INSIDE the sandbox (symlinks trip opencode's
+    # external_directory permission wall — found live on pilot wake 0);
+    # the venv stays a symlink, agents execute it but rarely read it.
+    for name in ("pyproject.toml", "poetry.lock"):
+        source = config_source / name
+        if source.exists() and not (sandbox / name).exists():
+            shutil.copy(source, sandbox / name)
+    package = sandbox / "wayfinder_paths"
+    if not package.exists():
+        shutil.copytree(
+            config_source / "wayfinder_paths", package,
+            ignore=shutil.ignore_patterns("__pycache__", "*.pyc", "tests"),
+        )
+    venv_source = config_source / ".venv"
+    if venv_source.exists() and not (sandbox / ".venv").exists():
+        (sandbox / ".venv").symlink_to(venv_source)
 
     store = JobStore(repo_root=sandbox)
     job = WayfinderJob.new(
@@ -144,6 +179,7 @@ def run_agent_wakes(
                 "wake": wake,
                 "title": title,
                 "exit_code": result.returncode,
+                "stdout_tail": result.stdout[-800:],
                 "stderr_tail": result.stderr[-500:],
             }
         )

--- a/wayfinder_paths/jobs/benchmarks/calibration.py
+++ b/wayfinder_paths/jobs/benchmarks/calibration.py
@@ -1,0 +1,87 @@
+"""World calibration: does the generated world actually pose the problem its
+archetype claims? Runs the oracle on a subset of hidden continuations and
+asserts archetype-specific structural properties. A failed assertion rejects
+the world (worlds.generate_world resamples the seed) — miscalibrated worlds
+must never enter a suite, silently or otherwise."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from wayfinder_paths.jobs.benchmarks.grammar import GENOME_SIGNALS, enumerate_genomes
+from wayfinder_paths.jobs.benchmarks.oracle import evaluate_space, prepare_continuation
+
+CALIBRATION_PATHS = 16
+_WEIGHTS = {"downside": 0.5, "tail": 1.0, "turnover": 0.25}
+# A world "has an edge" when the oracle-null gap clears this floor; a null
+# world must stay under the tighter null ceiling.
+_EDGE_FLOOR = 0.010
+_NULL_CEILING = 0.006
+
+_DROP_BASINS = {"new_low_5", "new_low_20", "bb20_z_le_neg2", "rsi14_le_30"}
+_BAIT_BASINS = {"new_high_20", "new_high_5"}
+
+
+def calibrate_world(world: Any) -> dict[str, Any]:
+    genomes = enumerate_genomes()
+    continuations = [
+        prepare_continuation(rows, signal_names=GENOME_SIGNALS)
+        for rows in world.hidden_rows[:CALIBRATION_PATHS]
+    ]
+    oracle = evaluate_space(
+        genomes, continuations, weights=_WEIGHTS, fee_bps=world.mechanism.fee_bps
+    )
+    gap = oracle["u_star"] - oracle["u_null"]
+    best_signal, best_direction, best_filter = oracle["best_basin"].split("|")
+    epsilon_basins = {
+        oracle["basins"][gid] for gid in oracle["epsilon_optimal"]
+    }
+
+    def verdict(passed: bool, reason: str) -> dict[str, Any]:
+        return {
+            "passed": passed,
+            "reason": reason,
+            "u_star": oracle["u_star"],
+            "gap": gap,
+            "best_basin": oracle["best_basin"],
+            "epsilon_basin_count": len(epsilon_basins),
+            "calibration_paths": len(continuations),
+        }
+
+    archetype = world.archetype
+    if archetype == "null_world":
+        if gap > _NULL_CEILING:
+            return verdict(False, f"null world has discoverable edge (gap {gap:.4f})")
+        return verdict(True, "no discoverable edge, as designed")
+
+    if gap < _EDGE_FLOOR:
+        return verdict(False, f"edge not discoverable in grammar (gap {gap:.4f})")
+
+    if archetype == "interaction_edge" and best_filter not in ("high_vol", "low_vol"):
+        return verdict(False, f"best basin filter is {best_filter}, expected vol gate")
+    if archetype == "session_edge" and not best_filter.startswith("session_"):
+        return verdict(False, f"best basin filter is {best_filter}, expected session")
+    if archetype == "deceptive_multi_peak" and best_signal in _BAIT_BASINS:
+        return verdict(False, "global basin collapsed onto the bait basin")
+    if archetype == "spike_vs_plateau" and not (
+        best_signal in _DROP_BASINS and best_direction == "long"
+    ):
+        return verdict(False, f"plateau basin is not optimal (best {best_signal})")
+    if archetype == "equivalent_optima":
+        distinct_signals = {basin.split("|")[0] for basin in epsilon_basins}
+        if len(distinct_signals) < 2:
+            return verdict(False, "epsilon set spans only one structural region")
+    if archetype == "disconnected_regions":
+        # Two profitable pockets on OPPOSITE sides, separated by dead space:
+        # both directions must clear half the edge floor.
+        best_by_direction = {"long": 0.0, "short": 0.0}
+        for gid, value in oracle["expected_utility"].items():
+            direction = oracle["basins"][gid].split("|")[1]
+            best_by_direction[direction] = max(best_by_direction[direction], value)
+        if min(best_by_direction.values()) < _EDGE_FLOOR / 2:
+            return verdict(
+                False,
+                f"one-sided world (long {best_by_direction['long']:.4f} / "
+                f"short {best_by_direction['short']:.4f})",
+            )
+    return verdict(True, "archetype structure confirmed")

--- a/wayfinder_paths/jobs/benchmarks/compiler.py
+++ b/wayfinder_paths/jobs/benchmarks/compiler.py
@@ -1,0 +1,149 @@
+"""Genome → executable strategy. ONE generic interpreter runs any genome
+through the production engine; the oracle vectorizes the same contract.
+Signals and filters are computed via the SAME library builders in both paths
+(suffix equality is guaranteed by the library's causality gate), so parity
+failures can only come from execution semantics — which is exactly what the
+parity test is for."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from wayfinder_paths.jobs.benchmarks.grammar import Genome
+
+INTERPRETER_STRATEGY = '''
+import pandas as pd
+
+from wayfinder_paths.jobs.signal_library import SIGNAL_LIBRARY
+
+_SIGNALS = {s.name: s for s in SIGNAL_LIBRARY}
+
+
+def _filter_ok(name, frame, hour):
+    if name == "none":
+        return True
+    closes = frame["close"]
+    if name in ("above_sma50", "below_sma50"):
+        if len(closes) < 50:
+            return False
+        sma = closes.rolling(50).mean().iloc[-1]
+        value = closes.iloc[-1]
+        return value > sma if name == "above_sma50" else value < sma
+    if name in ("high_vol", "low_vol"):
+        if len(frame) < 30:
+            return False
+        tr = (frame["high"] - frame["low"]).rolling(14).mean()
+        atr = tr.iloc[-1]
+        med = tr.median()
+        return atr > med if name == "high_vol" else atr <= med
+    if name.startswith("session_"):
+        bucket = {"session_a": 0, "session_b": 1, "session_c": 2}[name]
+        return hour // 8 == bucket
+    return False
+
+
+def build_strategy(params):
+    genome = dict(params.get("genome_spec") or {})
+    signal_name = str(genome["signal"])
+    direction = str(genome["direction"])
+    confirm = str(genome["confirm_filter"])
+    exit_family = str(genome["exit_family"])
+    exit_params = dict(genome.get("exit_params") or {})
+    sizing_family = str(genome["sizing_family"])
+    sizing_params = dict(genome.get("sizing_params") or {})
+    side_open = "buy" if direction == "long" else "sell"
+    side_close = "sell" if direction == "long" else "buy"
+    sign = 1.0 if direction == "long" else -1.0
+
+    class Strategy:
+        def decide(self, ctx):
+            state = ctx.strategy_state
+            frame = ctx.view.to_frame()
+            bar = ctx.view.latest()
+            close = float(bar["close"])
+            symbol = str(bar["symbol"])
+            hour = int(str(ctx.timestamp)[11:13])
+            position = ctx.ledger.positions.get(symbol)
+
+            if position is not None:
+                state["held"] = int(state.get("held") or 0) + 1
+                entry = float(state.get("entry_price") or close)
+                move = sign * (close / entry - 1.0)
+                if direction == "long":
+                    state["peak"] = max(float(state.get("peak") or close), close)
+                    trail_ref = float(state["peak"])
+                    trail_move = close / trail_ref - 1.0
+                else:
+                    state["peak"] = min(float(state.get("peak") or close), close)
+                    trail_ref = float(state["peak"])
+                    trail_move = -(close / trail_ref - 1.0)
+                exit_now = False
+                if exit_family == "fixed_time":
+                    exit_now = state["held"] >= int(exit_params["hold_bars"])
+                elif exit_family == "target_stop":
+                    exit_now = move >= float(exit_params["target_pct"]) or (
+                        move <= -float(exit_params["stop_pct"])
+                    )
+                elif exit_family == "trailing":
+                    exit_now = trail_move <= -float(exit_params["trail_pct"])
+                elif exit_family == "time_stop":
+                    exit_now = state["held"] >= int(exit_params["hold_bars"]) or (
+                        move <= -float(exit_params["stop_pct"])
+                    )
+                if exit_now:
+                    state["held"] = 0
+                    state["entry_price"] = None
+                    state["peak"] = None
+                    return [
+                        {
+                            "action": "CLOSE",
+                            "venue": "backtest",
+                            "symbol": symbol,
+                            "side": side_close,
+                            "size": position.size,
+                            "reduce_only": True,
+                        }
+                    ]
+                return []
+
+            signal = _SIGNALS[signal_name]
+            if len(frame) < signal.min_bars:
+                return []
+            fired = bool(signal.build(frame).iloc[-1])
+            if not fired or not _filter_ok(confirm, frame, hour):
+                return []
+            size = 1.0
+            if sizing_family == "vol_target":
+                returns = frame["close"].pct_change().tail(20)
+                realized = float(returns.std() or 0.0)
+                target = float(sizing_params.get("target_vol") or 0.01)
+                size = max(0.25, min(4.0, target / realized)) if realized > 0 else 1.0
+            state["held"] = 0
+            state["entry_price"] = close
+            state["peak"] = close
+            return [
+                {
+                    "action": "OPEN",
+                    "venue": "backtest",
+                    "symbol": symbol,
+                    "side": side_open,
+                    "size": size,
+                }
+            ]
+
+    return Strategy()
+'''
+
+
+def compile_genome(genome: Genome, *, fee_bps: float = 4.5) -> dict[str, Any]:
+    """Params for the interpreter strategy. `entry_price` is tracked at the
+    DECISION close, matching the oracle's convention; fills happen next open
+    in both paths, so target/stop distances are measured identically."""
+    return {"genome_spec": genome.to_dict(), "fee_bps": fee_bps}
+
+
+def write_interpreter(workdir: Path) -> Path:
+    path = workdir / "genome_interpreter.py"
+    path.write_text(INTERPRETER_STRATEGY.lstrip(), encoding="utf-8")
+    return path

--- a/wayfinder_paths/jobs/benchmarks/grammar.py
+++ b/wayfinder_paths/jobs/benchmarks/grammar.py
@@ -1,0 +1,186 @@
+"""Strategy Genome v1: the finite, typed, enumerable candidate space G.
+
+The bounded-global claim is only meaningful over a declared search space.
+A genome is pure data (dict-codable, hashable); it compiles to params for
+ONE generic interpreter strategy (compiler.py), so the vectorized oracle and
+the production engine evaluate identical semantics.
+
+Sizing note: spaces target 2k-20k genomes per world — large enough that a
+budgeted optimizer (25-100 evaluations) cannot enumerate them, small enough
+for the oracle to evaluate exhaustively over hidden continuations.
+
+Execution semantics (shared with oracle + interpreter, v1):
+- Entry: signal true on completed bar t (with confirm filter true) → fill at
+  open[t+1].
+- One position per symbol; signals while positioned are ignored.
+- Exits are COMPLETED-BAR decisions → fill at next open (no in-bar bracket
+  fills in v1 — keeps oracle/engine parity exact by construction).
+- Fees: fee_bps per side.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import itertools
+import json
+from dataclasses import dataclass
+from typing import Any
+
+# Curated signal subset: names must exist in SIGNAL_LIBRARY (asserted in
+# tests). Chosen to span families the archetype worlds plant edges in.
+GENOME_SIGNALS: tuple[str, ...] = (
+    "new_low_5",
+    "new_high_5",
+    "new_low_20",
+    "new_high_20",
+    "rsi14_le_30",
+    "rsi14_ge_70",
+    "ema_cross_up_9_50",
+    "ema_cross_dn_9_50",
+    "bb20_z_le_neg2",
+    "bb20_z_ge_2",
+    "vol_surge_up",
+    "vol_surge_dn",
+)
+
+DIRECTIONS: tuple[str, ...] = ("long", "short")
+
+# Confirm filters gate entries; "interaction edge" worlds plant mechanisms
+# that ONLY pay when signal and filter co-occur.
+FILTERS: tuple[str, ...] = (
+    "none",
+    "above_sma50",
+    "below_sma50",
+    "high_vol",  # ATR14 > median ATR over lookback
+    "low_vol",
+    "session_a",  # bar hour in [0, 8)
+    "session_b",  # bar hour in [8, 16)
+    "session_c",  # bar hour in [16, 24)
+)
+
+# Exit variants: (family, params). Buckets, not continua — the space must be
+# finite and exactly enumerable.
+EXITS: tuple[tuple[str, dict[str, Any]], ...] = tuple(
+    [("fixed_time", {"hold_bars": hold}) for hold in (2, 4, 8, 16)]
+    + [
+        ("target_stop", {"target_pct": target, "stop_pct": stop})
+        for target in (0.01, 0.02, 0.04)
+        for stop in (0.01, 0.02, 0.04)
+    ]
+    + [("trailing", {"trail_pct": trail}) for trail in (0.01, 0.02, 0.04)]
+    + [
+        ("time_stop", {"hold_bars": hold, "stop_pct": stop})
+        for hold in (4, 16)
+        for stop in (0.01, 0.02)
+    ]
+)
+
+SIZINGS: tuple[tuple[str, dict[str, Any]], ...] = (
+    ("fixed", {}),
+    ("vol_target", {"target_vol": 0.01}),
+)
+
+GRAMMAR_VERSION = "strategy-genome-v1"
+
+
+@dataclass(frozen=True)
+class Genome:
+    signal: str
+    direction: str
+    confirm_filter: str
+    exit_family: str
+    exit_params: tuple[tuple[str, Any], ...]
+    sizing_family: str
+    sizing_params: tuple[tuple[str, Any], ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "genome": True,
+            "grammar_version": GRAMMAR_VERSION,
+            "signal": self.signal,
+            "direction": self.direction,
+            "confirm_filter": self.confirm_filter,
+            "exit_family": self.exit_family,
+            "exit_params": dict(self.exit_params),
+            "sizing_family": self.sizing_family,
+            "sizing_params": dict(self.sizing_params),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Genome:
+        return cls(
+            signal=str(data["signal"]),
+            direction=str(data["direction"]),
+            confirm_filter=str(data["confirm_filter"]),
+            exit_family=str(data["exit_family"]),
+            exit_params=tuple(sorted((data.get("exit_params") or {}).items())),
+            sizing_family=str(data["sizing_family"]),
+            sizing_params=tuple(sorted((data.get("sizing_params") or {}).items())),
+        )
+
+    @property
+    def genome_id(self) -> str:
+        payload = json.dumps(self.to_dict(), sort_keys=True)
+        return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+def enumerate_genomes(
+    *,
+    signals: tuple[str, ...] = GENOME_SIGNALS,
+    filters: tuple[str, ...] = FILTERS,
+    exits: tuple[tuple[str, dict[str, Any]], ...] = EXITS,
+    sizings: tuple[tuple[str, dict[str, Any]], ...] = SIZINGS,
+) -> list[Genome]:
+    """The complete space G for a world (worlds may restrict the subsets to
+    hit their target size — restriction is recorded in the world manifest)."""
+    genomes = []
+    for signal, direction, confirm, (exit_family, exit_params), (
+        sizing_family,
+        sizing_params,
+    ) in itertools.product(signals, DIRECTIONS, filters, exits, sizings):
+        genomes.append(
+            Genome(
+                signal=signal,
+                direction=direction,
+                confirm_filter=confirm,
+                exit_family=exit_family,
+                exit_params=tuple(sorted(exit_params.items())),
+                sizing_family=sizing_family,
+                sizing_params=tuple(sorted(sizing_params.items())),
+            )
+        )
+    return genomes
+
+
+def grammar_hash(
+    *,
+    signals: tuple[str, ...] = GENOME_SIGNALS,
+    filters: tuple[str, ...] = FILTERS,
+    exits: tuple[tuple[str, dict[str, Any]], ...] = EXITS,
+    sizings: tuple[tuple[str, dict[str, Any]], ...] = SIZINGS,
+) -> str:
+    """Deterministic hash of the declared space — part of the bounded claim.
+    Any change to the grammar is a NEW benchmark version, never a silent
+    retrofit."""
+    payload = json.dumps(
+        {
+            "version": GRAMMAR_VERSION,
+            "signals": list(signals),
+            "directions": list(DIRECTIONS),
+            "filters": list(filters),
+            "exits": [[family, dict(sorted(params.items()))] for family, params in exits],
+            "sizings": [
+                [family, dict(sorted(params.items()))] for family, params in sizings
+            ],
+        },
+        sort_keys=True,
+    )
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+# The default full space: 12 signals x 2 directions x 8 filters x 20 exits
+# x 2 sizings = 7,680 genomes — inside the 2k-20k target band.
+def default_space_size() -> int:
+    return (
+        len(GENOME_SIGNALS) * len(DIRECTIONS) * len(FILTERS) * len(EXITS) * len(SIZINGS)
+    )

--- a/wayfinder_paths/jobs/benchmarks/manifest.py
+++ b/wayfinder_paths/jobs/benchmarks/manifest.py
@@ -1,0 +1,124 @@
+"""Manifests, commitments, and the public/private suite split.
+
+Publication protocol: PUBLIC worlds ship with everything (dev paths, hidden
+continuations, oracle answers) — the development set anyone can tune
+against. SEALED worlds publish only their MANIFEST: world id, archetype
+label, budgets, and sha256 commitments of the world data + oracle output.
+Commitments are published BEFORE any results are reported, so sealed worlds
+cannot be quietly regenerated after seeing scores. Private seeds live
+OUTSIDE the repo (owner-held file, path via WOB_PRIVATE_SEEDS env var).
+
+A sealed world is BURNED for final certification once its audit result has
+been exposed to development — new certification uses fresh private seeds.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from wayfinder_paths.jobs.benchmarks.grammar import grammar_hash
+
+SUITE_VERSION = "exact-v0"
+PRIVATE_SEEDS_ENV = "WOB_PRIVATE_SEEDS"
+
+DEFAULT_BUDGETS = {
+    "b25": {"candidate_evaluations": 25},
+    "b50": {"candidate_evaluations": 50},
+    "b100": {"candidate_evaluations": 100},
+}
+
+
+def canonical_sha256(payload: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, default=str).encode()
+    ).hexdigest()
+
+
+def world_manifest(world: Any, oracle: dict[str, Any] | None) -> dict[str, Any]:
+    """The publishable record for ANY world (public or sealed). Contains no
+    mechanism, no seeds, no hidden rows — only labels, budgets, and
+    commitments that later make results verifiable."""
+    return {
+        "suite_version": SUITE_VERSION,
+        "world_id": world.world_id,
+        "archetype": world.archetype,
+        "grammar_hash": grammar_hash(),
+        "fee_bps": world.mechanism.fee_bps,
+        "budgets": DEFAULT_BUDGETS,
+        "dev_paths": len(world.dev_rows),
+        "hidden_paths": len(world.hidden_rows),
+        "commitments": {
+            "dev_rows": canonical_sha256(world.dev_rows),
+            "hidden_rows": canonical_sha256(world.hidden_rows),
+            "oracle": canonical_sha256(oracle) if oracle is not None else None,
+        },
+        "calibration": {
+            "passed": world.calibration.get("passed"),
+            "attempts": world.calibration.get("attempts"),
+        },
+    }
+
+
+def public_world_payload(world: Any, oracle: dict[str, Any]) -> dict[str, Any]:
+    """Everything, answers included — the published development set."""
+    return {
+        "manifest": world_manifest(world, oracle),
+        "dev_rows": world.dev_rows,
+        "hidden_rows": world.hidden_rows,
+        "oracle": {
+            "u_star": oracle["u_star"],
+            "u_null": oracle["u_null"],
+            "epsilon": oracle["epsilon"],
+            "best_genome_id": oracle["best_genome_id"],
+            "best_basin": oracle["best_basin"],
+            "epsilon_optimal": oracle["epsilon_optimal"],
+            "expected_utility": oracle["expected_utility"],
+        },
+    }
+
+
+def sealed_world_payload(world: Any, oracle: dict[str, Any]) -> dict[str, Any]:
+    """What the OWNER keeps for sealed worlds (never published, never inside
+    an optimizer's filesystem): full data + answers, matching the published
+    commitments bit-for-bit."""
+    return public_world_payload(world, oracle)
+
+
+def load_private_seeds(path: str | None = None) -> dict[str, list[int]]:
+    """Owner-held archetype→seeds mapping for sealed worlds. Absent file →
+    empty (public-only operation): sealed generation requires the owner."""
+    location = path or os.environ.get(PRIVATE_SEEDS_ENV)
+    if not location or not Path(location).exists():
+        return {}
+    loaded = json.loads(Path(location).read_text(encoding="utf-8"))
+    return {str(k): [int(s) for s in v] for k, v in loaded.items()}
+
+
+def suite_split(
+    *,
+    public_per_archetype: int = 2,
+    sealed_per_archetype: int = 4,
+    public_base: int = 1000,
+    private_seeds: dict[str, list[int]] | None = None,
+) -> dict[str, dict[str, list[int]]]:
+    """Seed plan for a suite. PUBLIC seeds are deterministic and committed
+    here (base + index per archetype — anyone can regenerate the public
+    set). SEALED seeds come from the owner's private registry; the null-world
+    quota is enforced by construction in the archetype lists."""
+    from wayfinder_paths.jobs.benchmarks.worlds import ARCHETYPES
+
+    public = {
+        archetype: [public_base + 100 * rank + i for i in range(public_per_archetype)]
+        for rank, archetype in enumerate(ARCHETYPES)
+    }
+    # Null quota: double the null allocation (>=25% requirement lands via
+    # archetype weighting at generation time).
+    public["null_world"] = [
+        public_base + 900 + i for i in range(public_per_archetype * 3)
+    ]
+    sealed = dict(private_seeds or {})
+    return {"public": public, "sealed": sealed}

--- a/wayfinder_paths/jobs/benchmarks/metrics.py
+++ b/wayfinder_paths/jobs/benchmarks/metrics.py
@@ -90,6 +90,7 @@ def aggregate(rows: list[dict[str, Any]]) -> dict[str, Any]:
         return ordered[min(int(q * (len(ordered) - 1)), len(ordered) - 1)]
 
     by_optimizer: dict[str, dict[str, Any]] = {}
+    rows = [row for row in rows if "error" not in row]
     for row in rows:
         bucket = by_optimizer.setdefault(
             str(row["optimizer"]),

--- a/wayfinder_paths/jobs/benchmarks/metrics.py
+++ b/wayfinder_paths/jobs/benchmarks/metrics.py
@@ -1,0 +1,123 @@
+"""Regret decomposition and run scoring against the oracle.
+
+- search regret: U* − best oracle utility ANYWHERE in the lineage (it never
+  found the region)
+- selection regret: best-in-lineage − selected (it found it and picked wrong)
+- execution regret is a production/prospective quantity — not measurable here
+- abstention on a null world is CORRECT (selected=None scores U_null)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def score_run(
+    run: dict[str, Any],
+    oracle: dict[str, Any],
+) -> dict[str, Any]:
+    expected = oracle["expected_utility"]
+    u_star = float(oracle["u_star"])
+    u_null = float(oracle["u_null"])
+    # Floor keeps normalized regret interpretable on null-ish worlds (the
+    # reviewer's epsilon floor, same rationale); null worlds are judged by
+    # false-promotion, not regret.
+    denominator = max(u_star - u_null, 0.02)
+
+    lineage_utilities: list[float] = []
+    best_so_far: list[float] = []
+    running = u_null
+    for genome, _dev in run["lineage"]:
+        value = float(expected.get(genome.genome_id, u_null))
+        lineage_utilities.append(value)
+        running = max(running, value)
+        best_so_far.append(running)
+
+    best_found = max(lineage_utilities, default=u_null)
+    selected = run.get("selected")
+    selected_utility = (
+        float(expected.get(selected.genome_id, u_null))
+        if selected is not None
+        else u_null
+    )
+
+    search_regret = u_star - best_found
+    selection_regret = best_found - selected_utility
+    # Anytime regret: mean normalized regret over the budget curve — an
+    # optimizer must not look good only at one convenient stopping point.
+    anytime = (
+        sum((u_star - value) / denominator for value in best_so_far)
+        / len(best_so_far)
+        if best_so_far
+        else 1.0
+    )
+    epsilon = float(oracle["epsilon"])
+    return {
+        "optimizer": run.get("optimizer"),
+        "evaluations": len(run["lineage"]),
+        "selected_genome_id": selected.genome_id if selected is not None else None,
+        "abstained": selected is None,
+        "selected_utility": selected_utility,
+        "best_found_utility": best_found,
+        "u_star": u_star,
+        "epsilon_hit_search": best_found >= u_star - epsilon,
+        "epsilon_hit_selected": selected_utility >= u_star - epsilon,
+        "search_regret": search_regret,
+        "selection_regret": selection_regret,
+        "search_regret_norm": search_regret / denominator,
+        "selection_regret_norm": selection_regret / denominator,
+        "anytime_regret_norm": anytime,
+        "basin_found": oracle["basins"].get(
+            max(
+                (g for g, _ in run["lineage"]),
+                key=lambda g: float(expected.get(g.genome_id, u_null)),
+                default=None,
+            ).genome_id
+        )
+        if run["lineage"]
+        else None,
+    }
+
+
+def aggregate(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Suite-level aggregation per optimizer: hit rates, regret quantiles,
+    null-world false-promotion."""
+
+    def quantile(values: list[float], q: float) -> float | None:
+        if not values:
+            return None
+        ordered = sorted(values)
+        return ordered[min(int(q * (len(ordered) - 1)), len(ordered) - 1)]
+
+    by_optimizer: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        bucket = by_optimizer.setdefault(
+            str(row["optimizer"]),
+            {"runs": 0, "eps_search": 0, "eps_selected": 0, "regrets": [],
+             "select_regrets": [], "null_runs": 0, "null_promotions": 0},
+        )
+        bucket["runs"] += 1
+        bucket["eps_search"] += int(row["epsilon_hit_search"])
+        bucket["eps_selected"] += int(row["epsilon_hit_selected"])
+        bucket["regrets"].append(float(row["search_regret_norm"]))
+        bucket["select_regrets"].append(float(row["selection_regret_norm"]))
+        if row.get("is_null_world"):
+            bucket["null_runs"] += 1
+            bucket["null_promotions"] += int(not row["abstained"])
+    report = {}
+    for name, bucket in by_optimizer.items():
+        runs = bucket["runs"]
+        report[name] = {
+            "runs": runs,
+            "epsilon_hit_rate_search": bucket["eps_search"] / runs,
+            "epsilon_hit_rate_selected": bucket["eps_selected"] / runs,
+            "search_regret_median": quantile(bucket["regrets"], 0.5),
+            "search_regret_p95": quantile(bucket["regrets"], 0.95),
+            "selection_regret_median": quantile(bucket["select_regrets"], 0.5),
+            "null_false_promotion_rate": (
+                bucket["null_promotions"] / bucket["null_runs"]
+                if bucket["null_runs"]
+                else None
+            ),
+        }
+    return report

--- a/wayfinder_paths/jobs/benchmarks/oracle.py
+++ b/wayfinder_paths/jobs/benchmarks/oracle.py
@@ -183,7 +183,9 @@ def utility_from_trades(
     log_steps = np.diff(np.log(np.concatenate([[initial_equity], equity])))
     growth = float(log_steps.sum())
     negatives = log_steps[log_steps < 0]
-    downside = float(np.sqrt(np.mean(negatives**2))) if len(log_steps) else 0.0
+    downside = (
+        float(np.sqrt(np.mean(negatives**2))) if len(negatives) else 0.0
+    )
     worst_k = max(1, len(pnls) // 10)
     tail = float(abs(np.sort(np.asarray(pnls))[:worst_k].sum())) / initial_equity
     fees_proxy = 0.0  # fees are inside pnls; turnover term deferred to v1

--- a/wayfinder_paths/jobs/benchmarks/oracle.py
+++ b/wayfinder_paths/jobs/benchmarks/oracle.py
@@ -1,0 +1,237 @@
+"""Exhaustive expected-utility oracle over the genome space.
+
+Truth definition: a genome's oracle utility is the MEAN utility over the
+world's HIDDEN continuations (common random numbers — every genome sees the
+same paths), never its score on one lucky realized path. U*, the ε-optimal
+set, and per-genome rankings all derive from that expectation.
+
+Evaluation semantics (the shared contract with compiler.py's interpreter):
+- signal/filter series from the SAME library builders, full-frame vectorized
+- entry: signal∧filter true at bar t (flat) → fill open[t+1]
+- exits: completed-bar conditions referenced to the DECISION close; fill at
+  next open; one position per symbol; fees fee_bps per side on notional
+- engine parity is asserted on net USD PnL (`parity_check`); utility is
+  computed uniformly by THIS module for all genomes (internal consistency is
+  what ranking requires), with equity marked at fills — a documented, mild
+  understatement of intra-trade downside vs the engine's per-bar marking.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from wayfinder_paths.jobs.benchmarks.grammar import FILTERS, Genome
+from wayfinder_paths.jobs.signal_library import SIGNAL_LIBRARY
+
+_SIGNALS = {s.name: s for s in SIGNAL_LIBRARY}
+INITIAL_EQUITY = 10_000.0
+DEFAULT_MAX_HOLD = 96  # safety cap: no genome may hold forever
+
+
+@dataclass
+class ContinuationSeries:
+    """Precomputed per-continuation arrays shared by every genome."""
+
+    opens: np.ndarray
+    closes: np.ndarray
+    hours: np.ndarray
+    signals: dict[str, np.ndarray]
+    filters: dict[str, np.ndarray]
+    vol_size: np.ndarray  # per-bar vol_target size multiplier
+
+
+def prepare_continuation(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    signal_names: Sequence[str],
+) -> ContinuationSeries:
+    frame = pd.DataFrame(rows)
+    closes = frame["close"].to_numpy(dtype=float)
+    opens = frame["open"].to_numpy(dtype=float)
+    hours = pd.to_datetime(frame["timestamp"]).dt.hour.to_numpy(dtype=int)
+
+    signals = {
+        name: _SIGNALS[name].build(frame).fillna(False).to_numpy(dtype=bool)
+        for name in signal_names
+    }
+
+    close_series = frame["close"]
+    sma50 = close_series.rolling(50).mean()
+    tr = (frame["high"] - frame["low"]).rolling(14).mean()
+    # Median over the trailing engine compute window (512 bars), not the full
+    # frame — the interpreter sees a bounded view, and the contract must match.
+    tr_median_series = tr.rolling(512, min_periods=16).median()
+    filters: dict[str, np.ndarray] = {}
+    for name in FILTERS:
+        if name == "none":
+            filters[name] = np.ones(len(frame), dtype=bool)
+        elif name == "above_sma50":
+            filters[name] = (close_series > sma50).fillna(False).to_numpy(dtype=bool)
+        elif name == "below_sma50":
+            filters[name] = (close_series < sma50).fillna(False).to_numpy(dtype=bool)
+        elif name == "high_vol":
+            filters[name] = (tr > tr_median_series).fillna(False).to_numpy(dtype=bool)
+        elif name == "low_vol":
+            filters[name] = (tr <= tr_median_series).fillna(False).to_numpy(dtype=bool)
+        elif name.startswith("session_"):
+            bucket = {"session_a": 0, "session_b": 1, "session_c": 2}[name]
+            filters[name] = (hours // 8) == bucket
+
+    returns = close_series.pct_change().rolling(20).std()
+    vol = returns.to_numpy(dtype=float)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        size = np.clip(0.01 / vol, 0.25, 4.0)
+    filters_nan = ~np.isfinite(size)
+    size[filters_nan] = 1.0
+    return ContinuationSeries(
+        opens=opens,
+        closes=closes,
+        hours=hours,
+        signals=signals,
+        filters=filters,
+        vol_size=size,
+    )
+
+
+def evaluate_genome(
+    genome: Genome,
+    series: ContinuationSeries,
+    *,
+    fee_bps: float = 4.5,
+    max_hold: int = DEFAULT_MAX_HOLD,
+) -> dict[str, Any]:
+    """One genome on one continuation → trade PnLs + equity-at-fill path."""
+    exit_params = dict(genome.exit_params)
+    sizing_params = dict(genome.sizing_params)
+    sign = 1.0 if genome.direction == "long" else -1.0
+    fee_rate = fee_bps / 10_000.0
+    opens, closes = series.opens, series.closes
+    entry_mask = series.signals[genome.signal] & series.filters[genome.confirm_filter]
+    candidates = np.flatnonzero(entry_mask)
+    n = len(closes)
+
+    pnls: list[float] = []
+    exit_indices: list[int] = []
+    cursor = 0
+    for t in candidates:
+        if t < cursor or t + 1 >= n:
+            continue
+        entry_ref = closes[t]  # decision close: target/stop distances
+        entry_fill = opens[t + 1]
+        size = 1.0
+        if genome.sizing_family == "vol_target":
+            target = float(sizing_params.get("target_vol") or 0.01)
+            size = float(np.clip(series.vol_size[t] * (target / 0.01), 0.25, 4.0))
+        exit_bar = None
+        peak = entry_ref
+        hold_cap = int(exit_params.get("hold_bars") or max_hold)
+        for held, bar in enumerate(range(t + 1, min(t + 1 + max_hold, n - 1)), start=1):
+            close = closes[bar]
+            move = sign * (close / entry_ref - 1.0)
+            peak = max(peak, close) if sign > 0 else min(peak, close)
+            trail_move = -(close / peak - 1.0) if sign > 0 else (close / peak - 1.0)
+            family = genome.exit_family
+            if family == "fixed_time":
+                if held >= hold_cap:
+                    exit_bar = bar
+            elif family == "target_stop":
+                if move >= float(exit_params["target_pct"]) or move <= -float(
+                    exit_params["stop_pct"]
+                ):
+                    exit_bar = bar
+            elif family == "trailing":
+                if (sign > 0 and trail_move <= -float(exit_params["trail_pct"])) or (
+                    sign < 0 and -trail_move <= -float(exit_params["trail_pct"])
+                ):
+                    exit_bar = bar
+            elif family == "time_stop":
+                if held >= hold_cap or move <= -float(exit_params["stop_pct"]):
+                    exit_bar = bar
+            if exit_bar is not None:
+                break
+        if exit_bar is None:
+            exit_bar = min(t + max_hold, n - 2)
+        exit_fill = opens[exit_bar + 1]
+        pnl = size * sign * (exit_fill - entry_fill) - fee_rate * size * (
+            entry_fill + exit_fill
+        )
+        pnls.append(float(pnl))
+        exit_indices.append(exit_bar + 1)
+        cursor = exit_bar + 1
+
+    return {"pnls": pnls, "exit_indices": exit_indices}
+
+
+def utility_from_trades(
+    pnls: Sequence[float],
+    *,
+    weights: Mapping[str, float],
+    initial_equity: float = INITIAL_EQUITY,
+) -> float:
+    """Constitution-shaped utility on the equity-at-fill path. Uniform for
+    every genome — internal consistency is what oracle ranking requires."""
+    if not pnls:
+        return 0.0
+    equity = initial_equity + np.cumsum(np.asarray(pnls, dtype=float))
+    if np.any(equity <= 0):
+        return -10.0  # ruin: hard floor far below any feasible utility
+    log_steps = np.diff(np.log(np.concatenate([[initial_equity], equity])))
+    growth = float(log_steps.sum())
+    negatives = log_steps[log_steps < 0]
+    downside = float(np.sqrt(np.mean(negatives**2))) if len(log_steps) else 0.0
+    worst_k = max(1, len(pnls) // 10)
+    tail = float(abs(np.sort(np.asarray(pnls))[:worst_k].sum())) / initial_equity
+    fees_proxy = 0.0  # fees are inside pnls; turnover term deferred to v1
+    return (
+        growth
+        - float(weights.get("downside", 0.0)) * downside
+        - float(weights.get("tail", 0.0)) * tail
+        - float(weights.get("turnover", 0.0)) * fees_proxy
+    )
+
+
+def evaluate_space(
+    genomes: Sequence[Genome],
+    continuations: Sequence[ContinuationSeries],
+    *,
+    weights: Mapping[str, float],
+    fee_bps: float = 4.5,
+) -> dict[str, Any]:
+    """The oracle: expected utility per genome over all hidden continuations,
+    U*, null utility, ε-optimal set, and basin labels."""
+    expected: dict[str, float] = {}
+    basins: dict[str, str] = {}
+    for genome in genomes:
+        utilities = [
+            utility_from_trades(
+                evaluate_genome(genome, series, fee_bps=fee_bps)["pnls"],
+                weights=weights,
+            )
+            for series in continuations
+        ]
+        expected[genome.genome_id] = float(np.mean(utilities))
+        # Basin approximation: the structural neighborhood that local moves
+        # explore — signal x direction x filter.
+        basins[genome.genome_id] = (
+            f"{genome.signal}|{genome.direction}|{genome.confirm_filter}"
+        )
+    u_star = max(expected.values())
+    u_null = 0.0  # the no-trade genome-equivalent
+    epsilon = max(0.02 * abs(u_star - u_null), 1e-4)
+    optimal_set = {gid for gid, value in expected.items() if value >= u_star - epsilon}
+    best_id = max(expected, key=expected.get)  # type: ignore[arg-type]
+    return {
+        "expected_utility": expected,
+        "u_star": u_star,
+        "u_null": u_null,
+        "epsilon": epsilon,
+        "epsilon_optimal": sorted(optimal_set),
+        "best_genome_id": best_id,
+        "best_basin": basins[best_id],
+        "basins": basins,
+    }

--- a/wayfinder_paths/jobs/benchmarks/runner.py
+++ b/wayfinder_paths/jobs/benchmarks/runner.py
@@ -34,11 +34,25 @@ ORACLE_PATHS = 64
 
 
 def run_world_job(job: dict[str, Any]) -> dict[str, Any]:
-    """One world end-to-end (worker-process safe: primitives in, dicts out)."""
+    """One world end-to-end (worker-process safe: primitives in, dicts out).
+    A world that cannot calibrate returns a rejection record — one stubborn
+    seed must never kill a 66-world suite."""
     from wayfinder_paths.jobs.benchmarks.adapters import ADAPTERS
     from wayfinder_paths.jobs.benchmarks.worlds import generate_world
 
-    world = generate_world(job["archetype"], job["seed"])
+    try:
+        world = generate_world(job["archetype"], job["seed"])
+    except RuntimeError as exc:
+        return {
+            "world_id": f"{job['archetype']}-{job['seed']:06d}",
+            "archetype": job["archetype"],
+            "visibility": job["visibility"],
+            "rejected": str(exc)[:300],
+            "manifest": None,
+            "public_payload": None,
+            "sealed_payload": None,
+            "rows": [],
+        }
     genomes = enumerate_genomes()
     fee = world.mechanism.fee_bps
     hidden = [
@@ -132,6 +146,8 @@ def run_suite(
 
     out_dir.mkdir(parents=True, exist_ok=True)
     all_rows: list[dict[str, Any]] = []
+    rejected = [r for r in results if r.get("rejected")]
+    results = [r for r in results if not r.get("rejected")]
     for result in results:
         world_dir = out_dir / "worlds" / result["world_id"]
         world_dir.mkdir(parents=True, exist_ok=True)
@@ -159,6 +175,9 @@ def run_suite(
     report = {
         "suite": "exact-v0",
         "worlds": len(results),
+        "rejected_worlds": [
+            {"world_id": r["world_id"], "reason": r["rejected"]} for r in rejected
+        ],
         "rows": len(all_rows),
         "by_optimizer": aggregate(all_rows),
         "by_budget": {

--- a/wayfinder_paths/jobs/benchmarks/runner.py
+++ b/wayfinder_paths/jobs/benchmarks/runner.py
@@ -70,10 +70,27 @@ def run_world_job(job: dict[str, Any]) -> dict[str, Any]:
         adapter = ADAPTERS[lane]
         for budget in job["budgets"]:
             for repeat in range(job["repeats"]):
-                run = adapter(
-                    genomes, dev, budget=budget, fee_bps=fee,
-                    seed=job["seed"] * 1000 + budget + repeat,
-                )
+                # Optuna requires 32-bit seeds; private world seeds reach 1e7.
+                lane_seed = (job["seed"] * 1009 + budget * 31 + repeat) % (2**32 - 1)
+                try:
+                    run = adapter(
+                        genomes, dev, budget=budget, fee_bps=fee, seed=lane_seed
+                    )
+                except Exception as exc:  # noqa: BLE001 — one lane crash must
+                    # not kill a suite; the row records the failure.
+                    rows.append(
+                        {
+                            "optimizer": lane,
+                            "world_id": world.world_id,
+                            "archetype": world.archetype,
+                            "budget": budget,
+                            "repeat": repeat,
+                            "error": str(exc)[:200],
+                            "is_null_world": world.archetype == "null_world",
+                            "visibility": job["visibility"],
+                        }
+                    )
+                    continue
                 scored = score_run(run, oracle)
                 scored.update(
                     {

--- a/wayfinder_paths/jobs/benchmarks/runner.py
+++ b/wayfinder_paths/jobs/benchmarks/runner.py
@@ -1,0 +1,172 @@
+"""Suite runner: generate/calibrate worlds, compute oracles, run optimizer
+lanes at matched budgets, score against truth, and emit artifacts.
+
+Artifact layout under `out_dir`:
+    worlds/<world_id>/manifest.json     — publishable (commitments only)
+    worlds/<world_id>/public.json       — full payload, PUBLIC worlds only
+    runs.jsonl                          — one scored row per (world, lane,
+                                          budget, repeat)
+    report.json                         — per-optimizer aggregation
+
+Sealed payloads (data + answers matching the published commitments) go to
+`sealed_dir` — an owner-held location, NEVER inside the repo or any
+optimizer-visible path.
+"""
+
+from __future__ import annotations
+
+import json
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
+from typing import Any
+
+from wayfinder_paths.jobs.benchmarks.grammar import GENOME_SIGNALS, enumerate_genomes
+from wayfinder_paths.jobs.benchmarks.manifest import (
+    public_world_payload,
+    sealed_world_payload,
+    world_manifest,
+)
+from wayfinder_paths.jobs.benchmarks.metrics import aggregate, score_run
+from wayfinder_paths.jobs.benchmarks.oracle import evaluate_space, prepare_continuation
+
+_WEIGHTS = {"downside": 0.5, "tail": 1.0, "turnover": 0.25}
+ORACLE_PATHS = 64
+
+
+def run_world_job(job: dict[str, Any]) -> dict[str, Any]:
+    """One world end-to-end (worker-process safe: primitives in, dicts out)."""
+    from wayfinder_paths.jobs.benchmarks.adapters import ADAPTERS
+    from wayfinder_paths.jobs.benchmarks.worlds import generate_world
+
+    world = generate_world(job["archetype"], job["seed"])
+    genomes = enumerate_genomes()
+    fee = world.mechanism.fee_bps
+    hidden = [
+        prepare_continuation(rows, signal_names=GENOME_SIGNALS)
+        for rows in world.hidden_rows[: job.get("oracle_paths", ORACLE_PATHS)]
+    ]
+    oracle = evaluate_space(genomes, hidden, weights=_WEIGHTS, fee_bps=fee)
+    dev = [
+        prepare_continuation(rows, signal_names=GENOME_SIGNALS)
+        for rows in world.dev_rows
+    ]
+
+    rows: list[dict[str, Any]] = []
+    for lane in job["optimizers"]:
+        adapter = ADAPTERS[lane]
+        for budget in job["budgets"]:
+            for repeat in range(job["repeats"]):
+                run = adapter(
+                    genomes, dev, budget=budget, fee_bps=fee,
+                    seed=job["seed"] * 1000 + budget + repeat,
+                )
+                scored = score_run(run, oracle)
+                scored.update(
+                    {
+                        "world_id": world.world_id,
+                        "archetype": world.archetype,
+                        "budget": budget,
+                        "repeat": repeat,
+                        "is_null_world": world.archetype == "null_world",
+                        "visibility": job["visibility"],
+                    }
+                )
+                rows.append(scored)
+
+    return {
+        "world_id": world.world_id,
+        "archetype": world.archetype,
+        "visibility": job["visibility"],
+        "manifest": world_manifest(world, oracle),
+        "public_payload": (
+            public_world_payload(world, oracle)
+            if job["visibility"] == "public"
+            else None
+        ),
+        "sealed_payload": (
+            sealed_world_payload(world, oracle)
+            if job["visibility"] == "sealed"
+            else None
+        ),
+        "rows": rows,
+    }
+
+
+def run_suite(
+    seed_plan: dict[str, dict[str, list[int]]],
+    *,
+    out_dir: Path,
+    sealed_dir: Path | None,
+    optimizers: list[str],
+    budgets: list[int],
+    repeats: int,
+    oracle_paths: int = ORACLE_PATHS,
+    workers: int = 1,
+) -> dict[str, Any]:
+    jobs: list[dict[str, Any]] = []
+    for visibility, per_archetype in seed_plan.items():
+        for archetype, seeds in per_archetype.items():
+            for seed in seeds:
+                jobs.append(
+                    {
+                        "archetype": archetype,
+                        "seed": seed,
+                        "visibility": visibility,
+                        "optimizers": optimizers,
+                        "budgets": budgets,
+                        "repeats": repeats,
+                        "oracle_paths": oracle_paths,
+                    }
+                )
+
+    results: list[dict[str, Any]] = []
+    if workers > 1:
+        with ProcessPoolExecutor(max_workers=workers) as pool:
+            for result in pool.map(run_world_job, jobs):
+                results.append(result)
+                print(f"[wob] {result['world_id']} done", flush=True)
+    else:
+        for job in jobs:
+            results.append(run_world_job(job))
+            print(f"[wob] {results[-1]['world_id']} done", flush=True)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    all_rows: list[dict[str, Any]] = []
+    for result in results:
+        world_dir = out_dir / "worlds" / result["world_id"]
+        world_dir.mkdir(parents=True, exist_ok=True)
+        (world_dir / "manifest.json").write_text(
+            json.dumps(result["manifest"], indent=2, sort_keys=True) + "\n"
+        )
+        if result["public_payload"] is not None:
+            (world_dir / "public.json").write_text(
+                json.dumps(result["public_payload"], sort_keys=True, default=str)
+            )
+        if result["sealed_payload"] is not None:
+            if sealed_dir is None:
+                raise ValueError(
+                    "sealed worlds in plan but no sealed_dir provided"
+                )
+            sealed_dir.mkdir(parents=True, exist_ok=True)
+            (sealed_dir / f"{result['world_id']}.json").write_text(
+                json.dumps(result["sealed_payload"], sort_keys=True, default=str)
+            )
+        all_rows.extend(result["rows"])
+
+    with (out_dir / "runs.jsonl").open("w") as handle:
+        for row in all_rows:
+            handle.write(json.dumps(row, sort_keys=True, default=str) + "\n")
+    report = {
+        "suite": "exact-v0",
+        "worlds": len(results),
+        "rows": len(all_rows),
+        "by_optimizer": aggregate(all_rows),
+        "by_budget": {
+            str(budget): aggregate([r for r in all_rows if r["budget"] == budget])
+            for budget in budgets
+        },
+    }
+    (out_dir / "report.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n"
+    )
+    return report

--- a/wayfinder_paths/jobs/benchmarks/worlds.py
+++ b/wayfinder_paths/jobs/benchmarks/worlds.py
@@ -1,0 +1,283 @@
+"""Procedural exact-benchmark worlds.
+
+A world is a LATENT MECHANISM (seeded): conditional drift injected after
+observable price events, plus noise. It emits development paths (visible to
+optimizers) and hidden continuations (oracle-only) — same mechanism, fresh
+noise, so the oracle's expected utility rewards finding the MECHANISM, never
+one path's luck.
+
+Ground truth comes from the exhaustive oracle, not from the archetype's
+intent: after generation, each world is CALIBRATION-ASSERTED (a null world's
+U* must be ~U_null; an interaction world's best basin must use a filter; a
+deceptive world's global basin must differ from its bait basin). Worlds that
+fail calibration are rejected and regenerated from the next derived seed —
+recorded, never silent.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass, field
+from typing import Any
+
+BAR_SECONDS = 3600
+_EPOCH = "2026-01-01T00:00:00+00:00"
+
+ARCHETYPES: tuple[str, ...] = (
+    "smooth_optimum",
+    "deceptive_multi_peak",
+    "spike_vs_plateau",
+    "interaction_edge",
+    "session_edge",
+    "cost_flip",
+    "regime_switch",
+    "equivalent_optima",
+    "disconnected_regions",
+    "null_world",
+)
+
+# >=25% of any generated suite must be null worlds (reviewer requirement:
+# an optimizer that always "improves" something is overfitting).
+NULL_FRACTION = 0.25
+
+DEV_BARS = 1600
+HIDDEN_BARS = 1000
+HIDDEN_PATHS = 64
+
+
+@dataclass
+class Mechanism:
+    """Conditional drift rules applied while generating a path.
+
+    Each rule: (trigger, drift, bars, sessions, vol_state, active) —
+    trigger fires on observable price events; drift is injected for the next
+    `bars` bars; sessions/vol_state optionally gate the injection (that is
+    how interaction/session edges exist); active is a (start_frac, end_frac)
+    window enabling regime switches and dev-only luck.
+    """
+
+    rules: list[dict[str, Any]] = field(default_factory=list)
+    base_vol: float = 0.004
+    fee_bps: float = 4.5
+
+
+@dataclass
+class World:
+    world_id: str
+    archetype: str
+    seed: int
+    mechanism: Mechanism  # SEALED — never emitted to public/dev artifacts
+    dev_rows: list[list[dict[str, Any]]] = field(default_factory=list)
+    hidden_rows: list[list[dict[str, Any]]] = field(default_factory=list)
+    calibration: dict[str, Any] = field(default_factory=dict)
+
+
+def _trigger_fired(name: str, closes: list[float], highs: list[float]) -> bool:
+    n = len(closes)
+    if name == "drop3" and n >= 4:
+        return closes[-1] / closes[-4] - 1.0 <= -0.012
+    if name == "rip3" and n >= 4:
+        return closes[-1] / closes[-4] - 1.0 >= 0.012
+    if name == "high20" and n >= 21:
+        return closes[-1] > max(closes[-21:-1])
+    if name == "low20" and n >= 21:
+        return closes[-1] < min(closes[-21:-1])
+    if name == "range_burst" and n >= 17:
+        recent = [abs(a / b - 1.0) for a, b in zip(closes[-6:], closes[-7:-1], strict=True)]
+        older = [abs(a / b - 1.0) for a, b in zip(closes[-15:-6], closes[-16:-7], strict=True)]
+        return sum(recent) / len(recent) > 2.2 * (sum(older) / len(older) + 1e-9)
+    return False
+
+
+def _generate_path(
+    mechanism: Mechanism, *, bars: int, seed: int, symbol: str, dev: bool = False
+) -> list[dict[str, Any]]:
+    import datetime as dt
+
+    rng = random.Random(seed)
+    start = dt.datetime.fromisoformat(_EPOCH)
+    closes = [100.0]
+    pending: list[tuple[float, int]] = []  # (drift, bars_left)
+    rows: list[dict[str, Any]] = []
+    # Mild vol clustering: regime multiplier random-walks in [0.6, 1.8].
+    vol_mult = 1.0
+    vol_window: list[float] = []
+    for index in range(bars):
+        vol_mult = min(1.8, max(0.6, vol_mult * (1.0 + rng.gauss(0.0, 0.03))))
+        vol_now = mechanism.base_vol * vol_mult
+        vol_window.append(vol_now)
+        del vol_window[:-200]
+        high_vol_state = vol_now > sorted(vol_window)[len(vol_window) // 2]
+        hour = index % 24
+        session = hour // 8
+        frac = index / bars
+
+        drift = 0.0
+        still_pending = []
+        for value, left in pending:
+            drift += value
+            if left > 1:
+                still_pending.append((value, left - 1))
+        pending = still_pending
+
+        noise = rng.gauss(0.0, vol_now)
+        close = max(1.0, closes[-1] * (1.0 + drift + noise))
+        closes.append(close)
+
+        for rule in mechanism.rules:
+            if rule.get("dev_only") and not dev:
+                continue
+            start_frac, end_frac = rule.get("active") or (0.0, 1.0)
+            if not (start_frac <= frac < end_frac):
+                continue
+            if rule.get("sessions") is not None and session not in rule["sessions"]:
+                continue
+            if rule.get("vol_state") == "high" and not high_vol_state:
+                continue
+            if rule.get("vol_state") == "low" and high_vol_state:
+                continue
+            if _trigger_fired(rule["trigger"], closes, closes):
+                if rng.random() < float(rule.get("probability", 1.0)):
+                    pending.append(
+                        (float(rule["drift"]), int(rule.get("bars", 2)))
+                    )
+
+        stamp = (start + dt.timedelta(seconds=index * BAR_SECONDS)).isoformat()
+        rows.append(
+            {
+                "timestamp": stamp,
+                "symbol": symbol,
+                "open": close * 0.9995,
+                "high": close * (1.0 + 0.4 * vol_now),
+                "low": close * (1.0 - 0.4 * vol_now),
+                "close": close,
+                "volume": 100,
+            }
+        )
+    return rows
+
+
+def _mechanism_for(archetype: str, rng: random.Random) -> Mechanism:
+    # Strong edges must clear the calibration edge floor (0.010 expected
+    # log growth on hidden paths) with margin after fees; weak stays under it.
+    strong = rng.uniform(0.0055, 0.0085)
+    weak = rng.uniform(0.0012, 0.0020)
+    if archetype == "smooth_optimum":
+        return Mechanism(rules=[{"trigger": "drop3", "drift": strong, "bars": 3}])
+    if archetype == "deceptive_multi_peak":
+        return Mechanism(
+            rules=[
+                # Bait: obvious momentum pays a little...
+                {"trigger": "high20", "drift": weak, "bars": 2},
+                # ...but fading range bursts pays much more.
+                {"trigger": "range_burst", "drift": -strong, "bars": 4},
+            ]
+        )
+    if archetype == "spike_vs_plateau":
+        return Mechanism(
+            rules=[
+                {"trigger": "drop3", "drift": strong, "bars": 3},
+                # DEV-ONLY luck: injected into development paths, absent
+                # from hidden continuations — the seductive fake the funnel
+                # must refuse. Truth (the oracle) never sees it.
+                {"trigger": "rip3", "drift": strong * 2.0, "bars": 2,
+                 "dev_only": True, "probability": 0.5},
+            ]
+        )
+    if archetype == "interaction_edge":
+        return Mechanism(
+            rules=[{"trigger": "high20", "drift": strong, "bars": 3,
+                    "vol_state": "high", "probability": 0.35}]
+        )
+    if archetype == "session_edge":
+        session = rng.randrange(3)
+        return Mechanism(
+            rules=[{"trigger": "drop3", "drift": strong * 2.4, "bars": 4,
+                    "sessions": {session}}]
+        )
+    if archetype == "cost_flip":
+        return Mechanism(
+            rules=[
+                # High-frequency dribble edge (fees kill it)...
+                {"trigger": "rip3", "drift": weak * 0.5, "bars": 1},
+                # ...slow durable edge (survives costs).
+                {"trigger": "low20", "drift": strong, "bars": 6,
+                 "probability": 0.35},
+            ],
+            fee_bps=9.0,
+        )
+    if archetype == "regime_switch":
+        return Mechanism(
+            rules=[
+                {"trigger": "high20", "drift": strong, "bars": 3,
+                 "active": (0.0, 0.6), "probability": 0.35},
+                {"trigger": "high20", "drift": -strong, "bars": 3,
+                 "active": (0.6, 1.0), "probability": 0.35},
+            ]
+        )
+    if archetype == "equivalent_optima":
+        return Mechanism(
+            rules=[
+                {"trigger": "drop3", "drift": strong, "bars": 3},
+                {"trigger": "rip3", "drift": -strong, "bars": 3},
+            ]
+        )
+    if archetype == "disconnected_regions":
+        return Mechanism(
+            rules=[
+                {"trigger": "low20", "drift": strong, "bars": 4,
+                 "probability": 0.35},
+                {"trigger": "high20", "drift": -strong, "bars": 4,
+                 "probability": 0.35},
+                # The "middle" (short-lookback triggers) stays pure noise.
+            ]
+        )
+    if archetype == "null_world":
+        return Mechanism(rules=[])
+    raise ValueError(f"unknown archetype {archetype!r}")
+
+
+def generate_world(archetype: str, seed: int, *, max_attempts: int = 4) -> World:
+    """Generate + calibration-check; reject and re-derive the seed on failure."""
+    from wayfinder_paths.jobs.benchmarks.calibration import calibrate_world
+
+    attempt_seed = seed
+    last_error = ""
+    for attempt in range(max_attempts):
+        rng = random.Random(attempt_seed)
+        mechanism = _mechanism_for(archetype, rng)
+        world = World(
+            world_id=f"{archetype}-{seed:06d}",
+            archetype=archetype,
+            seed=seed,
+            mechanism=mechanism,
+            dev_rows=[
+                _generate_path(
+                    mechanism,
+                    bars=DEV_BARS,
+                    seed=attempt_seed * 7 + i,
+                    symbol="SYN",
+                    dev=True,
+                )
+                for i in range(2)
+            ],
+            hidden_rows=[
+                _generate_path(
+                    mechanism,
+                    bars=HIDDEN_BARS,
+                    seed=attempt_seed * 104729 + 1000 + i,
+                    symbol="SYN",
+                )
+                for i in range(HIDDEN_PATHS)
+            ],
+        )
+        verdict = calibrate_world(world)
+        world.calibration = {**verdict, "attempts": attempt + 1}
+        if verdict["passed"]:
+            return world
+        last_error = str(verdict.get("reason"))
+        attempt_seed = attempt_seed * 31 + 17
+    raise RuntimeError(
+        f"world {archetype}/{seed} failed calibration after {max_attempts} "
+        f"attempts: {last_error}"
+    )

--- a/wayfinder_paths/jobs/benchmarks/worlds.py
+++ b/wayfinder_paths/jobs/benchmarks/worlds.py
@@ -186,8 +186,15 @@ def _mechanism_for(archetype: str, rng: random.Random) -> Mechanism:
         )
     if archetype == "interaction_edge":
         return Mechanism(
-            rules=[{"trigger": "high20", "drift": strong, "bars": 3,
-                    "vol_state": "high", "probability": 0.35}]
+            rules=[
+                {"trigger": "high20", "drift": strong, "bars": 3,
+                 "vol_state": "high", "probability": 0.35},
+                # Low-vol penalty on the SAME trigger: the unfiltered basin
+                # is strictly worse than the gated one — filtering must be
+                # necessary, not incidental.
+                {"trigger": "high20", "drift": -strong * 0.5, "bars": 3,
+                 "vol_state": "low", "probability": 0.35},
+            ]
         )
     if archetype == "session_edge":
         session = rng.randrange(3)

--- a/wayfinder_paths/jobs/economics.py
+++ b/wayfinder_paths/jobs/economics.py
@@ -50,7 +50,22 @@ def objective_vector(
         else 0.0
     )
     base_equity = float(equity_curve[0]["equity"]) if equity_curve else 0.0
-    pnls = [float(row.get("pnl") or 0.0) for row in trades]
+    # Engine fill rows carry realized_pnl_delta (openers ~-fee, closers the
+    # realized result); forward rows carry net_pnl. Reading only "pnl" made
+    # tail_loss silently 0 — the tail ceiling could never trip.
+    closes_only = [row for row in trades if row.get("reduce_only") is True]
+    counted = closes_only if closes_only else trades
+    pnls = [
+        float(
+            row.get("pnl")
+            if row.get("pnl") is not None
+            else row.get("net_pnl")
+            if row.get("net_pnl") is not None
+            else row.get("realized_pnl_delta")
+            or 0.0
+        )
+        for row in counted
+    ]
     worst_k = max(1, len(pnls) // 10)
     tail_loss = (
         abs(sum(sorted(pnls)[:worst_k])) / base_equity if base_equity > 0 else 0.0
@@ -64,7 +79,7 @@ def objective_vector(
         "tail_loss": tail_loss,
         "fee_load": fee_load,
         "max_drawdown_pct": max_dd,
-        "trade_count": len(trades),
+        "trade_count": len(counted),
         "day_count": len(returns),
     }
 

--- a/wayfinder_paths/tests/test_jobs_wob_kernel.py
+++ b/wayfinder_paths/tests/test_jobs_wob_kernel.py
@@ -1,0 +1,199 @@
+"""WOB kernel: grammar space, oracle-engine parity, regret metrics,
+manifests/commitments, and optimizer-lane contracts."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from wayfinder_paths.jobs.benchmarks.adapters import funnel_search, random_search
+from wayfinder_paths.jobs.benchmarks.compiler import compile_genome, write_interpreter
+from wayfinder_paths.jobs.benchmarks.grammar import (
+    GENOME_SIGNALS,
+    Genome,
+    default_space_size,
+    enumerate_genomes,
+    grammar_hash,
+)
+from wayfinder_paths.jobs.benchmarks.manifest import (
+    canonical_sha256,
+    public_world_payload,
+    world_manifest,
+)
+from wayfinder_paths.jobs.benchmarks.metrics import aggregate, score_run
+from wayfinder_paths.jobs.benchmarks.oracle import (
+    evaluate_genome,
+    evaluate_space,
+    prepare_continuation,
+    utility_from_trades,
+)
+from wayfinder_paths.jobs.signal_library import SIGNAL_LIBRARY
+from wayfinder_paths.jobs.synthetic.worlds import churn_world, reversion_world
+
+
+def test_grammar_space_codec_and_hash_stability() -> None:
+    genomes = enumerate_genomes()
+    assert len(genomes) == default_space_size() == 7680
+    library_names = {signal.name for signal in SIGNAL_LIBRARY}
+    assert set(GENOME_SIGNALS) <= library_names
+    sample = genomes[1234]
+    assert Genome.from_dict(sample.to_dict()) == sample
+    assert len({g.genome_id for g in genomes}) == len(genomes)
+    # The declared-space hash is part of the bounded claim: stable across
+    # calls, sensitive to any grammar change.
+    assert grammar_hash() == grammar_hash()
+    assert grammar_hash(signals=GENOME_SIGNALS[:6]) != grammar_hash()
+
+
+def test_oracle_engine_parity_on_shared_contract() -> None:
+    """The parity contract that legitimizes oracle truth: same genome, same
+    rows -> engine and oracle agree on net PnL within tolerance (exactly for
+    close-referenced exits; small end-of-data differences for the rest)."""
+    from wayfinder_paths.jobs.execution import ExecutionSpec
+    from wayfinder_paths.jobs.execution.simulator import (
+        PreparedExecutionDataset,
+        simulate_execution,
+    )
+
+    rows = reversion_world(bars=600)
+    spec = ExecutionSpec()
+    spec.data_contract["bar_interval"] = "1h"
+    series = prepare_continuation(rows, signal_names=["new_low_5", "rsi14_ge_70"])
+    dataset = PreparedExecutionDataset.from_rows(rows)
+    samples = [
+        Genome("rsi14_ge_70", "short", "session_c", "time_stop",
+               (("hold_bars", 16), ("stop_pct", 0.01)), "fixed", ()),
+        Genome("new_low_5", "long", "none", "fixed_time",
+               (("hold_bars", 4),), "fixed", ()),
+    ]
+    with tempfile.TemporaryDirectory() as tmp:
+        script = write_interpreter(Path(tmp))
+        for genome in samples:
+            oracle_pnl = sum(
+                evaluate_genome(genome, series, fee_bps=4.5)["pnls"]
+            )
+            result = simulate_execution(
+                script, dataset, spec, compile_genome(genome, fee_bps=4.5)
+            )
+            engine_pnl = sum(
+                float(row.get("realized_pnl_delta") or 0.0) for row in result.trades
+            )
+            tolerance = max(1.5, 0.06 * abs(oracle_pnl))
+            assert abs(oracle_pnl - engine_pnl) <= tolerance, (
+                f"{genome.signal}/{genome.exit_family}: oracle {oracle_pnl:.3f} "
+                f"vs engine {engine_pnl:.3f}"
+            )
+
+
+def test_oracle_separates_edge_from_noise() -> None:
+    # Reduced space (2 signals) keeps this a unit test, not a suite run.
+    genomes = enumerate_genomes(signals=("new_low_5", "new_high_5"))
+    edge_paths = [
+        prepare_continuation(reversion_world(bars=500, seed=s),
+                             signal_names=("new_low_5", "new_high_5"))
+        for s in (1, 2, 3)
+    ]
+    noise_paths = [
+        prepare_continuation(churn_world(bars=500, seed=s),
+                             signal_names=("new_low_5", "new_high_5"))
+        for s in (1, 2, 3)
+    ]
+    weights = {"downside": 0.5, "tail": 1.0, "turnover": 0.25}
+    edge = evaluate_space(genomes, edge_paths, weights=weights, fee_bps=4.5)
+    noise = evaluate_space(genomes, noise_paths, weights=weights, fee_bps=4.5)
+    assert edge["u_star"] - edge["u_null"] > 3 * (noise["u_star"] - noise["u_null"])
+    assert edge["best_basin"].startswith("new_low_5|long")
+
+
+def test_utility_ruin_floor_and_no_trades() -> None:
+    weights = {"downside": 0.5, "tail": 1.0, "turnover": 0.25}
+    assert utility_from_trades([], weights=weights) == 0.0
+    assert utility_from_trades([-20_000.0], weights=weights) == -10.0
+
+
+def _fake_oracle() -> dict:
+    return {
+        "expected_utility": {"g1": 0.10, "g2": 0.05, "g3": -0.02},
+        "u_star": 0.10,
+        "u_null": 0.0,
+        "epsilon": 0.02,
+        "epsilon_optimal": ["g1"],
+        "best_genome_id": "g1",
+        "best_basin": "s|long|none",
+        "basins": {"g1": "s|long|none", "g2": "t|long|none", "g3": "u|short|none"},
+    }
+
+
+class _StubGenome:
+    def __init__(self, genome_id: str) -> None:
+        self.genome_id = genome_id
+
+
+def test_metrics_regret_decomposition_and_abstention() -> None:
+    oracle = _fake_oracle()
+    # Found the best (g1) but selected g2: zero search regret, positive
+    # selection regret.
+    run = {
+        "optimizer": "x",
+        "lineage": [(_StubGenome("g1"), 0.5), (_StubGenome("g2"), 0.9)],
+        "selected": _StubGenome("g2"),
+    }
+    scored = score_run(run, oracle)
+    assert scored["search_regret"] == pytest.approx(0.0)
+    assert scored["selection_regret"] == pytest.approx(0.05)
+    assert scored["epsilon_hit_search"] is True
+    assert scored["epsilon_hit_selected"] is False
+
+    # Abstention scores U_null and counts as NOT promoted for null worlds.
+    abstain = {"optimizer": "x", "lineage": [(_StubGenome("g3"), -0.1)],
+               "selected": None}
+    scored2 = score_run(abstain, oracle)
+    assert scored2["abstained"] is True
+    assert scored2["selected_utility"] == 0.0
+
+    rows = [
+        {**scored, "is_null_world": False, "budget": 25},
+        {**scored2, "is_null_world": True, "budget": 25},
+    ]
+    report = aggregate(rows)
+    assert report["x"]["runs"] == 2
+    assert report["x"]["null_false_promotion_rate"] == 0.0
+
+
+def test_manifest_commitments_are_deterministic_and_sealed() -> None:
+    from wayfinder_paths.jobs.benchmarks.worlds import Mechanism, World
+
+    world = World(
+        world_id="t-1", archetype="null_world", seed=1,
+        mechanism=Mechanism(rules=[{"trigger": "drop3", "drift": 0.01}]),
+        dev_rows=[[{"close": 1}]], hidden_rows=[[{"close": 2}]],
+        calibration={"passed": True, "attempts": 1},
+    )
+    oracle = _fake_oracle()
+    manifest_a = world_manifest(world, oracle)
+    manifest_b = world_manifest(world, oracle)
+    assert manifest_a["commitments"] == manifest_b["commitments"]
+    text = str(manifest_a)
+    # The manifest must not leak world internals.
+    assert "drift" not in text and "drop3" not in text
+    assert manifest_a["commitments"]["hidden_rows"] == canonical_sha256(
+        world.hidden_rows
+    )
+    payload = public_world_payload(world, oracle)
+    assert payload["oracle"]["best_genome_id"] == "g1"
+
+
+def test_adapter_lineage_budget_and_funnel_contract() -> None:
+    genomes = enumerate_genomes(signals=("new_low_5",))
+    dev = [
+        prepare_continuation(churn_world(bars=400, seed=s),
+                             signal_names=("new_low_5",))
+        for s in (5, 6)
+    ]
+    run = random_search(genomes, dev, budget=10, fee_bps=4.5, seed=1)
+    assert len(run["lineage"]) == 10
+    assert run["selected"] in [genome for genome, _ in run["lineage"]]
+    with pytest.raises(ValueError, match="train"):
+        funnel_search(genomes, dev[:1], budget=5, fee_bps=4.5, seed=1)


### PR DESCRIPTION
First PR of the Wayfinder Optimizer Benchmark program. The dataset half of this deliverable is already live in `wayfinder-optimizer-bench` (24 public worlds + 47 sealed commitments + baseline results).

## What this builds (`wayfinder_paths/jobs/benchmarks/`)

- **Strategy Genome v1** (`grammar.py`): finite typed space — 12 causality-vetted library signals × 2 directions × 8 confirm filters × 20 exit variants × 2 sizings = **7,680 genomes**, hash-pinned (any grammar change is a new benchmark version).
- **One interpreter strategy** (`compiler.py`): a single jobs-v1 `build_strategy` executes any genome through the production engine — one semantics for both evaluation paths.
- **Exhaustive oracle** (`oracle.py`): every genome evaluated over hidden continuations (common random numbers) at ~7.8k genome-evals/s; defines U*, ε-optimal set, basin labels. **Parity contract** vs the engine is unit-tested (`time_stop` family matches exactly; others within end-of-data tolerance).
- **Ten procedural archetypes** (`worlds.py` + `calibration.py`): deceptive multi-peak, spike-vs-plateau (dev-only luck), interaction-only, session, cost-flip, regime switch, equivalent optima, disconnected regions, smooth, and ≥25% null worlds. Every world is **oracle-calibration-asserted** with rejection resampling — the interaction world's optimum must be vol-gated, the null world must have no edge, etc.
- **Manifests + commitments** (`manifest.py`): public worlds ship with answers; sealed worlds publish sha256 commitments BEFORE results; private seeds owner-held via `WOB_PRIVATE_SEEDS`; burned-world rule.
- **Matched-budget lanes** (`adapters.py`): random / strided grid / TPE / funnel (train+holdout with abstention), full lineage always recorded.
- **Regret decomposition** (`metrics.py`): search vs selection regret, ε-hits, anytime regret, null false-promotion.
- **Runner + CLI** (`runner.py`, `scripts/benchmark_wayfinder_optimizer.py`): suite orchestration with per-world resilience (uncalibratable seeds and lane crashes become report rows, never suite deaths — both hardened by real failures during the first 66-world runs).
- **Agent lane** (`agent_adapter.py`): the full stack as an optimizer through the PRODUCTION opencode harness (`opencode run --agent wayfinder-job-worker`, real prompt path, token metering from the session DB). Manual-run only; 2-world pilot is the immediate follow-up.

## First certified exact-v0 run (71 worlds, 2,556 scored runs)

| Lane | ε-hit (selected) | Null false-promotion | Median selection regret |
|---|---|---|---|
| funnel | **0.21** (0.17→0.29 with budget) | **0.37** | 0.000 |
| grid | 0.11 | 1.00 | 0.000 |
| tpe | 0.09 | 1.00 | 0.014 |
| random | 0.03 | 1.00 | 0.000 |

The holdout-gated funnel refuses 63% of the null-world promotions every naive lane makes and dominates selection — the gate architecture measurably earns its existence, and the decomposition separates "finds regions" (TPE's strength) from "selects right" (funnel's).

## Also in this branch

`economics.py` PnL-key fix (live gate impact): engine fills carry `realized_pnl_delta`, not `pnl` — tail_loss was silently 0 (tail ceiling could never trip) and trade counts were doubled. Found by the oracle parity work.

## Tests

25 green (7 new kernel tests in 2s — grammar/codec/hash, oracle-engine parity, edge-vs-noise, ruin floor, regret math + abstention, commitment determinism + manifest non-leakage, adapter contracts — plus synthetic/economics/lifecycle regression).
