### PR TITLE
Mobile Agent - Override Ask-Default Permissions

### DIFF
--- a/.opencode/agents/wayfinder-mobile.md
+++ b/.opencode/agents/wayfinder-mobile.md
@@ -16,6 +16,13 @@ permission:
     wayfinder-sports: deny
 
   write: allow
+  # Override opencode's built-in ask defaults: a permission prompt is
+  # unanswerable over the messaging channel, so an ask freezes the turn (and
+  # the reply) forever. Paths outside the workspace are part of this agent's
+  # normal working surface; doom-loop protection stays on but as a hard stop
+  # the model can react to instead of a question nobody can answer.
+  external_directory: allow
+  doom_loop: deny
   wayfinder_*: deny
   # contracts_*
   wayfinder_contracts_*: allow


### PR DESCRIPTION
### Summary
- `external_directory: allow` — opencode's built-in default is `ask`, but the mobile messaging channel has no UI to answer a permission prompt, so any ask blocks the tool call (and the user's reply) indefinitely. Paths outside the workspace are part of this agent's normal working surface.
- `doom_loop: deny` — same unanswerable-ask problem; deny makes the loop breaker fail loud with an error the model can react to (and message about) instead of hanging on a question nobody can answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)