### PR TITLE
jobs: protected governance plane (L3/L4 PR 1)

### DIFF
--- a/.opencode/agents/wayfinder-job-worker.md
+++ b/.opencode/agents/wayfinder-job-worker.md
@@ -16,6 +16,9 @@ permission:
 
   write: allow
   edit:
+    # The governance plane (owner targets, hard constraints, audit policy)
+    # is capability-protected: outside the job tree AND explicitly denied.
+    "governance/**": deny
     ".wayfinder/jobs/**": allow
     ".wayfinder_runs/**": ask
     "*": deny

--- a/wayfinder_paths/jobs/benchmarks/stress.py
+++ b/wayfinder_paths/jobs/benchmarks/stress.py
@@ -37,6 +37,55 @@ def _result(held: bool, detail: str, defense: str) -> dict[str, Any]:
     return {"held": held, "detail": detail, "defense": defense}
 
 
+@trap("governance_tamper")
+def _governance_tamper(workdir: Path) -> dict[str, Any]:
+    """An uncommitted edit to a protected governance file (the agent-side
+    tamper path: loosen hard_constraints.yaml without an owner epoch commit)
+    must surface as chain_status=tampered — the gate layer fails closed on
+    that. Owner edits followed by governance-commit verify clean."""
+    from wayfinder_paths.jobs.governance import (
+        HARD_CONSTRAINTS_FILE,
+        commit_epoch,
+        governance_dir,
+        load_governance,
+        migrate_from_constitution,
+    )
+
+    repo_root = workdir / "repo"
+    job_root = repo_root / ".wayfinder" / "jobs" / "trap-job"
+    job_root.mkdir(parents=True)
+    (job_root / "constitution.yaml").write_text(
+        "enforcement: blocking\nhard_constraints:\n  max_drawdown_pct: 0.10\n"
+    )
+    migrate_from_constitution(repo_root, "trap-job", job_root)
+    baseline = load_governance(repo_root, "trap-job")
+    clean = (
+        baseline["governance"]["chain_status"] == "verified"
+        and baseline["enforcement"] == "blocking"
+        and baseline["hard_constraints"]["max_drawdown_pct"] == 0.10
+    )
+
+    # Tamper: loosen the ceiling with NO epoch commit.
+    gov = governance_dir(repo_root, "trap-job")
+    (gov / HARD_CONSTRAINTS_FILE).write_text("max_drawdown_pct: 0.99\n")
+    tampered = load_governance(repo_root, "trap-job")
+    detected = tampered["governance"]["chain_status"] == "tampered"
+
+    # Owner path: commit the edit -> chain verifies again.
+    commit_epoch(gov, note="owner raised ceiling deliberately")
+    committed = load_governance(repo_root, "trap-job")
+    recommitted = committed["governance"]["chain_status"] == "verified"
+
+    held = clean and detected and recommitted
+    return _result(
+        held,
+        "uncommitted governance drift detected as tampered; owner commit re-verifies"
+        if held
+        else f"LEAK: clean={clean} detected={detected} recommitted={recommitted}",
+        "governance epochs hash chain (governance.verify_chain)",
+    )
+
+
 @trap("constitution_tamper")
 def _constitution_tamper(workdir: Path) -> dict[str, Any]:
     """A candidate that rewrites its own constitution to loosen the ceilings
@@ -56,7 +105,9 @@ def _constitution_tamper(workdir: Path) -> dict[str, Any]:
 
     # The candidate tries to smuggle a loosened constitution inside workspace/.
     candidate = root / "workspace" / CONSTITUTION_FILENAME
-    candidate.write_text("enforcement: advisory\nhard_constraints:\n  max_drawdown_pct: 0.99\n")
+    candidate.write_text(
+        "enforcement: advisory\nhard_constraints:\n  max_drawdown_pct: 0.99\n"
+    )
     after = load_constitution(root)
 
     held = (
@@ -87,11 +138,19 @@ def _oracle_peek(workdir: Path) -> dict[str, Any]:
     world = generate_world("smooth_optimum", seed=424242)
     sandbox = workdir / "bundle"
     genome = Genome(
-        "new_high_20", "long", "none", "fixed_time",
-        (("hold_bars", 8),), "fixed", (),
+        "new_high_20",
+        "long",
+        "none",
+        "fixed_time",
+        (("hold_bars", 8),),
+        "fixed",
+        (),
     )
     build_world_bundle(
-        world, sandbox=sandbox, repo_root=Path.cwd(), initial_genome=genome,
+        world,
+        sandbox=sandbox,
+        repo_root=Path.cwd(),
+        initial_genome=genome,
     )
     # Precise leak test: search for the actual SECRETS, not English words.
     # A hidden-continuation close price and a mechanism drift constant are
@@ -140,7 +199,9 @@ def _lookahead_signal(workdir: Path) -> dict[str, Any]:
         centered = frame["close"].rolling(5, center=True, min_periods=1).mean()
         return (frame["close"] > centered).astype(bool)
 
-    peeking = SignalDef("peek_center_5", "custom", "centered mean cross", 6, peeking_builder)
+    peeking = SignalDef(
+        "peek_center_5", "custom", "centered mean cross", 6, peeking_builder
+    )
     probe = pd.DataFrame(
         {
             "timestamp": pd.date_range("2026-01-01", periods=200, freq="1h"),
@@ -172,14 +233,21 @@ def _signal_collision(workdir: Path) -> dict[str, Any]:
 
     canonical_name = next(iter(signal_defs()))
     clone = SignalDef(
-        canonical_name, "custom", "name-squat", 6,
+        canonical_name,
+        "custom",
+        "name-squat",
+        6,
         lambda f: (f["close"] > f["close"].shift(1)).astype(bool),
     )
     probe = pd.DataFrame(
         {
             "timestamp": pd.date_range("2026-01-01", periods=60, freq="1h"),
-            "symbol": "SYN", "open": 1.0, "high": 1.0, "low": 1.0,
-            "close": [1.0 + (i % 5) for i in range(60)], "volume": 100,
+            "symbol": "SYN",
+            "open": 1.0,
+            "high": 1.0,
+            "low": 1.0,
+            "close": [1.0 + (i % 5) for i in range(60)],
+            "volume": 100,
         }
     )
     try:
@@ -203,8 +271,11 @@ def _memory_poisoning(workdir: Path) -> dict[str, Any]:
 
     store = JobStore(repo_root=workdir)
     job = WayfinderJob.new(
-        "stress-mem", goal="x", script="workspace/src/s.py",
-        agent_mode="intervene", execution_contract="jobs_v1",
+        "stress-mem",
+        goal="x",
+        script="workspace/src/s.py",
+        agent_mode="intervene",
+        execution_contract="jobs_v1",
     )
     store.save(job)
     root = store.job_dir(job.id)
@@ -239,20 +310,42 @@ def _refuted_resubmit(workdir: Path) -> dict[str, Any]:
 
     store = JobStore(repo_root=workdir)
     job = WayfinderJob.new(
-        "stress-arch", goal="x", script="workspace/src/s.py",
-        agent_mode="intervene", execution_contract="jobs_v1",
+        "stress-arch",
+        goal="x",
+        script="workspace/src/s.py",
+        agent_mode="intervene",
+        execution_contract="jobs_v1",
     )
     store.save(job)
-    vec = {"net_log_growth": 0.02, "downside_deviation": 0.05,
-           "tail_loss": 0.1, "max_drawdown_pct": 0.2}
-    record_candidate(store, job.id, candidate_id="cand-x", family="params",
-                     summary="momentum idea", status="archived", objective=vec)
-    set_candidate_status(store, job.id, "cand-x", "refuted",
-                         evidence="0/3 OOS folds, PF 0.4")
+    vec = {
+        "net_log_growth": 0.02,
+        "downside_deviation": 0.05,
+        "tail_loss": 0.1,
+        "max_drawdown_pct": 0.2,
+    }
+    record_candidate(
+        store,
+        job.id,
+        candidate_id="cand-x",
+        family="params",
+        summary="momentum idea",
+        status="archived",
+        objective=vec,
+    )
+    set_candidate_status(
+        store, job.id, "cand-x", "refuted", evidence="0/3 OOS folds, PF 0.4"
+    )
     # Resubmit the SAME candidate — the archive must keep it refuted with its
     # evidence intact, not silently reset it to a fresh candidate.
-    record_candidate(store, job.id, candidate_id="cand-x", family="params",
-                     summary="momentum idea (again)", status="archived", objective=vec)
+    record_candidate(
+        store,
+        job.id,
+        candidate_id="cand-x",
+        family="params",
+        summary="momentum idea (again)",
+        status="archived",
+        objective=vec,
+    )
     doc = load_archive(store, job.id)
     entry = next(e for e in doc["candidates"] if e["candidate_id"] == "cand-x")
     held = entry["status"] == "refuted" and "OOS" in str(entry.get("evidence"))
@@ -279,8 +372,13 @@ def _holdout_erosion(workdir: Path) -> dict[str, Any]:
     # times it was "queried". The gate's LCB rule is the erosion defense.
     noise_report = {
         "status": "ok",
-        "objective": {"candidate": {"max_drawdown_pct": 0.05, "tail_loss": 0.02,
-                                    "trade_count": 40}},
+        "objective": {
+            "candidate": {
+                "max_drawdown_pct": 0.05,
+                "tail_loss": 0.02,
+                "trade_count": 40,
+            }
+        },
         "positive_folds": 2,
         "fold_count": 4,
         "paired_incumbent_delta": {"estimate": 0.001, "lcb": -0.004, "confidence": 0.9},

--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -1223,6 +1223,42 @@ def report_cmd(job_id: str) -> None:
 
 
 @job_cli.command(
+    name="migrate-governance",
+    help="Split the legacy job-root constitution into the protected "
+    "governance/<job_id>/ namespace (outside the agent-writable tree) and "
+    "commit epoch 0 of the tamper-evidence chain.",
+)
+@click.argument("job_id")
+def migrate_governance_cmd(job_id: str) -> None:
+    from wayfinder_paths.jobs.governance import migrate_from_constitution
+
+    store = JobStore()
+    result = migrate_from_constitution(store.repo_root, job_id, store.job_dir(job_id))
+    _echo_json({"ok": True, "result": result})
+
+
+@job_cli.command(
+    name="governance-commit",
+    help="Record the current governance file hashes as a new tamper-evidence "
+    "chain epoch. Run after every deliberate owner edit — uncommitted drift "
+    "loads as chain_status=tampered.",
+)
+@click.argument("job_id")
+@click.option("--note", default="", help="Why this epoch exists.")
+def governance_commit_cmd(job_id: str, note: str) -> None:
+    from wayfinder_paths.jobs.governance import commit_epoch, governance_dir
+
+    store = JobStore()
+    gov_dir = governance_dir(store.repo_root, job_id)
+    if not gov_dir.is_dir():
+        raise click.ClickException(
+            f"no governance dir for {job_id} — run migrate-governance first"
+        )
+    row = commit_epoch(gov_dir, note=note)
+    _echo_json({"ok": True, "result": row})
+
+
+@job_cli.command(
     name="set-script-mode",
     help="Flip the script loop between paper and live (recompiles the runner). "
     "Going live requires a passing live gate and a wallet_label.",

--- a/wayfinder_paths/jobs/constitution.py
+++ b/wayfinder_paths/jobs/constitution.py
@@ -53,12 +53,21 @@ DEFAULT_CONSTITUTION: dict[str, Any] = {
 
 
 def load_constitution(root: Path) -> dict[str, Any]:
-    """Load the job's constitution, merged over defaults.
+    """Load the job's economic standard, merged over defaults.
 
-    Returns the DEFAULT_CONSTITUTION (enforcement=advisory) when the file is
-    absent or unparseable — a broken constitution must degrade to advisory,
-    never brick promotion or silently enforce garbage.
+    Prefers the protected governance namespace (``governance/<job_id>/`` at
+    the repo root — OUTSIDE the agent-writable job tree; see governance.py)
+    when it exists; falls back to the legacy job-root ``constitution.yaml``.
+    Returns the DEFAULT_CONSTITUTION (enforcement=advisory) when neither
+    exists or the legacy file is unparseable — a broken constitution must
+    degrade to advisory, never brick promotion or silently enforce garbage.
     """
+    gov_dir = _governance_dir_for_job_root(root)
+    if gov_dir is not None:
+        from wayfinder_paths.jobs.governance import load_governance_from_dir
+
+        return load_governance_from_dir(gov_dir)
+
     path = root / CONSTITUTION_FILENAME
     if not path.exists():
         return {**DEFAULT_CONSTITUTION, "revision": None, "source": "defaults"}
@@ -77,9 +86,7 @@ def load_constitution(root: Path) -> dict[str, Any]:
 def load_benchmark_constitution() -> dict[str, Any]:
     """The certification profile (stricter than production defaults): all WOB
     certification runs gate against this one versioned standard."""
-    path = (
-        Path(__file__).parent / "benchmarks" / "constitution.benchmark.yaml"
-    )
+    path = Path(__file__).parent / "benchmarks" / "constitution.benchmark.yaml"
     loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
     merged = _merge(DEFAULT_CONSTITUTION, loaded)
     merged["revision"] = constitution_revision(path)
@@ -91,6 +98,22 @@ def constitution_revision(path: Path) -> str | None:
     if not path.exists():
         return None
     return hashlib.sha256(path.read_bytes()).hexdigest()[:12]
+
+
+def _governance_dir_for_job_root(root: Path) -> Path | None:
+    """Map a job root to its protected governance dir, ONLY for the canonical
+    ``<repo_root>/.wayfinder/jobs/<job_id>`` layout. Anything else (test
+    fixtures, ad-hoc dirs) keeps legacy behavior — the mapping must never
+    guess."""
+    root = Path(root)
+    parent = root.parent
+    if parent.name == "jobs" and parent.parent.name == ".wayfinder":
+        from wayfinder_paths.jobs.governance import governance_dir, has_governance
+
+        repo_root = parent.parent.parent
+        if has_governance(repo_root, root.name):
+            return governance_dir(repo_root, root.name)
+    return None
 
 
 def _merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:

--- a/wayfinder_paths/jobs/governance.py
+++ b/wayfinder_paths/jobs/governance.py
@@ -1,0 +1,262 @@
+"""Protected governance plane: the owner-owned files that define what
+"better" means, split by role and kept OUTSIDE the agent-writable job tree.
+
+The legacy `constitution.yaml` lived at the job root — inside
+`.wayfinder/jobs/**`, which the worker agent can write. That made the L4
+boundary prompt-enforced, not capability-enforced: an agent could loosen the
+ceilings, or relax enforcement between proposal evaluation and approval.
+This module moves the standard to `governance/<job_id>/` at the REPO root
+(covered by the worker manifest's catch-all edit deny) and splits it into
+four objects that must not be one mutable blob:
+
+- ``external_target.yaml``  — the invariant objective. Owner-only.
+- ``hard_constraints.yaml`` — non-negotiable risk ceilings. Owner-only.
+- ``audit_policy.yaml``     — enforcement, evidence requirements, promotion
+                              thresholds. Owner-only.
+- ``search_criterion.yaml`` — objective weights guiding internal candidate
+                              ranking. Evolvable later under L4 governance.
+
+Tamper evidence: ``epochs.jsonl`` is a hash-chained append-only record of
+every committed governance revision. The owner edits files then runs
+``wayfinder job governance-commit``; a file change with no commit makes the
+chain head disagree with the working tree and loads surface
+``chain_status: "tampered"`` — the gate layer fails closed on that for
+live-capable jobs. This is tamper-EVIDENT in code; making it tamper-PROOF
+is a box-ops task (root-owned, read-only files).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from wayfinder_paths.jobs.models import utc_now_iso
+
+GOVERNANCE_DIRNAME = "governance"
+EPOCHS_FILENAME = "epochs.jsonl"
+
+EXTERNAL_TARGET_FILE = "external_target.yaml"
+HARD_CONSTRAINTS_FILE = "hard_constraints.yaml"
+AUDIT_POLICY_FILE = "audit_policy.yaml"
+SEARCH_CRITERION_FILE = "search_criterion.yaml"
+
+GOVERNANCE_FILES = (
+    EXTERNAL_TARGET_FILE,
+    HARD_CONSTRAINTS_FILE,
+    AUDIT_POLICY_FILE,
+    SEARCH_CRITERION_FILE,
+)
+
+DEFAULT_EXTERNAL_TARGET: dict[str, Any] = {
+    "version": 1,
+    # The invariant the whole loop is FOR. Everything else is machinery.
+    "basis": "net_log_growth_after_costs",
+    "baseline": "incumbent",
+    "horizon": "forward_audit_window",
+}
+
+
+def governance_dir(repo_root: Path, job_id: str) -> Path:
+    return Path(repo_root) / GOVERNANCE_DIRNAME / job_id
+
+
+def file_revision(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:12]
+
+
+def _load_yaml(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError:
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+def has_governance(repo_root: Path, job_id: str) -> bool:
+    gov = governance_dir(repo_root, job_id)
+    return gov.is_dir() and any((gov / name).exists() for name in GOVERNANCE_FILES)
+
+
+def load_governance(repo_root: Path, job_id: str) -> dict[str, Any]:
+    """Compose the four governance files into the legacy constitution shape
+    (so every existing consumer keeps working) plus a ``governance`` metadata
+    block: per-file revisions, composite revision, and chain_status."""
+    return load_governance_from_dir(governance_dir(repo_root, job_id))
+
+
+def load_governance_from_dir(gov_dir: Path) -> dict[str, Any]:
+    from wayfinder_paths.jobs.constitution import DEFAULT_CONSTITUTION, _merge
+
+    target = _load_yaml(gov_dir / EXTERNAL_TARGET_FILE) or dict(DEFAULT_EXTERNAL_TARGET)
+    hard = _load_yaml(gov_dir / HARD_CONSTRAINTS_FILE) or dict(
+        DEFAULT_CONSTITUTION["hard_constraints"]
+    )
+    audit = _load_yaml(gov_dir / AUDIT_POLICY_FILE) or {}
+    criterion = _load_yaml(gov_dir / SEARCH_CRITERION_FILE) or {}
+
+    composed: dict[str, Any] = dict(DEFAULT_CONSTITUTION)
+    composed = _merge(
+        composed,
+        {
+            "hard_constraints": hard,
+            **{
+                key: audit[key]
+                for key in ("enforcement", "evaluation", "promotion", "verdict")
+                if key in audit
+            },
+            **(
+                {"objective": criterion["objective"]}
+                if "objective" in criterion
+                else {}
+            ),
+        },
+    )
+
+    revisions = {name: file_revision(gov_dir / name) for name in GOVERNANCE_FILES}
+    composite = hashlib.sha256(
+        "|".join(f"{name}:{revisions[name]}" for name in GOVERNANCE_FILES).encode()
+    ).hexdigest()[:12]
+    chain_status, epoch = verify_chain(gov_dir)
+
+    composed["revision"] = composite
+    composed["source"] = "governance"
+    composed["governance"] = {
+        "dir": str(gov_dir),
+        "external_target": target,
+        "revisions": revisions,
+        "composite_revision": composite,
+        "chain_status": chain_status,
+        "epoch": epoch,
+    }
+    return composed
+
+
+def verify_chain(gov_dir: Path) -> tuple[str, int]:
+    """Verify the epochs hash chain and that its head matches the working
+    tree. Returns (status, epoch_count) with status in:
+    verified | uncommitted | tampered | empty."""
+    epochs_path = gov_dir / EPOCHS_FILENAME
+    current = {name: file_revision(gov_dir / name) for name in GOVERNANCE_FILES}
+    has_files = any(value is not None for value in current.values())
+    if not epochs_path.exists():
+        return ("uncommitted" if has_files else "empty"), 0
+
+    rows: list[dict[str, Any]] = []
+    for line in epochs_path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except ValueError:
+            return "tampered", len(rows)
+        rows.append(row)
+    if not rows:
+        return ("uncommitted" if has_files else "empty"), 0
+
+    prev_hash = ""
+    for row in rows:
+        if str(row.get("prev") or "") != prev_hash:
+            return "tampered", len(rows)
+        prev_hash = _row_hash(row)
+
+    head = rows[-1]
+    if head.get("files") != current:
+        return "tampered", len(rows)
+    return "verified", len(rows)
+
+
+def commit_epoch(gov_dir: Path, *, note: str = "") -> dict[str, Any]:
+    """Record the current governance file hashes as a new chain epoch. The
+    owner runs this (via CLI) after every deliberate edit; loads treat any
+    uncommitted drift as tamper."""
+    epochs_path = gov_dir / EPOCHS_FILENAME
+    rows: list[dict[str, Any]] = []
+    if epochs_path.exists():
+        for line in epochs_path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                rows.append(json.loads(line))
+    prev_hash = _row_hash(rows[-1]) if rows else ""
+    revisions = {name: file_revision(gov_dir / name) for name in GOVERNANCE_FILES}
+    composite = hashlib.sha256(
+        "|".join(f"{name}:{revisions[name]}" for name in GOVERNANCE_FILES).encode()
+    ).hexdigest()[:12]
+    row = {
+        "epoch": len(rows),
+        "ts": utc_now_iso(),
+        "files": revisions,
+        "composite": composite,
+        "prev": prev_hash,
+        "note": note,
+    }
+    with epochs_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(row, sort_keys=True) + "\n")
+    return row
+
+
+def _row_hash(row: dict[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(row, sort_keys=True, default=str).encode()
+    ).hexdigest()[:16]
+
+
+def migrate_from_constitution(
+    repo_root: Path, job_id: str, job_root: Path
+) -> dict[str, Any]:
+    """Split a legacy job-root constitution.yaml (or the defaults) into the
+    governance namespace and commit epoch 0. The legacy file is left in
+    place — the loader prefers governance/ once it exists."""
+    from wayfinder_paths.jobs.constitution import (
+        CONSTITUTION_FILENAME,
+        DEFAULT_CONSTITUTION,
+        _merge,
+    )
+
+    legacy = _load_yaml(job_root / CONSTITUTION_FILENAME)
+    merged = _merge(DEFAULT_CONSTITUTION, legacy or {})
+
+    gov_dir = governance_dir(repo_root, job_id)
+    gov_dir.mkdir(parents=True, exist_ok=True)
+
+    warnings: list[str] = []
+    audit_floor = float(
+        (merged.get("promotion") or {}).get("audit_min_delta_utility") or 0.0
+    )
+    if audit_floor < 0:
+        warnings.append(
+            f"audit_min_delta_utility is negative ({audit_floor}) — a full-size "
+            "candidate can pass with negative audited utility; raise to >= 0.0"
+        )
+
+    _write_yaml(gov_dir / EXTERNAL_TARGET_FILE, dict(DEFAULT_EXTERNAL_TARGET))
+    _write_yaml(gov_dir / HARD_CONSTRAINTS_FILE, merged["hard_constraints"])
+    audit_policy = {
+        "enforcement": merged["enforcement"],
+        "evaluation": merged["evaluation"],
+        "promotion": merged["promotion"],
+    }
+    if isinstance(merged.get("verdict"), dict):
+        audit_policy["verdict"] = merged["verdict"]
+    _write_yaml(gov_dir / AUDIT_POLICY_FILE, audit_policy)
+    _write_yaml(gov_dir / SEARCH_CRITERION_FILE, {"objective": merged["objective"]})
+
+    epoch = commit_epoch(gov_dir, note=f"migrated from legacy constitution ({job_id})")
+    return {
+        "job_id": job_id,
+        "governance_dir": str(gov_dir),
+        "epoch": epoch["epoch"],
+        "composite_revision": epoch["composite"],
+        "source": "legacy_constitution" if legacy else "defaults",
+        "warnings": warnings,
+    }
+
+
+def _write_yaml(path: Path, data: dict[str, Any]) -> None:
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")

--- a/wayfinder_paths/tests/test_jobs_governance.py
+++ b/wayfinder_paths/tests/test_jobs_governance.py
@@ -1,0 +1,132 @@
+"""Protected governance plane: the constitution split into four owner-owned
+files OUTSIDE the agent-writable job tree, with a hash-chained epoch record
+so uncommitted drift (the agent-side tamper path) is detectable. The legacy
+job-root constitution.yaml keeps working until a job is migrated."""
+
+from __future__ import annotations
+
+import json
+
+from wayfinder_paths.jobs.constitution import DEFAULT_CONSTITUTION, load_constitution
+from wayfinder_paths.jobs.governance import (
+    AUDIT_POLICY_FILE,
+    HARD_CONSTRAINTS_FILE,
+    commit_epoch,
+    governance_dir,
+    load_governance,
+    migrate_from_constitution,
+    verify_chain,
+)
+
+
+def _legacy_job(tmp_path, constitution_text: str | None):
+    job_root = tmp_path / ".wayfinder" / "jobs" / "gov-demo"
+    job_root.mkdir(parents=True)
+    if constitution_text is not None:
+        (job_root / "constitution.yaml").write_text(constitution_text)
+    return job_root
+
+
+def test_migration_splits_and_composes_identically(tmp_path) -> None:
+    legacy = (
+        "enforcement: blocking\n"
+        "objective:\n  weights:\n    downside: 0.7\n"
+        "promotion:\n  min_oos_trades: 12\n  audit_min_delta_utility: 0.0\n"
+        "hard_constraints:\n  max_drawdown_pct: 0.18\n"
+        "verdict:\n  minimum_days: 2.0\n"
+    )
+    job_root = _legacy_job(tmp_path, legacy)
+    before = load_constitution(job_root)
+
+    result = migrate_from_constitution(tmp_path, "gov-demo", job_root)
+    assert result["epoch"] == 0
+    assert not result["warnings"]  # audit floor not negative in this fixture
+
+    after = load_constitution(job_root)  # facade now prefers governance/
+    assert after["source"] == "governance"
+    # Composition preserves every consumed field of the legacy load.
+    for key in (
+        "enforcement",
+        "objective",
+        "evaluation",
+        "promotion",
+        "hard_constraints",
+        "verdict",
+    ):
+        assert after[key] == before[key], key
+    assert after["governance"]["chain_status"] == "verified"
+    assert after["governance"]["revisions"][HARD_CONSTRAINTS_FILE] is not None
+
+
+def test_migration_warns_on_negative_audit_floor(tmp_path) -> None:
+    job_root = _legacy_job(tmp_path, "promotion:\n  audit_min_delta_utility: -0.005\n")
+    result = migrate_from_constitution(tmp_path, "gov-demo", job_root)
+    assert any("negative" in w for w in result["warnings"])
+
+
+def test_uncommitted_drift_reads_as_tampered(tmp_path) -> None:
+    job_root = _legacy_job(tmp_path, "enforcement: blocking\n")
+    migrate_from_constitution(tmp_path, "gov-demo", job_root)
+    gov = governance_dir(tmp_path, "gov-demo")
+
+    # Agent-style edit: loosen a ceiling with no epoch commit.
+    (gov / HARD_CONSTRAINTS_FILE).write_text("max_drawdown_pct: 0.99\n")
+    doc = load_governance(tmp_path, "gov-demo")
+    assert doc["governance"]["chain_status"] == "tampered"
+
+    # Owner path: commit -> verified again, ceiling change now on record.
+    commit_epoch(gov, note="owner change")
+    doc = load_governance(tmp_path, "gov-demo")
+    assert doc["governance"]["chain_status"] == "verified"
+    assert doc["hard_constraints"]["max_drawdown_pct"] == 0.99
+    status, epochs = verify_chain(gov)
+    assert (status, epochs) == ("verified", 2)
+
+
+def test_chain_linkage_break_is_tampered(tmp_path) -> None:
+    job_root = _legacy_job(tmp_path, "enforcement: blocking\n")
+    migrate_from_constitution(tmp_path, "gov-demo", job_root)
+    gov = governance_dir(tmp_path, "gov-demo")
+    commit_epoch(gov, note="second epoch")
+
+    epochs_path = gov / "epochs.jsonl"
+    rows = [json.loads(line) for line in epochs_path.read_text().splitlines()]
+    rows[0]["note"] = "history rewritten"  # breaks the next row's prev hash
+    epochs_path.write_text(
+        "\n".join(json.dumps(r, sort_keys=True) for r in rows) + "\n"
+    )
+    status, _ = verify_chain(gov)
+    assert status == "tampered"
+
+
+def test_legacy_and_default_paths_unchanged(tmp_path) -> None:
+    # No governance dir: legacy file loads exactly as before.
+    job_root = _legacy_job(tmp_path, "enforcement: blocking\n")
+    doc = load_constitution(job_root)
+    assert doc["source"] == "file"
+    assert doc["enforcement"] == "blocking"
+
+    # Neither governance nor legacy: defaults, advisory.
+    bare = tmp_path / "elsewhere" / "job"
+    bare.mkdir(parents=True)
+    doc = load_constitution(bare)
+    assert doc["source"] == "defaults"
+    assert doc["enforcement"] == DEFAULT_CONSTITUTION["enforcement"]
+
+
+def test_governance_composite_revision_changes_with_any_file(tmp_path) -> None:
+    job_root = _legacy_job(tmp_path, None)
+    migrate_from_constitution(tmp_path, "gov-demo", job_root)
+    first = load_governance(tmp_path, "gov-demo")["revision"]
+    gov = governance_dir(tmp_path, "gov-demo")
+    (gov / AUDIT_POLICY_FILE).write_text("enforcement: blocking\n")
+    commit_epoch(gov)
+    second = load_governance(tmp_path, "gov-demo")["revision"]
+    assert first != second
+
+
+def test_stress_trap_governance_tamper(tmp_path) -> None:
+    from wayfinder_paths.jobs.benchmarks.stress import TRAPS
+
+    outcome = TRAPS["governance_tamper"](tmp_path)
+    assert outcome["held"] is True, outcome


### PR DESCRIPTION
PR 1 of the approved L3/L4 program (external review: the constitution and system evidence are agent-writable — a prompt-enforced boundary, not capability-enforced; no approval-time freshness check).

## What this builds

**`governance/<job_id>/` at the repo root** — outside `.wayfinder/jobs/**`, covered by the worker manifest's catch-all deny plus a new explicit `governance/**: deny`. The constitution splits into the four objects the review said must not be one mutable blob:

| File | Role | Writable by |
|---|---|---|
| `external_target.yaml` | invariant objective | owner |
| `hard_constraints.yaml` | non-negotiable risk ceilings | owner |
| `audit_policy.yaml` | enforcement, evidence reqs, promotion thresholds | owner |
| `search_criterion.yaml` | objective weights guiding internal ranking | owner now, L4 later |

**Tamper evidence**: `epochs.jsonl` hash chain. The owner edits files then runs `wayfinder job governance-commit`; uncommitted drift (the agent-side tamper path) loads as `chain_status: tampered` — PR 2 wires the gate layer to fail closed on it. Honest scope note: this is tamper-EVIDENT in code; tamper-PROOF is the box-ops follow-up (root-owned, read-only files on /wf).

**Zero-breakage facade**: `load_constitution()` prefers the governance namespace (only for the canonical job layout — never guesses), falls back to the legacy job-root file, then defaults. All consumers (economics/gating/counterfactual) untouched. `wayfinder job migrate-governance <job_id>` performs the split (journaling a warning when the legacy audit floor is negative).

**New stress trap** `governance_tamper`: clean migrate → verified; loosen `hard_constraints.yaml` with no commit → tampered detected; owner commit → verified again.

## Verification

7 new tests (migration composes byte-identically to the legacy load across every consumed field; negative-floor warning; uncommitted drift → tampered; chain-linkage rewrite → tampered; legacy + defaults paths unchanged; composite revision moves with any file; stress trap holds). 45 tests green across economics/gating/counterfactual/stress consumer suites. ruff + format clean.

Ops after roll: `migrate-governance` the three live jobs, set box file perms, then flip `audit_policy.enforcement` to `blocking` (PR 2 gives blocking its teeth).