### PR TITLE
jobs: verdict states + censoring, trial lineage, ledger CIs, benchmark constitution (WOB PR III)

### DIFF
--- a/wayfinder_paths/jobs/benchmarks/constitution.benchmark.yaml
+++ b/wayfinder_paths/jobs/benchmarks/constitution.benchmark.yaml
@@ -1,0 +1,30 @@
+# WOB certification constitution — the standard ALL certification runs gate
+# against. Deliberately stricter than production defaults: production jobs
+# balance movability against rigor; certification claims must not.
+version: 1
+enforcement: blocking
+objective:
+  weights:
+    downside: 0.5
+    tail: 1.0
+    turnover: 0.25
+evaluation:
+  folds: 5
+  confidence: 0.95
+  bootstrap_iterations: 5000
+  block_days: 5
+  audit_days: 7
+promotion:
+  required_positive_folds: 4
+  min_oos_trades: 8
+  audit_min_delta_utility: 0.0
+  # No probation escape valve in certification: every promotion pays the LCB.
+  probation_requires_lcb: true
+hard_constraints:
+  max_drawdown_pct: 0.25
+  max_tail_loss: 0.15
+verdict:
+  minimum_days: 3.0
+  minimum_closed_trades: 3
+  maximum_days: 30.0
+  minimum_material_delta: 0.25

--- a/wayfinder_paths/jobs/constitution.py
+++ b/wayfinder_paths/jobs/constitution.py
@@ -74,6 +74,19 @@ def load_constitution(root: Path) -> dict[str, Any]:
     return merged
 
 
+def load_benchmark_constitution() -> dict[str, Any]:
+    """The certification profile (stricter than production defaults): all WOB
+    certification runs gate against this one versioned standard."""
+    path = (
+        Path(__file__).parent / "benchmarks" / "constitution.benchmark.yaml"
+    )
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    merged = _merge(DEFAULT_CONSTITUTION, loaded)
+    merged["revision"] = constitution_revision(path)
+    merged["source"] = "benchmark_profile"
+    return merged
+
+
 def constitution_revision(path: Path) -> str | None:
     if not path.exists():
         return None

--- a/wayfinder_paths/jobs/counterfactual.py
+++ b/wayfinder_paths/jobs/counterfactual.py
@@ -136,43 +136,126 @@ def counterfactual_job(
     return artifact
 
 
-# Verdict maturity: enough forward window that beat/hurt is not one bar of
-# noise, sized to our jobs' trade cadence (days between closes).
-_VERDICT_MIN_DAYS = 3.0
-_VERDICT_MIN_CLOSES = 3
 _VERDICTS_PATH = "state/promotion_verdicts.json"
+# Verdict maturity defaults — overridable per job via the constitution's
+# `verdict:` block (a universal 3-day/3-close rule mis-times both scalpers
+# and slow holders). maximum_days caps how long a verdict may stay pending
+# before it is finalized as insufficient_evidence.
+_VERDICT_DEFAULTS = {
+    "minimum_days": 3.0,
+    "minimum_closed_trades": 3,
+    "maximum_days": 30.0,
+    "minimum_material_delta": 0.25,
+}
+
+VERDICT_STATES = (
+    "pending",
+    "insufficient_evidence",
+    "beat",
+    "neutral",
+    "hurt",
+    "censored_by_next_change",
+)
+
+
+def _verdict_config(root: Path) -> dict[str, Any]:
+    from wayfinder_paths.jobs.constitution import load_constitution
+
+    constitution = load_constitution(root)
+    block = constitution.get("verdict")
+    merged = dict(_VERDICT_DEFAULTS)
+    if isinstance(block, dict):
+        merged.update({k: block[k] for k in _VERDICT_DEFAULTS if k in block})
+    return merged
 
 
 def _maybe_record_promotion_verdict(
     store: JobStore, job_id: str, artifact: dict[str, Any]
 ) -> None:
-    """Once per promotion: classify the forward shadow comparison as
-    beat/neutral/hurt and persist it — the promotion-reliability datapoint
-    the evolution ledger aggregates. Never raises."""
+    """Once per promotion: classify the forward shadow comparison and persist
+    it — the promotion-reliability datapoint the evolution ledger aggregates.
+
+    States: beat/neutral/hurt (mature evidence); insufficient_evidence (the
+    window aged out before enough closes); censored_by_next_change (a newer
+    promotion re-anchored the shadow before this verdict matured — recorded,
+    never silently dropped). Never raises."""
     try:
         proposal_id = str(artifact.get("proposal_id") or "")
         window = artifact.get("window") or {}
         if not proposal_id or not artifact.get("available"):
             return
+        root = store.job_dir(job_id)
+        config = _verdict_config(root)
+        verdicts = store.read_json(job_id, _VERDICTS_PATH) or {}
+
+        # CENSORING: any prior promotion still without a verdict when a NEW
+        # promotion re-anchors the shadow gets censored_by_next_change — its
+        # forward window is now confounded by the newer change.
+        censored = []
+        for prior_id, prior in list(verdicts.items()):
+            if prior_id != proposal_id and prior.get("verdict") == "pending":
+                prior.update(
+                    {
+                        "verdict": "censored_by_next_change",
+                        "censored_by": proposal_id,
+                        "recorded_at": utc_now_iso(),
+                    }
+                )
+                censored.append(prior_id)
+        for prior_id in censored:
+            store.append_journal(
+                job_id,
+                {
+                    "type": "promotion_verdict",
+                    "proposal_id": prior_id,
+                    **verdicts[prior_id],
+                },
+            )
+
+        existing = verdicts.get(proposal_id)
+        if existing and existing.get("verdict") != "pending":
+            if censored:
+                store.write_json(job_id, _VERDICTS_PATH, verdicts)
+            return
+
+        days = float(window.get("days") or 0.0)
         closes = max(
             int((artifact.get("actual") or {}).get("closes") or 0),
             int((artifact.get("shadow") or {}).get("closes") or 0),
         )
-        if float(window.get("days") or 0.0) < _VERDICT_MIN_DAYS:
+        mature = days >= float(config["minimum_days"]) and closes >= int(
+            config["minimum_closed_trades"]
+        )
+        aged_out = days >= float(config["maximum_days"])
+        if not mature and not aged_out:
+            # Track the open verdict so censoring has something to censor.
+            verdicts[proposal_id] = {
+                "verdict": "pending",
+                "window_days": days,
+                "closes": closes,
+                "recorded_at": utc_now_iso(),
+            }
+            store.write_json(job_id, _VERDICTS_PATH, verdicts)
             return
-        if closes < _VERDICT_MIN_CLOSES:
-            return
-        verdicts = store.read_json(job_id, _VERDICTS_PATH) or {}
-        if proposal_id in verdicts:
-            return
-        delta = float(artifact.get("delta_net_pnl") or 0.0)
-        shadow_pnl = float((artifact.get("shadow") or {}).get("net_pnl") or 0.0)
-        threshold = max(0.25, 0.02 * abs(shadow_pnl))
-        verdict = "beat" if delta > threshold else "hurt" if delta < -threshold else "neutral"
+
+        if not mature and aged_out:
+            verdict = "insufficient_evidence"
+            delta = float(artifact.get("delta_net_pnl") or 0.0)
+        else:
+            delta = float(artifact.get("delta_net_pnl") or 0.0)
+            shadow_pnl = float((artifact.get("shadow") or {}).get("net_pnl") or 0.0)
+            threshold = max(
+                float(config["minimum_material_delta"]), 0.02 * abs(shadow_pnl)
+            )
+            verdict = (
+                "beat" if delta > threshold
+                else "hurt" if delta < -threshold
+                else "neutral"
+            )
         record = {
             "verdict": verdict,
             "delta_net_pnl": delta,
-            "window_days": window.get("days"),
+            "window_days": days,
             "closes": closes,
             "recorded_at": utc_now_iso(),
         }

--- a/wayfinder_paths/jobs/evolution_ledger.py
+++ b/wayfinder_paths/jobs/evolution_ledger.py
@@ -55,14 +55,26 @@ def build_evolution_report(store: JobStore, job_id: str) -> dict[str, Any]:
             }
         )
 
-    verdict_counts = {"beat": 0, "neutral": 0, "hurt": 0}
+    verdict_counts = {
+        "beat": 0, "neutral": 0, "hurt": 0,
+        "pending": 0, "censored_by_next_change": 0, "insufficient_evidence": 0,
+    }
+    deltas: list[float] = []
     for record in verdicts.values():
         verdict = str(record.get("verdict") or "")
         if verdict in verdict_counts:
             verdict_counts[verdict] += 1
-    judged = sum(verdict_counts.values())
+        if verdict in ("beat", "neutral", "hurt"):
+            deltas.append(float(record.get("delta_net_pnl") or 0.0))
+    judged = verdict_counts["beat"] + verdict_counts["neutral"] + verdict_counts["hurt"]
+    beat_rate = (verdict_counts["beat"] / judged) if judged else None
+
+    # A raw beat_rate on 2 datapoints reads as certainty it does not have —
+    # the Wilson interval keeps small samples honest.
+    ci = _wilson_interval(verdict_counts["beat"], judged) if judged else None
 
     replication = _replication_summary(root)
+    promoted_total = sum(bucket["promoted"] for bucket in by_family.values())
     return {
         "job_id": job_id,
         "proposals_total": len(proposals),
@@ -73,12 +85,70 @@ def build_evolution_report(store: JobStore, job_id: str) -> dict[str, Any]:
             # Of promotions old enough to judge, how many actually beat the
             # incumbent forward — the single trackable scalar for whether the
             # improve loop is earning its keep.
-            "beat_rate": (verdict_counts["beat"] / judged) if judged else None,
+            "beat_rate": beat_rate,
+            "beat_rate_ci95": ci,
+            "mean_judged_delta_usd": (
+                sum(deltas) / len(deltas) if deltas else None
+            ),
         },
+        # A high beat_rate with near-zero promotions is not a working loop —
+        # yield pairs reliability with throughput.
+        "improvement_yield": {
+            "promoted": promoted_total,
+            "promoted_per_proposal": (
+                promoted_total / len(proposals) if proposals else None
+            ),
+        },
+        "opportunity_recall": _opportunity_recall(store, job_id),
         "replication": replication,
         "proposals": rows[-50:],
         "generated_at": utc_now_iso(),
     }
+
+
+def _wilson_interval(successes: int, n: int, z: float = 1.96) -> list[float]:
+    if n == 0:
+        return [0.0, 1.0]
+    p = successes / n
+    denominator = 1 + z * z / n
+    center = (p + z * z / (2 * n)) / denominator
+    margin = (z / denominator) * ((p * (1 - p) / n + z * z / (4 * n * n)) ** 0.5)
+    return [round(max(0.0, center - margin), 4), round(min(1.0, center + margin), 4)]
+
+
+def _opportunity_recall(store: JobStore, job_id: str) -> dict[str, Any] | None:
+    """Selection-regret telemetry: does the archive hold a LIVE candidate that
+    outscores the current incumbent but was never promoted? A yes is a
+    measured missed opportunity, not a vibe."""
+    try:
+        from wayfinder_paths.jobs.archive import load_archive
+
+        doc = load_archive(store, job_id)
+        candidates = [
+            entry for entry in doc.get("candidates") or []
+            if isinstance(entry.get("objective"), dict)
+            and entry.get("status") not in ("refuted", "retired")
+        ]
+        if not candidates:
+            return None
+        incumbent = next(
+            (e for e in candidates if e.get("status") == "incumbent"), None
+        )
+
+        def growth(entry: dict[str, Any]) -> float:
+            return float(entry["objective"].get("net_log_growth") or 0.0)
+
+        best = max(candidates, key=growth)
+        if incumbent is None or best is incumbent:
+            return {"missed": False}
+        gap = growth(best) - growth(incumbent)
+        return {
+            "missed": gap > 0,
+            "best_candidate_id": best.get("candidate_id"),
+            "growth_gap": round(gap, 6),
+        }
+    except Exception:  # noqa: BLE001 — telemetry never breaks the report
+        return None
 
 
 def evolution_snapshot_block(store: JobStore, job_id: str) -> dict[str, Any]:

--- a/wayfinder_paths/jobs/execution/experiments.py
+++ b/wayfinder_paths/jobs/execution/experiments.py
@@ -13,6 +13,62 @@ from wayfinder_paths.jobs.models import utc_now_iso
 from wayfinder_paths.jobs.store import JobStore
 
 EXPERIMENTS_FILE = "results/backtest/experiments.jsonl"
+TRIALS_FILE = "results/backtest/trials.jsonl"
+
+
+def _behavior_descriptor(stats: Mapping[str, Any]) -> dict[str, Any]:
+    """Compact behavioral fingerprint per trial — the population-search axes
+    (how a candidate TRADES, not just how much it made). Defensive: stats
+    keys vary by engine version; absent fields stay None."""
+    def _num(key: str) -> float | None:
+        value = stats.get(key)
+        return float(value) if isinstance(value, (int, float)) else None
+
+    return {
+        "trade_count": _num("trade_count"),
+        "win_rate": _num("win_rate"),
+        "avg_hold_bars": _num("avg_hold_bars") or _num("avg_holding_bars"),
+        "max_drawdown_pct": _num("max_drawdown_pct"),
+        "net_return": _num("net_return"),
+    }
+
+
+def record_trial_lineage(
+    job_id: str,
+    grid_payload: Mapping[str, Any],
+    *,
+    store: JobStore | None = None,
+    cap: int = 500,
+) -> int:
+    """EVERY evaluated trial becomes a lineage row — the archive-of-record a
+    global-search benchmark needs (the ranked top-N alone hides where search
+    actually went). One compact row per run, appended per grid/optuna
+    campaign; `cap` bounds pathological sweeps."""
+    store = store or JobStore()
+    result = grid_payload["result"]
+    rows = []
+    for run in list(result.get("runs") or [])[:cap]:
+        stats = run.get("stats") or {}
+        rows.append(
+            {
+                "ts": utc_now_iso(),
+                "grid_id": result.get("grid_id"),
+                "revision": grid_payload.get("revision"),
+                "optimizer": result.get("optimizer") or "grid",
+                "run_id": run.get("run_id"),
+                "params": run.get("params"),
+                "rank_metric": stats.get(result.get("rank_by") or "net_return"),
+                "behavior": _behavior_descriptor(stats),
+            }
+        )
+    if not rows:
+        return 0
+    path = store.job_dir(job_id) / TRIALS_FILE
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, sort_keys=True, default=str) + "\n")
+    return len(rows)
 
 
 def record_experiment(
@@ -54,6 +110,7 @@ def record_experiment(
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(row, sort_keys=True, default=str) + "\n")
+    row["trials_recorded"] = record_trial_lineage(job_id, grid_payload, store=store)
     return row
 
 

--- a/wayfinder_paths/jobs/synthetic/bench.py
+++ b/wayfinder_paths/jobs/synthetic/bench.py
@@ -49,9 +49,18 @@ def _spec() -> ExecutionSpec:
 
 
 def _constitution() -> dict[str, Any]:
-    constitution = json.loads(json.dumps(DEFAULT_CONSTITUTION))
-    constitution["enforcement"] = "blocking"
-    constitution["revision"] = "synthetic-bench"
+    from wayfinder_paths.jobs.constitution import load_benchmark_constitution
+
+    constitution = load_benchmark_constitution()
+    # Smoke worlds are small: the certification fold/iteration counts price
+    # them out — keep the certification RULES, scale the evaluation budget.
+    constitution["evaluation"] = {
+        **constitution["evaluation"], "folds": 4, "bootstrap_iterations": 500,
+        "confidence": 0.90,
+    }
+    constitution["promotion"] = {
+        **constitution["promotion"], "required_positive_folds": 2,
+    }
     return constitution
 
 

--- a/wayfinder_paths/tests/test_jobs_economics.py
+++ b/wayfinder_paths/tests/test_jobs_economics.py
@@ -227,7 +227,10 @@ def test_promotion_verdict_records_once_when_mature(tmp_path: Path) -> None:
         "delta_net_pnl": 1.0,
     }
     _maybe_record_promotion_verdict(store, job_id, immature)
-    assert store.read_json(job_id, "state/promotion_verdicts.json") is None
+    # Immature windows now TRACK as pending (so censoring has a target)
+    # instead of leaving no record.
+    verdicts = store.read_json(job_id, "state/promotion_verdicts.json")
+    assert verdicts["prop-young"]["verdict"] == "pending"
 
     mature = {
         "available": True,
@@ -241,8 +244,13 @@ def test_promotion_verdict_records_once_when_mature(tmp_path: Path) -> None:
     _maybe_record_promotion_verdict(store, job_id, mature)
     verdicts = store.read_json(job_id, "state/promotion_verdicts.json")
     assert verdicts["prop-mature"]["verdict"] == "beat"
+    # The maturing promotion CENSORS the still-pending prior verdict.
+    assert verdicts["prop-young"]["verdict"] == "censored_by_next_change"
+    assert verdicts["prop-young"]["censored_by"] == "prop-mature"
     journal = (store.job_dir(job_id) / "journal.jsonl").read_text(encoding="utf-8")
-    assert journal.count("promotion_verdict") == 1
+    # Two journal entries — the censor record + the beat verdict — and the
+    # repeated call added neither twice (dedup holds).
+    assert journal.count("promotion_verdict") == 2
 
     hurt = {**mature, "proposal_id": "prop-hurt", "delta_net_pnl": -2.0}
     _maybe_record_promotion_verdict(store, job_id, hurt)
@@ -298,3 +306,93 @@ def test_evolution_report_aggregates_path_and_reliability(tmp_path: Path) -> Non
     assert reliability["beat"] == 1 and reliability["beat_rate"] == 1.0
     promoted_row = next(r for r in report["proposals"] if r["proposal_id"] == "prop-a")
     assert promoted_row["forward_verdict"] == "beat"
+
+
+def test_verdict_ages_out_to_insufficient_evidence(tmp_path: Path) -> None:
+    """A promotion whose window exceeds maximum_days without reaching the
+    trade floor finalizes as insufficient_evidence — never a fake neutral."""
+    store, job_id = _store_with_job(tmp_path)
+    aged = {
+        "available": True,
+        "proposal_id": "prop-sparse",
+        "window": {"days": 45.0},
+        "actual": {"closes": 1, "net_pnl": 0.2},
+        "shadow": {"closes": 1, "net_pnl": 0.1},
+        "delta_net_pnl": 0.1,
+    }
+    _maybe_record_promotion_verdict(store, job_id, aged)
+    verdicts = store.read_json(job_id, "state/promotion_verdicts.json")
+    assert verdicts["prop-sparse"]["verdict"] == "insufficient_evidence"
+
+
+def test_trial_lineage_records_every_run(tmp_path: Path) -> None:
+    from wayfinder_paths.jobs.execution.experiments import record_trial_lineage
+
+    store, job_id = _store_with_job(tmp_path)
+    payload = {
+        "revision": "abc123",
+        "result": {
+            "grid_id": "g1",
+            "optimizer": "grid",
+            "rank_by": "net_return",
+            "runs": [
+                {"run_id": f"r{i}", "params": {"x": i},
+                 "stats": {"net_return": i / 100, "trade_count": 10 + i,
+                           "win_rate": 0.5, "max_drawdown_pct": 0.05}}
+                for i in range(7)
+            ],
+        },
+    }
+    recorded = record_trial_lineage(job_id, payload, store=store)
+    assert recorded == 7
+    path = store.job_dir(job_id) / "results" / "backtest" / "trials.jsonl"
+    rows = [json.loads(line) for line in path.read_text().splitlines()]
+    assert len(rows) == 7
+    assert rows[3]["behavior"]["trade_count"] == 13.0
+    assert rows[3]["rank_metric"] == 0.03
+
+
+def test_evolution_reliability_ci_and_opportunity_recall(tmp_path: Path) -> None:
+    from wayfinder_paths.jobs.archive import record_candidate, set_incumbent
+    from wayfinder_paths.jobs.evolution_ledger import build_evolution_report
+
+    store, job_id = _store_with_job(tmp_path)
+    store.write_json(
+        job_id,
+        "state/promotion_verdicts.json",
+        {
+            "p1": {"verdict": "beat", "delta_net_pnl": 2.0},
+            "p2": {"verdict": "hurt", "delta_net_pnl": -1.0},
+            "p3": {"verdict": "pending"},
+        },
+    )
+    vec = lambda g: {  # noqa: E731
+        "net_log_growth": g, "downside_deviation": 0.01,
+        "tail_loss": 0.01, "max_drawdown_pct": 0.05,
+    }
+    record_candidate(store, job_id, candidate_id="inc", family="params",
+                     summary="incumbent", status="archived", objective=vec(0.02))
+    set_incumbent(store, job_id, "inc")
+    record_candidate(store, job_id, candidate_id="better", family="params",
+                     summary="unpromoted better", status="archived",
+                     objective=vec(0.09))
+
+    report = build_evolution_report(store, job_id)
+    reliability = report["promotion_reliability"]
+    assert reliability["judged"] == 2
+    assert reliability["pending"] == 1
+    low, high = reliability["beat_rate_ci95"]
+    assert 0.0 <= low < 0.5 < high <= 1.0  # n=2: wide interval, honest
+    recall = report["opportunity_recall"]
+    assert recall["missed"] is True and recall["best_candidate_id"] == "better"
+
+
+def test_benchmark_constitution_profile_loads_strict() -> None:
+    from wayfinder_paths.jobs.constitution import load_benchmark_constitution
+
+    profile = load_benchmark_constitution()
+    assert profile["enforcement"] == "blocking"
+    assert profile["evaluation"]["confidence"] == 0.95
+    assert profile["promotion"]["probation_requires_lcb"] is True
+    assert profile["verdict"]["maximum_days"] == 30.0
+    assert profile["revision"]


### PR DESCRIPTION
Third WOB program PR — the production-instrumentation upgrades. This one **rolls to the box**: it upgrades live adjudication machinery, not just benchmark code.

## Verdict lifecycle grows up (`counterfactual.py`)

- **States**: `pending / insufficient_evidence / beat / neutral / hurt / censored_by_next_change` replace bare beat/neutral/hurt.
- **Per-job maturity** via a `verdict:` block in the constitution (min days/trades, max days, material delta) — the universal 3-day/3-close rule mis-timed both scalpers and slow holders.
- **Censoring**: a new promotion re-anchors the shadow, so the previous promotion's still-pending verdict is finalized as `censored_by_next_change` — recorded and journaled, never silently dropped. Immature windows now track as `pending` so there's always something to censor.
- **Honesty at the boundary**: a window that ages out below the trade floor becomes `insufficient_evidence`, never a fake neutral.

## Full search lineage (`experiments.py`)

`record_trial_lineage`: every evaluated grid/TPE trial → one compact row in `results/backtest/trials.jsonl` with a behavior descriptor. The benchmark's search-regret metric needs to know where search *actually went*, not just the ranked top-N — and production gets the same forensic trail for free.

## Ledger stops overstating (`evolution_ledger.py`)

`beat_rate` now ships with a **Wilson 95% CI** (two datapoints no longer read as certainty), verdict-state counts, mean judged delta, **improvement yield** (a high beat-rate on near-zero promotions is not a working loop), and **opportunity recall** — measured selection regret: is there a live archived candidate outscoring the incumbent that was never promoted?

## One certification standard (`constitution.benchmark.yaml`)

95% confidence, 5000 bootstrap iterations, 5 folds, 4 positive folds required, probation pays the LCB, zero audit floor. `load_benchmark_constitution()` is the single versioned source; the synthetic smoke bench now gates under it (budget-scaled) so smoke and certification rules can't drift apart.

## Tests

37 green: new verdict semantics (pending tracking, censor journaling, age-out), trial lineage, CI/recall math, profile loading, plus stress/lifecycle/kernel/synthetic regression.
