### PR TITLE
Notify - Mobile delivery via notification_send

### DIFF
--- a/.opencode/agents/wayfinder-mobile.md
+++ b/.opencode/agents/wayfinder-mobile.md
@@ -28,8 +28,6 @@ permission:
   wayfinder_contracts_*: allow
   wayfinder_contracts_deploy: allow
   wayfinder_contracts_execute: allow
-  # notify (mobile texting rides this tool)
-  wayfinder_notification_send: allow
   # core_*
   wayfinder_core_*: allow
   wayfinder_core_run_script: allow

--- a/.opencode/agents/wayfinder-mobile.md
+++ b/.opencode/agents/wayfinder-mobile.md
@@ -65,7 +65,7 @@ Some turns are scheduled rather than user prompt messages. They begin with `[asy
 
 ### Delivery
 
-Nothing you write on these turns reaches the user automatically — your final chat message is not sent anywhere. To actually message the user you must call `notification_send(delivery="sms")`. The same applies to post-compaction "Continue if you have next steps" turns: if a compaction interrupted you while the user's question was still unanswered, deliver the answer with that call — replies while the user is actively texting are never rate-limited, and the tool rejects anything you already sent, so when in doubt, send.
+Nothing you write on these turns reaches the user automatically — your final chat message is not sent anywhere. To actually message the user you must call `notification_send(delivery="sms")`.
 
 The point of initiative turns is to: 
 1) Monitor the user's positions: developing news on projects, public opinion or large capital rotations on the project, liquidation risk

--- a/.opencode/agents/wayfinder-mobile.md
+++ b/.opencode/agents/wayfinder-mobile.md
@@ -59,13 +59,13 @@ permission:
 
 You are Wayfinder's user-facing agent, reaching out over text message (iMessage/SMS). The user is texting you from their phone; everything you write is delivered as a text message in their messages app. You facilitate the entire positioning lifecycle: research, information gathering, information analysis, strategy / transaction preparation, writing code, executing strategies / transactions, strategy / position monitoring, and finally complete analysis. You have a capable tool suite (MCP), codebase (Wayfinder SDK) to accomplish your tasks.
 
-## Delivery on scheduled and continuation turns
-
-On turns triggered by an `[async-agent-turn]` check-in or by a post-compaction "Continue if you have next steps" prompt, your final chat message is NOT delivered to the user — the ONLY way to text them on those turns is `notification_send(delivery="mobile")`. If a compaction interrupted you while the user's question was still unanswered, deliver the answer with that tool — replies while the user is actively texting are never rate-limited, and the tool rejects anything you already sent, so when in doubt, send.
-
 ## Agent Initiative Turns
 
 Some turns are scheduled rather than user prompt messages. They begin with `[async-agent-turn]` and carry the user's standing instructions.
+
+### Delivery
+
+Nothing you write on these turns reaches the user automatically — your final chat message is not sent anywhere. To actually message the user you must call `notification_send(delivery="sms")`. The same applies to post-compaction "Continue if you have next steps" turns: if a compaction interrupted you while the user's question was still unanswered, deliver the answer with that call — replies while the user is actively texting are never rate-limited, and the tool rejects anything you already sent, so when in doubt, send.
 
 The point of initiative turns is to: 
 1) Monitor the user's positions: developing news on projects, public opinion or large capital rotations on the project, liquidation risk

--- a/.opencode/agents/wayfinder-mobile.md
+++ b/.opencode/agents/wayfinder-mobile.md
@@ -28,6 +28,8 @@ permission:
   wayfinder_contracts_*: allow
   wayfinder_contracts_deploy: allow
   wayfinder_contracts_execute: allow
+  # notify (mobile texting rides this tool)
+  wayfinder_notification_send: allow
   # core_*
   wayfinder_core_*: allow
   wayfinder_core_run_script: allow

--- a/.opencode/agents/wayfinder-mobile.md
+++ b/.opencode/agents/wayfinder-mobile.md
@@ -61,6 +61,10 @@ permission:
 
 You are Wayfinder's user-facing agent, reaching out over text message (iMessage/SMS). The user is texting you from their phone; everything you write is delivered as a text message in their messages app. You facilitate the entire positioning lifecycle: research, information gathering, information analysis, strategy / transaction preparation, writing code, executing strategies / transactions, strategy / position monitoring, and finally complete analysis. You have a capable tool suite (MCP), codebase (Wayfinder SDK) to accomplish your tasks.
 
+## Delivery on scheduled and continuation turns
+
+On turns triggered by an `[async-agent-turn]` check-in or by a post-compaction "Continue if you have next steps" prompt, your final chat message is NOT delivered to the user — the ONLY way to text them on those turns is `notification_send(delivery="mobile")`. If a compaction interrupted you while the user's question was still unanswered, deliver the answer with that tool — replies while the user is actively texting are never rate-limited, and the tool rejects anything you already sent, so when in doubt, send.
+
 ## Agent Initiative Turns
 
 Some turns are scheduled rather than user prompt messages. They begin with `[async-agent-turn]` and carry the user's standing instructions.

--- a/wayfinder_paths/core/clients/NotifyClient.py
+++ b/wayfinder_paths/core/clients/NotifyClient.py
@@ -6,15 +6,6 @@ from wayfinder_paths.core.clients.WayfinderClient import WayfinderClient
 from wayfinder_paths.core.config import get_api_base_url
 
 
-def normalize_notify_delivery(delivery: str | None) -> str:
-    value = str(delivery or "email").strip().lower()
-    if value in {"text", "imessage", "mobile-thread"}:
-        value = "mobile"
-    if value not in {"email", "mobile"}:
-        raise ValueError("delivery must be one of: email, mobile")
-    return value
-
-
 class NotifyClient(WayfinderClient):
     async def notify(
         self,

--- a/wayfinder_paths/core/clients/NotifyClient.py
+++ b/wayfinder_paths/core/clients/NotifyClient.py
@@ -8,10 +8,10 @@ from wayfinder_paths.core.config import get_api_base_url
 
 def normalize_notify_delivery(delivery: str | None) -> str:
     value = str(delivery or "email").strip().lower()
-    if value == "text":
-        value = "sms"
-    if value not in {"email", "sms"}:
-        raise ValueError("delivery must be one of: email, sms, text")
+    if value in {"text", "imessage", "mobile-thread"}:
+        value = "mobile"
+    if value not in {"email", "mobile"}:
+        raise ValueError("delivery must be one of: email, mobile")
     return value
 
 
@@ -20,15 +20,22 @@ class NotifyClient(WayfinderClient):
         self,
         title: str,
         message: str,
-        *,
-        delivery: str = "email",
     ) -> dict[str, Any]:
         url = f"{get_api_base_url()}/opencode/notify/"
-        delivery_normalized = normalize_notify_delivery(delivery)
-        payload = {"title": title, "message": message}
-        if delivery_normalized != "email":
-            payload["delivery"] = delivery_normalized
-        response = await self._authed_request("POST", url, json=payload)
+        response = await self._authed_request(
+            "POST", url, json={"title": title, "message": message}
+        )
+        return response.json()
+
+    async def notify_mobile(
+        self,
+        message: str,
+        override: bool = False,
+    ) -> dict[str, Any]:
+        url = f"{get_api_base_url()}/opencode/sendblue/agent-notify/"
+        response = await self._authed_request(
+            "POST", url, json={"message": message, "override": override}
+        )
         return response.json()
 
 

--- a/wayfinder_paths/core/clients/NotifyClient.py
+++ b/wayfinder_paths/core/clients/NotifyClient.py
@@ -17,8 +17,7 @@ class NotifyClient(WayfinderClient):
         """Direct callers (scripts, monitors, jobs) are trusted senders —
         override defaults on, so quiet hours and the frequency budget don't
         gate them. The agent's notification tool passes override=False and
-        goes through the warning handshake instead. Near-duplicate rejection
-        applies to everyone."""
+        goes through the warning handshake instead."""
         url = f"{get_api_base_url()}/opencode/notify/"
         payload: dict[str, Any] = {"title": title, "message": message}
         if delivery != "email":

--- a/wayfinder_paths/core/clients/NotifyClient.py
+++ b/wayfinder_paths/core/clients/NotifyClient.py
@@ -20,22 +20,16 @@ class NotifyClient(WayfinderClient):
         self,
         title: str,
         message: str,
-    ) -> dict[str, Any]:
-        url = f"{get_api_base_url()}/opencode/notify/"
-        response = await self._authed_request(
-            "POST", url, json={"title": title, "message": message}
-        )
-        return response.json()
-
-    async def notify_mobile(
-        self,
-        message: str,
+        delivery: str = "email",
         override: bool = False,
     ) -> dict[str, Any]:
-        url = f"{get_api_base_url()}/opencode/sendblue/agent-notify/"
-        response = await self._authed_request(
-            "POST", url, json={"message": message, "override": override}
-        )
+        url = f"{get_api_base_url()}/opencode/notify/"
+        payload: dict[str, Any] = {"title": title, "message": message}
+        if delivery != "email":
+            payload["delivery"] = delivery
+        if override:
+            payload["override"] = True
+        response = await self._authed_request("POST", url, json=payload)
         return response.json()
 
 

--- a/wayfinder_paths/core/clients/NotifyClient.py
+++ b/wayfinder_paths/core/clients/NotifyClient.py
@@ -12,14 +12,19 @@ class NotifyClient(WayfinderClient):
         title: str,
         message: str,
         delivery: str = "email",
-        override: bool = False,
+        override: bool = True,
     ) -> dict[str, Any]:
+        """Direct callers (scripts, monitors, jobs) are trusted senders —
+        override defaults on, so quiet hours and the frequency budget don't
+        gate them. The agent's notification tool passes override=False and
+        goes through the warning handshake instead. Near-duplicate rejection
+        applies to everyone."""
         url = f"{get_api_base_url()}/opencode/notify/"
         payload: dict[str, Any] = {"title": title, "message": message}
         if delivery != "email":
             payload["delivery"] = delivery
-        if override:
-            payload["override"] = True
+            if override:
+                payload["override"] = True
         response = await self._authed_request("POST", url, json=payload)
         return response.json()
 

--- a/wayfinder_paths/mcp/tools/notify.py
+++ b/wayfinder_paths/mcp/tools/notify.py
@@ -2,15 +2,12 @@ from __future__ import annotations
 
 import httpx
 
-from wayfinder_paths.core.clients.NotifyClient import (
-    NOTIFY_CLIENT,
-    normalize_notify_delivery,
-)
+from wayfinder_paths.core.clients.NotifyClient import NOTIFY_CLIENT
 from wayfinder_paths.mcp.utils import catch_errors, err, ok, throw_if_empty_str
 
 TITLE_MAX = 200
 MESSAGE_MAX = 20_000
-MOBILE_MESSAGE_MAX = 500
+SMS_MESSAGE_MAX = 500
 
 
 @catch_errors
@@ -19,43 +16,39 @@ async def notification_send(
 ) -> dict:
     """Notify the OpenCode instance owner by email or by texting their phone.
 
-    delivery="mobile" sends `message` as a text into the user's active mobile
-    conversation (iMessage/SMS) — this actually lands on their phone, so it is
-    for finished, user-facing updates only, never progress notes. Mobile texts
-    are plain text, hard cap 500 chars. Quiet hours and a frequency budget
-    gate unprompted mobile sends: a blocked call returns a warning instead of
-    sending, and only a repeat call with override=true pushes through — do
-    that only for genuinely urgent information. Replies while the user is
-    actively texting are never rate-limited, and near-duplicates of texts you
-    already sent are rejected, so answering the user is always safe.
+    delivery="sms" sends `message` as a text to the user's phone — for
+    finished, user-facing updates only, never progress notes. Plain text, hard
+    cap 500 chars. Quiet hours and a frequency budget gate unprompted texts: a
+    blocked call returns a warning instead of sending, and only a repeat call
+    with override=true pushes through — do that only for genuinely urgent
+    information. Replies while the user is actively texting are never
+    rate-limited, and near-duplicates of texts you already sent are rejected,
+    so answering the user is always safe.
 
     delivery="email" (default) requires a verified email address and renders
     Markdown into a themed HTML email.
 
     Args:
         title: Short subject line (<= 200 chars).
-        message: Body — Markdown for email, plain text (<= 500 chars) for
-            mobile.
-        delivery: "email" (default) or "mobile".
-        override: Mobile only — set true ONLY on a re-call after this tool
+        message: Body — Markdown for email, plain text (<= 500 chars) for sms.
+        delivery: "email" (default) or "sms".
+        override: sms only — set true ONLY on a re-call after this tool
             returned a quiet-hours or frequency warning, and only when the
             message is genuinely urgent.
     """
+    if delivery not in ("email", "sms"):
+        return err("invalid_request", 'delivery must be "email" or "sms"')
     title_s = throw_if_empty_str("title is required", title)
     if len(title_s) > TITLE_MAX:
         raise ValueError(f"title exceeds {TITLE_MAX} chars")
     throw_if_empty_str("message is required", message)
-    try:
-        delivery_s = normalize_notify_delivery(delivery)
-    except ValueError as exc:
-        return err("invalid_request", str(exc))
 
-    limit = MOBILE_MESSAGE_MAX if delivery_s == "mobile" else MESSAGE_MAX
+    limit = SMS_MESSAGE_MAX if delivery == "sms" else MESSAGE_MAX
     if len(message) > limit:
         raise ValueError(f"message exceeds {limit} chars")
     try:
         data = await NOTIFY_CLIENT.notify(
-            title=title_s, message=message, delivery=delivery_s, override=override
+            title=title_s, message=message, delivery=delivery, override=override
         )
     except httpx.HTTPStatusError as exc:
         try:

--- a/wayfinder_paths/mcp/tools/notify.py
+++ b/wayfinder_paths/mcp/tools/notify.py
@@ -62,13 +62,11 @@ async def notification_send(
     except ValueError as exc:
         return err("invalid_request", str(exc))
 
-    if delivery_s == "mobile":
-        if len(message) > MOBILE_MESSAGE_MAX:
-            raise ValueError(f"mobile message exceeds {MOBILE_MESSAGE_MAX} chars")
-        return await _relay(
-            NOTIFY_CLIENT.notify_mobile(message=message, override=override)
+    limit = MOBILE_MESSAGE_MAX if delivery_s == "mobile" else MESSAGE_MAX
+    if len(message) > limit:
+        raise ValueError(f"message exceeds {limit} chars")
+    return await _relay(
+        NOTIFY_CLIENT.notify(
+            title=title_s, message=message, delivery=delivery_s, override=override
         )
-
-    if len(message) > MESSAGE_MAX:
-        raise ValueError(f"message exceeds {MESSAGE_MAX} chars")
-    return await _relay(NOTIFY_CLIENT.notify(title=title_s, message=message))
+    )

--- a/wayfinder_paths/mcp/tools/notify.py
+++ b/wayfinder_paths/mcp/tools/notify.py
@@ -13,18 +13,6 @@ MESSAGE_MAX = 20_000
 MOBILE_MESSAGE_MAX = 500
 
 
-async def _relay(request) -> dict:
-    try:
-        data = await request
-    except httpx.HTTPStatusError as exc:
-        try:
-            body = exc.response.json()
-        except Exception:  # noqa: BLE001
-            body = {"detail": exc.response.text}
-        return err("notify_http_error", f"HTTP {exc.response.status_code}", body)
-    return ok(data)
-
-
 @catch_errors
 async def notification_send(
     title: str, message: str, delivery: str = "email", override: bool = False
@@ -65,8 +53,14 @@ async def notification_send(
     limit = MOBILE_MESSAGE_MAX if delivery_s == "mobile" else MESSAGE_MAX
     if len(message) > limit:
         raise ValueError(f"message exceeds {limit} chars")
-    return await _relay(
-        NOTIFY_CLIENT.notify(
+    try:
+        data = await NOTIFY_CLIENT.notify(
             title=title_s, message=message, delivery=delivery_s, override=override
         )
-    )
+    except httpx.HTTPStatusError as exc:
+        try:
+            body = exc.response.json()
+        except Exception:  # noqa: BLE001
+            body = {"detail": exc.response.text}
+        return err("notify_http_error", f"HTTP {exc.response.status_code}", body)
+    return ok(data)

--- a/wayfinder_paths/mcp/tools/notify.py
+++ b/wayfinder_paths/mcp/tools/notify.py
@@ -37,7 +37,9 @@ async def notification_send(
     are plain text, hard cap 500 chars. Quiet hours and a frequency budget
     gate unprompted mobile sends: a blocked call returns a warning instead of
     sending, and only a repeat call with override=true pushes through — do
-    that only for genuinely urgent information.
+    that only for genuinely urgent information. Replies while the user is
+    actively texting are never rate-limited, and near-duplicates of texts you
+    already sent are rejected, so answering the user is always safe.
 
     delivery="email" (default) requires a verified email address and renders
     Markdown into a themed HTML email.

--- a/wayfinder_paths/mcp/tools/notify.py
+++ b/wayfinder_paths/mcp/tools/notify.py
@@ -10,37 +10,12 @@ from wayfinder_paths.mcp.utils import catch_errors, err, ok, throw_if_empty_str
 
 TITLE_MAX = 200
 MESSAGE_MAX = 20_000
+MOBILE_MESSAGE_MAX = 500
 
 
-@catch_errors
-async def notification_send(title: str, message: str, delivery: str = "email") -> dict:
-    """Notify the OpenCode instance owner by email or SMS.
-
-    Email requires a verified email address and renders Markdown into a themed
-    HTML email. SMS requires a verified phone number and sends plain text.
-
-    Args:
-        title: Short subject line (<= 200 chars).
-        message: Markdown body (<= 20 000 chars).
-        delivery: "email" (default), "sms", or "text".
-    """
-    title_s = throw_if_empty_str("title is required", title)
-    if len(title_s) > TITLE_MAX:
-        raise ValueError(f"title exceeds {TITLE_MAX} chars")
-    throw_if_empty_str("message is required", message)
-    if len(message) > MESSAGE_MAX:
-        raise ValueError(f"message exceeds {MESSAGE_MAX} chars")
+async def _relay(request) -> dict:
     try:
-        delivery_s = normalize_notify_delivery(delivery)
-    except ValueError as exc:
-        return err("invalid_request", str(exc))
-
-    try:
-        data = await NOTIFY_CLIENT.notify(
-            title=title_s,
-            message=message,
-            delivery=delivery_s,
-        )
+        data = await request
     except httpx.HTTPStatusError as exc:
         try:
             body = exc.response.json()
@@ -48,3 +23,50 @@ async def notification_send(title: str, message: str, delivery: str = "email") -
             body = {"detail": exc.response.text}
         return err("notify_http_error", f"HTTP {exc.response.status_code}", body)
     return ok(data)
+
+
+@catch_errors
+async def notification_send(
+    title: str, message: str, delivery: str = "email", override: bool = False
+) -> dict:
+    """Notify the OpenCode instance owner by email or by texting their phone.
+
+    delivery="mobile" sends `message` as a text into the user's active mobile
+    conversation (iMessage/SMS) — this actually lands on their phone, so it is
+    for finished, user-facing updates only, never progress notes. Mobile texts
+    are plain text, hard cap 500 chars. Quiet hours and a frequency budget
+    gate unprompted mobile sends: a blocked call returns a warning instead of
+    sending, and only a repeat call with override=true pushes through — do
+    that only for genuinely urgent information.
+
+    delivery="email" (default) requires a verified email address and renders
+    Markdown into a themed HTML email.
+
+    Args:
+        title: Short subject line (<= 200 chars).
+        message: Body — Markdown for email, plain text (<= 500 chars) for
+            mobile.
+        delivery: "email" (default) or "mobile".
+        override: Mobile only — set true ONLY on a re-call after this tool
+            returned a quiet-hours or frequency warning, and only when the
+            message is genuinely urgent.
+    """
+    title_s = throw_if_empty_str("title is required", title)
+    if len(title_s) > TITLE_MAX:
+        raise ValueError(f"title exceeds {TITLE_MAX} chars")
+    throw_if_empty_str("message is required", message)
+    try:
+        delivery_s = normalize_notify_delivery(delivery)
+    except ValueError as exc:
+        return err("invalid_request", str(exc))
+
+    if delivery_s == "mobile":
+        if len(message) > MOBILE_MESSAGE_MAX:
+            raise ValueError(f"mobile message exceeds {MOBILE_MESSAGE_MAX} chars")
+        return await _relay(
+            NOTIFY_CLIENT.notify_mobile(message=message, override=override)
+        )
+
+    if len(message) > MESSAGE_MAX:
+        raise ValueError(f"message exceeds {MESSAGE_MAX} chars")
+    return await _relay(NOTIFY_CLIENT.notify(title=title_s, message=message))

--- a/wayfinder_paths/tests/test_notify_client.py
+++ b/wayfinder_paths/tests/test_notify_client.py
@@ -47,7 +47,7 @@ async def test_notify_client_default_email_payload_omits_delivery(
 
 
 @pytest.mark.asyncio
-async def test_notify_client_text_alias_requests_sms(
+async def test_notify_client_mobile_posts_message_and_override(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
@@ -58,13 +58,11 @@ async def test_notify_client_text_alias_requests_sms(
     client = NotifyClient()
     client._authed_request = AsyncMock(return_value=_Response({"sent": True}))  # type: ignore[method-assign]
 
-    await client.notify(title="Alert", message="Body", delivery="text")
+    await client.notify_mobile(message="Body", override=True)
 
-    assert client._authed_request.await_args.kwargs["json"] == {
-        "title": "Alert",
-        "message": "Body",
-        "delivery": "sms",
-    }
+    args = client._authed_request.await_args
+    assert args.args[1].endswith("/opencode/sendblue/agent-notify/")
+    assert args.kwargs["json"] == {"message": "Body", "override": True}
 
 
 def test_normalize_notify_delivery_rejects_unknown_delivery() -> None:
@@ -73,21 +71,17 @@ def test_normalize_notify_delivery_rejects_unknown_delivery() -> None:
 
 
 @pytest.mark.asyncio
-async def test_notification_send_passes_sms_delivery(
+async def test_notification_send_routes_text_alias_to_mobile(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     fake_client = AsyncMock()
-    fake_client.notify.return_value = {"sent": True, "delivery": "sms"}
+    fake_client.notify_mobile.return_value = {"sent": True}
     monkeypatch.setattr(notify_tool_module, "NOTIFY_CLIENT", fake_client)
 
     out = await notify_tool_module.notification_send("Alert", "Body", delivery="text")
 
-    assert out == {"ok": True, "result": {"sent": True, "delivery": "sms"}}
-    fake_client.notify.assert_awaited_once_with(
-        title="Alert",
-        message="Body",
-        delivery="sms",
-    )
+    assert out == {"ok": True, "result": {"sent": True}}
+    fake_client.notify_mobile.assert_awaited_once_with(message="Body", override=False)
 
 
 @pytest.mark.asyncio

--- a/wayfinder_paths/tests/test_notify_client.py
+++ b/wayfinder_paths/tests/test_notify_client.py
@@ -5,10 +5,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from wayfinder_paths.core.clients.NotifyClient import (
-    NotifyClient,
-    normalize_notify_delivery,
-)
+from wayfinder_paths.core.clients.NotifyClient import NotifyClient
 
 
 class _Response:
@@ -47,7 +44,7 @@ async def test_notify_client_default_email_payload_omits_delivery(
 
 
 @pytest.mark.asyncio
-async def test_notify_client_mobile_posts_message_and_override(
+async def test_notify_client_sms_posts_delivery_and_override(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
@@ -58,36 +55,38 @@ async def test_notify_client_mobile_posts_message_and_override(
     client = NotifyClient()
     client._authed_request = AsyncMock(return_value=_Response({"sent": True}))  # type: ignore[method-assign]
 
-    await client.notify(title="Alert", message="Body", delivery="mobile", override=True)
+    await client.notify(title="Alert", message="Body", delivery="sms", override=True)
 
     args = client._authed_request.await_args
     assert args.args[1].endswith("/opencode/notify/")
     assert args.kwargs["json"] == {
         "title": "Alert",
         "message": "Body",
-        "delivery": "mobile",
+        "delivery": "sms",
         "override": True,
     }
 
 
-def test_normalize_notify_delivery_rejects_unknown_delivery() -> None:
-    with pytest.raises(ValueError):
-        normalize_notify_delivery("fax")
+@pytest.mark.asyncio
+async def test_notification_send_guards_delivery_choices() -> None:
+    out = await notify_tool_module.notification_send("Alert", "Body", delivery="fax")
+    assert out["ok"] is False
+    assert out["error"]["code"] == "invalid_request"
 
 
 @pytest.mark.asyncio
-async def test_notification_send_routes_text_alias_to_mobile(
+async def test_notification_send_passes_sms_delivery(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     fake_client = AsyncMock()
     fake_client.notify.return_value = {"sent": True}
     monkeypatch.setattr(notify_tool_module, "NOTIFY_CLIENT", fake_client)
 
-    out = await notify_tool_module.notification_send("Alert", "Body", delivery="text")
+    out = await notify_tool_module.notification_send("Alert", "Body", delivery="sms")
 
     assert out == {"ok": True, "result": {"sent": True}}
     fake_client.notify.assert_awaited_once_with(
-        title="Alert", message="Body", delivery="mobile", override=False
+        title="Alert", message="Body", delivery="sms", override=False
     )
 
 

--- a/wayfinder_paths/tests/test_notify_client.py
+++ b/wayfinder_paths/tests/test_notify_client.py
@@ -58,11 +58,16 @@ async def test_notify_client_mobile_posts_message_and_override(
     client = NotifyClient()
     client._authed_request = AsyncMock(return_value=_Response({"sent": True}))  # type: ignore[method-assign]
 
-    await client.notify_mobile(message="Body", override=True)
+    await client.notify(title="Alert", message="Body", delivery="mobile", override=True)
 
     args = client._authed_request.await_args
-    assert args.args[1].endswith("/opencode/sendblue/agent-notify/")
-    assert args.kwargs["json"] == {"message": "Body", "override": True}
+    assert args.args[1].endswith("/opencode/notify/")
+    assert args.kwargs["json"] == {
+        "title": "Alert",
+        "message": "Body",
+        "delivery": "mobile",
+        "override": True,
+    }
 
 
 def test_normalize_notify_delivery_rejects_unknown_delivery() -> None:
@@ -75,13 +80,15 @@ async def test_notification_send_routes_text_alias_to_mobile(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     fake_client = AsyncMock()
-    fake_client.notify_mobile.return_value = {"sent": True}
+    fake_client.notify.return_value = {"sent": True}
     monkeypatch.setattr(notify_tool_module, "NOTIFY_CLIENT", fake_client)
 
     out = await notify_tool_module.notification_send("Alert", "Body", delivery="text")
 
     assert out == {"ok": True, "result": {"sent": True}}
-    fake_client.notify_mobile.assert_awaited_once_with(message="Body", override=False)
+    fake_client.notify.assert_awaited_once_with(
+        title="Alert", message="Body", delivery="mobile", override=False
+    )
 
 
 @pytest.mark.asyncio

--- a/wayfinder_paths/tests/test_notify_client.py
+++ b/wayfinder_paths/tests/test_notify_client.py
@@ -55,7 +55,8 @@ async def test_notify_client_sms_posts_delivery_and_override(
     client = NotifyClient()
     client._authed_request = AsyncMock(return_value=_Response({"sent": True}))  # type: ignore[method-assign]
 
-    await client.notify(title="Alert", message="Body", delivery="sms", override=True)
+    # Script-style call: override defaults on for direct client callers.
+    await client.notify(title="Alert", message="Body", delivery="sms")
 
     args = client._authed_request.await_args
     assert args.args[1].endswith("/opencode/notify/")


### PR DESCRIPTION
### Summary

- Two deliveries, guarded at the tool: `notification_send(delivery="email" | "sms")` — anything else errors early, no alias normalization anywhere. `sms` texts the message to the user's phone through the existing `/opencode/notify/` route (`delivery` joins the payload only when non-email, `override` only when set).
- Enforcement is server-side: unprompted texts are gated by quiet hours and a daily budget (blocked call returns a warning; a re-call with `override=true` pushes through for genuinely urgent updates), near-duplicates of already-sent texts are rejected, and replies while the user is actively texting are never rate-limited.
- The mobile agent prompt gains a `### Delivery` subsection under Agent Initiative Turns: nothing written on `[async-agent-turn]` (or post-compaction continuation) turns reaches the user automatically — the tool call is how you actually message them. The tool permission itself is granted per turn by the backend (allowed on check-ins, denied on user turns — vault-backend #1333), so user turns can't double-deliver alongside the plugin.
- Scripts and jobs are trusted senders: the client defaults `override=True`, so monitors text when they fire; the MCP tool passes `override=False` and keeps the check-in loop on the warning handshake.
- Simplification: local gate/ledger/config/outbox machinery deleted, `normalize_notify_delivery` deleted, error handling inline. Scope: exactly four files (tool, client, agent prompt, tests).

