### PR TITLE
core: wallet listing rides the backend ring read (fixes wallet-blind agents)

### DIFF
--- a/wayfinder_paths/core/clients/WalletClient.py
+++ b/wayfinder_paths/core/clients/WalletClient.py
@@ -17,11 +17,35 @@ class WalletClient(WayfinderClient):
     async def list_wallets(
         self, instance_id: str | None = None
     ) -> list[dict[str, Any]]:
-        url = f"{get_api_base_url()}/wallets/"
+        """Flat wallet rows via the backend's ring read.
+
+        The 2026-07-16 backend refactor removed the collection GET (405) and
+        consolidated the wallet read on `GET /wallets/rings` — one entry per
+        ring: {label, evm: {leg}, svm: {leg}}, instance-scoped, ring label as
+        the source of truth. Every SDK caller expects flat per-wallet rows,
+        so flatten each ring into one row per leg here. (The unpatched 405
+        made every shell agent wallet-blind: load_remote_wallets swallowed it
+        and reported an empty wallet list.)"""
+        url = f"{get_api_base_url()}/wallets/rings"
         if instance_id:
             url += f"?instance_id={instance_id}"
         resp = await self._authed_request("GET", url)
-        return resp.json()
+        rings = resp.json()
+        wallets: list[dict[str, Any]] = []
+        for ring in rings if isinstance(rings, list) else []:
+            label = ring.get("label")
+            for chain_key, chain_type in (("evm", "ethereum"), ("svm", "solana")):
+                leg = ring.get(chain_key)
+                if not isinstance(leg, dict) or not leg.get("wallet_address"):
+                    continue
+                wallets.append(
+                    {
+                        **leg,
+                        "label": label,
+                        "chain_type": leg.get("chain_type") or chain_type,
+                    }
+                )
+        return wallets
 
     async def create_wallet(
         self,

--- a/wayfinder_paths/tests/test_wallet_ring_read.py
+++ b/wayfinder_paths/tests/test_wallet_ring_read.py
@@ -1,0 +1,61 @@
+"""Wallet listing rides the backend's ring read (the collection GET 405s
+since the 2026-07-16 backend refactor) and flattens rings to the legacy
+per-wallet rows every caller expects."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from wayfinder_paths.core.clients.WalletClient import WalletClient
+
+
+class _FakeResponse:
+    def __init__(self, payload: Any) -> None:
+        self._payload = payload
+
+    def json(self) -> Any:
+        return self._payload
+
+
+@pytest.mark.asyncio
+async def test_list_wallets_flattens_rings(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, str] = {}
+
+    async def fake_request(self, method: str, url: str, **kwargs: Any) -> _FakeResponse:
+        captured["method"] = method
+        captured["url"] = url
+        return _FakeResponse(
+            [
+                {
+                    "label": "funding-carry-basket",
+                    "evm": {
+                        "wallet_address": "0xabc",
+                        "wallet_type": "session",
+                        "session_expires_at": 1786700000,
+                    },
+                    "svm": {
+                        "wallet_address": "So1abc",
+                        "wallet_type": "session",
+                    },
+                },
+                {
+                    "label": "empty-ring",
+                    "evm": None,
+                    "svm": {},
+                },
+            ]
+        )
+
+    monkeypatch.setattr(WalletClient, "_authed_request", fake_request)
+    wallets = await WalletClient().list_wallets(instance_id="oc-test")
+
+    assert captured["method"] == "GET"
+    assert "/wallets/rings?instance_id=oc-test" in captured["url"]
+    # One flat row per leg with an address; ring label is the source of truth.
+    assert [(w["label"], w["wallet_address"], w["chain_type"]) for w in wallets] == [
+        ("funding-carry-basket", "0xabc", "ethereum"),
+        ("funding-carry-basket", "So1abc", "solana"),
+    ]
+    assert wallets[0]["session_expires_at"] == 1786700000


### PR DESCRIPTION
Production fix: the 2026-07-16 backend refactor moved the wallet read to `GET /wallets/rings` and removed the collection GET (now 405). `load_remote_wallets` swallowed the 405, so **every agent on the box reported an empty wallet list** — the 'there are no wallets in this environment / funding-carry-basket wallet doesn't exist' responses were faithful reports of a broken lookup, while three real rings existed (verified live from the box: 200, including the funded `funding-carry-basket` wallet).

`list_wallets` now calls the ring read and flattens rings into the legacy per-wallet rows (one row per leg, ring label as source of truth, per-leg chain_type) so every existing caller keeps working. Unit-tested against the ring shape; endpoint verified against the live backend. Wants a bake+roll after merge — can ride the same roll as #642/#643.