### PR TITLE
jobs: three-book prospective + improver A/B harness (WOB PR VI+VII)

### DIFF
--- a/wayfinder_paths/jobs/benchmarks/meta_improver.py
+++ b/wayfinder_paths/jobs/benchmarks/meta_improver.py
@@ -1,0 +1,451 @@
+"""Improver A/B harness (WOB L3): hold the benchmark worlds fixed, vary the
+HARNESS. Two improver variants — prompt contract, gate configuration,
+exploration allocation, archive policy — run through the production agent
+lane on the SAME sealed worlds with matched model, wake count, and timeout.
+
+Scored on descendant productivity, not one-shot utility: what each harness
+BREEDS over generations — promotions per 100 wakes, false promotions
+(promoted then judged hurt), utility per 1k output tokens, lineage
+diversity, and (when oracle answers exist) true utility and regret of the
+selected genome. The verdict is a paired per-world delta with a bootstrap
+CI; an improver change whose CI straddles zero does not ship.
+
+Run manually (never CI): model spend is real.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from wayfinder_paths.jobs.benchmarks.agent_adapter import (
+    DEFAULT_AGENT,
+    DEFAULT_OPENCODE,
+    DEFAULT_SESSION_DB,
+    build_world_bundle,
+    harvest_lineage,
+    meter_sessions,
+    run_agent_wakes,
+)
+from wayfinder_paths.jobs.benchmarks.metrics import score_run
+from wayfinder_paths.jobs.constitution import CONSTITUTION_FILENAME
+from wayfinder_paths.jobs.models import utc_now_iso
+from wayfinder_paths.jobs.store import JobStore
+
+MANIFEST_FILE = "manifest.json"
+RUNS_FILE = "runs.jsonl"
+REPORT_FILE = "report.json"
+_GENERATION_CHECKPOINTS = (1, 3, 5)
+_BOOTSTRAP_ITERATIONS = 2000
+_BOOTSTRAP_SEED = 7
+
+
+@dataclass(frozen=True)
+class ImproverVariant:
+    """One harness configuration under test. Every field is an override on
+    top of the stock bundle; a variant with no overrides IS the stock
+    harness (the natural control arm)."""
+
+    name: str
+    description: str = ""
+    # Full markdown replacing the worker agent definition (the prompt
+    # contract) inside the sandbox's .opencode/agents/.
+    agent_definition: str | None = None
+    # Deep-merged into the job's constitution.yaml (gate configuration).
+    constitution_overrides: Mapping[str, Any] | None = None
+    # Deep-merged into job.yaml execution_params (exploration allocation,
+    # archive policy knobs — whatever the harness reads from params).
+    execution_param_overrides: Mapping[str, Any] | None = None
+
+    def fingerprint(self) -> str:
+        payload = json.dumps(
+            {
+                "name": self.name,
+                "agent_definition": self.agent_definition,
+                "constitution_overrides": self.constitution_overrides,
+                "execution_param_overrides": self.execution_param_overrides,
+            },
+            sort_keys=True,
+            default=str,
+        )
+        return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+def build_paired_campaign(
+    worlds: list[Any],
+    variant_a: ImproverVariant,
+    variant_b: ImproverVariant,
+    *,
+    campaign_dir: Path,
+    repo_root: Path,
+    initial_genomes: Mapping[str, Any],
+    wakes: int,
+    model: str,
+    timeout_s: int = 1800,
+    bundle_builder: Callable[..., str] = build_world_bundle,
+) -> dict[str, Any]:
+    """One sandbox per (arm, world), both arms seeded with the SAME initial
+    genome per world — the pairing is the design; only the harness differs.
+    The manifest commits the arm fingerprints and matched budget BEFORE any
+    wake runs (same commit-then-run discipline as the sealed worlds)."""
+    if variant_a.name == variant_b.name:
+        raise ValueError("arms must have distinct names")
+
+    pairs: list[dict[str, Any]] = []
+    for variant in (variant_a, variant_b):
+        for world in worlds:
+            genome = initial_genomes[world.world_id]
+            sandbox = campaign_dir / "arms" / variant.name / world.world_id
+            job_id = bundle_builder(
+                world, sandbox=sandbox, repo_root=repo_root, initial_genome=genome
+            )
+            _apply_variant(sandbox, job_id, variant)
+            pairs.append(
+                {
+                    "world_id": world.world_id,
+                    "arm": variant.name,
+                    "sandbox": str(sandbox),
+                    "job_id": job_id,
+                }
+            )
+
+    campaign_id = hashlib.sha256(
+        json.dumps(
+            {
+                "worlds": sorted(world.world_id for world in worlds),
+                "arms": [variant_a.fingerprint(), variant_b.fingerprint()],
+                "budget": {"wakes": wakes, "model": model, "timeout_s": timeout_s},
+            },
+            sort_keys=True,
+        ).encode()
+    ).hexdigest()[:16]
+    manifest = {
+        "campaign_id": campaign_id,
+        "campaign_dir": str(campaign_dir),
+        "arm_order": [variant_a.name, variant_b.name],
+        "arms": {
+            variant.name: {
+                "fingerprint": variant.fingerprint(),
+                "description": variant.description,
+            }
+            for variant in (variant_a, variant_b)
+        },
+        "budget": {"wakes": wakes, "model": model, "timeout_s": timeout_s},
+        "worlds": [world.world_id for world in worlds],
+        "pairs": pairs,
+        "created_at": utc_now_iso(),
+    }
+    campaign_dir.mkdir(parents=True, exist_ok=True)
+    (campaign_dir / MANIFEST_FILE).write_text(
+        json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+    )
+    return manifest
+
+
+def _apply_variant(
+    sandbox: Path, job_id: str, variant: ImproverVariant, *, agent: str = DEFAULT_AGENT
+) -> None:
+    store = JobStore(repo_root=sandbox)
+    root = store.job_dir(job_id)
+
+    if variant.agent_definition is not None:
+        agents_dir = sandbox / ".opencode" / "agents"
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        (agents_dir / f"{agent}.md").write_text(
+            variant.agent_definition, encoding="utf-8"
+        )
+
+    if variant.constitution_overrides:
+        path = root / CONSTITUTION_FILENAME
+        base = yaml.safe_load(path.read_text(encoding="utf-8")) if path.exists() else {}
+        merged = _deep_merge(base or {}, dict(variant.constitution_overrides))
+        path.write_text(yaml.safe_dump(merged, sort_keys=False), encoding="utf-8")
+
+    if variant.execution_param_overrides:
+        job_yaml_path = root / "job.yaml"
+        job_yaml = yaml.safe_load(job_yaml_path.read_text(encoding="utf-8")) or {}
+        job_yaml["execution_params"] = _deep_merge(
+            dict(job_yaml.get("execution_params") or {}),
+            dict(variant.execution_param_overrides),
+        )
+        job_yaml_path.write_text(
+            yaml.safe_dump(job_yaml, sort_keys=False), encoding="utf-8"
+        )
+
+    store.write_json(
+        job_id,
+        "meta_variant.json",
+        {"name": variant.name, "fingerprint": variant.fingerprint()},
+    )
+
+
+def _deep_merge(base: dict[str, Any], overrides: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(base)
+    for key, value in overrides.items():
+        if isinstance(value, Mapping) and isinstance(merged.get(key), Mapping):
+            merged[key] = _deep_merge(dict(merged[key]), dict(value))
+        else:
+            merged[key] = value
+    return merged
+
+
+def run_paired_campaign(
+    manifest: Mapping[str, Any],
+    *,
+    opencode: Path = DEFAULT_OPENCODE,
+    session_db: Path = DEFAULT_SESSION_DB,
+    wake_runner: Callable[..., list[dict[str, Any]]] = run_agent_wakes,
+    meter: Callable[..., dict[str, Any]] = meter_sessions,
+) -> list[dict[str, Any]]:
+    """Drive every (arm, world) through the agent lane, arm-interleaved per
+    world so slow drift in model behavior lands on both arms evenly. Appends
+    each record to runs.jsonl as it completes — a killed campaign keeps its
+    finished pairs."""
+    budget = manifest["budget"]
+    arm_rank = {name: i for i, name in enumerate(manifest["arm_order"])}
+    ordered = sorted(
+        manifest["pairs"], key=lambda p: (p["world_id"], arm_rank[p["arm"]])
+    )
+    runs_path = Path(manifest["campaign_dir"]) / RUNS_FILE
+    records: list[dict[str, Any]] = []
+    for pair in ordered:
+        sessions = wake_runner(
+            sandbox=Path(pair["sandbox"]),
+            job_id=pair["job_id"],
+            wakes=int(budget["wakes"]),
+            model=str(budget["model"]),
+            opencode=opencode,
+            timeout_s=int(budget["timeout_s"]),
+        )
+        tokens = meter(sessions, session_db=session_db)
+        record = {**pair, "sessions": sessions, "tokens": tokens}
+        records.append(record)
+        with runs_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, default=str) + "\n")
+    return records
+
+
+def score_paired_campaign(
+    manifest: Mapping[str, Any],
+    *,
+    oracles: Mapping[str, Mapping[str, Any]] | None = None,
+    run_records: list[dict[str, Any]] | None = None,
+    bootstrap_seed: int = _BOOTSTRAP_SEED,
+) -> dict[str, Any]:
+    """Descendant-productivity scoring per pair, then paired per-world deltas
+    (arm A − arm B) with a world-resampled bootstrap CI per metric."""
+    if run_records is None:
+        run_records = _read_runs(Path(manifest["campaign_dir"]) / RUNS_FILE)
+    tokens_by_pair = {
+        (r["world_id"], r["arm"]): (r.get("tokens") or {}) for r in run_records
+    }
+
+    wakes = int(manifest["budget"]["wakes"])
+    per_pair: list[dict[str, Any]] = []
+    for pair in manifest["pairs"]:
+        tokens = tokens_by_pair.get((pair["world_id"], pair["arm"]), {})
+        metrics = _pair_metrics(
+            Path(pair["sandbox"]),
+            pair["job_id"],
+            wakes=wakes,
+            tokens_out=int(tokens.get("tokens_out") or 0),
+        )
+        if oracles and pair["world_id"] in oracles:
+            harvest = harvest_lineage(
+                sandbox=Path(pair["sandbox"]), job_id=pair["job_id"]
+            )
+            score = score_run(harvest, dict(oracles[pair["world_id"]]))
+            metrics.update(
+                {
+                    "selected_utility": score["selected_utility"],
+                    "search_regret_norm": score["search_regret_norm"],
+                    "selection_regret_norm": score["selection_regret_norm"],
+                    "epsilon_hit_selected": int(score["epsilon_hit_selected"]),
+                }
+            )
+        per_pair.append({"world_id": pair["world_id"], "arm": pair["arm"], **metrics})
+
+    arm_a, arm_b = manifest["arm_order"]
+    by_key = {(row["world_id"], row["arm"]): row for row in per_pair}
+    metric_names = sorted(
+        {
+            key
+            for row in per_pair
+            for key, value in row.items()
+            if key not in ("world_id", "arm") and isinstance(value, (int, float))
+        }
+    )
+    paired: dict[str, Any] = {}
+    for metric in metric_names:
+        deltas = []
+        for world_id in manifest["worlds"]:
+            row_a = by_key.get((world_id, arm_a))
+            row_b = by_key.get((world_id, arm_b))
+            if row_a is None or row_b is None:
+                continue
+            value_a, value_b = row_a.get(metric), row_b.get(metric)
+            if value_a is None or value_b is None:
+                continue
+            deltas.append(float(value_a) - float(value_b))
+        if not deltas:
+            continue
+        low, high = _paired_bootstrap_ci(deltas, seed=bootstrap_seed)
+        paired[metric] = {
+            "mean_delta": round(sum(deltas) / len(deltas), 6),
+            "ci95": [round(low, 6), round(high, 6)],
+            "n_worlds": len(deltas),
+        }
+
+    report = {
+        "campaign_id": manifest["campaign_id"],
+        "arm_order": [arm_a, arm_b],
+        "per_pair": per_pair,
+        # Positive mean_delta = arm A ahead on that metric; the CI decides.
+        "paired": paired,
+        "generated_at": utc_now_iso(),
+    }
+    campaign_dir = Path(manifest["campaign_dir"])
+    if campaign_dir.is_dir():
+        (campaign_dir / REPORT_FILE).write_text(
+            json.dumps(report, indent=2, default=str) + "\n", encoding="utf-8"
+        )
+    return report
+
+
+def ab_verdict(
+    report: Mapping[str, Any],
+    *,
+    primary: tuple[str, ...] = ("selected_utility", "promoted_per_100_wakes"),
+) -> dict[str, Any]:
+    """Ship gate for improver changes: the first primary metric present
+    decides. Winner only when the paired CI excludes zero — otherwise the
+    change does not ship."""
+    arm_a, arm_b = report["arm_order"]
+    for metric in primary:
+        entry = (report.get("paired") or {}).get(metric)
+        if not entry:
+            continue
+        low, high = entry["ci95"]
+        winner = arm_a if low > 0 else arm_b if high < 0 else None
+        return {
+            "metric": metric,
+            "winner": winner,
+            "mean_delta": entry["mean_delta"],
+            "ci95": entry["ci95"],
+            "n_worlds": entry["n_worlds"],
+            "ships": winner is not None,
+        }
+    return {"metric": None, "winner": None, "ships": False}
+
+
+def _pair_metrics(
+    sandbox: Path, job_id: str, *, wakes: int, tokens_out: int
+) -> dict[str, Any]:
+    """Descendant productivity from the job dir the harness left behind —
+    proposals, verdicts, archive, and trial lineage are the phenotype of the
+    harness, independent of any oracle."""
+    store = JobStore(repo_root=sandbox)
+    root = store.job_dir(job_id)
+
+    proposals = []
+    for path in sorted((root / "proposals").glob("*.json")):
+        try:
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+        except ValueError:
+            continue
+        if isinstance(loaded, dict):
+            proposals.append(loaded)
+    promoted = [
+        p for p in proposals if (p.get("application") or {}).get("status") == "applied"
+    ]
+
+    verdicts = store.read_json(job_id, "state/promotion_verdicts.json") or {}
+    verdict_of = [str(v.get("verdict") or "") for v in verdicts.values()]
+
+    archive = store.read_json(job_id, "state/archive.json") or {}
+    growths = [
+        float(entry["objective"].get("net_log_growth") or 0.0)
+        for entry in sorted(
+            (
+                e
+                for e in archive.get("candidates") or []
+                if isinstance(e.get("objective"), dict)
+            ),
+            key=lambda e: str(e.get("created_at") or ""),
+        )
+    ]
+    generation_utility = {
+        f"utility_after_gen_{n}": (max(growths[:n]) if len(growths) >= n else None)
+        for n in _GENERATION_CHECKPOINTS
+    }
+    utility_gain = (max(growths) - growths[0]) if len(growths) > 1 else 0.0
+
+    trials = _read_runs(root / "results" / "backtest" / "trials.jsonl")
+    distinct_params = len(
+        {json.dumps(t.get("params"), sort_keys=True, default=str) for t in trials}
+    )
+    behavior_returns = [
+        float((t.get("behavior") or {}).get("net_return"))
+        for t in trials
+        if isinstance((t.get("behavior") or {}).get("net_return"), (int, float))
+    ]
+
+    return {
+        "proposals": len(proposals),
+        "promoted": len(promoted),
+        "promoted_per_100_wakes": (
+            round(len(promoted) / wakes * 100, 4) if wakes else None
+        ),
+        "false_promotions": verdict_of.count("hurt"),
+        "beats": verdict_of.count("beat"),
+        "trials": len(trials),
+        "lineage_diversity": distinct_params,
+        "behavior_spread": (
+            round(_std(behavior_returns), 6) if len(behavior_returns) > 1 else 0.0
+        ),
+        **generation_utility,
+        "utility_gain": round(utility_gain, 6),
+        "tokens_out": tokens_out,
+        "utility_per_1k_tokens": (
+            round(utility_gain / tokens_out * 1000, 6) if tokens_out else None
+        ),
+    }
+
+
+def _paired_bootstrap_ci(
+    deltas: list[float],
+    *,
+    seed: int,
+    iterations: int = _BOOTSTRAP_ITERATIONS,
+) -> tuple[float, float]:
+    rng = random.Random(seed)
+    means = sorted(
+        sum(rng.choice(deltas) for _ in deltas) / len(deltas) for _ in range(iterations)
+    )
+    return means[int(0.025 * iterations)], means[int(0.975 * iterations) - 1]
+
+
+def _std(values: list[float]) -> float:
+    mean = sum(values) / len(values)
+    return (sum((v - mean) ** 2 for v in values) / (len(values) - 1)) ** 0.5
+
+
+def _read_runs(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(row, dict):
+            rows.append(row)
+    return rows

--- a/wayfinder_paths/jobs/counterfactual.py
+++ b/wayfinder_paths/jobs/counterfactual.py
@@ -1,18 +1,26 @@
-"""Post-apply shadow counterfactual: replay the pre-apply strategy over the
-forward window and diff it against the actual book.
+"""Post-apply THREE-BOOK prospective: incumbent shadow (A), candidate shadow
+(B), and the actual book (C) over identical forward bars.
 
 A proposal that gates or reshapes entries leaves no live evidence of what it
 cost — skipped trades never print. This module makes the counterfactual
 mechanical instead of something the agent must remember to reconstruct: after
 any promoted proposal, the rollback backup (`applications/{pid}/backup/`)
-holds the exact pre-apply strategy, so we run it through the same simulator
-the backtests use, over venue bars covering the forward window, and diff the
-shadow book against the actual one. The wake prompt renders the result, so
-"the old revision is beating the new one" is read, not recomputed.
+holds the exact pre-apply strategy (A) and the active workspace holds the
+promoted one (B); both run through the same simulator the backtests use over
+the same venue bars, and are diffed against the live book (C). The two-book
+delta (C − A) cannot say WHY a promotion underperforms — three books can:
 
-Basis caveat (recorded in the artifact): the shadow sizes off the simulator's
-base equity while the live book sizes off its own equity at apply time, so
-absolute PnL is comparable in direction and rough magnitude, not to the cent.
+  strategy_effect  = B − A   (both simulated — pure effect of the change)
+  execution_effect = C − B   (same strategy, real fills vs simulated fills)
+
+The wake prompt renders the result, so "the old revision is beating the new
+one, and it is an execution problem, not a strategy problem" is read, not
+recomputed.
+
+Basis caveat (recorded in the artifact): both shadows size off the
+simulator's base equity while the live book sizes off its own equity at
+apply time, so absolute PnL is comparable in direction and rough magnitude,
+not to the cent.
 """
 
 from __future__ import annotations
@@ -38,13 +46,20 @@ _LOCK_TIMEOUT_S = 60.0
 _EXAMPLE_LIMIT = 5
 
 BASIS_NOTE = (
-    "Shadow book = the PRE-apply strategy (rollback backup) replayed by the "
-    "backtest simulator over the same forward bars; actual = the live paper "
-    "book. delta_net_pnl = actual - shadow: negative means the pre-change "
-    "revision would have done better since apply. Shadow sizes off simulator "
-    "base equity, so compare direction and magnitude, not cents. "
-    "entries_skipped_by_change fired in the shadow but not the live book "
-    "(what the change suppressed); entries_added_by_change is the reverse."
+    "Three books over identical forward bars. shadow (A) = the PRE-apply "
+    "strategy (rollback backup) replayed by the backtest simulator; "
+    "active_shadow (B) = the PROMOTED strategy through the same simulator; "
+    "actual (C) = the live paper book. effects.strategy_effect = B - A "
+    "(what the change itself did, execution held equal); "
+    "effects.execution_effect = C - B (same strategy, real fills vs "
+    "simulated — slippage, missed entries, sizing base). delta_net_pnl = "
+    "C - A = their sum: negative means the pre-change revision would have "
+    "done better since apply. Shadows size off simulator base equity, so "
+    "compare direction and magnitude, not cents. entries_skipped_by_change "
+    "fired in shadow A but not the live book; entries_added_by_change is "
+    "the reverse. entries_execution_missed fired in active_shadow B but "
+    "not the live book (the strategy wanted them; execution never printed "
+    "them); entries_execution_extra is the reverse."
 )
 
 
@@ -248,8 +263,10 @@ def _maybe_record_promotion_verdict(
                 float(config["minimum_material_delta"]), 0.02 * abs(shadow_pnl)
             )
             verdict = (
-                "beat" if delta > threshold
-                else "hurt" if delta < -threshold
+                "beat"
+                if delta > threshold
+                else "hurt"
+                if delta < -threshold
                 else "neutral"
             )
         record = {
@@ -259,6 +276,13 @@ def _maybe_record_promotion_verdict(
             "closes": closes,
             "recorded_at": utc_now_iso(),
         }
+        # Three-book split, when the artifact has it: a "hurt" verdict whose
+        # delta is execution_effect is an execution problem, not evidence
+        # against the strategy change — the ledger aggregates both.
+        effects = artifact.get("effects") or {}
+        if effects:
+            record["strategy_effect"] = effects.get("strategy_effect")
+            record["execution_effect"] = effects.get("execution_effect")
         verdicts[proposal_id] = record
         store.write_json(job_id, _VERDICTS_PATH, verdicts)
         store.append_journal(
@@ -319,6 +343,11 @@ def _compute(
 
     spec = ExecutionSpec.from_dict(backup_spec_data)
     params = dict(backup_data.get("execution_params") or {})
+    active_spec = ExecutionSpec.from_dict(active_spec_data)
+    active_params = dict(active_data.get("execution_params") or {})
+    active_script = store.resolve_script_entrypoint(job_id, active_data)
+    if active_script is None or not active_script.exists():
+        raise RuntimeError(f"active entrypoint not found: {active_script}")
     bar_interval = spec.data_contract.get("bar_interval")
     interval_seconds = bar_interval_seconds(bar_interval)
     if not interval_seconds:
@@ -385,17 +414,16 @@ def _compute(
         timeout_s=_LOCK_TIMEOUT_S,
     ):
         result = run(script, dataset, spec, params)
+        active_result = run(active_script, dataset, active_spec, active_params)
     shadow_rows = [dict(row) for row in result.trades]
+    active_rows = [dict(row) for row in active_result.trades]
 
     shadow_entries = _entries(shadow_rows, effective_from, interval_seconds)
-    shadow_closes = [
-        row
-        for row in shadow_rows
-        if row.get("reduce_only") and _ts(row.get("timestamp")) >= effective_from
-    ]
-    shadow_net = sum(
-        float(row.get("realized_pnl_delta") or 0.0) for row in shadow_closes
-    )
+    active_shadow_entries = _entries(active_rows, effective_from, interval_seconds)
+    shadow_closes = _sim_closes(shadow_rows, effective_from)
+    active_shadow_closes = _sim_closes(active_rows, effective_from)
+    shadow_net = _sim_net(shadow_closes)
+    active_shadow_net = _sim_net(active_shadow_closes)
 
     actual_close_rows = [
         row
@@ -412,6 +440,8 @@ def _compute(
 
     skipped = sorted(set(shadow_entries) - set(actual_entries))
     added = sorted(set(actual_entries) - set(shadow_entries))
+    execution_missed = sorted(set(active_shadow_entries) - set(actual_entries))
+    execution_extra = sorted(set(actual_entries) - set(active_shadow_entries))
 
     by_symbol: dict[str, dict[str, Any]] = {}
     for symbol in symbols:
@@ -432,11 +462,22 @@ def _compute(
                 ),
                 4,
             ),
+            "active_shadow_net_pnl": round(
+                sum(
+                    float(row.get("realized_pnl_delta") or 0.0)
+                    for row in active_shadow_closes
+                    if str(row.get("symbol")) == symbol
+                ),
+                4,
+            ),
             "actual_closes": sum(
                 1 for row in actual_close_rows if str(row.get("symbol")) == symbol
             ),
             "shadow_closes": sum(
                 1 for row in shadow_closes if str(row.get("symbol")) == symbol
+            ),
+            "active_shadow_closes": sum(
+                1 for row in active_shadow_closes if str(row.get("symbol")) == symbol
             ),
         }
 
@@ -453,7 +494,16 @@ def _compute(
         },
         "actual": {"closes": len(actual_close_rows), "net_pnl": round(actual_net, 4)},
         "shadow": {"closes": len(shadow_closes), "net_pnl": round(shadow_net, 4)},
+        "active_shadow": {
+            "closes": len(active_shadow_closes),
+            "net_pnl": round(active_shadow_net, 4),
+        },
         "delta_net_pnl": round(actual_net - shadow_net, 4),
+        "effects": {
+            "strategy_effect": round(active_shadow_net - shadow_net, 4),
+            "execution_effect": round(actual_net - active_shadow_net, 4),
+            "total_delta": round(actual_net - shadow_net, 4),
+        },
         "by_symbol": by_symbol,
         "entries_skipped_by_change": {
             "count": len(skipped),
@@ -462,6 +512,18 @@ def _compute(
         "entries_added_by_change": {
             "count": len(added),
             "examples": [_entry_dict(item) for item in added[:_EXAMPLE_LIMIT]],
+        },
+        "entries_execution_missed": {
+            "count": len(execution_missed),
+            "examples": [
+                _entry_dict(item) for item in execution_missed[:_EXAMPLE_LIMIT]
+            ],
+        },
+        "entries_execution_extra": {
+            "count": len(execution_extra),
+            "examples": [
+                _entry_dict(item) for item in execution_extra[:_EXAMPLE_LIMIT]
+            ],
         },
         "_basis": BASIS_NOTE,
         "computed_at": utc_now_iso(),
@@ -496,6 +558,20 @@ def _fetch_venue_bars(
         return CompletedBarsView.from_rows(rows).to_rows()
 
     return asyncio.run(_fetch())
+
+
+def _sim_closes(
+    rows: list[dict[str, Any]], effective_from: Any
+) -> list[dict[str, Any]]:
+    return [
+        row
+        for row in rows
+        if row.get("reduce_only") and _ts(row.get("timestamp")) >= effective_from
+    ]
+
+
+def _sim_net(closes: list[dict[str, Any]]) -> float:
+    return sum(float(row.get("realized_pnl_delta") or 0.0) for row in closes)
 
 
 def _entries(

--- a/wayfinder_paths/jobs/evolution_ledger.py
+++ b/wayfinder_paths/jobs/evolution_ledger.py
@@ -56,16 +56,26 @@ def build_evolution_report(store: JobStore, job_id: str) -> dict[str, Any]:
         )
 
     verdict_counts = {
-        "beat": 0, "neutral": 0, "hurt": 0,
-        "pending": 0, "censored_by_next_change": 0, "insufficient_evidence": 0,
+        "beat": 0,
+        "neutral": 0,
+        "hurt": 0,
+        "pending": 0,
+        "censored_by_next_change": 0,
+        "insufficient_evidence": 0,
     }
     deltas: list[float] = []
+    strategy_effects: list[float] = []
+    execution_effects: list[float] = []
     for record in verdicts.values():
         verdict = str(record.get("verdict") or "")
         if verdict in verdict_counts:
             verdict_counts[verdict] += 1
         if verdict in ("beat", "neutral", "hurt"):
             deltas.append(float(record.get("delta_net_pnl") or 0.0))
+            if record.get("strategy_effect") is not None:
+                strategy_effects.append(float(record["strategy_effect"]))
+            if record.get("execution_effect") is not None:
+                execution_effects.append(float(record["execution_effect"]))
     judged = verdict_counts["beat"] + verdict_counts["neutral"] + verdict_counts["hurt"]
     beat_rate = (verdict_counts["beat"] / judged) if judged else None
 
@@ -87,8 +97,18 @@ def build_evolution_report(store: JobStore, job_id: str) -> dict[str, Any]:
             # improve loop is earning its keep.
             "beat_rate": beat_rate,
             "beat_rate_ci95": ci,
-            "mean_judged_delta_usd": (
-                sum(deltas) / len(deltas) if deltas else None
+            "mean_judged_delta_usd": (sum(deltas) / len(deltas) if deltas else None),
+            # Three-book split (when recorded): a hurt-leaning mean driven by
+            # execution_effect indicts the fill path, not the strategy loop.
+            "mean_strategy_effect_usd": (
+                sum(strategy_effects) / len(strategy_effects)
+                if strategy_effects
+                else None
+            ),
+            "mean_execution_effect_usd": (
+                sum(execution_effects) / len(execution_effects)
+                if execution_effects
+                else None
             ),
         },
         # A high beat_rate with near-zero promotions is not a working loop —
@@ -125,7 +145,8 @@ def _opportunity_recall(store: JobStore, job_id: str) -> dict[str, Any] | None:
 
         doc = load_archive(store, job_id)
         candidates = [
-            entry for entry in doc.get("candidates") or []
+            entry
+            for entry in doc.get("candidates") or []
             if isinstance(entry.get("objective"), dict)
             and entry.get("status") not in ("refuted", "retired")
         ]

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import hashlib
 import datetime as dt
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -121,9 +121,10 @@ def _attribution_block(root: Path) -> dict[str, Any]:
 
 
 def _counterfactual_block(store: JobStore, job_id: str) -> dict[str, Any]:
-    """Mechanical post-apply A/B: the pre-apply strategy (rollback backup)
-    replayed over the forward bars since apply, diffed against the actual
-    book. Computed here (cached, ~6h refresh) so the evidence EXISTS every
+    """Mechanical post-apply three-book: pre-apply shadow (A) and promoted
+    shadow (B) replayed over the forward bars since apply, diffed against
+    the actual book (C) — strategy effect (B-A) split from execution effect
+    (C-B). Computed here (cached, ~6h refresh) so the evidence EXISTS every
     wake — the agent reads it, it never reconstructs counterfactuals."""
     from wayfinder_paths.jobs.counterfactual import counterfactual_job
 
@@ -139,10 +140,14 @@ def _counterfactual_block(store: JobStore, job_id: str) -> dict[str, Any]:
         "window",
         "actual",
         "shadow",
+        "active_shadow",
         "delta_net_pnl",
+        "effects",
         "by_symbol",
         "entries_skipped_by_change",
         "entries_added_by_change",
+        "entries_execution_missed",
+        "entries_execution_extra",
         "_basis",
     )
     return {key: doc[key] for key in keys if key in doc}
@@ -257,9 +262,7 @@ def _ideation_bookkeeping(store: JobStore, job_id: str) -> None:
                 "buckets": buckets,
             },
         )
-        store.write_json(
-            job_id, _IDEATION_SEEN_PATH, {"generated_at": generated_at}
-        )
+        store.write_json(job_id, _IDEATION_SEEN_PATH, {"generated_at": generated_at})
         return
     age = _ideation_age_s(root)
     overdue = age is None or age > _IDEATION_OVERDUE_S

--- a/wayfinder_paths/tests/test_jobs_counterfactual.py
+++ b/wayfinder_paths/tests/test_jobs_counterfactual.py
@@ -1,5 +1,6 @@
-"""Post-apply shadow counterfactual: replay the pre-apply strategy over the
-forward window, diff against the actual book, surface skipped/added entries."""
+"""Post-apply three-book prospective: replay the pre-apply strategy (A) and
+the promoted strategy (B) over the forward window, diff against the actual
+book (C) — strategy effect (B-A) split from execution effect (C-B)."""
 
 from __future__ import annotations
 
@@ -43,6 +44,13 @@ def _mk_job(tmp_path, *, applied_hours_ago: float = 24.0) -> tuple[JobStore, str
         "def build_strategy():\n    raise NotImplementedError\n", encoding="utf-8"
     )
     (backup / "job.yaml").write_text(yaml.safe_dump(job_yaml), encoding="utf-8")
+
+    # The promoted revision lives in the ACTIVE workspace — book B's script.
+    active_src = root / "workspace" / "src"
+    active_src.mkdir(parents=True, exist_ok=True)
+    (active_src / "strategy.py").write_text(
+        "def build_strategy():\n    raise NotImplementedError\n", encoding="utf-8"
+    )
 
     applied = pd.Timestamp.now(tz="UTC") - pd.Timedelta(hours=applied_hours_ago)
     versions = root / "versions"
@@ -95,10 +103,11 @@ def test_counterfactual_diffs_shadow_against_actual(tmp_path) -> None:
     now = pd.Timestamp.now(tz="UTC").floor("5min")
     t_shared = now - pd.Timedelta(hours=6)
     t_skipped = now - pd.Timedelta(hours=4)
+    t_unfilled = now - pd.Timedelta(hours=2)
 
-    # Shadow (pre-apply strategy) trades BOTH entries; the live book only took
-    # the shared one — t_skipped is what the change suppressed, and its shadow
-    # close won +0.9.
+    # Shadow A (pre-apply strategy) trades BOTH entries; the live book only
+    # took the shared one — t_skipped is what the change suppressed, and its
+    # shadow close won +0.9.
     shadow_trades = [
         _fill(t_shared, side="sell", reduce_only=False),
         _fill(
@@ -107,6 +116,18 @@ def test_counterfactual_diffs_shadow_against_actual(tmp_path) -> None:
         _fill(t_skipped, side="sell", reduce_only=False),
         _fill(
             t_skipped + pd.Timedelta(minutes=80), side="buy", reduce_only=True, pnl=0.9
+        ),
+    ]
+    # Shadow B (promoted strategy, simulated) takes the shared entry plus one
+    # at t_unfilled that the live book never printed — an execution miss.
+    active_trades = [
+        _fill(t_shared, side="sell", reduce_only=False),
+        _fill(
+            t_shared + pd.Timedelta(minutes=80), side="buy", reduce_only=True, pnl=-0.2
+        ),
+        _fill(t_unfilled, side="sell", reduce_only=False),
+        _fill(
+            t_unfilled + pd.Timedelta(minutes=40), side="buy", reduce_only=True, pnl=0.3
         ),
     ]
     forward = root / "results" / "forward"
@@ -136,32 +157,49 @@ def test_counterfactual_diffs_shadow_against_actual(tmp_path) -> None:
         return _bars()
 
     def fake_sim(script, dataset, spec, params):
-        captured["script"] = str(script)
-        return SimpleNamespace(trades=shadow_trades)
+        captured.setdefault("scripts", []).append(str(script))
+        if "backup" in str(script):
+            return SimpleNamespace(trades=shadow_trades)
+        return SimpleNamespace(trades=active_trades)
 
     doc = counterfactual_job(
         job_id, store=store, fetch_bars=fake_fetch, simulate=fake_sim
     )
     assert doc["available"] is True
     assert doc["proposal_id"] == "prop-x"
-    assert "applications/prop-x/backup" in captured["script"]
+    # Both books simulated: A from the rollback backup, B from the active
+    # workspace, over the same dataset.
+    assert any("applications/prop-x/backup" in s for s in captured["scripts"])
+    assert any("backup" not in s for s in captured["scripts"])
 
     assert doc["actual"] == {"closes": 1, "net_pnl": -0.25}
     assert doc["shadow"] == {"closes": 2, "net_pnl": 0.7}
+    assert doc["active_shadow"] == {"closes": 2, "net_pnl": 0.1}
     assert doc["delta_net_pnl"] == -0.95
+    # Three-book split: the change itself cost -0.6 (B-A); execution lost a
+    # further -0.35 (C-B); the two sum to the two-book delta.
+    assert doc["effects"] == {
+        "strategy_effect": -0.6,
+        "execution_effect": -0.35,
+        "total_delta": -0.95,
+    }
     assert doc["entries_skipped_by_change"]["count"] == 1
     assert doc["entries_skipped_by_change"]["examples"][0]["side"] == "short"
     assert doc["entries_added_by_change"]["count"] == 0
+    assert doc["entries_execution_missed"]["count"] == 1
+    assert doc["entries_execution_extra"]["count"] == 0
     assert doc["by_symbol"]["LIT"]["shadow_closes"] == 2
+    assert doc["by_symbol"]["LIT"]["active_shadow_closes"] == 2
+    assert doc["by_symbol"]["LIT"]["active_shadow_net_pnl"] == 0.1
 
     # Artifact persisted and served from cache while inputs are unchanged.
     assert load_counterfactual(store, job_id)["delta_net_pnl"] == -0.95
-    captured["script"] = None
+    captured["scripts"] = []
     again = counterfactual_job(
         job_id, store=store, fetch_bars=fake_fetch, simulate=fake_sim
     )
     assert again["computed_at"] == doc["computed_at"]
-    assert captured["script"] is None  # sim was not re-run
+    assert captured["scripts"] == []  # sims were not re-run
 
     # A new actual close invalidates the fingerprint and recomputes.
     with (forward / "trades.jsonl").open("a", encoding="utf-8") as fh:
@@ -181,7 +219,7 @@ def test_counterfactual_diffs_shadow_against_actual(tmp_path) -> None:
         job_id, store=store, fetch_bars=fake_fetch, simulate=fake_sim
     )
     assert recomputed["actual"]["closes"] == 2
-    assert captured["script"] is not None
+    assert len(captured["scripts"]) == 2  # both books re-simulated
 
 
 def test_counterfactual_unavailable_paths(tmp_path) -> None:
@@ -224,10 +262,18 @@ def test_worker_block_renders_topline(tmp_path) -> None:
             "window": {"days": 3.0},
             "actual": {"closes": 4, "net_pnl": -0.5},
             "shadow": {"closes": 6, "net_pnl": 0.4},
+            "active_shadow": {"closes": 5, "net_pnl": -0.1},
             "delta_net_pnl": -0.9,
+            "effects": {
+                "strategy_effect": -0.5,
+                "execution_effect": -0.4,
+                "total_delta": -0.9,
+            },
             "by_symbol": {},
             "entries_skipped_by_change": {"count": 2, "examples": []},
             "entries_added_by_change": {"count": 0, "examples": []},
+            "entries_execution_missed": {"count": 1, "examples": []},
+            "entries_execution_extra": {"count": 0, "examples": []},
             "_basis": "note",
             "computed_at": pd.Timestamp.now(tz="UTC").isoformat(),
             "fingerprint": {"revision": "rev-new", "actual_closes_total": 0},
@@ -236,4 +282,7 @@ def test_worker_block_renders_topline(tmp_path) -> None:
     block = _counterfactual_block(store, job_id)
     assert block["delta_net_pnl"] == -0.9
     assert block["proposal_id"] == "prop-x"
+    assert block["effects"]["execution_effect"] == -0.4
+    assert block["active_shadow"]["net_pnl"] == -0.1
+    assert block["entries_execution_missed"]["count"] == 1
     assert "fingerprint" not in block and "computed_at" not in block

--- a/wayfinder_paths/tests/test_jobs_meta_improver.py
+++ b/wayfinder_paths/tests/test_jobs_meta_improver.py
@@ -1,0 +1,246 @@
+"""Improver A/B harness: paired campaign construction (variant overrides
+applied per sandbox), descendant-productivity scoring from harvested job
+dirs, and the CI-gated ship verdict."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import yaml
+
+from wayfinder_paths.jobs.benchmarks.meta_improver import (
+    ImproverVariant,
+    ab_verdict,
+    build_paired_campaign,
+    run_paired_campaign,
+    score_paired_campaign,
+)
+from wayfinder_paths.jobs.constitution import CONSTITUTION_FILENAME
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.store import JobStore
+
+_WORLDS = [SimpleNamespace(world_id="w1"), SimpleNamespace(world_id="w2")]
+_GENOMES = {"w1": object(), "w2": object()}
+
+STOCK = ImproverVariant(name="stock", description="production harness as-is")
+TUNED = ImproverVariant(
+    name="tuned",
+    description="stricter gate + exploration boost",
+    agent_definition="# tuned worker\nExplore harder.\n",
+    constitution_overrides={"verdict": {"minimum_days": 1.0}},
+    execution_param_overrides={"exploration": {"epsilon": 0.25}},
+)
+
+
+def _stub_bundle_builder(world, *, sandbox, repo_root, initial_genome) -> str:
+    """Minimal stand-in for build_world_bundle: a real JobStore job dir with
+    a job.yaml, no SDK tree copy."""
+    store = JobStore(repo_root=sandbox)
+    job = WayfinderJob.new(f"wob-{world.world_id}", agent_mode="intervene")
+    store.save(job)
+    root = store.job_dir(job.id)
+    job_yaml_path = root / "job.yaml"
+    job_yaml = yaml.safe_load(job_yaml_path.read_text()) or {}
+    job_yaml["execution_params"] = {"genome_spec": {"genome": "seed"}}
+    job_yaml_path.write_text(yaml.safe_dump(job_yaml, sort_keys=False))
+    return job.id
+
+
+def _campaign(tmp_path):
+    return build_paired_campaign(
+        _WORLDS,
+        STOCK,
+        TUNED,
+        campaign_dir=tmp_path / "campaign",
+        repo_root=tmp_path,
+        initial_genomes=_GENOMES,
+        wakes=4,
+        model="test-model",
+        bundle_builder=_stub_bundle_builder,
+    )
+
+
+def test_build_paired_campaign_applies_variants(tmp_path) -> None:
+    manifest = _campaign(tmp_path)
+
+    assert manifest["arm_order"] == ["stock", "tuned"]
+    assert len(manifest["pairs"]) == 4  # 2 arms x 2 worlds
+    assert manifest["budget"] == {"wakes": 4, "model": "test-model", "timeout_s": 1800}
+    assert (tmp_path / "campaign" / "manifest.json").exists()
+    fp_stock = manifest["arms"]["stock"]["fingerprint"]
+    fp_tuned = manifest["arms"]["tuned"]["fingerprint"]
+    assert fp_stock != fp_tuned
+
+    # The tuned arm's overrides landed in ITS sandboxes only.
+    tuned_pair = next(
+        p for p in manifest["pairs"] if p["arm"] == "tuned" and p["world_id"] == "w1"
+    )
+    sandbox = tmp_path / "campaign" / "arms" / "tuned" / "w1"
+    root = JobStore(repo_root=sandbox).job_dir(tuned_pair["job_id"])
+    constitution = yaml.safe_load((root / CONSTITUTION_FILENAME).read_text())
+    assert constitution["verdict"]["minimum_days"] == 1.0
+    job_yaml = yaml.safe_load((root / "job.yaml").read_text())
+    assert job_yaml["execution_params"]["exploration"]["epsilon"] == 0.25
+    assert job_yaml["execution_params"]["genome_spec"] == {"genome": "seed"}
+    agent_md = sandbox / ".opencode" / "agents" / "wayfinder-job-worker.md"
+    assert "Explore harder" in agent_md.read_text()
+    variant_stamp = json.loads((root / "meta_variant.json").read_text())
+    assert variant_stamp == {"name": "tuned", "fingerprint": fp_tuned}
+
+    stock_pair = next(
+        p for p in manifest["pairs"] if p["arm"] == "stock" and p["world_id"] == "w1"
+    )
+    stock_root = JobStore(
+        repo_root=tmp_path / "campaign" / "arms" / "stock" / "w1"
+    ).job_dir(stock_pair["job_id"])
+    assert not (stock_root / CONSTITUTION_FILENAME).exists()
+
+    # Same worlds + variants + budget -> same campaign id, wherever it lives.
+    again = build_paired_campaign(
+        _WORLDS,
+        STOCK,
+        TUNED,
+        campaign_dir=tmp_path / "elsewhere",
+        repo_root=tmp_path,
+        initial_genomes=_GENOMES,
+        wakes=4,
+        model="test-model",
+        bundle_builder=_stub_bundle_builder,
+    )
+    assert again["campaign_id"] == manifest["campaign_id"]
+
+
+def test_run_paired_campaign_interleaves_and_persists(tmp_path) -> None:
+    manifest = _campaign(tmp_path)
+    calls: list[tuple[str, str]] = []
+
+    def fake_wakes(*, sandbox, job_id, wakes, model, opencode, timeout_s):
+        # job ids collide across arms (same job name per world) — the sandbox
+        # is the unique key.
+        pair = next(p for p in manifest["pairs"] if p["sandbox"] == str(sandbox))
+        calls.append((pair["world_id"], pair["arm"]))
+        return [{"wake": 0, "title": f"t-{pair['arm']}-{job_id}", "exit_code": 0}]
+
+    def fake_meter(sessions, *, session_db):
+        return {"tokens_out": 1000}
+
+    records = run_paired_campaign(manifest, wake_runner=fake_wakes, meter=fake_meter)
+    # Arm-interleaved per world: A then B on w1, A then B on w2.
+    assert calls == [("w1", "stock"), ("w1", "tuned"), ("w2", "stock"), ("w2", "tuned")]
+    assert all(r["tokens"] == {"tokens_out": 1000} for r in records)
+    runs_file = tmp_path / "campaign" / "runs.jsonl"
+    assert len(runs_file.read_text().splitlines()) == 4
+
+
+def _seed_arm_artifacts(
+    manifest, *, arm: str, promoted: int, hurt: int, growths: list[float]
+) -> None:
+    for pair in manifest["pairs"]:
+        if pair["arm"] != arm:
+            continue
+        store = JobStore(repo_root=Path(pair["sandbox"]))
+        job_id = pair["job_id"]
+        root = store.job_dir(job_id)
+        proposals_dir = root / "proposals"
+        proposals_dir.mkdir(exist_ok=True)
+        for i in range(promoted + 1):
+            applied = i < promoted
+            (proposals_dir / f"p{i}.json").write_text(
+                json.dumps(
+                    {
+                        "proposal_id": f"p{i}",
+                        "application": {"status": "applied"} if applied else {},
+                    }
+                )
+            )
+        verdicts = {
+            f"p{i}": {"verdict": "hurt" if i < hurt else "beat"}
+            for i in range(promoted)
+        }
+        store.write_json(job_id, "state/promotion_verdicts.json", verdicts)
+        store.write_json(
+            job_id,
+            "state/archive.json",
+            {
+                "candidates": [
+                    {
+                        "candidate_id": f"c{i}",
+                        "created_at": f"2026-01-0{i + 1}T00:00:00Z",
+                        "objective": {"net_log_growth": growth},
+                    }
+                    for i, growth in enumerate(growths)
+                ]
+            },
+        )
+        trials_path = root / "results" / "backtest" / "trials.jsonl"
+        trials_path.parent.mkdir(parents=True, exist_ok=True)
+        trials_path.write_text(
+            "\n".join(
+                json.dumps({"params": {"x": i}, "behavior": {"net_return": 0.01 * i}})
+                for i in range(4)
+            )
+            + "\n"
+        )
+
+
+def test_score_paired_campaign_and_ship_verdict(tmp_path) -> None:
+    manifest = _campaign(tmp_path)
+    # Stock: 3 promotions (1 later judged hurt), climbing archive. Tuned: 1
+    # promotion, flat archive — stock strictly dominates on productivity.
+    _seed_arm_artifacts(
+        manifest, arm="stock", promoted=3, hurt=1, growths=[0.0, 0.05, 0.12]
+    )
+    _seed_arm_artifacts(manifest, arm="tuned", promoted=1, hurt=0, growths=[0.0, 0.01])
+    run_records = [
+        {"world_id": p["world_id"], "arm": p["arm"], "tokens": {"tokens_out": 2000}}
+        for p in manifest["pairs"]
+    ]
+
+    report = score_paired_campaign(manifest, run_records=run_records)
+    stock_w1 = next(
+        r for r in report["per_pair"] if r["arm"] == "stock" and r["world_id"] == "w1"
+    )
+    assert stock_w1["promoted"] == 3
+    assert stock_w1["promoted_per_100_wakes"] == 75.0
+    assert stock_w1["false_promotions"] == 1
+    assert stock_w1["beats"] == 2
+    assert stock_w1["utility_after_gen_1"] == 0.0
+    assert stock_w1["utility_after_gen_3"] == 0.12
+    assert stock_w1["utility_gain"] == 0.12
+    assert stock_w1["utility_per_1k_tokens"] == 0.06
+    assert stock_w1["lineage_diversity"] == 4
+
+    paired = report["paired"]["promoted_per_100_wakes"]
+    assert paired["mean_delta"] == 50.0  # stock - tuned, both worlds
+    assert paired["n_worlds"] == 2
+    low, high = paired["ci95"]
+    assert low > 0  # identical deltas -> degenerate CI above zero
+
+    verdict = ab_verdict(report)
+    assert verdict["metric"] == "promoted_per_100_wakes"
+    assert verdict["winner"] == "stock"
+    assert verdict["ships"] is True
+
+    assert (tmp_path / "campaign" / "report.json").exists()
+
+
+def test_ab_verdict_inconclusive_on_straddling_ci(tmp_path) -> None:
+    manifest = _campaign(tmp_path)
+    # Arms split the worlds: stock wins w1, tuned wins w2 -> CI straddles 0.
+    for pair in manifest["pairs"]:
+        wins = (pair["arm"] == "stock") == (pair["world_id"] == "w1")
+        store = JobStore(repo_root=Path(pair["sandbox"]))
+        root = store.job_dir(pair["job_id"])
+        proposals_dir = root / "proposals"
+        proposals_dir.mkdir(exist_ok=True)
+        if wins:
+            (proposals_dir / "p0.json").write_text(
+                json.dumps({"proposal_id": "p0", "application": {"status": "applied"}})
+            )
+
+    report = score_paired_campaign(manifest, run_records=[])
+    verdict = ab_verdict(report)
+    assert verdict["winner"] is None
+    assert verdict["ships"] is False


### PR DESCRIPTION
Implements the two harness-side WOB workstreams in one PR, per owner direction.

## PR VI — Three-book prospective (production instrumentation)

The post-apply counterfactual becomes a three-book decomposition over identical forward bars:

| Book | What | How |
|------|------|-----|
| A | incumbent shadow | pre-apply strategy from the rollback backup, backtest simulator |
| B | candidate shadow | the PROMOTED strategy through the same simulator, same dataset |
| C | actual | the live paper book |

- **`strategy_effect = B − A`** — pure effect of the change, execution held equal
- **`execution_effect = C − B`** — same strategy, real fills vs simulated (slippage, missed entries, sizing base)
- `delta_net_pnl = C − A` unchanged (their sum) — back-compatible with existing verdict logic and renderers

The two-book delta could say a promotion underperforms but never WHY. Now a "hurt" verdict driven by `execution_effect` indicts the fill path, not the strategy loop — and the artifact says so mechanically:

- Both sims run under one compute-lock hold on the shared fetched dataset (one venue fetch, not two)
- Verdict records carry the effect split; `evolution_ledger` aggregates `mean_strategy_effect_usd` / `mean_execution_effect_usd` over judged promotions
- Entry diffs gain execution attribution: `entries_execution_missed` (B fired, live never printed) and `entries_execution_extra`
- Wake prompt (`_counterfactual_block`) renders books, effects, and the new entry diffs

## PR VII — Improver A/B harness (`benchmarks/meta_improver.py`)

The L3 instrument: hold the benchmark worlds fixed, vary the HARNESS.

- **`ImproverVariant`** — named override bundle: agent-definition markdown (prompt contract), constitution deep-merge (gate config), execution-param deep-merge (exploration/archive knobs). No overrides = the stock harness (natural control arm).
- **`build_paired_campaign`** — one sandbox per (arm, world) via the agent lane's bundle builder, both arms seeded with the SAME initial genome per world; manifest commits arm fingerprints + matched budget (wakes/model/timeout) before any wake runs.
- **`run_paired_campaign`** — arm-interleaved per world (drift lands on both arms evenly), tokens metered from the session DB per pair, records appended to `runs.jsonl` as they finish (a killed campaign keeps its finished pairs).
- **`score_paired_campaign`** — descendant productivity from the job dirs each harness leaves behind: promotions per 100 wakes, false promotions (promoted → judged hurt), beats, utility at generation checkpoints 1/3/5, utility per 1k output tokens, lineage diversity + behavior spread from `trials.jsonl`; plus oracle-side selected-utility/regret via the existing `score_run` when answers exist. Paired per-world deltas (A − B) with a world-resampled bootstrap CI per metric.
- **`ab_verdict`** — the ship gate: a winner only when the paired CI excludes zero. Once live: no improver change ships without it.

Run manually, never CI — model spend is real.

## Verification

- 21 tests green: three-book decomposition (effects sum to the two-book delta, execution-missed attribution, cache/recompute runs both sims), verdict + censoring unchanged (17 in counterfactual/economics), and 4 new meta-improver tests (variant overrides land in the right arm only, deterministic campaign id, arm interleave + persistence, dominance → ships / split worlds → CI straddles zero → does not ship)
- Broader jobs subset: 466 passed, 1 pre-existing failure (`test_worker_prompt_carries_priors_and_quant_loop` — fails identically on the unmodified tip)
- ruff check + format clean; mypy on touched files: 9 errors vs 12 on the tip (net reduction, none new)

Note: the three-book side needs a bake+roll to reach the box.