### PR TITLE
jobs: engine-level leverage wire + detached gate restamp

### DIFF
--- a/wayfinder_paths/jobs/background.py
+++ b/wayfinder_paths/jobs/background.py
@@ -1,0 +1,71 @@
+"""Detached job ops from synchronous (non-MCP) call sites.
+
+The MCP server has its own async spawn (+ in-process reaper) in
+mcp/tools/jobs.py; this is the CLI/sync counterpart writing the same
+status-file shape, so `core_jobs(action="op_status")` polls either. No
+reaper here — op_status already resolves reaper-less children (dead pid +
+parseable result file = done)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from typing import Any
+
+from wayfinder_paths.jobs.models import utc_now_iso
+from wayfinder_paths.jobs.store import JobStore
+
+
+def _pid_alive(pid: Any) -> bool:
+    import os
+
+    if not isinstance(pid, int) or pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def spawn_detached_op(
+    store: JobStore, job_id: str, op: str, kwargs: dict[str, Any]
+) -> dict[str, Any]:
+    ops_dir = store.job_dir(job_id) / "state" / "background_ops"
+    ops_dir.mkdir(parents=True, exist_ok=True)
+    status_path = ops_dir / f"{op}.json"
+    try:
+        existing = json.loads(status_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        existing = None
+    if (
+        isinstance(existing, dict)
+        and existing.get("state") == "running"
+        and _pid_alive(existing.get("pid"))
+    ):
+        return {"already_running": True, **existing}
+
+    log_path = ops_dir / f"{op}.log"
+    result_path = ops_dir / f"{op}.result.json"
+    result_path.unlink(missing_ok=True)
+    with log_path.open("wb") as log_handle, result_path.open("wb") as result_handle:
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "wayfinder_paths.jobs.execution.op_runner"],
+            stdin=subprocess.PIPE,
+            stdout=result_handle,
+            stderr=log_handle,
+            start_new_session=True,
+        )
+    assert proc.stdin is not None
+    proc.stdin.write(json.dumps({"op": op, "kwargs": kwargs}).encode())
+    proc.stdin.close()
+    status = {
+        "op": op,
+        "job_id": job_id,
+        "state": "running",
+        "pid": proc.pid,
+        "started_at": utc_now_iso(),
+    }
+    status_path.write_text(json.dumps(status), encoding="utf-8")
+    return {"started": True, **status}

--- a/wayfinder_paths/jobs/execution/engine.py
+++ b/wayfinder_paths/jobs/execution/engine.py
@@ -13,6 +13,7 @@ import pandas as pd
 
 from wayfinder_paths.jobs.execution.primitives import (
     DEFAULT_INITIAL_CAPITAL,
+    REDUCE_ONLY_ACTIONS,
     BracketEngine,
     CompletedBarsView,
     ExecutionContext,
@@ -390,6 +391,7 @@ async def _run_tick_inner(
         case _:
             decided = list(decided)
     intents = [OrderIntent.from_any(item) for item in decided]
+    _apply_engine_leverage(intents, params)
 
     for index, intent in enumerate(intents):
         if client_order_prefix and intent.client_order_id is None:
@@ -500,6 +502,37 @@ async def _run_tick_inner(
         }
     )
     return result
+
+
+def _apply_engine_leverage(
+    intents: list[OrderIntent], params: Mapping[str, Any]
+) -> None:
+    """Operator leverage knob, applied at the ONE seam backtest and live
+    share. Scales unstamped, non-reduce-only intents by params.leverage so
+    the knob works for every strategy with no strategy-code changes.
+    Compound-mode strategies already multiply equity x leverage themselves
+    and stamp `leverage_applied` — the stamp guarantees leverage is applied
+    exactly once wherever the sizing happens. Defensive-inert: bad values
+    never raise mid-tick (the knob validates its own range upstream)."""
+    try:
+        leverage = float(params.get("leverage") or 1.0)
+    except (TypeError, ValueError):
+        return
+    if leverage == 1.0 or leverage <= 0:
+        return
+    for intent in intents:
+        if intent.reduce_only or str(intent.action).upper() in REDUCE_ONLY_ACTIONS:
+            continue
+        if (intent.metadata or {}).get("leverage_applied"):
+            continue
+        if intent.notional is not None:
+            intent.notional = float(intent.notional) * leverage
+        if intent.size is not None:
+            intent.size = float(intent.size) * leverage
+        metadata = dict(intent.metadata or {})
+        metadata["leverage_applied"] = True
+        metadata["engine_leverage"] = leverage
+        intent.metadata = metadata
 
 
 def _record_fill(

--- a/wayfinder_paths/jobs/execution/op_runner.py
+++ b/wayfinder_paths/jobs/execution/op_runner.py
@@ -94,6 +94,30 @@ def _run(op: str, kwargs: dict[str, Any]) -> Any:
         if isinstance(backtest, dict) and not full:
             result["backtest"] = summarize_backtest_payload(backtest)
         return result
+    if op == "restamp":
+        # Full gate refresh after an execution_params change (leverage knob):
+        # any job.yaml edit bumps the workspace revision and invalidates the
+        # validation/backtest/preflight stamps — re-run all three and report
+        # the resulting gate. backtest takes the heavy-compute lock itself.
+        from wayfinder_paths.jobs.execution.job import backtest_execution_job
+        from wayfinder_paths.jobs.execution.preflight import run_preflight
+        from wayfinder_paths.jobs.execution.validation import (
+            validate_execution_job,
+        )
+        from wayfinder_paths.jobs.gating import evaluate_live_gate
+
+        job_id = kwargs.pop("job_id")
+        validation = validate_execution_job(job_id)
+        backtest = backtest_execution_job(job_id)
+        preflight = run_preflight(job_id)
+        return {
+            "validation": (validation or {}).get("status"),
+            "backtest": ((backtest.get("result") or {}).get("stats") or {}).get(
+                "net_return"
+            ),
+            "preflight": (preflight or {}).get("status"),
+            "gate": evaluate_live_gate(job_id),
+        }
     if op == "promote_params":
         from wayfinder_paths.jobs.execution.experiments import promote_params
 

--- a/wayfinder_paths/jobs/execution/primitives.py
+++ b/wayfinder_paths/jobs/execution/primitives.py
@@ -347,6 +347,11 @@ class CompletedBarsView:
         return self._bars.to_dict(orient="records")
 
 
+# Actions that only ever shrink an existing position — never sized up by
+# engine-level leverage, never blocked as fresh exposure.
+REDUCE_ONLY_ACTIONS = frozenset({"CLOSE", "STOP_LOSS", "TAKE_PROFIT"})
+
+
 @dataclass
 class OrderIntent:
     action: OrderAction

--- a/wayfinder_paths/jobs/execution/simulator.py
+++ b/wayfinder_paths/jobs/execution/simulator.py
@@ -25,6 +25,7 @@ from wayfinder_paths.jobs.execution.engine import (
 from wayfinder_paths.jobs.execution.features import apply_precompute
 from wayfinder_paths.jobs.execution.primitives import (
     DEFAULT_INITIAL_CAPITAL,
+    REDUCE_ONLY_ACTIONS,
     CompletedBarsView,
     ExecutionSpec,
     ExecutionTrace,
@@ -38,8 +39,6 @@ from wayfinder_paths.jobs.execution.primitives import (
 )
 from wayfinder_paths.jobs.execution.validation import validate_execution_trace
 from wayfinder_paths.jobs.execution.venues import VenueCapabilities, VenueState
-
-REDUCE_ONLY_ACTIONS = frozenset({"CLOSE", "STOP_LOSS", "TAKE_PROFIT"})
 
 
 @dataclass

--- a/wayfinder_paths/jobs/strategies/_base.py
+++ b/wayfinder_paths/jobs/strategies/_base.py
@@ -226,7 +226,16 @@ class ShortMomentumStrategy:
                 "bracket": {
                     "stop_loss": current_close * (1 + float(self.params["stop_pct"]))
                 },
-                "metadata": {"entry_reason": "new_low_5"},
+                "metadata": {
+                    "entry_reason": "new_low_5",
+                    # Compound sizing already multiplied equity x leverage —
+                    # the stamp stops the engine-level knob from scaling twice.
+                    **(
+                        {"leverage_applied": True}
+                        if self.params["sizing"] == "compound"
+                        else {}
+                    ),
+                },
             }
         ]
 

--- a/wayfinder_paths/jobs/sync.py
+++ b/wayfinder_paths/jobs/sync.py
@@ -224,7 +224,7 @@ def snapshot_job(job_id: str, *, store: JobStore | None = None) -> dict[str, Any
             if validation
             else {}
         ),
-        "gate": evaluate_live_gate(job_id, store=store),
+        "gate": _gate_with_restamp(job_id, store),
         # Manual kill-switch detail (contract C4): scorecard already reports
         # live_execution_status="halted" while set; this carries reason/ts.
         "halt": read_halt(store.job_dir(job_id)),
@@ -333,6 +333,36 @@ def apply_script_mode(
 MAX_OPERATOR_LEVERAGE = 25.0
 
 
+def _gate_with_restamp(job_id: str, store: JobStore) -> dict[str, Any]:
+    """Live gate + pending-not-red context: while a detached restamp is
+    running the gate is transiently red by construction — surface that so
+    UIs and wake agents render 'refreshing' instead of alarming. The
+    authoritative live_ready stays strict."""
+    gate = evaluate_live_gate(job_id, store=store)
+    try:
+        import json as _json
+        import os
+
+        status_path = (
+            store.job_dir(job_id) / "state" / "background_ops" / "restamp.json"
+        )
+        status = _json.loads(status_path.read_text(encoding="utf-8"))
+        pid = status.get("pid")
+        alive = False
+        if isinstance(pid, int) and pid > 0:
+            try:
+                os.kill(pid, 0)
+                alive = True
+            except OSError:
+                alive = False
+        if status.get("state") == "running" and alive:
+            gate["restamp_in_progress"] = True
+            gate["restamp_started_at"] = status.get("started_at")
+    except (OSError, ValueError):
+        pass
+    return gate
+
+
 def apply_execution_leverage(
     job_id: str, leverage: float, *, store: JobStore | None = None
 ) -> dict[str, Any]:
@@ -358,7 +388,27 @@ def apply_execution_leverage(
         {"type": "operator_leverage_set", "from": previous, "to": value},
     )
     sync_all_jobs(store=store)
-    return {"job_id": job_id, "leverage": value, "previous": previous}
+    restamp: dict[str, Any] | None = None
+    if previous != value:
+        # The params edit bumped the workspace revision, so the
+        # validation/backtest/preflight stamps just went stale and the live
+        # gate is red until they re-run. Kick the refresh detached — the
+        # knob applies next tick regardless; op_status(op="restamp") polls.
+        try:
+            from wayfinder_paths.jobs.background import spawn_detached_op
+
+            restamp = spawn_detached_op(store, job_id, "restamp", {"job_id": job_id})
+            store.append_journal(
+                job_id, {"type": "gate_restamp_kicked", "trigger": "set_leverage"}
+            )
+        except Exception as exc:  # noqa: BLE001 — knob must not fail on this
+            restamp = {"error": str(exc)[:200]}
+    return {
+        "job_id": job_id,
+        "leverage": value,
+        "previous": previous,
+        "restamp": restamp,
+    }
 
 
 def _shadow_topline(store: JobStore, job_id: str) -> dict[str, Any]:

--- a/wayfinder_paths/tests/test_jobs_leverage_wire.py
+++ b/wayfinder_paths/tests/test_jobs_leverage_wire.py
@@ -1,0 +1,203 @@
+"""Engine-level leverage wire: the operator knob (execution_params.leverage)
+scales order sizing at the ONE seam backtest and live share, exactly once
+(compound strategies stamp leverage_applied and are skipped), never on
+reduce-only intents — plus the detached gate-restamp flow the knob kicks."""
+
+from __future__ import annotations
+
+import json
+
+from wayfinder_paths.jobs.execution.engine import _apply_engine_leverage
+from wayfinder_paths.jobs.execution.primitives import OrderIntent
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.store import JobStore
+
+
+def _open(**kw) -> OrderIntent:
+    defaults = dict(action="OPEN", venue="hyperliquid", symbol="HYPE", side="sell")
+    defaults.update(kw)
+    return OrderIntent.from_any(defaults)
+
+
+def test_engine_scales_unstamped_open_intents() -> None:
+    intents = [_open(notional=500.0), _open(size=3.0)]
+    _apply_engine_leverage(intents, {"leverage": 2.0})
+    assert intents[0].notional == 1000.0
+    assert intents[1].size == 6.0
+    for intent in intents:
+        assert intent.metadata["leverage_applied"] is True
+        assert intent.metadata["engine_leverage"] == 2.0
+
+
+def test_engine_skips_reduce_only_and_stamped() -> None:
+    close = _open(action="CLOSE", size=3.0)
+    reduce = _open(size=3.0, reduce_only=True)
+    stamped = _open(notional=500.0, metadata={"leverage_applied": True})
+    intents = [close, reduce, stamped]
+    _apply_engine_leverage(intents, {"leverage": 2.0})
+    assert close.size == 3.0
+    assert reduce.size == 3.0
+    assert stamped.notional == 500.0
+
+
+def test_engine_inert_without_leverage() -> None:
+    for params in (
+        {},
+        {"leverage": None},
+        {"leverage": 1.0},
+        {"leverage": 0},
+        {"leverage": "x"},
+    ):
+        intent = _open(notional=500.0)
+        _apply_engine_leverage([intent], params)
+        assert intent.notional == 500.0
+        assert "leverage_applied" not in (intent.metadata or {})
+
+
+def test_engine_scaling_is_idempotent() -> None:
+    intent = _open(notional=500.0)
+    _apply_engine_leverage([intent], {"leverage": 2.0})
+    _apply_engine_leverage([intent], {"leverage": 2.0})  # persisted pending intent
+    assert intent.notional == 1000.0
+
+
+def test_compound_base_stamps_leverage_applied() -> None:
+    import inspect
+
+    from wayfinder_paths.jobs import strategies as strategies_pkg
+    from wayfinder_paths.jobs.strategies import _base
+
+    source = inspect.getsource(_base)
+    # The stamp is the double-scaling guard: compound sizing already
+    # multiplied equity x leverage, so its intents must opt out of the
+    # engine-level knob.
+    assert "leverage_applied" in source
+    assert strategies_pkg is not None
+
+
+def test_apply_execution_leverage_kicks_restamp(tmp_path, monkeypatch) -> None:
+    from wayfinder_paths.jobs import sync as sync_module
+    from wayfinder_paths.jobs.sync import apply_execution_leverage
+
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("lev-wire", agent_mode="intervene")
+    job.execution_params["leverage"] = 2.0
+    store.save(job)
+
+    monkeypatch.setattr(sync_module, "sync_all_jobs", lambda **kwargs: None)
+    spawned: list[tuple[str, str, dict]] = []
+
+    def fake_spawn(store_arg, job_id, op, kwargs):
+        spawned.append((job_id, op, kwargs))
+        return {"started": True, "op": op, "pid": 1}
+
+    monkeypatch.setattr("wayfinder_paths.jobs.background.spawn_detached_op", fake_spawn)
+
+    result = apply_execution_leverage(job.id, 3.0, store=store)
+    assert result["restamp"]["started"] is True
+    assert spawned == [(job.id, "restamp", {"job_id": job.id})]
+    journal = (store.job_dir(job.id) / "journal.jsonl").read_text()
+    assert "gate_restamp_kicked" in journal
+
+    # Unchanged value: no restamp churn.
+    result = apply_execution_leverage(job.id, 3.0, store=store)
+    assert result["restamp"] is None
+    assert len(spawned) == 1
+
+    # Spawn failure degrades to an error note; the knob still succeeds.
+    def boom(*args):
+        raise RuntimeError("no subprocess")
+
+    monkeypatch.setattr("wayfinder_paths.jobs.background.spawn_detached_op", boom)
+    result = apply_execution_leverage(job.id, 4.0, store=store)
+    assert result["leverage"] == 4.0
+    assert "error" in result["restamp"]
+
+
+def test_spawn_detached_op_echo_round_trip(tmp_path) -> None:
+    from wayfinder_paths.jobs.background import spawn_detached_op
+
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("bg-echo", agent_mode="intervene")
+    store.save(job)
+
+    outcome = spawn_detached_op(store, job.id, "__echo__", {"hello": "world"})
+    assert outcome["started"] is True
+    ops_dir = store.job_dir(job.id) / "state" / "background_ops"
+    status = json.loads((ops_dir / "__echo__.json").read_text())
+    assert status["state"] == "running"
+    assert status["pid"] == outcome["pid"]
+
+    # The detached child completes and writes the result file op_status reads.
+    import time
+
+    result_path = ops_dir / "__echo__.result.json"
+    for _ in range(100):
+        try:
+            if json.loads(result_path.read_text()) == {"hello": "world"}:
+                break
+        except (OSError, ValueError):
+            pass
+        time.sleep(0.1)
+    assert json.loads(result_path.read_text()) == {"hello": "world"}
+
+
+def test_gate_shows_restamp_in_progress(tmp_path, monkeypatch) -> None:
+    import os
+
+    from wayfinder_paths.jobs import sync as sync_module
+
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("gate-flag", agent_mode="intervene")
+    store.save(job)
+    monkeypatch.setattr(
+        sync_module,
+        "evaluate_live_gate",
+        lambda job_id, store=None: {"live_ready": False, "reasons": ["stale"]},
+    )
+
+    gate = sync_module._gate_with_restamp(job.id, store)
+    assert "restamp_in_progress" not in gate
+
+    ops_dir = store.job_dir(job.id) / "state" / "background_ops"
+    ops_dir.mkdir(parents=True, exist_ok=True)
+    (ops_dir / "restamp.json").write_text(
+        json.dumps({"state": "running", "pid": os.getpid(), "started_at": "2026-08-17"})
+    )
+    gate = sync_module._gate_with_restamp(job.id, store)
+    assert gate["restamp_in_progress"] is True
+    assert gate["live_ready"] is False  # authoritative gate stays strict
+
+    (ops_dir / "restamp.json").write_text(
+        json.dumps({"state": "running", "pid": 2**22 - 1})
+    )
+    gate = sync_module._gate_with_restamp(job.id, store)
+    assert "restamp_in_progress" not in gate
+
+
+def test_op_runner_restamp_dispatch(monkeypatch, tmp_path) -> None:
+    from wayfinder_paths.jobs.execution import op_runner
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.execution.validation.validate_execution_job",
+        lambda job_id: calls.append("validate") or {"status": "passed"},
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.execution.job.backtest_execution_job",
+        lambda job_id: calls.append("backtest")
+        or {"result": {"stats": {"net_return": 0.1}}},
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.execution.preflight.run_preflight",
+        lambda job_id: calls.append("preflight") or {"status": "green"},
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.gating.evaluate_live_gate",
+        lambda job_id: {"live_ready": True, "reasons": []},
+    )
+    result = op_runner._run("restamp", {"job_id": "x"})
+    assert calls == ["validate", "backtest", "preflight"]
+    assert result["validation"] == "passed"
+    assert result["preflight"] == "green"
+    assert result["gate"]["live_ready"] is True

--- a/wayfinder_paths/tests/test_jobs_operator_controls.py
+++ b/wayfinder_paths/tests/test_jobs_operator_controls.py
@@ -29,15 +29,25 @@ def test_apply_execution_leverage_writes_and_journals(tmp_path, monkeypatch) -> 
         "wayfinder_paths.jobs.sync.sync_all_jobs",
         lambda **kwargs: synced.append(True),
     )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.background.spawn_detached_op",
+        lambda *args: {"started": True},
+    )
 
     result = apply_execution_leverage(job_id, 3.5, store=store)
-    assert result == {"job_id": job_id, "leverage": 3.5, "previous": 2.0}
+    assert result["job_id"] == job_id
+    assert result["leverage"] == 3.5
+    assert result["previous"] == 2.0
+    # A changed value kicks the detached gate restamp.
+    assert result["restamp"] == {"started": True}
     assert store.load(job_id).execution_params["leverage"] == 3.5
     journal = (store.job_dir(job_id) / "journal.jsonl").read_text(encoding="utf-8")
-    row = json.loads(journal.strip().splitlines()[-1])
-    assert row["type"] == "operator_leverage_set"
-    assert row["from"] == 2.0
-    assert row["to"] == 3.5
+    rows = [json.loads(line) for line in journal.strip().splitlines()[-2:]]
+    types = {row["type"] for row in rows}
+    assert types == {"operator_leverage_set", "gate_restamp_kicked"}
+    leverage_row = next(r for r in rows if r["type"] == "operator_leverage_set")
+    assert leverage_row["from"] == 2.0
+    assert leverage_row["to"] == 3.5
     assert synced  # snapshot pushed so backend/frontend see the new value
 
 

--- a/wayfinder_paths/tests/test_jobs_sizing.py
+++ b/wayfinder_paths/tests/test_jobs_sizing.py
@@ -45,14 +45,28 @@ def _opens(result) -> list[dict[str, Any]]:
     return [row for row in result.trace["intents"] if row["action"] == "OPEN"]
 
 
-def test_fixed_notional_default_is_unchanged() -> None:
+def test_fixed_notional_unset_leverage_unchanged() -> None:
     implicit = _run({})
-    explicit = _run({"sizing": "fixed_notional", "leverage": 3.0})
+    explicit = _run({"sizing": "fixed_notional", "leverage": 1.0})
 
     assert [o["size"] for o in _opens(implicit)] == [
         o["size"] for o in _opens(explicit)
-    ], "leverage must be inert under fixed_notional sizing"
+    ], "leverage 1.0 must be a no-op under fixed_notional sizing"
     assert implicit.trace["fills"] == explicit.trace["fills"]
+
+
+def test_fixed_notional_scales_with_operator_leverage() -> None:
+    # The engine-level knob: fixed-notional strategies ignore leverage
+    # themselves, so the engine scales their intents — same entries, 3x size.
+    base = _run({})
+    levered = _run({"sizing": "fixed_notional", "leverage": 3.0})
+
+    base_opens = _opens(base)
+    lev_opens = _opens(levered)
+    assert [o["symbol"] for o in base_opens] == [o["symbol"] for o in lev_opens]
+    for base_open, lev_open in zip(base_opens, lev_opens, strict=True):
+        assert lev_open["size"] == pytest.approx(base_open["size"] * 3.0)
+        assert lev_open["metadata"]["leverage_applied"] is True
 
 
 def test_compound_sizing_scales_with_equity_and_leverage() -> None:


### PR DESCRIPTION
PR B of the approved plan. **Stacked on #652** (rebased onto tip today) — merge #652 first and this diff shrinks to its own commits.

## Problem

The operator leverage knob (`execution_params.leverage`, #652 + backend #1341 + FE #2104) didn't reach sizing: strategies size as equity fractions, and the param only fed backtest margin accounting. A UI knob that silently does nothing.

## Design (the two traps and their resolutions)

**Double-scaling.** Compound-mode strategies already compute `equity × leverage` at the strategy layer. Resolution: they stamp `metadata.leverage_applied`; the engine scales only **unstamped, non-reduce-only** intents. Leverage is applied exactly once wherever sizing happens — and identically in backtest and live, because both share the one `run_tick` seam (scaling sits right after `decide()`, before validation/auto_limits, so caps evaluate true gross exposure). Reduce-only/CLOSE/STOP/TP never scale — exits close what exists; open positions are untouched by construction. Stamps make persisted pending intents idempotent. A self-contained strategy that hand-rolls equity×leverage (none known) can stamp its own intents — documented escape hatch.

**Margin arithmetic.** `margin_used = peak_notional / leverage` stays correct **unchanged**: with once-only application guaranteed, ledger notional is always leverage-applied, so the division yields unlevered capital in both compound and engine-scaled cases. The no-double-scale proof: `test_compound_sizing_scales_with_equity_and_leverage` and `test_margin_stats_arithmetic` pass **untouched**.

## Gate restamp flow

Changing `execution_params.leverage` bumps the workspace revision → validation/backtest/preflight stamps go stale → live gate red (observed live this week from a mere goal edit). `apply_execution_leverage` now kicks a **detached** restamp (new `jobs/background.spawn_detached_op`, the sync counterpart of #649's MCP background op writing the same status-file shape `op_status` polls; new `op_runner` `restamp` op = validate → backtest → preflight → gate). UX: leverage applies next tick immediately; stamps refresh in background; `snapshot_job`'s gate carries `restamp_in_progress` so UIs and wake agents render "refreshing" instead of alarming. `live_ready` stays strict throughout — an unproven revision is never promotable, even transiently.

## Intentional behavior change

`test_fixed_notional_default_is_unchanged` asserted leverage is *inert* under fixed sizing — precisely the semantics this PR exists to change. Split into: unset/1.0 → byte-identical, explicit 3.0 → 3× sizes with the stamp asserted.

## Verification

9 new tests (scale notional+size, skip reduce-only/CLOSE/stamped, inert on absent/1.0/0/garbage, idempotent re-application, restamp kick + no-churn-on-unchanged + spawn-failure degradation, real detached `__echo__` round-trip, `restamp_in_progress` gate flag incl. dead-pid drop, op_runner restamp dispatch order). 67 tests green across sizing/engine/live-driver/reconcile/operator suites; ruff + format clean.

Post-roll smoke: `wayfinder job set-leverage <paper-job> 2` → next tick order notional doubles; `op_status(op="restamp")` reaches done; gate green with no manual re-stamp.