### PR TITLE
jobs: operator-owned script mode + no-orphan live-exit guard

### DIFF
--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -1224,9 +1224,22 @@ def report_cmd(job_id: str) -> None:
 )
 @click.argument("job_id")
 @click.argument("mode", type=click.Choice(["paper", "live"]))
-def set_script_mode_cmd(job_id: str, mode: str) -> None:
+@click.option(
+    "--by",
+    "set_by",
+    type=click.Choice(["owner", "agent"]),
+    default="owner",
+    help="Who is making this change (recorded in state/operator.json).",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Leave live even if the engine holds open positions (orphans them).",
+)
+def set_script_mode_cmd(job_id: str, mode: str, set_by: str, force: bool) -> None:
     try:
-        result = apply_script_mode(job_id, mode)
+        result = apply_script_mode(job_id, mode, set_by=set_by, force=force)
     except ValueError as exc:
         raise click.ClickException(str(exc)) from exc
     _echo_json({"ok": True, "result": result})

--- a/wayfinder_paths/jobs/sync.py
+++ b/wayfinder_paths/jobs/sync.py
@@ -19,6 +19,7 @@ from wayfinder_paths.jobs.execution.primitives import ExecutionSpec
 from wayfinder_paths.jobs.forward import load_forward_snapshot
 from wayfinder_paths.jobs.gating import evaluate_live_gate
 from wayfinder_paths.jobs.halt import read_halt
+from wayfinder_paths.jobs.models import utc_now_iso
 from wayfinder_paths.jobs.runner_bridge import RunnerBridge
 from wayfinder_paths.jobs.store import JobStore
 
@@ -237,8 +238,16 @@ def sync_all_jobs(*, store: JobStore | None = None) -> None:
     WAYFINDER_JOBS_CLIENT.sync(snapshots)
 
 
+OPERATOR_STATE_PATH = "state/operator.json"
+
+
 def apply_script_mode(
-    job_id: str, mode: str, *, store: JobStore | None = None
+    job_id: str,
+    mode: str,
+    *,
+    store: JobStore | None = None,
+    set_by: str = "owner",
+    force: bool = False,
 ) -> dict[str, Any]:
     """Flip a job's script-loop mode (paper<->live) the compiler-safe way.
 
@@ -250,8 +259,17 @@ def apply_script_mode(
 
     Going live is gated: the job must pass ``evaluate_live_gate`` (``live_ready``)
     and declare ``execution_params.wallet_label``. A blocked gate raises
-    ``ValueError`` naming the blocker and writes nothing. Reverting to paper is
-    always allowed.
+    ``ValueError`` naming the blocker and writes nothing.
+
+    Leaving live is guarded: if the live engine state holds open positions,
+    the flip is REFUSED unless ``force=True`` — a live->paper flip resets the
+    engine state, which orphans real venue positions with no stop and no
+    manager (observed live: a reverted canary left a HYPE short unmanaged
+    for 26 hours). Flatten first (halt --flatten), or force explicitly.
+
+    Every flip records WHO made it in ``state/operator.json`` — the wake
+    prompt renders it, so agents can distinguish an operator decision from
+    the unexplained-flip incidents their halt discipline was built on.
     """
     if mode not in SCRIPT_MODES:
         raise ValueError(f"script mode must be one of {SCRIPT_MODES}, got {mode!r}")
@@ -270,11 +288,44 @@ def apply_script_mode(
             reasons = "; ".join(gate["reasons"]) or "live gate not ready"
             raise ValueError(f"cannot go live: {reasons}")
 
+    if mode == "paper" and str(job.script_loop.mode) == "live" and not force:
+        engine = store.read_json(job_id, "state/engine_state.json") or {}
+        open_positions = {
+            symbol: position
+            for symbol, position in (engine.get("positions") or {}).items()
+            if position
+        }
+        if str(engine.get("mode")) == "live" and open_positions:
+            raise ValueError(
+                "cannot leave live: the live engine holds open positions "
+                f"({', '.join(sorted(open_positions))}) — flipping to paper "
+                "resets the engine and orphans them on the venue with no "
+                "stop and no manager. Flatten first (wayfinder job halt "
+                "--flatten), or pass force=True to orphan deliberately."
+            )
+
     job.script_loop.mode = mode
     store.save(job)
     result = JobCompiler(store=store).compile(job)
+    operator_state = store.read_json(job_id, OPERATOR_STATE_PATH) or {}
+    operator_state["script_mode"] = {
+        "mode": mode,
+        "set_by": set_by,
+        "set_at": utc_now_iso(),
+        "forced": bool(force),
+    }
+    store.write_json(job_id, OPERATOR_STATE_PATH, operator_state)
+    store.append_journal(
+        job_id,
+        {
+            "type": "script_mode_set",
+            "mode": mode,
+            "set_by": set_by,
+            "forced": bool(force),
+        },
+    )
     sync_all_jobs(store=store)
-    return {"job_id": job_id, "mode": mode, "compile": result}
+    return {"job_id": job_id, "mode": mode, "set_by": set_by, "compile": result}
 
 
 def _shadow_topline(store: JobStore, job_id: str) -> dict[str, Any]:

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -120,6 +120,24 @@ def _attribution_block(root: Path) -> dict[str, Any]:
     return block
 
 
+def _operator_block(store: JobStore, job_id: str) -> dict[str, Any]:
+    """Operator decisions of record (state/operator.json) — who last set the
+    script mode and when. Rendered in the stable prefix so agents can tell an
+    authorized owner decision from the unexplained-flip incidents their halt
+    discipline was built on."""
+    doc = store.read_json(job_id, "state/operator.json") or {}
+    if not isinstance(doc, dict) or not doc:
+        return {}
+    return {
+        **doc,
+        "_basis": (
+            "Operator decisions of record. script_mode.set_by=owner means the "
+            "current mode is an AUTHORIZED operator decision — never revert "
+            "it, never halt solely because it changed."
+        ),
+    }
+
+
 def _counterfactual_block(store: JobStore, job_id: str) -> dict[str, Any]:
     """Mechanical post-apply three-book: pre-apply shadow (A) and promoted
     shadow (B) replayed over the forward bars since apply, diffed against
@@ -554,6 +572,7 @@ def _build_worker_prompt_sections(
         # re-explore a logged no_edge/rejected candidate family unchanged).
         "backtest": backtest_block,
         "gate": snapshot.get("gate") or {},
+        "operator": _operator_block(store, job_id),
         "ledgers": {
             "candidates": tail_ledger(store, job_id, "candidates", limit=20),
             "decisions": tail_ledger(store, job_id, "decisions", limit=20),
@@ -609,6 +628,14 @@ def _build_worker_prompt_sections(
         "baked from job.yaml, so a hand-patch is a split-brain the next recompile "
         "reverts. If the runner mode and job.yaml disagree, the fix is a recompile "
         "(sync/set_script_mode), not an env edit.\n"
+        "- script_loop.mode is OPERATOR-OWNED. The stable spec's `operator."
+        "script_mode` block records who last set it and when. When set_by is "
+        "`owner`, the mode is an AUTHORIZED decision: NEVER flip it back and "
+        "NEVER halt solely because the mode changed — halt is for concrete "
+        "risk (mounting losses, venue failure, runaway sizing), and mode "
+        "concerns belong in your wake report for the owner to read. Only a "
+        "mode change with NO operator record is the split-brain incident "
+        "case — reconcile that via recompile and say so in the report.\n"
         "- Use structured forward results first (summary, runs, trades, orders, fills); "
         "raw runner logs are fallback/debug only.\n"
         "- Wallet/venue errors: the live wallet is `execution_params.wallet_label` in "

--- a/wayfinder_paths/mcp/tools/jobs.py
+++ b/wayfinder_paths/mcp/tools/jobs.py
@@ -493,7 +493,11 @@ async def core_jobs(
                 "set_script_mode requires script_mode='live' or 'paper'",
             )
         try:
-            return ok(apply_script_mode(job_id, script_mode, store=store))
+            # MCP callers are agents (wake workers, conversation sessions);
+            # the operator surfaces (CLI, backend button) default to "owner".
+            return ok(
+                apply_script_mode(job_id, script_mode, store=store, set_by="agent")
+            )
         except ValueError as exc:
             # Live-gate / wallet blockers name the missing precondition; surface
             # them as an actionable error rather than a generic failure.

--- a/wayfinder_paths/tests/test_jobs_operator_mode.py
+++ b/wayfinder_paths/tests/test_jobs_operator_mode.py
@@ -1,0 +1,110 @@
+"""Operator-owned mode: every flip records WHO made it, and leaving live
+with open engine positions is refused (a live->paper flip resets the engine
+and orphans real venue positions — observed live: a reverted canary left a
+HYPE short unmanaged, stopless, for 26 hours)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import yaml
+
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.jobs.sync import OPERATOR_STATE_PATH, apply_script_mode
+
+
+def _job(tmp_path, *, mode: str = "paper") -> tuple[JobStore, str]:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        "op-demo", script="workspace/src/strategy.py", agent_mode="intervene"
+    )
+    job.script_loop.mode = mode
+    job.execution_params["wallet_label"] = "funding-carry-basket"
+    store.save(job)
+    src = store.job_dir(job.id) / "workspace" / "src"
+    src.mkdir(parents=True, exist_ok=True)
+    (src / "strategy.py").write_text("def build_strategy():\n    pass\n")
+    return store, job.id
+
+
+def _quiet_pipeline(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.sync.JobCompiler",
+        lambda store: type("C", (), {"compile": lambda self, job: {"ok": True}})(),
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.sync.sync_all_jobs", lambda **kwargs: None
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.sync.evaluate_live_gate",
+        lambda job_id, store=None: {"live_ready": True, "reasons": []},
+    )
+
+
+def test_flip_records_operator_state_and_journal(tmp_path, monkeypatch) -> None:
+    store, job_id = _job(tmp_path)
+    _quiet_pipeline(monkeypatch)
+
+    result = apply_script_mode(job_id, "live", store=store)
+    assert result["set_by"] == "owner"
+    operator = store.read_json(job_id, OPERATOR_STATE_PATH)
+    assert operator["script_mode"]["mode"] == "live"
+    assert operator["script_mode"]["set_by"] == "owner"
+    assert operator["script_mode"]["forced"] is False
+
+    journal = (store.job_dir(job_id) / "journal.jsonl").read_text()
+    row = json.loads(journal.strip().splitlines()[-1])
+    assert row["type"] == "script_mode_set"
+    assert row["set_by"] == "owner"
+
+    # An agent-made flip is recorded as the agent's — provenance, not a block.
+    apply_script_mode(job_id, "paper", store=store, set_by="agent")
+    operator = store.read_json(job_id, OPERATOR_STATE_PATH)
+    assert operator["script_mode"]["set_by"] == "agent"
+
+
+def test_leaving_live_with_open_positions_is_refused(tmp_path, monkeypatch) -> None:
+    store, job_id = _job(tmp_path, mode="live")
+    _quiet_pipeline(monkeypatch)
+    store.write_json(
+        job_id,
+        "state/engine_state.json",
+        {"mode": "live", "positions": {"HYPE": {"side": "short", "size": 0.48}}},
+    )
+
+    with pytest.raises(ValueError, match="orphans them"):
+        apply_script_mode(job_id, "paper", store=store)
+    # Nothing written: mode unchanged, no operator record of the refused flip.
+    job_yaml = yaml.safe_load((store.job_dir(job_id) / "job.yaml").read_text())
+    assert job_yaml["script_loop"]["mode"] == "live"
+
+    # force=True is the explicit orphaning escape hatch, and says so on record.
+    result = apply_script_mode(job_id, "paper", store=store, force=True)
+    assert result["mode"] == "paper"
+    operator = store.read_json(job_id, OPERATOR_STATE_PATH)
+    assert operator["script_mode"]["forced"] is True
+
+
+def test_leaving_live_flat_needs_no_force(tmp_path, monkeypatch) -> None:
+    store, job_id = _job(tmp_path, mode="live")
+    _quiet_pipeline(monkeypatch)
+    store.write_json(
+        job_id, "state/engine_state.json", {"mode": "live", "positions": {}}
+    )
+    result = apply_script_mode(job_id, "paper", store=store)
+    assert result["mode"] == "paper"
+
+
+def test_worker_stable_prompt_carries_operator_record(tmp_path, monkeypatch) -> None:
+    from wayfinder_paths.jobs.worker import _operator_block
+
+    store, job_id = _job(tmp_path)
+    assert _operator_block(store, job_id) == {}
+
+    _quiet_pipeline(monkeypatch)
+    apply_script_mode(job_id, "live", store=store)
+    block = _operator_block(store, job_id)
+    assert block["script_mode"]["set_by"] == "owner"
+    assert "AUTHORIZED" in block["_basis"]


### PR DESCRIPTION
## The incident class this retires

Three times this week the loop fought the operator on `majors-5m-lab`:

1. An advisor wake **reverted** the owner's paper→live switch ("reconciling" a mode divergence caused by a separate state-parsing bug)
2. When the owner flipped again, a wake **halted** it: *"Unauthorized paper→live flip … owner policy is paper-only"*
3. The reversion **orphaned a real HYPE short** on the venue — no stop, no manager, for 26 hours

Root cause: the system has no representation of operator intent. Every guardian behavior was built from real split-brain incidents (agents flipping `WAYFINDER_JOB_MODE`), so an owner's deliberate switch is indistinguishable from the thing those defenses exist to catch.

## What this adds

**1. Operator intent as first-class state.** `apply_script_mode` records `{mode, set_by, set_at, forced}` in `state/operator.json` and journals `script_mode_set`. The CLI gains `--by owner|agent` (default `owner` — the backend button path inherits it); MCP `set_script_mode` callers are stamped `agent`. Provenance, not permissioning — agents can still flip, it's just on the record.

**2. The wake prompt knows the difference.** The stable prefix renders the operator record plus a hard rule: owner-set mode is an AUTHORIZED decision — never flip it back, never halt solely because the mode changed; halt is for concrete risk (losses, venue failure, runaway sizing), and mode concerns belong in the wake report. Only a mode change with **no** operator record remains the split-brain incident case.

**3. No-orphan guard.** Leaving live while the live engine holds open positions is **refused**, naming the positions and the flatten-first path. `force=True` (CLI `--force`) is the explicit, journaled escape hatch. Leaving live flat needs no force. This makes the orphaning failure mode impossible for every caller — agent, button, or CLI.

## Verification

4 new tests: provenance recorded + journaled (owner and agent), open-positions refusal leaves job.yaml untouched + force overrides with `forced: true` on record, flat live→paper unguarded, worker stable-prompt block renders the record. Adjacent sync/worker suites: only pre-existing failures (2× gorlami retry, 1× campaign-factorial prompt — all fail identically on the clean base). ruff + format clean.

Needs a bake+roll. Companion follow-up (separate PR): async `set-script-mode` via the #649 op_status pattern + risk_halt trigger debounce + wake-ID dedup.