### PR TITLE
jobs: global-search + evidence disciplines from the self-evolving-agents survey

### DIFF
--- a/wayfinder_paths/jobs/evolution_ledger.py
+++ b/wayfinder_paths/jobs/evolution_ledger.py
@@ -232,6 +232,9 @@ def evolution_snapshot_block(store: JobStore, job_id: str) -> dict[str, Any]:
         "by_family": report["by_family"],
         "promotion_reliability": report["promotion_reliability"],
         "research_staleness": report["research_staleness"],
+        # A LIVE archived candidate outscoring the incumbent is a measured
+        # missed opportunity — the branch-revival lane reads this.
+        "opportunity_recall": report["opportunity_recall"],
         "_basis": (
             "Full update path + forward promotion verdicts. Low beat_rate in a "
             "family means that family's evidence bar is too weak — raise your "

--- a/wayfinder_paths/jobs/prompts/research_priors.md
+++ b/wayfinder_paths/jobs/prompts/research_priors.md
@@ -41,6 +41,45 @@ block's archetype counts and pick the family that treats YOUR disease.
   (`--condition-regime`) over demanding all-history stationarity; use
   `--window-days N` for declared recent-window families.
 
+## Global-search discipline (why this is an optimizer, not a tinkerer)
+
+- **Classify every research move**: does this wake reduce SEARCH regret
+  (sampling a region never tried — new family, new symbol, new sizing axis,
+  archived branch) or SELECTION regret (better evidence on candidates
+  already found)? Say which in the report. A loop that only ever refines
+  the incumbent's neighborhood is a local optimizer with a good diary.
+- **Branch revival**: the archive is a frontier, not a graveyard. When
+  `evolution.opportunity_recall.missed` is true, a LIVE archived candidate
+  outscores the incumbent and was never promoted — investigating it
+  OUTRANKS inventing a new hypothesis. Cite the candidate_id.
+- **Consult lineage before proposing**: `results/backtest/trials.jsonl`
+  records every evaluated trial with behavior descriptors. Re-sampling a
+  known-flat neighborhood is spent budget; a proposal whose params sit
+  inside a well-sampled flat region must say why this time is different.
+- **Behavioral diversity**: concurrent probation legs should differ in
+  BEHAVIOR (holding period, direction bias, entry frequency — the trial
+  descriptors), not just parameters. A book of clones is one bet wearing
+  several names.
+- **Stuck rule**: two consecutive neutral/hurt verdicts on same-family
+  refinements means the local basin is flat or hostile — JUMP: new family,
+  universe-scan, archived branch, or the sizing/leverage axis. Do not
+  propose a third refinement of the same neighborhood.
+
+## Evidence discipline (dev vs audit)
+
+- Evidence that guided candidate GENERATION or SELECTION is development
+  evidence; it cannot also be the evidence that promotes the same change.
+  Every proposal names which is which — the gate's holdout/walk-forward
+  exists precisely to supply audit evidence the search never touched.
+- **Promotion is a hypothesis, not a result.** An applied change has proven
+  only that it could be applied; the forward window and its verdict are
+  the experiment. Plan the next move for BOTH outcomes at proposal time.
+- **Interference check**: every treatment names the slices it must NOT
+  degrade (other symbols' books, other regime cells, the untreated
+  archetypes) and the post-apply artifact that will show it (by-symbol
+  shadow, factor attribution). Fixing one cell by silently breaking two
+  others is how aggregate metrics rot.
+
 ## Protocol reminders
 
 - **Diagnose before treating**: every hypothesis cites the attribution slice

--- a/wayfinder_paths/tests/test_jobs_wake_productivity.py
+++ b/wayfinder_paths/tests/test_jobs_wake_productivity.py
@@ -146,6 +146,9 @@ def test_snapshot_block_renders_staleness(tmp_path) -> None:
     store, job_id = _job(tmp_path)
     block = evolution_snapshot_block(store, job_id)
     assert "research_staleness" in block
+    # Branch-revival lane needs the missed-opportunity signal in the wake
+    # context, not buried in the full report.
+    assert "opportunity_recall" in block
 
 
 def test_worker_stable_rules_carry_research_mandate(tmp_path) -> None:


### PR DESCRIPTION
Rescue of the second commit that missed the #657 merge (pushed moments before the merge landed).

Prompt audit against the survey that seeded this program. The mechanisms it prescribes are largely built; four concepts never reached the curriculum, and one signal was invisible:

- **Global-search discipline**: every research move self-classifies as reducing SEARCH regret (new region) or SELECTION regret (better evidence on known candidates); branch revival outranks new hypotheses when `opportunity_recall` shows a missed live candidate; consult `trials.jsonl` lineage before re-sampling flat neighborhoods; behavioral diversity across probation legs; stuck rule (2 consecutive neutral/hurt verdicts on same-family refinements → jump family/universe/branch/sizing axis).
- **Evidence discipline**: development evidence (guided generation/selection) cannot also be the promoting evidence — name which is which per proposal; promotion is a hypothesis, the forward verdict is the experiment; every treatment names its interference check (slices it must NOT degrade).
- **Code**: `evolution_snapshot_block` now surfaces `opportunity_recall` — the ledger computed it but wakes never saw it, so the branch-revival lane had no signal to act on.

One prompt file + one ledger line + test. 20 tests green.