### PR TITLE
wob: e2b-isolated agent lane (first successful in-VM wake)

### DIFF
--- a/scripts/wob_e2b_agent_lane.py
+++ b/scripts/wob_e2b_agent_lane.py
@@ -1,0 +1,101 @@
+"""WOB agent-lane wake inside an E2B microVM: real OS isolation (the fix for
+the bash-escape finding). Bootstraps python 3.12 + SDK + opencode, runs one
+production-agent wake against the world bundle, harvests results."""
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+from e2b import Sandbox
+
+SP = Path(__file__).parent
+WAYFINDER_KEY = json.load(
+    open("/Users/adrianhaldenby/Documents/wayfinder-paths-sdk/config.json")
+)["system"]["api_key"]
+
+
+class _Result:
+    def __init__(self, exit_code, stdout, stderr):
+        self.exit_code, self.stdout, self.stderr = exit_code, stdout, stderr
+
+
+def run(sbx, cmd, timeout=600, env=None, label=""):
+    from e2b.sandbox.commands.command_handle import CommandExitException
+
+    started = time.time()
+    try:
+        result = sbx.commands.run(cmd, timeout=timeout, envs=env or {})
+    except CommandExitException as exc:
+        # Nonzero exit raises in the e2b SDK; normalize so failures are
+        # reported, not fatal.
+        result = _Result(exc.exit_code, "".join(exc.stdout or []), "".join(exc.stderr or []))
+    print(
+        f"[{label or cmd[:40]}] exit={result.exit_code} "
+        f"({time.time() - started:.0f}s)",
+        flush=True,
+    )
+    if result.exit_code != 0:
+        print("  STDERR:", (result.stderr or "")[-600:], flush=True)
+        print("  STDOUT:", (result.stdout or "")[-300:], flush=True)
+    return result
+
+
+sbx = Sandbox.create(template="wob-agent-4g", timeout=3600, envs={"WAYFINDER_API_KEY": WAYFINDER_KEY})
+print("sandbox:", sbx.sandbox_id, flush=True)
+
+for name in ("e2b_bundle.tgz", "e2b_sdk.tgz", "e2b_requirements.txt", "e2b_prompt.txt"):
+    sbx.files.write(f"/home/user/{name}", (SP / name).read_bytes())
+    print("uploaded", name, flush=True)
+
+run(sbx, "curl -LsSf https://astral.sh/uv/install.sh | sh", label="install uv")
+UV = "$HOME/.local/bin/uv"
+run(sbx, f"{UV} python install 3.12 && {UV} venv /home/user/venv -p 3.12",
+    label="python 3.12 venv", timeout=300)
+run(sbx,
+    f"{UV} pip install --python /home/user/venv/bin/python "
+    "-r /home/user/e2b_requirements.txt",
+    label="deps", timeout=900)
+run(sbx,
+    "mkdir -p /home/user/sdk && tar xzf /home/user/e2b_sdk.tgz -C /home/user/sdk && "
+    f"{UV} pip install --python /home/user/venv/bin/python --no-deps /home/user/sdk",
+    label="sdk install", timeout=600)
+# `poetry run X` shim -> exec X from the venv PATH (no poetry in the VM).
+run(sbx,
+    "printf '#!/bin/sh\\nif [ \"$1\" = \"run\" ]; then shift; exec \"$@\"; fi\\n"
+    "echo \"poetry shim: only run supported\" >&2; exit 1\\n' "
+    "| sudo tee /usr/local/bin/poetry >/dev/null && sudo chmod +x /usr/local/bin/poetry",
+    label="poetry shim")
+run(sbx, "curl -fsSL https://opencode.ai/install | bash", label="install opencode",
+    timeout=300)
+run(sbx, "mkdir -p /home/user/wob && tar xzf /home/user/e2b_bundle.tgz -C /home/user/wob",
+    label="bundle extract")
+check = run(sbx,
+    "PATH=/home/user/venv/bin:$PATH wayfinder job gate wob-smooth_optimum-777001 "
+    "2>&1 | tail -3 || true",
+    label="cli smoke", env={"HOME": "/home/user"},
+    timeout=300)
+print("CLI:", (check.stdout or check.stderr or "")[-300:], flush=True)
+
+run(sbx, "ls -la $HOME/.opencode/bin/ 2>&1; $HOME/.opencode/bin/opencode --version 2>&1",
+    label="opencode check", env={"HOME": "/home/user"})
+wake = run(sbx,
+    'cd /home/user/wob && PATH=/home/user/venv/bin:$PATH '
+    '$HOME/.opencode/bin/opencode run --agent wayfinder-job-worker '
+    '-m wayfinder/deepseek-v4-pro --dir /home/user/wob '
+    '--title wob-e2b-wake-0 "$(cat /home/user/e2b_prompt.txt)" 2>&1',
+    label="WAKE", timeout=1500,
+    env={"WAYFINDER_API_KEY": WAYFINDER_KEY, "HOME": "/home/user"})
+print("WAKE STDOUT tail:", (wake.stdout or "")[-800:], flush=True)
+
+harvest = run(sbx,
+    "J=/home/user/wob/.wayfinder/jobs/wob-smooth_optimum-777001; "
+    "echo '--- proposals'; ls $J/proposals/ 2>/dev/null; "
+    "echo '--- journal'; tail -5 $J/journal.jsonl 2>/dev/null | cut -c1-200; "
+    "echo '--- reports'; find $J/reports -name latest.json 2>/dev/null "
+    "-exec sh -c 'head -c 400 {}' \\;",
+    label="harvest", timeout=120)
+print(harvest.stdout[-1500:], flush=True)
+sbx.kill()
+print("E2B-RUN-DONE", flush=True)

--- a/scripts/wob_e2b_campaign.py
+++ b/scripts/wob_e2b_campaign.py
@@ -84,8 +84,12 @@ def main() -> int:
     parser.add_argument("--world", default="smooth_optimum")
     parser.add_argument("--seed", type=int, default=777001)
     parser.add_argument("--model", default="wayfinder/deepseek-v4-pro")
-    parser.add_argument("--wake-seconds", type=int, default=300)
-    parser.add_argument("--hours", type=float, default=3.0)
+    parser.add_argument("--wake-seconds", type=int, default=240)
+    # This e2b plan caps TOTAL sandbox lifetime at ~1h (extensions cannot
+    # outrun it — learned when a 2h campaign died at the 60-minute mark).
+    # Campaigns must fit inside one VM life; longer runs need cross-VM
+    # resume (harvest + rebuild), not yet built.
+    parser.add_argument("--hours", type=float, default=0.9)
     parser.add_argument("--poll-seconds", type=int, default=600)
     args = parser.parse_args()
 

--- a/scripts/wob_e2b_campaign.py
+++ b/scripts/wob_e2b_campaign.py
@@ -1,0 +1,235 @@
+"""Free-running harness campaign in an e2b microVM.
+
+THE measurement the WOB agent lane exists for: the production harness — the
+runner daemon waking the auto-worker on cadence, sessions queued into a real
+`opencode serve`, proposals gated and AUTO-APPLIED — evolving a job against
+a benchmark world, unattended, for a budgeted campaign. No hand-fed prompts:
+every wake is generated and delivered by the same machinery as production.
+
+Parameterized for future cross-harness/model benchmarking:
+    --model wayfinder/deepseek-v4-pro     (any opencode-routable model)
+    --wake-seconds 300 --hours 3 --world smooth_optimum --seed 777001
+
+Usage:
+    E2B_API_KEY=... python scripts/wob_e2b_campaign.py --hours 3
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from e2b import Sandbox  # noqa: E402
+from e2b.sandbox.commands.command_handle import CommandExitException  # noqa: E402
+
+PRIMARY = Path("/Users/adrianhaldenby/Documents/wayfinder-paths-sdk")
+TEMPLATE = "wob-agent-4g"
+OPENCODE_PORT = 3096  # OpenCodeClient default (localhost:3096)
+
+
+class _Result:
+    def __init__(self, exit_code: int, stdout: str, stderr: str) -> None:
+        self.exit_code, self.stdout, self.stderr = exit_code, stdout, stderr
+
+
+def run(sbx, cmd, timeout=600, env=None, label="", background=False):
+    started = time.time()
+    if background:
+        handle = sbx.commands.run(cmd, envs=env or {}, background=True)
+        print(f"[{label}] backgrounded", flush=True)
+        return handle
+    try:
+        result = sbx.commands.run(cmd, timeout=timeout, envs=env or {})
+    except CommandExitException as exc:
+        result = _Result(exc.exit_code, "".join(exc.stdout or []), "".join(exc.stderr or []))
+    print(f"[{label or cmd[:40]}] exit={result.exit_code} ({time.time()-started:.0f}s)", flush=True)
+    if result.exit_code != 0:
+        print("  STDERR:", (result.stderr or "")[-500:], flush=True)
+    return result
+
+
+def stage_bundle(scratch: Path, *, archetype: str, seed: int, wake_seconds: int) -> str:
+    from wayfinder_paths.jobs.benchmarks.agent_adapter import build_world_bundle
+    from wayfinder_paths.jobs.benchmarks.grammar import Genome
+    from wayfinder_paths.jobs.benchmarks.worlds import generate_world
+
+    stage = scratch / "bundle"
+    if stage.exists():
+        shutil.rmtree(stage)
+    world = generate_world(archetype, seed=seed)
+    initial = Genome(
+        "new_high_20", "long", "none", "fixed_time",
+        (("hold_bars", 8),), "fixed", (),
+    )
+    job_id = build_world_bundle(
+        world, sandbox=stage, repo_root=REPO_ROOT, initial_genome=initial,
+        agent_mode="auto", agent_wake_seconds=wake_seconds,
+    )
+    shutil.rmtree(stage / "wayfinder_paths")
+    (stage / ".venv").unlink(missing_ok=True)
+    return job_id
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--world", default="smooth_optimum")
+    parser.add_argument("--seed", type=int, default=777001)
+    parser.add_argument("--model", default="wayfinder/deepseek-v4-pro")
+    parser.add_argument("--wake-seconds", type=int, default=300)
+    parser.add_argument("--hours", type=float, default=3.0)
+    parser.add_argument("--poll-seconds", type=int, default=600)
+    args = parser.parse_args()
+
+    wayfinder_key = json.load(open(PRIMARY / "config.json"))["system"]["api_key"]
+    scratch = Path(tempfile.mkdtemp(prefix="wob-campaign-"))
+    job_id = stage_bundle(
+        scratch, archetype=args.world, seed=args.seed, wake_seconds=args.wake_seconds
+    )
+    print("staged job:", job_id, "at", scratch, flush=True)
+
+    subprocess.run(
+        f"cd {scratch}/bundle && COPYFILE_DISABLE=1 tar --no-xattrs -czf ../bundle.tgz . 2>/dev/null",
+        shell=True, check=True,
+    )
+    subprocess.run(
+        f"cd {REPO_ROOT} && COPYFILE_DISABLE=1 tar --no-xattrs -czf {scratch}/sdk.tgz "
+        "--exclude='__pycache__' --exclude='*.pyc' --exclude='tests' "
+        "pyproject.toml README.md wayfinder_paths 2>/dev/null",
+        shell=True, check=True,
+    )
+    from importlib.metadata import distributions
+
+    requirements = sorted(
+        f"{d.metadata['Name']}=={d.version}"
+        for d in distributions()
+        if d.metadata["Name"] and not d.metadata["Name"].startswith("wayfinder")
+    )
+    (scratch / "requirements.txt").write_text("\n".join(requirements))
+
+    # E2B caps creation timeout at 1h; the poll loop slides it forward.
+    sbx = Sandbox.create(
+        template=TEMPLATE,
+        timeout=3500,
+        envs={"WAYFINDER_API_KEY": wayfinder_key},
+    )
+    print("sandbox:", sbx.sandbox_id, flush=True)
+    for name in ("bundle.tgz", "sdk.tgz", "requirements.txt"):
+        sbx.files.write(f"/home/user/{name}", (scratch / name).read_bytes())
+
+    env = {"WAYFINDER_API_KEY": wayfinder_key, "HOME": "/home/user"}
+    run(sbx, "curl -LsSf https://astral.sh/uv/install.sh | sh", label="uv")
+    uv = "$HOME/.local/bin/uv"
+    run(sbx, f"{uv} python install 3.12 && {uv} venv /home/user/venv -p 3.12", label="venv", timeout=300)
+    run(sbx, f"{uv} pip install --python /home/user/venv/bin/python -r /home/user/requirements.txt",
+        label="deps", timeout=900)
+    run(sbx, f"mkdir -p /home/user/sdk && tar xzf /home/user/sdk.tgz -C /home/user/sdk 2>/dev/null; "
+        f"{uv} pip install --python /home/user/venv/bin/python --no-deps /home/user/sdk",
+        label="sdk", timeout=600)
+    run(sbx, "printf '#!/bin/sh\\nif [ \"$1\" = \"run\" ]; then shift; exec \"$@\"; fi\\n"
+        "echo shim >&2; exit 1\\n' | sudo tee /usr/local/bin/poetry >/dev/null && "
+        "sudo chmod +x /usr/local/bin/poetry", label="poetry shim")
+    run(sbx, "curl -fsSL https://opencode.ai/install -o /tmp/oc.sh && "
+    # Latest upstream: its `run` mode executes full multi-round sessions
+    # (1.15's run caps at one round; 1.15's serve executes prompt_async but
+    # only in the production fork). The delivery shim below uses `run`.
+    "bash /tmp/oc.sh", label="opencode latest", timeout=300)
+    run(sbx, "mkdir -p /home/user/wob && tar xzf /home/user/bundle.tgz -C /home/user/wob 2>/dev/null; true",
+        label="bundle")
+
+    # Compile = register runner lanes + start the daemon (production path).
+    compile_result = run(
+        sbx, f"cd /home/user/wob && PATH=/home/user/venv/bin:$PATH "
+        f"wayfinder job compile {job_id} > /home/user/compile.log 2>&1; "
+        "status=$?; tail -4 /home/user/compile.log; exit $status",
+        label="job compile", env=env, timeout=300)
+    if compile_result.exit_code != 0:
+        print("COMPILE FAILED — aborting campaign", flush=True)
+        log = run(sbx, "tail -40 /home/user/compile.log", label="compile log", env=env)
+        print((log.stdout or "")[-1800:], flush=True)
+        sbx.kill()
+        return 1
+    # DELIVERY SHIM: the sandbox runs upstream opencode, whose server does
+    # not process queued prompt_async (production runs the forked build that
+    # does). Swap the agent lane's DELIVERY from queue-to-server to
+    # `opencode run` — identical prompt bytes, agent, tools, model, and
+    # cadence; only the transport differs. Fork-binary-in-template is the
+    # planned fidelity upgrade.
+    wrapper = f"""
+import subprocess, sys, json, os
+from pathlib import Path
+from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.jobs.worker import prepare_job_worker_prompt
+
+store = JobStore(repo_root=Path("/home/user/wob"))
+prepared = prepare_job_worker_prompt(store=store, job_id="{job_id}", mode="auto")
+result = subprocess.run(
+    [os.path.expanduser("~/.opencode/bin/opencode"), "run",
+     "--agent", "wayfinder-job-auto-worker", "-m", "{args.model}",
+     "--dir", "/home/user/wob", prepared["prompt"]],
+    capture_output=True, text=True, timeout=840, cwd="/home/user/wob",
+)
+store.append_journal("{job_id}", {{
+    "type": "benchmark_wake_executed",
+    "exit_code": result.returncode,
+    "stdout_tail": (result.stdout or "")[-400:],
+}})
+print(json.dumps({{"exit": result.returncode}}))
+"""
+    sbx.files.write("/home/user/wob/.wayfinder_runs/jobs/wob_agent_wrapper.py", wrapper)
+    run(sbx,
+        f"cd /home/user/wob && ls .wayfinder_runs/jobs/ | head -4 && "
+        f"AGENT_WRAPPER=$(ls .wayfinder_runs/jobs/*_agent.py | head -1) && "
+        f"cp /home/user/wob/.wayfinder_runs/jobs/wob_agent_wrapper.py $AGENT_WRAPPER && "
+        f"echo wrapper swapped: $AGENT_WRAPPER",
+        label="wrapper swap", env=env)
+
+    # The script lane would tick a live driver against a nonexistent venue —
+    # pause it; the improve loop (agent lane) is the campaign's subject.
+    run(sbx, f"cd /home/user/wob && PATH=/home/user/venv/bin:$PATH "
+        f"wayfinder runner pause {job_id}-script 2>&1 | tail -2 || true",
+        label="pause script lane", env=env)
+    run(sbx, f"cd /home/user/wob && PATH=/home/user/venv/bin:$PATH "
+        "wayfinder runner status 2>/dev/null | grep -E '\"name\"|\"status\"' | head -8",
+        label="runner status", env=env)
+
+    deadline = time.time() + args.hours * 3600
+    while time.time() < deadline:
+        time.sleep(min(args.poll_seconds, max(30, deadline - time.time())))
+        try:
+            sbx.set_timeout(3500)
+        except Exception as exc:  # noqa: BLE001
+            print("timeout extension failed:", exc, flush=True)
+        poll = run(sbx,
+            f"J=/home/user/wob/.wayfinder/jobs/{job_id}; "
+            "echo wakes=$(grep -c '\"mode\"' $J/journal.jsonl 2>/dev/null); "
+            "echo proposals=$(ls $J/proposals/ 2>/dev/null | wc -l); "
+            "echo applied=$(grep -c proposal_promoted $J/journal.jsonl 2>/dev/null); "
+            "tail -1 $J/journal.jsonl 2>/dev/null | cut -c1-160",
+            label="poll", env=env, timeout=120)
+        print(poll.stdout.strip()[-400:], flush=True)
+
+    harvest = run(sbx,
+        f"J=/home/user/wob/.wayfinder/jobs/{job_id}; "
+        "tar czf /home/user/harvest.tgz -C $J proposals journal.jsonl job.yaml "
+        "state ledgers reports 2>/dev/null; ls -la /home/user/harvest.tgz",
+        label="harvest", env=env, timeout=300)
+    data = sbx.files.read("/home/user/harvest.tgz", format="bytes")
+    out = scratch / "harvest.tgz"
+    out.write_bytes(data)
+    print("harvest saved:", out, len(data), "bytes", flush=True)
+    sbx.kill()
+    print("CAMPAIGN-DONE", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/wayfinder_paths/jobs/benchmarks/agent_adapter.py
+++ b/wayfinder_paths/jobs/benchmarks/agent_adapter.py
@@ -48,6 +48,8 @@ def build_world_bundle(
     sandbox: Path,
     repo_root: Path,
     initial_genome: Genome,
+    agent_mode: str = "auto",
+    agent_wake_seconds: int = 300,
 ) -> str:
     """Sandbox job bundle: SDK-visible workspace + the world's dev data as
     the job dataset + the interpreter as the strategy. Hidden rows and the
@@ -94,22 +96,35 @@ def build_world_bundle(
         (sandbox / ".venv").symlink_to(venv_source)
 
     store = JobStore(repo_root=sandbox)
+    # A NORMAL job with a normal goal — the harness under test must see the
+    # same kind of job it sees in production, not benchmark-flavored prompt
+    # text. The agent discovers its situation with its own tools.
     job = WayfinderJob.new(
         f"wob-{world.world_id}",
         goal=(
-            "BENCHMARK JOB: maximize risk-adjusted return by improving the "
-            "genome parameters in execution_params.genome_spec (fields: "
-            "signal, direction, confirm_filter, exit_family+exit_params, "
-            "sizing_family). Method: run `wayfinder job backtest` / grid "
-            "sweeps over genome variants on the FIXED dataset in "
-            "results/backtest/input_bars.json, then `wayfinder job propose` "
-            "the best genome as an execution_params change. There is no "
-            "live venue, no external data, and nothing useful outside this "
-            "job bundle — do not research the benchmark itself; optimize "
-            "within it."
+            "Maximize risk-adjusted return of this strategy. Improve it "
+            "through the standard evidence loop: backtests, grids, "
+            "walk-forward, and gated proposals."
         ),
         script="workspace/src/strategy.py",
-        agent_mode="intervene",
+        # The script lane needs a schedule to compile; it gets paused
+        # immediately in campaigns (no live venue), but registration must
+        # succeed for the agent lane to register after it.
+        interval_seconds=3600,
+        agent_mode=agent_mode,
+        agent_wake_seconds=agent_wake_seconds,
+        # Auto mode refuses to run with empty limits (production guard).
+        # Benchmark worlds have no live venue: the backtest venue with
+        # bounded paper limits satisfies the guard without enabling any
+        # real execution surface.
+        auto_limits={
+            "enabled_venues": ["backtest"],
+            "allowed_symbols": ["SYN"],
+            "max_notional_per_decision": 1000,
+            "max_daily_notional": 10000,
+            "max_open_positions": 1,
+            "max_open_orders": 2,
+        },
         execution_contract="jobs_v1",
     )
     store.save(job)
@@ -127,7 +142,9 @@ def build_world_bundle(
         "genome_spec": initial_genome.to_dict(),
         "fee_bps": world.mechanism.fee_bps,
     }
-    job_yaml["script_loop"] = {"enabled": True, "entrypoint": "workspace/src/strategy.py"}
+    # NEVER touch script_loop: WayfinderJob.new already configured it fully;
+    # a hand-replacement dropped interval_seconds and crashed `job compile`
+    # before the agent lane could register (found live).
     job_yaml_path.write_text(yaml.safe_dump(job_yaml, sort_keys=False))
 
     # Benchmark jobs must not burn wakes on production side-quests: a fresh

--- a/wayfinder_paths/jobs/benchmarks/agent_adapter.py
+++ b/wayfinder_paths/jobs/benchmarks/agent_adapter.py
@@ -97,10 +97,16 @@ def build_world_bundle(
     job = WayfinderJob.new(
         f"wob-{world.world_id}",
         goal=(
-            "Maximize risk-adjusted return of this strategy by improving its "
-            "genome parameters (signal/filter/exit/sizing in "
-            "execution_params.genome_spec). The dataset is fixed; there is "
-            "no live venue."
+            "BENCHMARK JOB: maximize risk-adjusted return by improving the "
+            "genome parameters in execution_params.genome_spec (fields: "
+            "signal, direction, confirm_filter, exit_family+exit_params, "
+            "sizing_family). Method: run `wayfinder job backtest` / grid "
+            "sweeps over genome variants on the FIXED dataset in "
+            "results/backtest/input_bars.json, then `wayfinder job propose` "
+            "the best genome as an execution_params change. There is no "
+            "live venue, no external data, and nothing useful outside this "
+            "job bundle — do not research the benchmark itself; optimize "
+            "within it."
         ),
         script="workspace/src/strategy.py",
         agent_mode="intervene",
@@ -124,9 +130,53 @@ def build_world_bundle(
     job_yaml["script_loop"] = {"enabled": True, "entrypoint": "workspace/src/strategy.py"}
     job_yaml_path.write_text(yaml.safe_dump(job_yaml, sort_keys=False))
 
+    # Benchmark jobs must not burn wakes on production side-quests: a fresh
+    # ideation artifact parks the forced-expedition contract (external
+    # research tools are absent in sandboxes — found on pilot wake 0).
+    ideation_dir = root / "research" / "ideation"
+    ideation_dir.mkdir(parents=True, exist_ok=True)
+    from wayfinder_paths.jobs.models import utc_now_iso
+
+    (ideation_dir / "latest.json").write_text(
+        json.dumps(
+            {
+                "generated_at": utc_now_iso(),
+                "sources_consulted": [
+                    {
+                        "tool": "benchmark_bundle",
+                        "query": "n/a",
+                        "takeaway": "Benchmark world: no external research "
+                        "surface exists; optimize the genome on the fixed "
+                        "dataset instead.",
+                    }
+                ],
+                "hypotheses": [
+                    {
+                        "title": "Genome search on the fixed dataset",
+                        "thesis": "The only improvable surface is "
+                        "execution_params.genome_spec.",
+                        "bucket": "testable",
+                        "next_step": "wayfinder job backtest/grid, then "
+                        "propose better genome params",
+                    }
+                ],
+            }
+        )
+    )
+
+    # The backtest CLI needs an execution spec at the job root — without it
+    # the agent cannot evaluate anything (found on the first e2b run).
+    from wayfinder_paths.jobs.execution import ExecutionSpec
+
+    spec = ExecutionSpec()
+    spec.data_contract["bar_interval"] = "1h"
+    (root / "execution_spec.json").write_text(json.dumps(spec.to_dict(), indent=2))
+
     dataset_dir = root / "results" / "backtest"
     dataset_dir.mkdir(parents=True, exist_ok=True)
-    rows = [row for path_rows in world.dev_rows for row in path_rows]
+    # ONE dev path only: the paths share a timeline, so concatenating them
+    # creates duplicate timestamps (pandas reindex failures downstream).
+    rows = list(world.dev_rows[0])
     (dataset_dir / "input_bars.json").write_text(
         json.dumps(
             {


### PR DESCRIPTION
Follow-up to #639: the agent lane now runs in an e2b Firecracker microVM — the fix for the pilot's bash-escape finding. Bundle contract fixes (execution_spec, single-timeline dataset, pre-stamped ideation, sharpened goal) + the e2b runner script. Verified live: toolchain green in-VM, wake exit 0 in 123s on the 4GB `wob-agent-4g` template, and the permission layer auto-rejected an out-of-dir SDK read — isolation holds in headless mode. Next: multi-wake runs + baking the bootstrap into the template for the 5-10-world sample.