### PR TITLE
core: break wallets<->transaction import cycle (lazy imports)

### DIFF
--- a/wayfinder_paths/core/utils/transaction.py
+++ b/wayfinder_paths/core/utils/transaction.py
@@ -8,7 +8,6 @@ import httpx
 from loguru import logger
 from web3 import AsyncWeb3
 
-from wayfinder_paths.core.clients.WalletClient import WALLET_CLIENT
 from wayfinder_paths.core.config import get_rpc_urls
 from wayfinder_paths.core.constants.base import (
     GAS_BUFFER_MULTIPLIER,
@@ -21,13 +20,23 @@ from wayfinder_paths.core.constants.chains import (
     MIN_PRIORITY_FEE_BY_CHAIN_ID,
     PRE_EIP_1559_CHAIN_IDS,
 )
-from wayfinder_paths.core.utils.wallets import _prepare_tx_for_privy
 from wayfinder_paths.core.utils.web3 import (
     _is_gorlami_fork_rpc,
     get_transaction_chain_id,
     web3_from_chain_id,
     web3s_from_chain_id,
 )
+
+
+def _wallet_client():
+    # Lazy: importing WalletClient runs clients/__init__, which transitively
+    # imports tokens.py -> this module. A top-level import here (or of
+    # _prepare_tx_for_privy below) makes whichever of wallets/transaction is
+    # imported first blow up on a partially-initialized cycle — found live on
+    # the box as "cannot import name '_prepare_tx_for_privy'".
+    from wayfinder_paths.core.clients.WalletClient import WALLET_CLIENT
+
+    return WALLET_CLIENT
 
 _DEFAULT_CONFIRMATIONS = 3
 
@@ -247,7 +256,7 @@ async def broadcast_transaction(chain_id, signed_transaction: bytes) -> str:
 async def sponsorship_enabled() -> bool:
     # Fetch failure falls back to the local sign-and-broadcast path.
     try:
-        features = await WALLET_CLIENT.get_features()
+        features = await _wallet_client().get_features()
         return "privy_gas_sponsorship_enabled" in features["enabledSwitches"]
     except Exception:
         return False
@@ -275,7 +284,7 @@ async def wait_for_sponsored_transaction(
                 f"after {timeout}s"
             )
         await asyncio.sleep(2)
-        status = await WALLET_CLIENT.get_privy_transaction_status(
+        status = await _wallet_client().get_privy_transaction_status(
             wallet_address, result["transaction_id"]
         )
         if status["status"] == "failed":
@@ -295,7 +304,10 @@ async def send_sponsored_transaction(wallet_address: str, transaction: dict) -> 
     tx = dict(transaction)
     tx["from"] = wallet_address
     try:
-        result = await WALLET_CLIENT.send_privy_transaction_sponsored(
+        # Lazy for the same cycle _wallet_client() documents.
+        from wayfinder_paths.core.utils.wallets import _prepare_tx_for_privy
+
+        result = await _wallet_client().send_privy_transaction_sponsored(
             wallet_address, _prepare_tx_for_privy(tx)
         )
     except httpx.HTTPStatusError as exc:

--- a/wayfinder_paths/tests/test_import_cycles.py
+++ b/wayfinder_paths/tests/test_import_cycles.py
@@ -1,0 +1,32 @@
+"""A circular import only detonates for specific first-import entry points,
+and one shared pytest process can never see it: whichever module conftest
+pulls in first settles sys.modules for the whole run. Each module here is
+imported as the very first wayfinder import in a fresh interpreter — the
+standalone-script pattern that broke live (wallets-first on shells)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+FIRST_IMPORT_MODULES = [
+    "wayfinder_paths.core.utils.wallets",
+    "wayfinder_paths.core.utils.transaction",
+    "wayfinder_paths.core.utils.tokens",
+    "wayfinder_paths.core.utils.svm_tokens",
+    "wayfinder_paths.core.clients",
+    "wayfinder_paths.mcp.scripting",
+]
+
+
+@pytest.mark.parametrize("module", FIRST_IMPORT_MODULES)
+def test_first_import_resolves(module: str) -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", f"import {module}"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, f"first import of {module} failed:\n{result.stderr}"


### PR DESCRIPTION
## Problem

On the box (and locally, and on **pure origin/main** — this is pre-existing upstream, delivered to jobs-v1 by the #645 merge):

```
python -c "from wayfinder_paths.core.utils.wallets import load_wallets"
ImportError: cannot import name '_prepare_tx_for_privy' from partially initialized module
```

The reverse direction fails too (`import wayfinder_paths.core.utils.transaction` first → `cannot import name 'encode_call'`). The cycle:

- `transaction.py` → `WALLET_CLIENT` (module level) → `clients/__init__` → `TokenClient` → `svm_tokens` → `tokens.py` → `from transaction import encode_call, send_transaction` (boom, direction A)
- `transaction.py` → `from wallets import _prepare_tx_for_privy` (module level) (boom, direction B)

`from wayfinder_paths.core.utils.wallets import load_wallets` is the **documented first-import pattern** for agent scripts (CLAUDE.md), so this breaks real script authors on shells. The full test suite never caught it because tests import other modules first.

## Fix

Both edges become function-local in `transaction.py` (one file): a `_wallet_client()` lazy accessor for the 3 `WALLET_CLIENT` call sites, and a lazy `_prepare_tx_for_privy` import at its single use.

## Verification

- All five first-import orders now resolve: `wallets`, `transaction`, `tokens`, `clients`, `svm_tokens` — each as the very first wayfinder import.
- `pytest -k "transaction or wallet or token or gas or sponsor"`: **355 passed / 33 failed — byte-identical to the unmodified tip** (the 33 are pre-existing live-network tests in `test_token_resolver_live.py`).

This should also be cherry-picked to `main` — both directions fail there today.