### PR TITLE
jobs: fix live HL state parsing for the UnifiedAccount tool shape

### DIFF
--- a/wayfinder_paths/jobs/execution/hyperliquid.py
+++ b/wayfinder_paths/jobs/execution/hyperliquid.py
@@ -306,13 +306,21 @@ class HyperliquidPerpBroker:
         )
 
     async def fetch_state(self, symbols: Sequence[str] | Any = ()) -> VenueState:
+        # _hl_state_result raises on any failed leg (the tool errs whole-hog),
+        # so a returned result IS a successful fetch. The tool speaks the
+        # UnifiedAccount shape: flat `perp_positions` rows + a money `summary`
+        # — parsing the pre-unified `perp.state.assetPositions` shape here
+        # made every live tick raise "perp state fetch unsuccessful", which
+        # fired reconcile_mismatch wakes until the advisor reverted the
+        # operator's live switch (observed live on majors-5m-lab).
         result = await _hl_state_result(self.wallet_label)
-        perp = (result.get("perp") or {}).get("state") or {}
-        if not (result.get("perp") or {}).get("success"):
-            raise RuntimeError("hyperliquid perp state fetch unsuccessful")
+        if "perp_positions" not in result:
+            raise RuntimeError(
+                "hyperliquid state fetch returned unexpected shape "
+                f"(keys: {sorted(result)})"
+            )
         positions: dict[str, PositionRecord] = {}
-        for item in perp.get("assetPositions") or []:
-            position = item.get("position") or {}
+        for position in result.get("perp_positions") or []:
             szi = _float_or_none(position.get("szi"))
             coin = str(position.get("coin") or "")
             if not coin or not szi:
@@ -324,9 +332,11 @@ class HyperliquidPerpBroker:
                 avg_price=_float_or_none(position.get("entryPx")) or 0.0,
                 metadata={"source": "hyperliquid"},
             )
+        summary = result.get("summary") or {}
+        account_value = _float_or_none(summary.get("unified_usdc_equity"))
+        if account_value is None:  # classic (non-unified) account ledgers
+            account_value = _float_or_none(summary.get("perp_account_value"))
         balances: dict[str, float] = {}
-        margin = perp.get("crossMarginSummary") or {}
-        account_value = _float_or_none(margin.get("accountValue"))
         if account_value is not None:
             balances["accountValue"] = account_value
         return VenueState(

--- a/wayfinder_paths/tests/test_jobs_live_state_shape.py
+++ b/wayfinder_paths/tests/test_jobs_live_state_shape.py
@@ -1,0 +1,84 @@
+"""Live-broker state parsing against the REAL hyperliquid_get_state shape.
+
+The engine's fetch_state parsed the pre-unified `perp.state.assetPositions`
+shape long after the tool moved to flat `perp_positions` + `summary` — every
+live tick raised "perp state fetch unsuccessful", reconcile_mismatch wakes
+fired for 25 minutes, and the advisor reverted the operator's live switch
+(observed live on majors-5m-lab). No test exercised the real parser, so the
+drift shipped silently; this one pins the CURRENT tool shape."""
+
+from __future__ import annotations
+
+import pytest
+
+import wayfinder_paths.jobs.execution.hyperliquid as hl_module
+from wayfinder_paths.jobs.execution.hyperliquid import HyperliquidPerpBroker
+
+UNIFIED_STATE = {
+    "label": "funding-carry-basket",
+    "address": "0x283b6931F4c7610F7235cE3b3cF50fDfd0b7e487",
+    "account_abstraction": "unifiedAccount",
+    "summary": {
+        "unified_usdc_equity": 109.86377,
+        "unified_usdc_unrealized_pnl": 1.2,
+        "unified_usdc_margin_used": 20.0,
+        "unified_usdc_margin_available": 89.86,
+    },
+    "perp_positions": [
+        {"coin": "SOL", "szi": "2.5", "entryPx": "150.0", "asset_name": "SOL-USDC"},
+        {"coin": "HYPE", "szi": "-10", "entryPx": "40.5", "asset_name": "HYPE-USDC"},
+        {"coin": "XRP", "szi": "0", "entryPx": "2.0"},  # flat — skipped
+    ],
+    "spot_positions": [],
+    "outcome_positions": [],
+    "open_orders": [],
+}
+
+
+@pytest.mark.asyncio
+async def test_fetch_state_parses_unified_shape(monkeypatch) -> None:
+    async def fake_state(wallet_label: str):
+        assert wallet_label == "funding-carry-basket"
+        return dict(UNIFIED_STATE)
+
+    monkeypatch.setattr(hl_module, "_hl_state_result", fake_state)
+    broker = HyperliquidPerpBroker(wallet_label="funding-carry-basket")
+    state = await broker.fetch_state()
+
+    assert set(state.positions) == {"SOL", "HYPE"}
+    assert state.positions["SOL"].side == "long"
+    assert state.positions["SOL"].size == 2.5
+    assert state.positions["SOL"].avg_price == 150.0
+    assert state.positions["HYPE"].side == "short"
+    assert state.positions["HYPE"].size == 10.0
+    assert state.balances["accountValue"] == 109.86377
+
+
+@pytest.mark.asyncio
+async def test_fetch_state_classic_account_balance(monkeypatch) -> None:
+    async def fake_state(wallet_label: str):
+        return {
+            "account_abstraction": "default",
+            "summary": {"perp_account_value": 55.5, "spot_usdc_total": 10.0},
+            "perp_positions": [],
+            "open_orders": [],
+        }
+
+    monkeypatch.setattr(hl_module, "_hl_state_result", fake_state)
+    broker = HyperliquidPerpBroker(wallet_label="main")
+    state = await broker.fetch_state()
+    assert state.positions == {}
+    assert state.balances["accountValue"] == 55.5
+
+
+@pytest.mark.asyncio
+async def test_fetch_state_rejects_unknown_shape(monkeypatch) -> None:
+    async def fake_state(wallet_label: str):
+        # The pre-unified shape (or any future drift) must fail LOUDLY with
+        # the shape named — not a misleading "fetch unsuccessful".
+        return {"perp": {"success": True, "state": {"assetPositions": []}}}
+
+    monkeypatch.setattr(hl_module, "_hl_state_result", fake_state)
+    broker = HyperliquidPerpBroker(wallet_label="main")
+    with pytest.raises(RuntimeError, match="unexpected shape"):
+        await broker.fetch_state()


### PR DESCRIPTION
## What broke the majors-5m-lab live canary

The operator flipped `majors-5m-lab` to live at 04:24 UTC. Every live tick then raised `hyperliquid perp state fetch unsuccessful`; 25 minutes of `reconcile_mismatch` triggers woke the advisor, which "reconciled" job.yaml by reverting the operator's switch to paper at 04:49 (`mode_flip_state_reset live→paper` at 04:50).

The wallet was never the problem: `funding-carry-basket` resolved fine and holds **$109.86 unified USDC equity** on Hyperliquid. The bug is a contract drift:

- `hyperliquid_get_state` (MCP tool) returns the **UnifiedAccount shape**: flat `perp_positions` rows + a money `summary` (`unified_usdc_equity`, …), erring whole-hog on any failed leg
- the live broker's `fetch_state` still parsed the **pre-unified shape**: `result.perp.state.assetPositions` + `crossMarginSummary`, gated on `result.perp.success`

So the parser found no `perp` key and raised on **every tick, deterministically** — live mode has been unusable for any jobs_v1 job since the tool's unified refactor.

## Fix

`fetch_state` parses the current shape: positions from `perp_positions` (szi/entryPx), account value from `summary.unified_usdc_equity` with a `perp_account_value` fallback for classic accounts. Success gating drops (the tool already errs atomically — `_hl_state_result` raises on that); any future shape drift fails loudly **naming the keys it got** instead of a misleading "fetch unsuccessful".

## Why no test caught it

Nothing exercised the real parser — engine tests use fake venue adapters. `test_jobs_live_state_shape.py` now pins the tool shape end-to-end: unified parse (long/short/flat rows, equity), classic-account fallback, and a loud rejection of the pre-unified shape.

34 tests green across the live-driver/engine suites; ruff clean.

Follow-up (separate PR): the advisor should never flip `script_loop.mode` against an operator decision — reconcile wakes should halt entries + surface, not rewrite the operator's switch. Bundling that policy guard with the wake-dedup + idle-window orchestration work.