### PR TITLE
jobs: live fee capture, funding attribution, equity reconciliation

### DIFF
--- a/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
+++ b/wayfinder_paths/adapters/hyperliquid_adapter/adapter.py
@@ -1372,6 +1372,37 @@ class HyperliquidAdapter(BaseAdapter):
             self.logger.error(f"Failed to fetch user_fills for {address}: {exc}")
             return False, str(exc)
 
+    async def get_user_fills_by_time(
+        self, address: str, start_ms: int, end_ms: int | None = None
+    ) -> tuple[bool, list[dict[str, Any]]] | tuple[Literal[False], str]:
+        try:
+            data = get_info().user_fills_by_time(
+                address, start_ms, end_ms or int(time.time() * 1000)
+            )
+            return True, data if isinstance(data, list) else []
+        except Exception as exc:
+            self.logger.error(
+                f"Failed to fetch user_fills_by_time for {address}: {exc}"
+            )
+            return False, str(exc)
+
+    async def get_user_funding_history(
+        self, address: str, start_ms: int, end_ms: int | None = None
+    ) -> tuple[bool, list[dict[str, Any]]] | tuple[Literal[False], str]:
+        """Signed user funding payments (delta.usdc: negative = paid) — the
+        only exact source; position cumFunding vanishes when the position
+        closes."""
+        try:
+            data = get_info().user_funding_history(
+                address, start_ms, end_ms or int(time.time() * 1000)
+            )
+            return True, data if isinstance(data, list) else []
+        except Exception as exc:
+            self.logger.error(
+                f"Failed to fetch user_funding_history for {address}: {exc}"
+            )
+            return False, str(exc)
+
     async def check_recent_liquidations(
         self, address: str, since_ms: int
     ) -> tuple[bool, list[dict[str, Any]]]:

--- a/wayfinder_paths/jobs/execution/driver.py
+++ b/wayfinder_paths/jobs/execution/driver.py
@@ -356,6 +356,7 @@ async def tick_job(
             )
 
     state.save(state_path)
+    funding_rows = await _collect_funding(brokers, root, mode, now)
     _record(
         recorder
         or ForwardRecorder(
@@ -366,6 +367,9 @@ async def tick_job(
         params=params,
         now=now,
         engine_state_pre=engine_state_pre,
+        funding_rows=funding_rows,
+        root=root,
+        mode=mode,
     )
     try:
         _record_pending_trade_forensics(root, view)
@@ -509,6 +513,143 @@ async def _reconcile(
     return StateSnapshot(status="valid", data=data), notes
 
 
+_FUNDING_STATE_PATH = "state/funding_state.json"
+_EQUITY_RECON_PATH = "state/equity_recon.json"
+
+
+async def _collect_funding(
+    brokers: Mapping[str, Any],
+    root: Path,
+    mode: str,
+    now: pd.Timestamp,
+) -> list[dict[str, Any]]:
+    """Best-effort venue funding rows since the persisted cursor. Funding is
+    real PnL that never appears in trade rows; it is recorded ONLY on the
+    forward side (never the engine ledger — the drift reconciler replays
+    ticks offline and network-injected PnL would flag false drift). The
+    cursor seeds at now on first run: pre-go-live funding is not this
+    job's."""
+    if mode != "live":
+        return []
+    state_path = root / _FUNDING_STATE_PATH
+    now_ms = int(now.timestamp() * 1000)
+    try:
+        cursor_doc = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        cursor_doc = {}
+    cursor = cursor_doc.get("cursor_ms")
+    if not isinstance(cursor, (int, float)):
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        state_path.write_text(json.dumps({"cursor_ms": now_ms}), encoding="utf-8")
+        return []
+    rows: list[dict[str, Any]] = []
+    max_seen = int(cursor)
+    for broker in brokers.values():
+        fetch = getattr(broker, "get_funding_payments", None)
+        if fetch is None:
+            continue
+        try:
+            for row in await fetch(int(cursor) + 1):
+                time_ms = row.get("time_ms")
+                if not isinstance(time_ms, (int, float)) or time_ms <= cursor:
+                    continue
+                rows.append(dict(row))
+                max_seen = max(max_seen, int(time_ms))
+        except Exception:  # noqa: BLE001 — telemetry must never fail a tick
+            continue
+    if max_seen > cursor:
+        state_path.write_text(json.dumps({"cursor_ms": max_seen}), encoding="utf-8")
+    return rows
+
+
+def _reconciliation_block(
+    tick: TickResult,
+    *,
+    root: Path,
+    recorder: ForwardRecorder,
+    mode: str,
+    view: CompletedBarsView,
+) -> dict[str, Any] | None:
+    """Per-tick decomposition of venue equity vs what the books explain:
+    expected = equity_start + ledger_realized_delta + funding + unrealized.
+    Drift is the unexplained remainder (deposits/withdrawals land here by
+    design). Uses ledger realized — NOT trades net — because entry fees sit
+    in non-reduce-only rows the trade-close recorder skips."""
+    if mode != "live":
+        return None
+    account_value = (tick.snapshot.data or {}).get("account_value")
+    if account_value is None:
+        return None
+    try:
+        recon_path = root / _EQUITY_RECON_PATH
+        ledger = tick.ledger_snapshot or {}
+        realized = float(ledger.get("realized_pnl") or 0.0)
+        reset_fired = any(
+            event.get("kind") == "mode_flip_state_reset"
+            for event in tick.guard_events or []
+        )
+        try:
+            seed = json.loads(recon_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            seed = {}
+        if reset_fired or "venue_equity_start" not in seed:
+            # Mode flips archive the engine state — the realized baseline
+            # restarts with it.
+            seed = {
+                "venue_equity_start": float(account_value),
+                "ledger_realized_at_seed": realized,
+                "seeded_at": pd.Timestamp.now(tz="UTC").isoformat(),
+            }
+            recon_path.parent.mkdir(parents=True, exist_ok=True)
+            recon_path.write_text(json.dumps(seed), encoding="utf-8")
+
+        unrealized = 0.0
+        for symbol, position in (ledger.get("positions") or {}).items():
+            latest = view.latest(symbol)
+            close = (
+                float(latest.get("close"))
+                if latest and latest.get("close") is not None
+                else None
+            )
+            if close is None:
+                continue
+            avg = float(position.get("avg_price") or 0.0)
+            size = float(position.get("size") or 0.0)
+            direction = 1.0 if str(position.get("side")) == "long" else -1.0
+            unrealized += direction * (close - avg) * size
+
+        summary = recorder.summary()
+        funding_total = float((summary.get("funding") or {}).get("total_usd") or 0.0)
+        trades_net = float((summary.get("trades") or {}).get("net_pnl") or 0.0)
+        fees_total = float((summary.get("fills") or {}).get("fees_total") or 0.0)
+        realized_delta = realized - float(seed.get("ledger_realized_at_seed") or 0.0)
+        expected = (
+            float(seed.get("venue_equity_start") or 0.0)
+            + realized_delta
+            + funding_total
+            + unrealized
+        )
+        return {
+            "venue_equity_start": seed.get("venue_equity_start"),
+            "venue_equity_now": float(account_value),
+            "ledger_realized_delta": round(realized_delta, 6),
+            "unrealized": round(unrealized, 6),
+            "funding_total": round(funding_total, 6),
+            "trades_net": round(trades_net, 6),
+            "fees_total": round(fees_total, 6),
+            "expected_equity": round(expected, 6),
+            "drift": round(float(account_value) - expected, 6),
+            "_basis": (
+                "expected = equity_start + ledger_realized_delta + funding + "
+                "unrealized; drift = venue - expected (deposits/withdrawals "
+                "surface as drift by design). trades_net/fees_total are "
+                "reported for visibility, not used in drift."
+            ),
+        }
+    except Exception:  # noqa: BLE001 — telemetry must never fail a tick
+        return None
+
+
 def _record(
     recorder: ForwardRecorder,
     tick: TickResult,
@@ -517,11 +658,39 @@ def _record(
     params: Mapping[str, Any],
     now: pd.Timestamp,
     engine_state_pre: Mapping[str, Any] | None = None,
+    funding_rows: list[dict[str, Any]] | None = None,
+    root: Path | None = None,
+    mode: str | None = None,
 ) -> None:
     intents = [intent.to_dict() for intent in tick.intents]
     fills = [fill.to_dict() for fill in tick.fills]
     timestamps = view.timestamps
+    for intent in intents:
+        recorder.record_order(intent)
+    for row in fills:
+        recorder.record_fill(row)
+    # trade_rows are FillEvent.to_dict() + realized_pnl_delta: fixed shape.
+    for row in tick.trade_rows:
+        if row["reduce_only"]:
+            recorder.record_trade_close(
+                symbol=row["symbol"],
+                side=row["side"],
+                size=row["filled_size"],
+                price=row["avg_price"],
+                net_pnl=row["realized_pnl_delta"],
+                closed_at=row["timestamp"],
+            )
+    for row in funding_rows or []:
+        recorder.record_funding(row)
+    # Reconciliation runs AFTER the rows above so summary totals include
+    # this tick's fees/funding.
+    reconciliation = (
+        _reconciliation_block(tick, root=root, recorder=recorder, mode=mode, view=view)
+        if root is not None and mode is not None
+        else None
+    )
     recorder.record_tick(
+        reconciliation=reconciliation,
         ts=now.isoformat(),
         bar_ts=tick.bar_timestamp,
         skipped=tick.skipped,
@@ -549,21 +718,6 @@ def _record(
         reason=tick.skip_reason,
         metrics={"fill_count": len(fills), "guard_event_count": len(tick.guard_events)},
     )
-    for intent in intents:
-        recorder.record_order(intent)
-    for row in fills:
-        recorder.record_fill(row)
-    # trade_rows are FillEvent.to_dict() + realized_pnl_delta: fixed shape.
-    for row in tick.trade_rows:
-        if row["reduce_only"]:
-            recorder.record_trade_close(
-                symbol=row["symbol"],
-                side=row["side"],
-                size=row["filled_size"],
-                price=row["avg_price"],
-                net_pnl=row["realized_pnl_delta"],
-                closed_at=row["timestamp"],
-            )
 
 
 def view_hash(view: CompletedBarsView) -> str:

--- a/wayfinder_paths/jobs/execution/hyperliquid.py
+++ b/wayfinder_paths/jobs/execution/hyperliquid.py
@@ -262,9 +262,19 @@ class HyperliquidPerpBroker:
 
     capabilities = HYPERLIQUID_CAPABILITIES
 
-    def __init__(self, *, wallet_label: str = "main", slippage: float = 0.01) -> None:
+    def __init__(
+        self,
+        *,
+        wallet_label: str = "main",
+        slippage: float = 0.01,
+        fee_bps: float = 4.5,
+    ) -> None:
         self.wallet_label = wallet_label
         self.slippage = slippage
+        # Fallback taker rate when the user-fills fee lookup cannot resolve
+        # the actual venue fee — a fee_bps estimate beats recording 0.0
+        # (observed live: gross-of-fee trade rows overstated PnL ~2x).
+        self.fee_bps = fee_bps
         self.snapshot = StateSnapshot(status="valid")
 
     async def place(
@@ -303,6 +313,7 @@ class HyperliquidPerpBroker:
             size=intent.size,
             usd_amount=intent.notional if intent.size is None else None,
             slippage=self.slippage,
+            fee_bps=self.fee_bps,
         )
 
     async def fetch_state(self, symbols: Sequence[str] | Any = ()) -> VenueState:
@@ -330,7 +341,14 @@ class HyperliquidPerpBroker:
                 side="long" if szi > 0 else "short",
                 size=abs(szi),
                 avg_price=_float_or_none(position.get("entryPx")) or 0.0,
-                metadata={"source": "hyperliquid"},
+                metadata={
+                    "source": "hyperliquid",
+                    # Observability only — exact funding accounting uses the
+                    # user-funding ledger (cumFunding vanishes at close).
+                    "cum_funding_since_open": _float_or_none(
+                        (position.get("cumFunding") or {}).get("sinceOpen")
+                    ),
+                },
             )
         summary = result.get("summary") or {}
         account_value = _float_or_none(summary.get("unified_usdc_equity"))
@@ -350,6 +368,20 @@ class HyperliquidPerpBroker:
     async def get_capacity(self, symbol: str, side: str) -> TradeCapacity:
         return await get_trade_capacity(self.wallet_label, symbol, side=side)
 
+    async def get_funding_payments(self, since_ms: int) -> list[dict[str, Any]]:
+        """Signed user funding rows since `since_ms` ({time_ms, coin, usdc,
+        funding_rate, szi}; usdc negative = paid). Exceptions bubble — the
+        driver treats funding collection as best-effort telemetry."""
+        # lazy: keeps execution/ decoupled from the MCP tool stack
+        from wayfinder_paths.mcp.tools.hyperliquid import hyperliquid_get_user_funding
+
+        outcome = await hyperliquid_get_user_funding(self.wallet_label, since_ms)
+        match outcome:
+            case {"ok": True, "result": {"rows": list() as rows}}:
+                return rows
+            case _:
+                raise RuntimeError(f"user funding fetch failed: {_mcp_error(outcome)}")
+
     async def cancel(self, client_order_id: str) -> FillEvent:
         return _cancel_needs_asset_context("hyperliquid", client_order_id)
 
@@ -365,6 +397,11 @@ class HyperliquidPerpAdapter:
             self.broker: Any = HyperliquidPerpBroker(
                 wallet_label=str(params.get("wallet_label") or "main"),
                 slippage=float(params.get("live_slippage") or 0.01),
+                fee_bps=(
+                    float(params["fee_bps"])
+                    if params.get("fee_bps") is not None
+                    else 4.5
+                ),
             )
         else:
             self.broker = _paper_broker(HYPERLIQUID_CAPABILITIES, params)
@@ -399,6 +436,7 @@ async def _submit_market_order(
     size: float | None,
     usd_amount: float | None,
     slippage: float,
+    fee_bps: float = 0.0,
 ) -> FillEvent:
     """Shared MCP submit -> FillEvent normalization for the perp and HIP-4
     brokers. Transport failures and missing exchange results return
@@ -406,6 +444,7 @@ async def _submit_market_order(
     # lazy: keeps execution/ decoupled from the MCP tool stack and patchable in tests
     from wayfinder_paths.mcp.tools.hyperliquid import hyperliquid_place_market_order
 
+    submit_ms = int(time.time() * 1000)
     try:
         outcome = await hyperliquid_place_market_order(
             wallet_label=wallet_label,
@@ -456,7 +495,82 @@ async def _submit_market_order(
         intent, state_snapshot=snapshot, capacity=capacity, raw_result=raw
     )
     fill.timestamp = timestamp
+    if fill.status == "filled":
+        await _attach_fill_fee(
+            fill, wallet_label=wallet_label, submit_ms=submit_ms, fee_bps=fee_bps
+        )
     return fill
+
+
+async def _user_fills_result(wallet_label: str, start_ms: int) -> list[dict[str, Any]]:
+    # lazy: keeps execution/ decoupled from the MCP tool stack and patchable in tests
+    from wayfinder_paths.mcp.tools.hyperliquid import hyperliquid_get_user_fills
+
+    outcome = await hyperliquid_get_user_fills(wallet_label, start_ms=start_ms)
+    match outcome:
+        case {"ok": True, "result": {"rows": list() as rows}}:
+            return rows
+    raise RuntimeError(f"user fills fetch failed: {_mcp_error(outcome)}")
+
+
+# userFills can lag the order ack; bounded backoff, then estimate.
+_FEE_LOOKUP_DELAYS_S = (0.0, 1.5, 3.0)
+_FEE_LOOKUP_EARLY_MS = 5_000
+_FEE_LOOKUP_LATE_MS = 30_000
+
+
+async def _attach_fill_fee(
+    fill: FillEvent, *, wallet_label: str, submit_ms: int, fee_bps: float
+) -> None:
+    """Resolve the ACTUAL venue fee for a filled order via the user-fills
+    ledger (the HL order ack carries no fee — recording 0.0 made live trade
+    PnL gross of fees, overstating it ~2x in the observed sample). Falls
+    back to a fee_bps estimate when the ledger has not caught up; the
+    source is tagged either way for audit."""
+    matched_fee = None
+    try:
+        for delay in _FEE_LOOKUP_DELAYS_S:
+            if delay:
+                await asyncio.sleep(delay)
+            rows = await _user_fills_result(
+                wallet_label, submit_ms - _FEE_LOOKUP_EARLY_MS
+            )
+            fee_total = 0.0
+            size_total = 0.0
+            for row in rows:
+                time_ms = row.get("time")
+                if (
+                    isinstance(time_ms, (int, float))
+                    and time_ms > submit_ms + _FEE_LOOKUP_LATE_MS
+                ):
+                    continue
+                oid_match = fill.order_id is not None and str(row.get("oid")) == str(
+                    fill.order_id
+                )
+                cloid_match = fill.client_order_id is not None and row.get(
+                    "cloid"
+                ) == str(fill.client_order_id)
+                if not (oid_match or cloid_match):
+                    continue
+                fee_total += float(row.get("fee") or 0.0) + float(
+                    row.get("builderFee") or 0.0
+                )
+                size_total += abs(float(row.get("sz") or 0.0))
+            if size_total > 0:
+                # Ledger may not carry every partial yet — pro-rata up.
+                if size_total < abs(fill.filled_size) * 0.99:
+                    fee_total *= abs(fill.filled_size) / size_total
+                matched_fee = fee_total
+                break
+    except Exception:
+        matched_fee = None
+    if matched_fee is not None:
+        fill.fee = matched_fee
+        fill.raw["fee_source"] = "user_fills"
+    else:
+        notional = abs(fill.filled_size * (fill.avg_price or 0.0))
+        fill.fee = notional * fee_bps / 10_000
+        fill.raw["fee_source"] = "estimate"
 
 
 async def _hl_state_result(wallet_label: str) -> dict[str, Any]:

--- a/wayfinder_paths/jobs/execution/risk.py
+++ b/wayfinder_paths/jobs/execution/risk.py
@@ -88,6 +88,9 @@ def build_risk_snapshot(
     summary = _read_json(Path(root) / FORWARD_SUMMARY_PATH) or {}
     trades_summary = summary.get("trades") or {}
     net_pnl = float(trades_summary.get("net_pnl") or 0.0)
+    # Funding is real PnL that never appears in trade rows — excluding it
+    # fires false drawdown halts on funding-heavy shorts (and vice versa).
+    funding_total = float((summary.get("funding") or {}).get("total_usd") or 0.0)
 
     unrealized = 0.0
     gross_exposure = 0.0
@@ -104,7 +107,7 @@ def build_risk_snapshot(
         gross_exposure += abs(notional)
         positions_usd[symbol] = direction * notional
 
-    equity = initial_capital + net_pnl + unrealized
+    equity = initial_capital + net_pnl + funding_total + unrealized
     risk_state = _read_json(Path(root) / RISK_STATE_PATH)
     peak_equity = float(risk_state["peak_equity"]) if risk_state else None
     if peak_equity is None or equity > peak_equity:

--- a/wayfinder_paths/jobs/forward.py
+++ b/wayfinder_paths/jobs/forward.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from wayfinder_paths.jobs.models import (
     DEFAULT_FORWARD_FILLS,
+    DEFAULT_FORWARD_FUNDING,
     DEFAULT_FORWARD_ORDERS,
     DEFAULT_FORWARD_RUNS,
     DEFAULT_FORWARD_SUMMARY,
@@ -23,6 +24,7 @@ FORWARD_FILES = {
     "trade": DEFAULT_FORWARD_TRADES,
     "order": DEFAULT_FORWARD_ORDERS,
     "fill": DEFAULT_FORWARD_FILLS,
+    "funding": DEFAULT_FORWARD_FUNDING,
     "tick": DEFAULT_FORWARD_TICKS,
 }
 
@@ -49,7 +51,10 @@ def default_forward_summary(job_id: str | None = None) -> dict[str, Any]:
             "current_loss_streak": 0,
         },
         "orders": {"count": 0, "last_order_at": None, "pending_count": 0},
-        "fills": {"count": 0, "last_fill_at": None},
+        "fills": {"count": 0, "last_fill_at": None, "fees_total": 0.0},
+        # Signed usd funding payments (negative = paid) — real PnL that never
+        # appears in trade rows; the reconciliation block needs it.
+        "funding": {"count": 0, "total_usd": 0.0, "last_funding_at": None},
     }
 
 
@@ -224,6 +229,12 @@ class ForwardRecorder:
     ) -> dict[str, Any]:
         return self.append("fill", _merge_payload(payload, fields))
 
+    def record_funding(
+        self, payload: Mapping[str, Any] | None = None, **fields: Any
+    ) -> dict[str, Any]:
+        """One signed venue funding payment ({time_ms, coin, usdc, ...})."""
+        return self.append("funding", _merge_payload(payload, fields))
+
     def record_tick(
         self, payload: Mapping[str, Any] | None = None, **fields: Any
     ) -> dict[str, Any]:
@@ -231,6 +242,10 @@ class ForwardRecorder:
         replay the decision: bar timestamp, view hash, snapshot, intents,
         fills, and guard events."""
         return self.append("tick", _merge_payload(payload, fields))
+
+    def summary(self) -> dict[str, Any]:
+        path = self.forward_dir / Path(DEFAULT_FORWARD_SUMMARY).name
+        return _read_json(path, default_forward_summary(self.job_id))
 
     def append(self, kind: str, payload: Mapping[str, Any]) -> dict[str, Any]:
         if kind not in FORWARD_FILES:
@@ -316,6 +331,16 @@ class ForwardRecorder:
             fills = summary.setdefault("fills", {})
             fills["count"] = int(fills.get("count") or 0) + 1
             fills["last_fill_at"] = row.get("ts")
+            fills["fees_total"] = float(fills.get("fees_total") or 0.0) + float(
+                row.get("fee") or 0.0
+            )
+        elif kind == "funding":
+            funding = summary.setdefault("funding", {})
+            funding["count"] = int(funding.get("count") or 0) + 1
+            funding["total_usd"] = float(funding.get("total_usd") or 0.0) + float(
+                row.get("usdc") or 0.0
+            )
+            funding["last_funding_at"] = row.get("ts")
         elif kind == "tick":
             ticks = summary.setdefault("ticks", {})
             ticks["count"] = int(ticks.get("count") or 0) + 1
@@ -326,6 +351,10 @@ class ForwardRecorder:
                 ticks["guard_event_count"] = int(
                     ticks.get("guard_event_count") or 0
                 ) + len(row["guard_events"])
+            if row.get("reconciliation"):
+                # Last-write-wins: each live tick carries the current
+                # trades/fees/funding vs venue-equity decomposition.
+                summary["reconciliation"] = row["reconciliation"]
         _write_json(path, summary)
 
 

--- a/wayfinder_paths/jobs/models.py
+++ b/wayfinder_paths/jobs/models.py
@@ -13,6 +13,7 @@ DEFAULT_FORWARD_RUNS = "results/forward/runs.jsonl"
 DEFAULT_FORWARD_TRADES = "results/forward/trades.jsonl"
 DEFAULT_FORWARD_ORDERS = "results/forward/orders.jsonl"
 DEFAULT_FORWARD_FILLS = "results/forward/fills.jsonl"
+DEFAULT_FORWARD_FUNDING = "results/forward/funding.jsonl"
 DEFAULT_FORWARD_TICKS = "results/forward/ticks.jsonl"
 DEFAULT_FORWARD_SUMMARY = "results/forward/summary.json"
 

--- a/wayfinder_paths/mcp/server.py
+++ b/wayfinder_paths/mcp/server.py
@@ -79,6 +79,8 @@ from wayfinder_paths.mcp.tools.hyperliquid import (
     hyperliquid_get_funding_history,
     hyperliquid_get_state,
     hyperliquid_get_trade_asset,
+    hyperliquid_get_user_fills,
+    hyperliquid_get_user_funding,
     hyperliquid_place_limit_order,
     hyperliquid_place_market_order,
     hyperliquid_place_trigger_order,
@@ -184,6 +186,8 @@ def build_mcp(
     # ─── hyperliquid_* ─────────────────────────────────────────────────
     # Coin naming reference: /using-hyperliquid-adapter/rules/coin-naming.md.
     mcp.tool()(hyperliquid_get_state)
+    mcp.tool()(hyperliquid_get_user_fills)
+    mcp.tool()(hyperliquid_get_user_funding)
     mcp.tool()(hyperliquid_get_trade_asset)
     mcp.tool()(hyperliquid_search_market)
     mcp.tool()(hyperliquid_search_hip4)

--- a/wayfinder_paths/mcp/tools/hyperliquid.py
+++ b/wayfinder_paths/mcp/tools/hyperliquid.py
@@ -1920,6 +1920,60 @@ async def hyperliquid_place_limit_order(
 
 
 @catch_errors
+async def hyperliquid_get_user_fills(
+    label: str, start_ms: int | None = None, end_ms: int | None = None
+) -> dict[str, Any]:
+    """User fill rows (they carry the actual `fee` the order ack omits).
+    With start_ms, uses the time-windowed endpoint; otherwise full history."""
+    addr, _ = await resolve_wallet_address(wallet_label=label)
+    if not addr:
+        return err("not_found", f"Wallet not found: {label}")
+    adapter = HyperliquidAdapter()
+    if start_ms is not None:
+        ok_flag, rows = await adapter.get_user_fills_by_time(addr, start_ms, end_ms)
+    else:
+        ok_flag, rows = await adapter.get_user_fills(addr)
+    if not ok_flag:
+        return err("state_error", f"Could not fetch user fills: {rows}")
+    return ok({"label": label, "address": addr, "rows": rows})
+
+
+@catch_errors
+async def hyperliquid_get_user_funding(
+    label: str, start_ms: int, end_ms: int | None = None
+) -> dict[str, Any]:
+    """Signed user funding payments, flattened: {time_ms, coin, usdc,
+    funding_rate, szi}. usdc negative = paid by the account."""
+    addr, _ = await resolve_wallet_address(wallet_label=label)
+    if not addr:
+        return err("not_found", f"Wallet not found: {label}")
+    adapter = HyperliquidAdapter()
+    ok_flag, rows = await adapter.get_user_funding_history(addr, start_ms, end_ms)
+    if not ok_flag:
+        return err("state_error", f"Could not fetch user funding: {rows}")
+    normalized = []
+    for row in rows if isinstance(rows, list) else []:
+        delta = row.get("delta") or {}
+        normalized.append(
+            {
+                "time_ms": row.get("time"),
+                "coin": delta.get("coin"),
+                "usdc": _float_or_none_tool(delta.get("usdc")),
+                "funding_rate": _float_or_none_tool(delta.get("fundingRate")),
+                "szi": _float_or_none_tool(delta.get("szi")),
+            }
+        )
+    return ok({"label": label, "address": addr, "rows": normalized})
+
+
+def _float_or_none_tool(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+@catch_errors
 async def hyperliquid_get_state(label: str) -> dict[str, Any]:
     """Return a Hyperliquid account snapshot: money `summary`, open
     `perp_positions` / `spot_positions` / `outcome_positions`, and all

--- a/wayfinder_paths/tests/test_jobs_live_fees.py
+++ b/wayfinder_paths/tests/test_jobs_live_fees.py
@@ -1,0 +1,296 @@
+"""Live fee capture + funding attribution + equity reconciliation.
+
+Live HL fills recorded fee=0.0 (the order ack carries no fee), making live
+trade PnL gross of fees — observed live: trades +18.2c while venue equity
+gained +8.8c (~5c fees + ~4c funding invisible). These pin the fee lookup,
+the estimate fallback, funding recording, and the reconciliation identity.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+import wayfinder_paths.jobs.execution.hyperliquid as hl_module
+from wayfinder_paths.jobs.execution.hyperliquid import (
+    HyperliquidPerpBroker,
+    _attach_fill_fee,
+)
+from wayfinder_paths.jobs.execution.primitives import FillEvent, PositionLedger
+from wayfinder_paths.jobs.forward import ForwardRecorder
+
+
+def _filled(size: float = 0.48, px: float = 57.32, **kw) -> FillEvent:
+    return FillEvent(
+        status="filled",
+        venue="hyperliquid",
+        symbol="HYPE",
+        side="sell",
+        filled_size=size,
+        avg_price=px,
+        order_id="12345",
+        client_order_id="0xabc",
+        **kw,
+    )
+
+
+def _no_sleep(monkeypatch) -> None:
+    async def instant(_delay):
+        return None
+
+    monkeypatch.setattr(hl_module.asyncio, "sleep", instant)
+
+
+@pytest.mark.asyncio
+async def test_fee_from_user_fills_by_oid(monkeypatch) -> None:
+    _no_sleep(monkeypatch)
+
+    async def fake_fills(wallet_label, start_ms):
+        return [
+            {
+                "oid": 12345,
+                "sz": "0.48",
+                "fee": "0.0125",
+                "builderFee": "0.001",
+                "time": start_ms + 100,
+            },
+            # decoy: different oid
+            {"oid": 999, "sz": "1.0", "fee": "5.0", "time": start_ms + 100},
+        ]
+
+    monkeypatch.setattr(hl_module, "_user_fills_result", fake_fills)
+    fill = _filled()
+    await _attach_fill_fee(fill, wallet_label="w", submit_ms=1000, fee_bps=4.5)
+    assert fill.fee == pytest.approx(0.0135)
+    assert fill.raw["fee_source"] == "user_fills"
+
+
+@pytest.mark.asyncio
+async def test_fee_fallback_estimate_when_ledger_lags(monkeypatch) -> None:
+    _no_sleep(monkeypatch)
+
+    async def empty(wallet_label, start_ms):
+        return []
+
+    monkeypatch.setattr(hl_module, "_user_fills_result", empty)
+    fill = _filled(size=0.48, px=57.32)
+    await _attach_fill_fee(fill, wallet_label="w", submit_ms=1000, fee_bps=4.5)
+    assert fill.fee == pytest.approx(abs(0.48 * 57.32) * 4.5 / 10_000)
+    assert fill.raw["fee_source"] == "estimate"
+
+    # Lookup blowing up entirely also degrades to the estimate, never raises.
+    async def boom(wallet_label, start_ms):
+        raise RuntimeError("venue down")
+
+    monkeypatch.setattr(hl_module, "_user_fills_result", boom)
+    fill2 = _filled()
+    await _attach_fill_fee(fill2, wallet_label="w", submit_ms=1000, fee_bps=4.5)
+    assert fill2.raw["fee_source"] == "estimate"
+
+
+@pytest.mark.asyncio
+async def test_fee_pro_rata_on_partial_ledger_coverage(monkeypatch) -> None:
+    _no_sleep(monkeypatch)
+
+    async def half(wallet_label, start_ms):
+        # Ledger has caught up with only half the filled size.
+        return [{"oid": 12345, "sz": "0.24", "fee": "0.00625", "time": 1100}]
+
+    monkeypatch.setattr(hl_module, "_user_fills_result", half)
+    fill = _filled(size=0.48)
+    await _attach_fill_fee(fill, wallet_label="w", submit_ms=1000, fee_bps=4.5)
+    assert fill.fee == pytest.approx(0.0125)  # pro-rata doubled
+    assert fill.raw["fee_source"] == "user_fills"
+
+
+def test_exit_fee_nets_into_realized_pnl() -> None:
+    ledger = PositionLedger()
+    entry = _filled(size=1.0, px=100.0)
+    entry.side = "sell"
+    entry.fee = 0.05
+    ledger.apply_fill(entry)
+    exit_fill = _filled(size=1.0, px=90.0, reduce_only=True)
+    exit_fill.side = "buy"
+    exit_fill.fee = 0.04
+    before = ledger.realized_pnl
+    ledger.apply_fill(exit_fill)
+    # Short 100 -> 90 = +10 price pnl, minus the exit fee only in this delta.
+    assert ledger.realized_pnl - before == pytest.approx(10.0 - 0.04)
+    # Whole-trade realized includes BOTH fees.
+    assert ledger.realized_pnl == pytest.approx(10.0 - 0.05 - 0.04)
+
+
+@pytest.mark.asyncio
+async def test_fetch_state_stamps_cum_funding(monkeypatch) -> None:
+    async def fake_state(wallet_label):
+        return {
+            "perp_positions": [
+                {
+                    "coin": "HYPE",
+                    "szi": "-0.48",
+                    "entryPx": "57.32",
+                    "cumFunding": {"sinceOpen": "-0.00892"},
+                }
+            ],
+            "summary": {"unified_usdc_equity": 109.86},
+        }
+
+    monkeypatch.setattr(hl_module, "_hl_state_result", fake_state)
+    broker = HyperliquidPerpBroker(wallet_label="w")
+    state = await broker.fetch_state()
+    assert state.positions["HYPE"].metadata["cum_funding_since_open"] == pytest.approx(
+        -0.00892
+    )
+
+
+def test_forward_funding_and_reconciliation_summary(tmp_path) -> None:
+    recorder = ForwardRecorder(job_id="j", job_dir=tmp_path, mode="live")
+    recorder.record_fill({"symbol": "HYPE", "fee": 0.0125})
+    recorder.record_fill({"symbol": "HYPE", "fee": 0.011, "reduce_only": True})
+    recorder.record_funding({"time_ms": 1, "coin": "HYPE", "usdc": -0.004})
+    recorder.record_funding({"time_ms": 2, "coin": "HYPE", "usdc": 0.009})
+    recon = {"drift": 0.0, "venue_equity_now": 109.95}
+    recorder.record_tick(reconciliation=recon)
+
+    summary = recorder.summary()
+    assert summary["fills"]["fees_total"] == pytest.approx(0.0235)
+    assert summary["funding"]["count"] == 2
+    assert summary["funding"]["total_usd"] == pytest.approx(0.005)
+    assert summary["reconciliation"] == recon
+    funding_path = tmp_path / "results" / "forward" / "funding.jsonl"
+    assert len(funding_path.read_text().splitlines()) == 2
+
+
+@pytest.mark.asyncio
+async def test_collect_funding_cursor_dedupe(tmp_path) -> None:
+    from wayfinder_paths.jobs.execution.driver import _collect_funding
+
+    calls: list[int] = []
+
+    class FakeBroker:
+        async def get_funding_payments(self, since_ms):
+            calls.append(since_ms)
+            return [
+                {"time_ms": 5_000, "coin": "HYPE", "usdc": -0.004},
+                {"time_ms": 6_000, "coin": "HYPE", "usdc": -0.001},
+            ]
+
+    brokers = {"hyperliquid": FakeBroker()}
+    now = pd.Timestamp("2026-08-17T00:00:00Z")
+
+    # First call seeds the cursor at now and returns nothing (pre-go-live
+    # funding is not the job's).
+    rows = await _collect_funding(brokers, tmp_path, "live", now)
+    assert rows == []
+    assert not calls
+    cursor = json.loads((tmp_path / "state" / "funding_state.json").read_text())
+    assert cursor["cursor_ms"] == int(now.timestamp() * 1000)
+
+    # Rewind the cursor: rows past it are returned and advance it.
+    (tmp_path / "state" / "funding_state.json").write_text(
+        json.dumps({"cursor_ms": 4_000})
+    )
+    rows = await _collect_funding(brokers, tmp_path, "live", now)
+    assert [r["time_ms"] for r in rows] == [5_000, 6_000]
+    cursor = json.loads((tmp_path / "state" / "funding_state.json").read_text())
+    assert cursor["cursor_ms"] == 6_000
+
+    # Same rows again: all at/below cursor -> deduped to nothing.
+    rows = await _collect_funding(brokers, tmp_path, "live", now)
+    assert rows == []
+
+    # Paper mode records nothing and never touches the cursor.
+    assert await _collect_funding(brokers, tmp_path, "paper", now) == []
+
+
+def test_reconciliation_block_identity(tmp_path) -> None:
+    from wayfinder_paths.jobs.execution.driver import _reconciliation_block
+
+    recorder = ForwardRecorder(job_id="j", job_dir=tmp_path, mode="live")
+    recorder.record_funding({"time_ms": 1, "coin": "HYPE", "usdc": 0.009})
+
+    class FakeView:
+        def latest(self, symbol):
+            return {"close": 55.0}
+
+    tick = SimpleNamespace(
+        snapshot=SimpleNamespace(data={"account_value": 110.0}),
+        ledger_snapshot={
+            "realized_pnl": 0.15,
+            "positions": {"HYPE": {"side": "short", "size": 0.48, "avg_price": 57.32}},
+        },
+        guard_events=[],
+    )
+    block = _reconciliation_block(
+        tick, root=tmp_path, recorder=recorder, mode="live", view=FakeView()
+    )
+    # First tick seeds: start=110, realized_at_seed=0.15 -> delta 0.
+    unrealized = (57.32 - 55.0) * 0.48
+    assert block["venue_equity_start"] == 110.0
+    assert block["ledger_realized_delta"] == 0.0
+    assert block["unrealized"] == pytest.approx(unrealized, abs=1e-6)
+    assert block["funding_total"] == pytest.approx(0.009)
+    assert block["drift"] == pytest.approx(
+        110.0 - (110.0 + 0.0 + 0.009 + unrealized), abs=1e-6
+    )
+
+    # Later tick: realized moved +0.10, venue equity fully explains it.
+    tick2 = SimpleNamespace(
+        snapshot=SimpleNamespace(
+            data={"account_value": 110.0 + 0.10 + 0.009 + unrealized}
+        ),
+        ledger_snapshot={
+            "realized_pnl": 0.25,
+            "positions": {"HYPE": {"side": "short", "size": 0.48, "avg_price": 57.32}},
+        },
+        guard_events=[],
+    )
+    block2 = _reconciliation_block(
+        tick2, root=tmp_path, recorder=recorder, mode="live", view=FakeView()
+    )
+    assert block2["drift"] == pytest.approx(0.0, abs=1e-6)
+
+    # Paper mode / missing account_value -> no block.
+    tick3 = SimpleNamespace(
+        snapshot=SimpleNamespace(data={}), ledger_snapshot={}, guard_events=[]
+    )
+    assert (
+        _reconciliation_block(
+            tick3, root=tmp_path, recorder=recorder, mode="live", view=FakeView()
+        )
+        is None
+    )
+
+
+def test_risk_equity_includes_funding(tmp_path) -> None:
+    import wayfinder_paths.jobs.execution.risk as risk_module
+
+    summary_path = tmp_path / "results" / "forward" / "summary.json"
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text(
+        json.dumps(
+            {
+                "trades": {"net_pnl": 1.0},
+                "funding": {"total_usd": -0.4},
+            }
+        )
+    )
+    from wayfinder_paths.jobs.execution.engine import EngineState
+
+    class EmptyView:
+        symbols: list[str] = []
+
+        def latest(self, symbol):
+            return None
+
+    snapshot = risk_module.build_risk_snapshot(
+        state=EngineState(),
+        view=EmptyView(),
+        params={"initial_capital": 100.0},
+        root=tmp_path,
+        now=pd.Timestamp("2026-08-17T00:00:00Z"),
+    )
+    assert snapshot["equity"] == pytest.approx(100.0 + 1.0 - 0.4)


### PR DESCRIPTION
PR A of the approved accounting/leverage/orchestration plan.

## Problem (observed on the first live canary)

The trades view said **+18.2c**; the venue account gained **+8.8c**. The missing ~9.4c: live fills record `fee: 0.0` (HL's order ack carries no fee — only the user-fills ledger does), and funding accrues to equity with no attribution anywhere. Live per-trade PnL was gross of costs — fatal for judging few-bps-edge strategies.

## Fix (three layers)

**Fees** — after a filled ack, `_submit_market_order` resolves the actual fee from the user-fills ledger by oid/cloid (bounded 0/1.5/3s backoff for ledger lag; `builderFee` included; pro-rata scale-up when partials haven't landed). Fallback: `notional × fee_bps/10k` with `fee_bps` threaded from job params (default 4.5 taker). Either way `raw.fee_source = "user_fills" | "estimate"` for audit. The ledger already netted `fill.fee` into realized PnL — the input was just zero.

**Funding** — exact signed user-funding rows via new adapter `get_user_funding_history` + read-only `hyperliquid_get_user_funding` tool (position `cumFunding` vanishes at close — precisely the observed hole). The driver collects rows per live tick behind a persisted cursor (seeded at go-live: prior funding isn't the job's), records `results/forward/funding.jsonl`, and the summary carries `funding.total_usd`. Deliberately **never** enters the engine ledger — the drift reconciler replays ticks offline and network-injected PnL would false-flag drift.

**Reconciliation** — every live tick embeds `{venue_equity_start/now, ledger_realized_delta, unrealized, funding_total, trades_net, fees_total, expected_equity, drift}` in ticks.jsonl, mirrored into the forward summary. Drift = venue − expected: deposits/withdrawals surface there by design. Uses **ledger realized**, not trades net — entry fees hide in non-reduce-only rows the trade-close recorder skips. Baseline re-seeds on `mode_flip_state_reset`. `risk.py` equity now includes funding (excluding it mis-fires drawdown halts on funding-heavy shorts).

The wake prompt's forward summary now shows the decomposition the operator had to reverse-engineer by hand: "trades +18.2c, fees −5c, funding −4c, net +8.8c".

## Verification

9 new tests (oid fee match + decoy rejection, ledger-lag fallback + exception degradation, pro-rata partials, both-fees-in-realized regression, cumFunding stamp, funding/fees summary math, cursor seed/advance/dedupe + paper no-op, reconciliation identity incl. drift≈0 on a fully-explained tick, risk equity funding term). Adjacent suites green: 183 tests across live-driver/forward/engine/risk/state-shape. ruff + format clean.

Post-roll smoke: one live tick on majors → `fills.jsonl` rows carry `fee > 0` with `fee_source`, `funding.jsonl` accrues hourly, `summary.reconciliation.drift ≈ 0`.