### PR TITLE
jobs: operator leverage knob (apply_execution_leverage + CLI set-leverage)

### DIFF
--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -62,7 +62,12 @@ from wayfinder_paths.jobs.research import (
 from wayfinder_paths.jobs.runner_bridge import RunnerBridge
 from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.jobs.strategies import library_catalog
-from wayfinder_paths.jobs.sync import apply_script_mode, snapshot_job, sync_all_jobs
+from wayfinder_paths.jobs.sync import (
+    apply_execution_leverage,
+    apply_script_mode,
+    snapshot_job,
+    sync_all_jobs,
+)
 from wayfinder_paths.jobs.universe import universe_scan_job
 from wayfinder_paths.jobs.worker import run_job_worker
 
@@ -1240,6 +1245,21 @@ def report_cmd(job_id: str) -> None:
 def set_script_mode_cmd(job_id: str, mode: str, set_by: str, force: bool) -> None:
     try:
         result = apply_script_mode(job_id, mode, set_by=set_by, force=force)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+    _echo_json({"ok": True, "result": result})
+
+
+@job_cli.command(
+    name="set-leverage",
+    help="Operator sizing knob: set execution_params.leverage (takes effect "
+    "next tick, no recompile).",
+)
+@click.argument("job_id")
+@click.argument("leverage", type=float)
+def set_leverage_cmd(job_id: str, leverage: float) -> None:
+    try:
+        result = apply_execution_leverage(job_id, leverage)
     except ValueError as exc:
         raise click.ClickException(str(exc)) from exc
     _echo_json({"ok": True, "result": result})

--- a/wayfinder_paths/jobs/sync.py
+++ b/wayfinder_paths/jobs/sync.py
@@ -328,6 +328,39 @@ def apply_script_mode(
     return {"job_id": job_id, "mode": mode, "set_by": set_by, "compile": result}
 
 
+# Operator sizing ceiling — venue max leverage on majors is higher, but an
+# operator fat-fingering 40x through a UI control is not a trade thesis.
+MAX_OPERATOR_LEVERAGE = 25.0
+
+
+def apply_execution_leverage(
+    job_id: str, leverage: float, *, store: JobStore | None = None
+) -> dict[str, Any]:
+    """Operator-owned sizing knob: write ``execution_params.leverage``.
+
+    Params are re-read from job.yaml every tick, so the change takes effect
+    on the next tick without a recompile (unlike script mode, which is baked
+    into the runner env). Journaled so wake context shows who changed sizing
+    and from what."""
+    value = float(leverage)
+    if not value > 0 or value > MAX_OPERATOR_LEVERAGE:
+        raise ValueError(
+            f"leverage must be in (0, {MAX_OPERATOR_LEVERAGE:g}], got {value:g}"
+        )
+    store = store or JobStore()
+    job = store.load(job_id)
+    previous = job.execution_params.get("leverage")
+    job.execution_params["leverage"] = value
+    job.touch()
+    store.save(job)
+    store.append_journal(
+        job_id,
+        {"type": "operator_leverage_set", "from": previous, "to": value},
+    )
+    sync_all_jobs(store=store)
+    return {"job_id": job_id, "leverage": value, "previous": previous}
+
+
 def _shadow_topline(store: JobStore, job_id: str) -> dict[str, Any]:
     """Read-only topline of the post-apply counterfactual for the UI — the
     artifact is computed on the wake path, never during sync."""

--- a/wayfinder_paths/tests/test_jobs_operator_controls.py
+++ b/wayfinder_paths/tests/test_jobs_operator_controls.py
@@ -1,0 +1,76 @@
+"""Operator controls: the leverage knob (execution_params.leverage) and its
+CLI surface. Mode switching (apply_script_mode) is covered elsewhere; these
+pin the new sizing primitive the frontend button drives."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.jobs.sync import MAX_OPERATOR_LEVERAGE, apply_execution_leverage
+
+
+def _job(tmp_path) -> tuple[JobStore, str]:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("lev-demo", agent_mode="intervene")
+    job.execution_params["leverage"] = 2.0
+    store.save(job)
+    return store, job.id
+
+
+def test_apply_execution_leverage_writes_and_journals(tmp_path, monkeypatch) -> None:
+    store, job_id = _job(tmp_path)
+    synced: list[bool] = []
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.sync.sync_all_jobs",
+        lambda **kwargs: synced.append(True),
+    )
+
+    result = apply_execution_leverage(job_id, 3.5, store=store)
+    assert result == {"job_id": job_id, "leverage": 3.5, "previous": 2.0}
+    assert store.load(job_id).execution_params["leverage"] == 3.5
+    journal = (store.job_dir(job_id) / "journal.jsonl").read_text(encoding="utf-8")
+    row = json.loads(journal.strip().splitlines()[-1])
+    assert row["type"] == "operator_leverage_set"
+    assert row["from"] == 2.0
+    assert row["to"] == 3.5
+    assert synced  # snapshot pushed so backend/frontend see the new value
+
+
+@pytest.mark.parametrize("bad", [0, -1, MAX_OPERATOR_LEVERAGE + 0.1, "nan"])
+def test_apply_execution_leverage_rejects_out_of_range(tmp_path, bad) -> None:
+    store, job_id = _job(tmp_path)
+    with pytest.raises(ValueError):
+        apply_execution_leverage(job_id, float(bad), store=store)
+    assert store.load(job_id).execution_params["leverage"] == 2.0
+
+
+def test_set_leverage_cli_round_trip(tmp_path, monkeypatch) -> None:
+    from wayfinder_paths.jobs import cli as cli_module
+
+    store, job_id = _job(tmp_path)
+    monkeypatch.setattr(
+        cli_module,
+        "apply_execution_leverage",
+        lambda jid, lev: {"job_id": jid, "leverage": lev, "previous": 2.0},
+    )
+    runner = CliRunner()
+    outcome = runner.invoke(cli_module.job_cli, ["set-leverage", job_id, "4"])
+    assert outcome.exit_code == 0, outcome.output
+    payload = json.loads(outcome.output)
+    assert payload["ok"] is True
+    assert payload["result"]["leverage"] == 4.0
+
+    # Out-of-range surfaces as a clean CLI error, not a traceback.
+    monkeypatch.setattr(
+        cli_module,
+        "apply_execution_leverage",
+        lambda jid, lev: (_ for _ in ()).throw(ValueError("leverage must be in")),
+    )
+    outcome = runner.invoke(cli_module.job_cli, ["set-leverage", job_id, "40"])
+    assert outcome.exit_code != 0
+    assert "leverage must be in" in outcome.output


### PR DESCRIPTION
SDK leg of the frontend mode-toggle + leverage controls. The mode toggle needs no SDK change (`wayfinder job set-script-mode` already exists, gated via `apply_script_mode`); this adds the missing leverage primitive:

- `apply_execution_leverage(job_id, leverage)` in `jobs/sync.py`: writes `execution_params.leverage`, bounded (0, 25], journals `operator_leverage_set` with from/to, and pushes a sync snapshot so the backend/frontend see the new value immediately. Params are re-read every tick — takes effect next tick, no recompile (unlike script mode, which is env-baked).
- `wayfinder job set-leverage <job_id> <value>` CLI command in the `{\"ok\": true, \"result\": ...}` convention the backend's action-exec path parses.

6 tests: write+journal+sync, out-of-range rejection (0 / negative / >25 / NaN), CLI round-trip incl. clean error surface.

Pairs with a vault-backend action mapping (`set_script_mode` / `set_leverage` in `WayfinderJobsService._command_parts`) and the vault-frontend JobOverview controls — PRs following. Needs a bake+roll to reach the box.