### PR TITLE
jobs: fail-closed gates + governance freshness + evidence ledger (L3/L4 PR 2)

### DIFF
--- a/.opencode/agents/wayfinder-job-worker.md
+++ b/.opencode/agents/wayfinder-job-worker.md
@@ -16,6 +16,9 @@ permission:
 
   write: allow
   edit:
+    # The governance plane (owner targets, hard constraints, audit policy)
+    # is capability-protected: outside the job tree AND explicitly denied.
+    "governance/**": deny
     ".wayfinder/jobs/**": allow
     ".wayfinder_runs/**": ask
     "*": deny

--- a/wayfinder_paths/jobs/application.py
+++ b/wayfinder_paths/jobs/application.py
@@ -61,6 +61,14 @@ def resume_job_loops(store: JobStore, job_id: str) -> list[dict[str, Any]]:
 
 
 def claim_application(store: JobStore, job_id: str, proposal_id: str) -> dict[str, Any]:
+    from wayfinder_paths.jobs.constitution import load_constitution
+
+    constitution = load_constitution(store.job_dir(job_id))
+    if (constitution.get("governance") or {}).get("chain_status") == "tampered":
+        raise ValueError(
+            "ESCALATE: governance chain is tampered — no application may be "
+            "claimed until the owner inspects and re-commits"
+        )
     proposal = store.load_proposal(job_id, proposal_id)
     application_status = proposal["application"]["status"]
     if proposal["status"] != "approved":

--- a/wayfinder_paths/jobs/benchmarks/stress.py
+++ b/wayfinder_paths/jobs/benchmarks/stress.py
@@ -37,6 +37,55 @@ def _result(held: bool, detail: str, defense: str) -> dict[str, Any]:
     return {"held": held, "detail": detail, "defense": defense}
 
 
+@trap("governance_tamper")
+def _governance_tamper(workdir: Path) -> dict[str, Any]:
+    """An uncommitted edit to a protected governance file (the agent-side
+    tamper path: loosen hard_constraints.yaml without an owner epoch commit)
+    must surface as chain_status=tampered — the gate layer fails closed on
+    that. Owner edits followed by governance-commit verify clean."""
+    from wayfinder_paths.jobs.governance import (
+        HARD_CONSTRAINTS_FILE,
+        commit_epoch,
+        governance_dir,
+        load_governance,
+        migrate_from_constitution,
+    )
+
+    repo_root = workdir / "repo"
+    job_root = repo_root / ".wayfinder" / "jobs" / "trap-job"
+    job_root.mkdir(parents=True)
+    (job_root / "constitution.yaml").write_text(
+        "enforcement: blocking\nhard_constraints:\n  max_drawdown_pct: 0.10\n"
+    )
+    migrate_from_constitution(repo_root, "trap-job", job_root)
+    baseline = load_governance(repo_root, "trap-job")
+    clean = (
+        baseline["governance"]["chain_status"] == "verified"
+        and baseline["enforcement"] == "blocking"
+        and baseline["hard_constraints"]["max_drawdown_pct"] == 0.10
+    )
+
+    # Tamper: loosen the ceiling with NO epoch commit.
+    gov = governance_dir(repo_root, "trap-job")
+    (gov / HARD_CONSTRAINTS_FILE).write_text("max_drawdown_pct: 0.99\n")
+    tampered = load_governance(repo_root, "trap-job")
+    detected = tampered["governance"]["chain_status"] == "tampered"
+
+    # Owner path: commit the edit -> chain verifies again.
+    commit_epoch(gov, note="owner raised ceiling deliberately")
+    committed = load_governance(repo_root, "trap-job")
+    recommitted = committed["governance"]["chain_status"] == "verified"
+
+    held = clean and detected and recommitted
+    return _result(
+        held,
+        "uncommitted governance drift detected as tampered; owner commit re-verifies"
+        if held
+        else f"LEAK: clean={clean} detected={detected} recommitted={recommitted}",
+        "governance epochs hash chain (governance.verify_chain)",
+    )
+
+
 @trap("constitution_tamper")
 def _constitution_tamper(workdir: Path) -> dict[str, Any]:
     """A candidate that rewrites its own constitution to loosen the ceilings
@@ -56,7 +105,9 @@ def _constitution_tamper(workdir: Path) -> dict[str, Any]:
 
     # The candidate tries to smuggle a loosened constitution inside workspace/.
     candidate = root / "workspace" / CONSTITUTION_FILENAME
-    candidate.write_text("enforcement: advisory\nhard_constraints:\n  max_drawdown_pct: 0.99\n")
+    candidate.write_text(
+        "enforcement: advisory\nhard_constraints:\n  max_drawdown_pct: 0.99\n"
+    )
     after = load_constitution(root)
 
     held = (
@@ -87,11 +138,19 @@ def _oracle_peek(workdir: Path) -> dict[str, Any]:
     world = generate_world("smooth_optimum", seed=424242)
     sandbox = workdir / "bundle"
     genome = Genome(
-        "new_high_20", "long", "none", "fixed_time",
-        (("hold_bars", 8),), "fixed", (),
+        "new_high_20",
+        "long",
+        "none",
+        "fixed_time",
+        (("hold_bars", 8),),
+        "fixed",
+        (),
     )
     build_world_bundle(
-        world, sandbox=sandbox, repo_root=Path.cwd(), initial_genome=genome,
+        world,
+        sandbox=sandbox,
+        repo_root=Path.cwd(),
+        initial_genome=genome,
     )
     # Precise leak test: search for the actual SECRETS, not English words.
     # A hidden-continuation close price and a mechanism drift constant are
@@ -140,7 +199,9 @@ def _lookahead_signal(workdir: Path) -> dict[str, Any]:
         centered = frame["close"].rolling(5, center=True, min_periods=1).mean()
         return (frame["close"] > centered).astype(bool)
 
-    peeking = SignalDef("peek_center_5", "custom", "centered mean cross", 6, peeking_builder)
+    peeking = SignalDef(
+        "peek_center_5", "custom", "centered mean cross", 6, peeking_builder
+    )
     probe = pd.DataFrame(
         {
             "timestamp": pd.date_range("2026-01-01", periods=200, freq="1h"),
@@ -172,14 +233,21 @@ def _signal_collision(workdir: Path) -> dict[str, Any]:
 
     canonical_name = next(iter(signal_defs()))
     clone = SignalDef(
-        canonical_name, "custom", "name-squat", 6,
+        canonical_name,
+        "custom",
+        "name-squat",
+        6,
         lambda f: (f["close"] > f["close"].shift(1)).astype(bool),
     )
     probe = pd.DataFrame(
         {
             "timestamp": pd.date_range("2026-01-01", periods=60, freq="1h"),
-            "symbol": "SYN", "open": 1.0, "high": 1.0, "low": 1.0,
-            "close": [1.0 + (i % 5) for i in range(60)], "volume": 100,
+            "symbol": "SYN",
+            "open": 1.0,
+            "high": 1.0,
+            "low": 1.0,
+            "close": [1.0 + (i % 5) for i in range(60)],
+            "volume": 100,
         }
     )
     try:
@@ -203,8 +271,11 @@ def _memory_poisoning(workdir: Path) -> dict[str, Any]:
 
     store = JobStore(repo_root=workdir)
     job = WayfinderJob.new(
-        "stress-mem", goal="x", script="workspace/src/s.py",
-        agent_mode="intervene", execution_contract="jobs_v1",
+        "stress-mem",
+        goal="x",
+        script="workspace/src/s.py",
+        agent_mode="intervene",
+        execution_contract="jobs_v1",
     )
     store.save(job)
     root = store.job_dir(job.id)
@@ -239,20 +310,42 @@ def _refuted_resubmit(workdir: Path) -> dict[str, Any]:
 
     store = JobStore(repo_root=workdir)
     job = WayfinderJob.new(
-        "stress-arch", goal="x", script="workspace/src/s.py",
-        agent_mode="intervene", execution_contract="jobs_v1",
+        "stress-arch",
+        goal="x",
+        script="workspace/src/s.py",
+        agent_mode="intervene",
+        execution_contract="jobs_v1",
     )
     store.save(job)
-    vec = {"net_log_growth": 0.02, "downside_deviation": 0.05,
-           "tail_loss": 0.1, "max_drawdown_pct": 0.2}
-    record_candidate(store, job.id, candidate_id="cand-x", family="params",
-                     summary="momentum idea", status="archived", objective=vec)
-    set_candidate_status(store, job.id, "cand-x", "refuted",
-                         evidence="0/3 OOS folds, PF 0.4")
+    vec = {
+        "net_log_growth": 0.02,
+        "downside_deviation": 0.05,
+        "tail_loss": 0.1,
+        "max_drawdown_pct": 0.2,
+    }
+    record_candidate(
+        store,
+        job.id,
+        candidate_id="cand-x",
+        family="params",
+        summary="momentum idea",
+        status="archived",
+        objective=vec,
+    )
+    set_candidate_status(
+        store, job.id, "cand-x", "refuted", evidence="0/3 OOS folds, PF 0.4"
+    )
     # Resubmit the SAME candidate — the archive must keep it refuted with its
     # evidence intact, not silently reset it to a fresh candidate.
-    record_candidate(store, job.id, candidate_id="cand-x", family="params",
-                     summary="momentum idea (again)", status="archived", objective=vec)
+    record_candidate(
+        store,
+        job.id,
+        candidate_id="cand-x",
+        family="params",
+        summary="momentum idea (again)",
+        status="archived",
+        objective=vec,
+    )
     doc = load_archive(store, job.id)
     entry = next(e for e in doc["candidates"] if e["candidate_id"] == "cand-x")
     held = entry["status"] == "refuted" and "OOS" in str(entry.get("evidence"))
@@ -279,8 +372,13 @@ def _holdout_erosion(workdir: Path) -> dict[str, Any]:
     # times it was "queried". The gate's LCB rule is the erosion defense.
     noise_report = {
         "status": "ok",
-        "objective": {"candidate": {"max_drawdown_pct": 0.05, "tail_loss": 0.02,
-                                    "trade_count": 40}},
+        "objective": {
+            "candidate": {
+                "max_drawdown_pct": 0.05,
+                "tail_loss": 0.02,
+                "trade_count": 40,
+            }
+        },
         "positive_folds": 2,
         "fold_count": 4,
         "paired_incumbent_delta": {"estimate": 0.001, "lcb": -0.004, "confidence": 0.9},

--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -1223,6 +1223,42 @@ def report_cmd(job_id: str) -> None:
 
 
 @job_cli.command(
+    name="migrate-governance",
+    help="Split the legacy job-root constitution into the protected "
+    "governance/<job_id>/ namespace (outside the agent-writable tree) and "
+    "commit epoch 0 of the tamper-evidence chain.",
+)
+@click.argument("job_id")
+def migrate_governance_cmd(job_id: str) -> None:
+    from wayfinder_paths.jobs.governance import migrate_from_constitution
+
+    store = JobStore()
+    result = migrate_from_constitution(store.repo_root, job_id, store.job_dir(job_id))
+    _echo_json({"ok": True, "result": result})
+
+
+@job_cli.command(
+    name="governance-commit",
+    help="Record the current governance file hashes as a new tamper-evidence "
+    "chain epoch. Run after every deliberate owner edit — uncommitted drift "
+    "loads as chain_status=tampered.",
+)
+@click.argument("job_id")
+@click.option("--note", default="", help="Why this epoch exists.")
+def governance_commit_cmd(job_id: str, note: str) -> None:
+    from wayfinder_paths.jobs.governance import commit_epoch, governance_dir
+
+    store = JobStore()
+    gov_dir = governance_dir(store.repo_root, job_id)
+    if not gov_dir.is_dir():
+        raise click.ClickException(
+            f"no governance dir for {job_id} — run migrate-governance first"
+        )
+    row = commit_epoch(gov_dir, note=note)
+    _echo_json({"ok": True, "result": row})
+
+
+@job_cli.command(
     name="set-script-mode",
     help="Flip the script loop between paper and live (recompiles the runner). "
     "Going live requires a passing live gate and a wallet_label.",

--- a/wayfinder_paths/jobs/constitution.py
+++ b/wayfinder_paths/jobs/constitution.py
@@ -53,12 +53,21 @@ DEFAULT_CONSTITUTION: dict[str, Any] = {
 
 
 def load_constitution(root: Path) -> dict[str, Any]:
-    """Load the job's constitution, merged over defaults.
+    """Load the job's economic standard, merged over defaults.
 
-    Returns the DEFAULT_CONSTITUTION (enforcement=advisory) when the file is
-    absent or unparseable — a broken constitution must degrade to advisory,
-    never brick promotion or silently enforce garbage.
+    Prefers the protected governance namespace (``governance/<job_id>/`` at
+    the repo root — OUTSIDE the agent-writable job tree; see governance.py)
+    when it exists; falls back to the legacy job-root ``constitution.yaml``.
+    Returns the DEFAULT_CONSTITUTION (enforcement=advisory) when neither
+    exists or the legacy file is unparseable — a broken constitution must
+    degrade to advisory, never brick promotion or silently enforce garbage.
     """
+    gov_dir = _governance_dir_for_job_root(root)
+    if gov_dir is not None:
+        from wayfinder_paths.jobs.governance import load_governance_from_dir
+
+        return load_governance_from_dir(gov_dir)
+
     path = root / CONSTITUTION_FILENAME
     if not path.exists():
         return {**DEFAULT_CONSTITUTION, "revision": None, "source": "defaults"}
@@ -77,9 +86,7 @@ def load_constitution(root: Path) -> dict[str, Any]:
 def load_benchmark_constitution() -> dict[str, Any]:
     """The certification profile (stricter than production defaults): all WOB
     certification runs gate against this one versioned standard."""
-    path = (
-        Path(__file__).parent / "benchmarks" / "constitution.benchmark.yaml"
-    )
+    path = Path(__file__).parent / "benchmarks" / "constitution.benchmark.yaml"
     loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
     merged = _merge(DEFAULT_CONSTITUTION, loaded)
     merged["revision"] = constitution_revision(path)
@@ -91,6 +98,22 @@ def constitution_revision(path: Path) -> str | None:
     if not path.exists():
         return None
     return hashlib.sha256(path.read_bytes()).hexdigest()[:12]
+
+
+def _governance_dir_for_job_root(root: Path) -> Path | None:
+    """Map a job root to its protected governance dir, ONLY for the canonical
+    ``<repo_root>/.wayfinder/jobs/<job_id>`` layout. Anything else (test
+    fixtures, ad-hoc dirs) keeps legacy behavior — the mapping must never
+    guess."""
+    root = Path(root)
+    parent = root.parent
+    if parent.name == "jobs" and parent.parent.name == ".wayfinder":
+        from wayfinder_paths.jobs.governance import governance_dir, has_governance
+
+        repo_root = parent.parent.parent
+        if has_governance(repo_root, root.name):
+            return governance_dir(repo_root, root.name)
+    return None
 
 
 def _merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:

--- a/wayfinder_paths/jobs/execution/op_runner.py
+++ b/wayfinder_paths/jobs/execution/op_runner.py
@@ -25,8 +25,36 @@ import json
 import sys
 from typing import Any
 
+_EVIDENCE_OPS = {
+    "backtest_job",
+    "experiments",
+    "signal_scan",
+    "holdout_check",
+    "restamp",
+}
+
 
 def _run(op: str, kwargs: dict[str, Any]) -> Any:
+    if op in _EVIDENCE_OPS and kwargs.get("job_id"):
+        # Every validation query is on the protected record (audit/<job_id>/)
+        # — the review's evidence-access ledger. Best-effort, never blocks.
+        from wayfinder_paths.jobs.governance import record_evidence_access
+        from wayfinder_paths.jobs.store import JobStore
+
+        try:
+            store = JobStore()
+            record_evidence_access(
+                store.repo_root,
+                str(kwargs["job_id"]),
+                op,
+                {"kwargs_keys": sorted(k for k in kwargs if k != "job_id")},
+            )
+        except Exception:  # noqa: BLE001
+            pass
+    return _run_op(op, kwargs)
+
+
+def _run_op(op: str, kwargs: dict[str, Any]) -> Any:
     # Imports live inside each branch so the child only pays for what it runs.
     if op == "__echo__":
         # Health-check / test op: round-trips kwargs through the full pipe.

--- a/wayfinder_paths/jobs/gating.py
+++ b/wayfinder_paths/jobs/gating.py
@@ -235,7 +235,9 @@ def evaluate_economic_gate(
         "probation": probation,
         "enforcement": constitution["enforcement"],
         "constitution_revision": constitution.get("revision"),
-        "objective": (evaluation.get("objective") if evaluation.get("status") == "ok" else None),
+        "objective": (
+            evaluation.get("objective") if evaluation.get("status") == "ok" else None
+        ),
         "paired_incumbent_delta": evaluation.get("paired_incumbent_delta"),
         "positive_folds": evaluation.get("positive_folds"),
         "fold_count": evaluation.get("fold_count"),
@@ -266,6 +268,9 @@ def _economic_unavailable(
         "enforcement": constitution["enforcement"],
         "constitution_revision": constitution.get("revision"),
         "status": "unavailable",
+        # Unavailable evidence is an escalation, not an approval: the gate
+        # fails closed on live-capable blocking jobs.
+        "escalate": True,
         "checked_at": utc_now_iso(),
     }
 

--- a/wayfinder_paths/jobs/governance.py
+++ b/wayfinder_paths/jobs/governance.py
@@ -258,5 +258,40 @@ def migrate_from_constitution(
     }
 
 
+AUDIT_DIRNAME = "audit"
+
+
+def record_evidence_access(
+    repo_root: Path, job_id: str, op: str, detail: dict[str, Any] | None = None
+) -> None:
+    """Append one row to the protected evidence-access ledger
+    (``audit/<job_id>/evidence_access.jsonl`` — same manifest-denied plane
+    as governance). Every validation query a revision makes is on the
+    record; the gate can report how mined the evidence is. Never raises —
+    the ledger is telemetry, the op must not fail on it."""
+    try:
+        audit_dir = Path(repo_root) / AUDIT_DIRNAME / job_id
+        audit_dir.mkdir(parents=True, exist_ok=True)
+        row = {"op": op, "ts": utc_now_iso(), **(detail or {})}
+        with (audit_dir / "evidence_access.jsonl").open(
+            "a", encoding="utf-8"
+        ) as handle:
+            handle.write(json.dumps(row, sort_keys=True, default=str) + "\n")
+    except Exception:  # noqa: BLE001
+        return
+
+
+def evidence_access_count(repo_root: Path, job_id: str) -> int:
+    try:
+        path = Path(repo_root) / AUDIT_DIRNAME / job_id / "evidence_access.jsonl"
+        if not path.exists():
+            return 0
+        return sum(
+            1 for line in path.read_text(encoding="utf-8").splitlines() if line.strip()
+        )
+    except Exception:  # noqa: BLE001
+        return 0
+
+
 def _write_yaml(path: Path, data: dict[str, Any]) -> None:
     path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")

--- a/wayfinder_paths/jobs/governance.py
+++ b/wayfinder_paths/jobs/governance.py
@@ -1,0 +1,262 @@
+"""Protected governance plane: the owner-owned files that define what
+"better" means, split by role and kept OUTSIDE the agent-writable job tree.
+
+The legacy `constitution.yaml` lived at the job root — inside
+`.wayfinder/jobs/**`, which the worker agent can write. That made the L4
+boundary prompt-enforced, not capability-enforced: an agent could loosen the
+ceilings, or relax enforcement between proposal evaluation and approval.
+This module moves the standard to `governance/<job_id>/` at the REPO root
+(covered by the worker manifest's catch-all edit deny) and splits it into
+four objects that must not be one mutable blob:
+
+- ``external_target.yaml``  — the invariant objective. Owner-only.
+- ``hard_constraints.yaml`` — non-negotiable risk ceilings. Owner-only.
+- ``audit_policy.yaml``     — enforcement, evidence requirements, promotion
+                              thresholds. Owner-only.
+- ``search_criterion.yaml`` — objective weights guiding internal candidate
+                              ranking. Evolvable later under L4 governance.
+
+Tamper evidence: ``epochs.jsonl`` is a hash-chained append-only record of
+every committed governance revision. The owner edits files then runs
+``wayfinder job governance-commit``; a file change with no commit makes the
+chain head disagree with the working tree and loads surface
+``chain_status: "tampered"`` — the gate layer fails closed on that for
+live-capable jobs. This is tamper-EVIDENT in code; making it tamper-PROOF
+is a box-ops task (root-owned, read-only files).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from wayfinder_paths.jobs.models import utc_now_iso
+
+GOVERNANCE_DIRNAME = "governance"
+EPOCHS_FILENAME = "epochs.jsonl"
+
+EXTERNAL_TARGET_FILE = "external_target.yaml"
+HARD_CONSTRAINTS_FILE = "hard_constraints.yaml"
+AUDIT_POLICY_FILE = "audit_policy.yaml"
+SEARCH_CRITERION_FILE = "search_criterion.yaml"
+
+GOVERNANCE_FILES = (
+    EXTERNAL_TARGET_FILE,
+    HARD_CONSTRAINTS_FILE,
+    AUDIT_POLICY_FILE,
+    SEARCH_CRITERION_FILE,
+)
+
+DEFAULT_EXTERNAL_TARGET: dict[str, Any] = {
+    "version": 1,
+    # The invariant the whole loop is FOR. Everything else is machinery.
+    "basis": "net_log_growth_after_costs",
+    "baseline": "incumbent",
+    "horizon": "forward_audit_window",
+}
+
+
+def governance_dir(repo_root: Path, job_id: str) -> Path:
+    return Path(repo_root) / GOVERNANCE_DIRNAME / job_id
+
+
+def file_revision(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:12]
+
+
+def _load_yaml(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError:
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+def has_governance(repo_root: Path, job_id: str) -> bool:
+    gov = governance_dir(repo_root, job_id)
+    return gov.is_dir() and any((gov / name).exists() for name in GOVERNANCE_FILES)
+
+
+def load_governance(repo_root: Path, job_id: str) -> dict[str, Any]:
+    """Compose the four governance files into the legacy constitution shape
+    (so every existing consumer keeps working) plus a ``governance`` metadata
+    block: per-file revisions, composite revision, and chain_status."""
+    return load_governance_from_dir(governance_dir(repo_root, job_id))
+
+
+def load_governance_from_dir(gov_dir: Path) -> dict[str, Any]:
+    from wayfinder_paths.jobs.constitution import DEFAULT_CONSTITUTION, _merge
+
+    target = _load_yaml(gov_dir / EXTERNAL_TARGET_FILE) or dict(DEFAULT_EXTERNAL_TARGET)
+    hard = _load_yaml(gov_dir / HARD_CONSTRAINTS_FILE) or dict(
+        DEFAULT_CONSTITUTION["hard_constraints"]
+    )
+    audit = _load_yaml(gov_dir / AUDIT_POLICY_FILE) or {}
+    criterion = _load_yaml(gov_dir / SEARCH_CRITERION_FILE) or {}
+
+    composed: dict[str, Any] = dict(DEFAULT_CONSTITUTION)
+    composed = _merge(
+        composed,
+        {
+            "hard_constraints": hard,
+            **{
+                key: audit[key]
+                for key in ("enforcement", "evaluation", "promotion", "verdict")
+                if key in audit
+            },
+            **(
+                {"objective": criterion["objective"]}
+                if "objective" in criterion
+                else {}
+            ),
+        },
+    )
+
+    revisions = {name: file_revision(gov_dir / name) for name in GOVERNANCE_FILES}
+    composite = hashlib.sha256(
+        "|".join(f"{name}:{revisions[name]}" for name in GOVERNANCE_FILES).encode()
+    ).hexdigest()[:12]
+    chain_status, epoch = verify_chain(gov_dir)
+
+    composed["revision"] = composite
+    composed["source"] = "governance"
+    composed["governance"] = {
+        "dir": str(gov_dir),
+        "external_target": target,
+        "revisions": revisions,
+        "composite_revision": composite,
+        "chain_status": chain_status,
+        "epoch": epoch,
+    }
+    return composed
+
+
+def verify_chain(gov_dir: Path) -> tuple[str, int]:
+    """Verify the epochs hash chain and that its head matches the working
+    tree. Returns (status, epoch_count) with status in:
+    verified | uncommitted | tampered | empty."""
+    epochs_path = gov_dir / EPOCHS_FILENAME
+    current = {name: file_revision(gov_dir / name) for name in GOVERNANCE_FILES}
+    has_files = any(value is not None for value in current.values())
+    if not epochs_path.exists():
+        return ("uncommitted" if has_files else "empty"), 0
+
+    rows: list[dict[str, Any]] = []
+    for line in epochs_path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except ValueError:
+            return "tampered", len(rows)
+        rows.append(row)
+    if not rows:
+        return ("uncommitted" if has_files else "empty"), 0
+
+    prev_hash = ""
+    for row in rows:
+        if str(row.get("prev") or "") != prev_hash:
+            return "tampered", len(rows)
+        prev_hash = _row_hash(row)
+
+    head = rows[-1]
+    if head.get("files") != current:
+        return "tampered", len(rows)
+    return "verified", len(rows)
+
+
+def commit_epoch(gov_dir: Path, *, note: str = "") -> dict[str, Any]:
+    """Record the current governance file hashes as a new chain epoch. The
+    owner runs this (via CLI) after every deliberate edit; loads treat any
+    uncommitted drift as tamper."""
+    epochs_path = gov_dir / EPOCHS_FILENAME
+    rows: list[dict[str, Any]] = []
+    if epochs_path.exists():
+        for line in epochs_path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                rows.append(json.loads(line))
+    prev_hash = _row_hash(rows[-1]) if rows else ""
+    revisions = {name: file_revision(gov_dir / name) for name in GOVERNANCE_FILES}
+    composite = hashlib.sha256(
+        "|".join(f"{name}:{revisions[name]}" for name in GOVERNANCE_FILES).encode()
+    ).hexdigest()[:12]
+    row = {
+        "epoch": len(rows),
+        "ts": utc_now_iso(),
+        "files": revisions,
+        "composite": composite,
+        "prev": prev_hash,
+        "note": note,
+    }
+    with epochs_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(row, sort_keys=True) + "\n")
+    return row
+
+
+def _row_hash(row: dict[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(row, sort_keys=True, default=str).encode()
+    ).hexdigest()[:16]
+
+
+def migrate_from_constitution(
+    repo_root: Path, job_id: str, job_root: Path
+) -> dict[str, Any]:
+    """Split a legacy job-root constitution.yaml (or the defaults) into the
+    governance namespace and commit epoch 0. The legacy file is left in
+    place — the loader prefers governance/ once it exists."""
+    from wayfinder_paths.jobs.constitution import (
+        CONSTITUTION_FILENAME,
+        DEFAULT_CONSTITUTION,
+        _merge,
+    )
+
+    legacy = _load_yaml(job_root / CONSTITUTION_FILENAME)
+    merged = _merge(DEFAULT_CONSTITUTION, legacy or {})
+
+    gov_dir = governance_dir(repo_root, job_id)
+    gov_dir.mkdir(parents=True, exist_ok=True)
+
+    warnings: list[str] = []
+    audit_floor = float(
+        (merged.get("promotion") or {}).get("audit_min_delta_utility") or 0.0
+    )
+    if audit_floor < 0:
+        warnings.append(
+            f"audit_min_delta_utility is negative ({audit_floor}) — a full-size "
+            "candidate can pass with negative audited utility; raise to >= 0.0"
+        )
+
+    _write_yaml(gov_dir / EXTERNAL_TARGET_FILE, dict(DEFAULT_EXTERNAL_TARGET))
+    _write_yaml(gov_dir / HARD_CONSTRAINTS_FILE, merged["hard_constraints"])
+    audit_policy = {
+        "enforcement": merged["enforcement"],
+        "evaluation": merged["evaluation"],
+        "promotion": merged["promotion"],
+    }
+    if isinstance(merged.get("verdict"), dict):
+        audit_policy["verdict"] = merged["verdict"]
+    _write_yaml(gov_dir / AUDIT_POLICY_FILE, audit_policy)
+    _write_yaml(gov_dir / SEARCH_CRITERION_FILE, {"objective": merged["objective"]})
+
+    epoch = commit_epoch(gov_dir, note=f"migrated from legacy constitution ({job_id})")
+    return {
+        "job_id": job_id,
+        "governance_dir": str(gov_dir),
+        "epoch": epoch["epoch"],
+        "composite_revision": epoch["composite"],
+        "source": "legacy_constitution" if legacy else "defaults",
+        "warnings": warnings,
+    }
+
+
+def _write_yaml(path: Path, data: dict[str, Any]) -> None:
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")

--- a/wayfinder_paths/jobs/proposals.py
+++ b/wayfinder_paths/jobs/proposals.py
@@ -33,7 +33,11 @@ from wayfinder_paths.jobs.execution.job import (
     synthesize_scenario_plan,
 )
 from wayfinder_paths.jobs.execution.primitives import ExecutionSpec
-from wayfinder_paths.jobs.gating import compute_workspace_revision, evaluate_live_gate, evaluate_economic_gate
+from wayfinder_paths.jobs.gating import (
+    compute_workspace_revision,
+    evaluate_economic_gate,
+    evaluate_live_gate,
+)
 from wayfinder_paths.jobs.models import utc_now_iso
 from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.jobs.sync import sync_all_jobs
@@ -148,8 +152,10 @@ def propose_change(
             job_id,
             candidate_id=pid,
             family=(
-                "probation" if change.get("probation")
-                else "params" if change.get("execution_params")
+                "probation"
+                if change.get("probation")
+                else "params"
+                if change.get("execution_params")
                 else str(kind or "code")
             ),
             summary=str(summary or ""),
@@ -240,12 +246,20 @@ def _generate_candidate_report(
                 probation=probation,
             )
         except Exception as exc:  # noqa: BLE001 — a crashed economic eval must
-            # degrade to advisory-unavailable, never break propose.
+            # not break propose; the record carries the REAL enforcement so
+            # the approval gate can fail closed on live-capable jobs
+            # (previously the crash forced "advisory" — the review's central
+            # fail-open finding).
+            from wayfinder_paths.jobs.constitution import load_constitution
+
+            constitution = load_constitution(store.job_dir(job_id))
             economic = {
                 "ready": None,
                 "reasons": [f"economic evaluation failed: {exc}"[:300]],
-                "enforcement": "advisory",
+                "enforcement": constitution.get("enforcement") or "advisory",
+                "constitution_revision": constitution.get("revision"),
                 "status": "error",
+                "escalate": True,
             }
     else:
         # Research-only / no-dataset jobs: nothing to backtest or gate — the

--- a/wayfinder_paths/jobs/store.py
+++ b/wayfinder_paths/jobs/store.py
@@ -373,12 +373,77 @@ class JobStore:
             reasons = "; ".join(gate.get("reasons") or ["unknown"])
             raise ValueError(f"candidate gate is not live-ready: {reasons}")
         economic = report.get("economic") or {}
-        # ready=None (advisory constitution, unavailable, or crashed eval)
-        # never blocks — only a computed False under a blocking constitution.
-        if economic.get("enforcement") == "blocking" and economic.get("ready") is False:
-            reasons = "; ".join(economic.get("reasons") or ["unknown"])
-            raise ValueError(f"candidate is not economic-ready: {reasons}")
+        self._ensure_governance_gate(job_id, economic)
         self._ensure_candidate_matches_report(job_id, proposal, report)
+
+    def _ensure_governance_gate(self, job_id: str, economic: dict[str, Any]) -> None:
+        """Fail-closed economic gating for live-capable jobs.
+
+        The old semantics blocked only on an explicit ready=False under a
+        blocking constitution — a crashed evaluator, missing constitution,
+        or a constitution swapped between evaluation and approval all
+        promoted freely (observed as the review's central fail-open finding).
+        For a job whose script loop has entered paper/live:
+        - blocking + ready is not True  -> ESCALATE (None = missing evidence)
+        - governance changed since evaluation -> ESCALATE (re-run the report)
+        - governance chain tampered -> ESCALATE
+        Advisory jobs keep the old behavior (report, never block)."""
+        from wayfinder_paths.jobs.constitution import load_constitution
+
+        current = load_constitution(self.job_dir(job_id))
+        live_capable = self._job_is_live_capable(job_id)
+
+        chain_status = (current.get("governance") or {}).get("chain_status")
+        if live_capable and chain_status == "tampered":
+            raise ValueError(
+                "ESCALATE: governance chain is tampered (uncommitted edit to "
+                "a protected file) — owner must inspect and re-commit "
+                "(wayfinder job governance-commit) before any promotion"
+            )
+
+        enforcement = str(
+            current.get("enforcement") or economic.get("enforcement") or "advisory"
+        )
+        if enforcement != "blocking" or not live_capable:
+            # Pre-live/advisory: old semantics — only an explicit False blocks.
+            if (
+                economic.get("enforcement") == "blocking"
+                and economic.get("ready") is False
+            ):
+                reasons = "; ".join(economic.get("reasons") or ["unknown"])
+                raise ValueError(f"candidate is not economic-ready: {reasons}")
+            return
+
+        # Live-capable + blocking: fail closed.
+        evaluated_revision = economic.get("constitution_revision")
+        if evaluated_revision and evaluated_revision != current.get("revision"):
+            raise ValueError(
+                "ESCALATE: governance changed since the candidate was "
+                f"evaluated (report {evaluated_revision} vs current "
+                f"{current.get('revision')}) — re-run the economic report"
+            )
+        if economic.get("ready") is not True:
+            reasons = "; ".join(
+                economic.get("reasons")
+                or ["economic evidence unavailable (ready is not True)"]
+            )
+            raise ValueError(
+                "ESCALATE: blocking governance requires economic_ready=True "
+                f"for a live-capable job; got {economic.get('ready')!r}: "
+                f"{reasons}"
+            )
+
+    def _job_is_live_capable(self, job_id: str) -> bool:
+        """A job that has entered paper/live operation: script loop enabled
+        with any recorded forward runs. Never raises."""
+        try:
+            job = self.load(job_id)
+            if not job.script_loop.enabled:
+                return False
+            summary = self.read_json(job_id, "results/forward/summary.json") or {}
+            return int(((summary.get("runs") or {}).get("count")) or 0) > 0
+        except Exception:
+            return False
 
     def _ensure_candidate_matches_report(
         self, job_id: str, proposal: dict[str, Any], report: dict[str, Any]

--- a/wayfinder_paths/tests/test_jobs_fail_closed.py
+++ b/wayfinder_paths/tests/test_jobs_fail_closed.py
@@ -1,0 +1,187 @@
+"""Fail-closed economic gating: for a live-capable job under blocking
+governance, missing evidence (ready=None), a governance change between
+evaluation and approval, or a tampered chain all ESCALATE instead of
+silently promoting — the review's central fail-open findings."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from wayfinder_paths.jobs.governance import (
+    HARD_CONSTRAINTS_FILE,
+    commit_epoch,
+    governance_dir,
+    migrate_from_constitution,
+    record_evidence_access,
+)
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.store import JobStore
+
+
+def _live_job(tmp_path, *, enforcement: str = "blocking", forward_runs: int = 3):
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        "fc-demo",
+        script="workspace/src/strategy.py",
+        agent_mode="intervene",
+        execution_contract="jobs_v1",
+    )
+    store.save(job)
+    root = store.job_dir(job.id)
+    (root / "constitution.yaml").write_text(f"enforcement: {enforcement}\n")
+    migrate_from_constitution(tmp_path, job.id, root)
+    if forward_runs:
+        summary = root / "results" / "forward" / "summary.json"
+        summary.parent.mkdir(parents=True, exist_ok=True)
+        summary.write_text(json.dumps({"runs": {"count": forward_runs}}))
+    return store, job.id
+
+
+def _proposal(economic: dict) -> dict:
+    return {
+        "proposal_id": "p1",
+        "candidate_report": {
+            "revision": "cafecafecafe",
+            "validation_summary": {"status": "passed"},
+            "gate": {"live_ready": True, "reasons": []},
+            "economic": economic,
+        },
+    }
+
+
+def _gate(store, job_id, economic, monkeypatch=None) -> None:
+    # _ensure_candidate_matches_report needs a real candidate dir; bypass it —
+    # this test targets the governance gate specifically.
+    store._ensure_candidate_matches_report = lambda *a, **k: None
+    store._ensure_candidate_report_gate(
+        job_id, _proposal(economic), allow_ungated=False
+    )
+
+
+def test_ready_none_escalates_for_live_blocking(tmp_path) -> None:
+    store, job_id = _live_job(tmp_path)
+    current_rev = None  # revision matching skipped when absent from report
+    with pytest.raises(ValueError, match="ESCALATE.*ready"):
+        _gate(store, job_id, {"ready": None, "enforcement": "blocking"})
+    with pytest.raises(ValueError, match="ESCALATE"):
+        _gate(store, job_id, {"ready": False, "enforcement": "blocking"})
+    assert current_rev is None
+
+
+def test_ready_true_passes_and_prelive_keeps_old_semantics(tmp_path) -> None:
+    store, job_id = _live_job(tmp_path)
+    from wayfinder_paths.jobs.constitution import load_constitution
+
+    rev = load_constitution(store.job_dir(job_id))["revision"]
+    _gate(
+        store,
+        job_id,
+        {"ready": True, "enforcement": "blocking", "constitution_revision": rev},
+    )
+
+    # Pre-live job (no forward runs): ready=None passes (old semantics).
+    store2, job2 = _live_job(tmp_path / "b", forward_runs=0)
+    _gate(store2, job2, {"ready": None, "enforcement": "blocking"})
+
+    # Advisory governance: even a live job passes on None (report-only).
+    store3, job3 = _live_job(tmp_path / "c", enforcement="advisory")
+    _gate(store3, job3, {"ready": None, "enforcement": "advisory"})
+    # ...but an explicit computed False under a blocking REPORT still blocks.
+    with pytest.raises(ValueError, match="not economic-ready"):
+        _gate(store3, job3, {"ready": False, "enforcement": "blocking"})
+
+
+def test_governance_change_between_eval_and_approval_escalates(tmp_path) -> None:
+    store, job_id = _live_job(tmp_path)
+    from wayfinder_paths.jobs.constitution import load_constitution
+
+    old_rev = load_constitution(store.job_dir(job_id))["revision"]
+    gov = governance_dir(tmp_path, job_id)
+    (gov / HARD_CONSTRAINTS_FILE).write_text("max_drawdown_pct: 0.30\n")
+    commit_epoch(gov, note="owner loosened after evaluation")
+
+    with pytest.raises(ValueError, match="ESCALATE.*changed since"):
+        _gate(
+            store,
+            job_id,
+            {
+                "ready": True,
+                "enforcement": "blocking",
+                "constitution_revision": old_rev,
+            },
+        )
+
+
+def test_tampered_chain_escalates_approval_and_claim(tmp_path) -> None:
+    store, job_id = _live_job(tmp_path)
+    gov = governance_dir(tmp_path, job_id)
+    (gov / HARD_CONSTRAINTS_FILE).write_text("max_drawdown_pct: 0.99\n")  # no commit
+
+    with pytest.raises(ValueError, match="ESCALATE.*tampered"):
+        _gate(store, job_id, {"ready": True, "enforcement": "blocking"})
+
+    from wayfinder_paths.jobs.application import claim_application
+
+    with pytest.raises(ValueError, match="ESCALATE.*tampered"):
+        claim_application(store, job_id, "p1")
+
+
+def test_crash_record_carries_real_enforcement(tmp_path, monkeypatch) -> None:
+    store, job_id = _live_job(tmp_path)
+    import wayfinder_paths.jobs.proposals as proposals_module
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("dataset missing")
+
+    monkeypatch.setattr(proposals_module, "evaluate_economic_gate", boom)
+    # Reach into the propose flow's except branch via a direct call shape:
+    # simulate what propose_change builds when evaluation crashes.
+    from wayfinder_paths.jobs.constitution import load_constitution
+
+    constitution = load_constitution(store.job_dir(job_id))
+    assert constitution["enforcement"] == "blocking"
+    # The new except-branch behavior is exercised end-to-end in propose tests;
+    # here we assert the invariant it exists to protect: a crash record under
+    # blocking governance can never pass the live gate.
+    with pytest.raises(ValueError, match="ESCALATE"):
+        _gate(
+            store,
+            job_id,
+            {
+                "ready": None,
+                "enforcement": "blocking",
+                "status": "error",
+                "escalate": True,
+            },
+        )
+
+
+def test_evidence_access_ledger(tmp_path) -> None:
+    record_evidence_access(tmp_path, "fc-demo", "backtest_job", {"quick_bars": 500})
+    record_evidence_access(tmp_path, "fc-demo", "experiments")
+    path = tmp_path / "audit" / "fc-demo" / "evidence_access.jsonl"
+    rows = [json.loads(line) for line in path.read_text().splitlines()]
+    assert [row["op"] for row in rows] == ["backtest_job", "experiments"]
+    from wayfinder_paths.jobs.governance import evidence_access_count
+
+    assert evidence_access_count(tmp_path, "fc-demo") == 2
+
+
+def test_op_runner_records_evidence_access(tmp_path, monkeypatch) -> None:
+    from wayfinder_paths.jobs.execution import op_runner
+
+    recorded: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.governance.record_evidence_access",
+        lambda repo_root, job_id, op, detail=None: recorded.append((job_id, op)),
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.store.JobStore",
+        lambda: type("S", (), {"repo_root": tmp_path})(),
+    )
+    monkeypatch.setattr(op_runner, "_run_op", lambda op, kwargs: {"ok": True})
+    op_runner._run("backtest_job", {"job_id": "fc-demo", "quick_bars": 100})
+    op_runner._run("__echo__", {"job_id": "fc-demo"})  # not an evidence op
+    assert recorded == [("fc-demo", "backtest_job")]

--- a/wayfinder_paths/tests/test_jobs_governance.py
+++ b/wayfinder_paths/tests/test_jobs_governance.py
@@ -1,0 +1,132 @@
+"""Protected governance plane: the constitution split into four owner-owned
+files OUTSIDE the agent-writable job tree, with a hash-chained epoch record
+so uncommitted drift (the agent-side tamper path) is detectable. The legacy
+job-root constitution.yaml keeps working until a job is migrated."""
+
+from __future__ import annotations
+
+import json
+
+from wayfinder_paths.jobs.constitution import DEFAULT_CONSTITUTION, load_constitution
+from wayfinder_paths.jobs.governance import (
+    AUDIT_POLICY_FILE,
+    HARD_CONSTRAINTS_FILE,
+    commit_epoch,
+    governance_dir,
+    load_governance,
+    migrate_from_constitution,
+    verify_chain,
+)
+
+
+def _legacy_job(tmp_path, constitution_text: str | None):
+    job_root = tmp_path / ".wayfinder" / "jobs" / "gov-demo"
+    job_root.mkdir(parents=True)
+    if constitution_text is not None:
+        (job_root / "constitution.yaml").write_text(constitution_text)
+    return job_root
+
+
+def test_migration_splits_and_composes_identically(tmp_path) -> None:
+    legacy = (
+        "enforcement: blocking\n"
+        "objective:\n  weights:\n    downside: 0.7\n"
+        "promotion:\n  min_oos_trades: 12\n  audit_min_delta_utility: 0.0\n"
+        "hard_constraints:\n  max_drawdown_pct: 0.18\n"
+        "verdict:\n  minimum_days: 2.0\n"
+    )
+    job_root = _legacy_job(tmp_path, legacy)
+    before = load_constitution(job_root)
+
+    result = migrate_from_constitution(tmp_path, "gov-demo", job_root)
+    assert result["epoch"] == 0
+    assert not result["warnings"]  # audit floor not negative in this fixture
+
+    after = load_constitution(job_root)  # facade now prefers governance/
+    assert after["source"] == "governance"
+    # Composition preserves every consumed field of the legacy load.
+    for key in (
+        "enforcement",
+        "objective",
+        "evaluation",
+        "promotion",
+        "hard_constraints",
+        "verdict",
+    ):
+        assert after[key] == before[key], key
+    assert after["governance"]["chain_status"] == "verified"
+    assert after["governance"]["revisions"][HARD_CONSTRAINTS_FILE] is not None
+
+
+def test_migration_warns_on_negative_audit_floor(tmp_path) -> None:
+    job_root = _legacy_job(tmp_path, "promotion:\n  audit_min_delta_utility: -0.005\n")
+    result = migrate_from_constitution(tmp_path, "gov-demo", job_root)
+    assert any("negative" in w for w in result["warnings"])
+
+
+def test_uncommitted_drift_reads_as_tampered(tmp_path) -> None:
+    job_root = _legacy_job(tmp_path, "enforcement: blocking\n")
+    migrate_from_constitution(tmp_path, "gov-demo", job_root)
+    gov = governance_dir(tmp_path, "gov-demo")
+
+    # Agent-style edit: loosen a ceiling with no epoch commit.
+    (gov / HARD_CONSTRAINTS_FILE).write_text("max_drawdown_pct: 0.99\n")
+    doc = load_governance(tmp_path, "gov-demo")
+    assert doc["governance"]["chain_status"] == "tampered"
+
+    # Owner path: commit -> verified again, ceiling change now on record.
+    commit_epoch(gov, note="owner change")
+    doc = load_governance(tmp_path, "gov-demo")
+    assert doc["governance"]["chain_status"] == "verified"
+    assert doc["hard_constraints"]["max_drawdown_pct"] == 0.99
+    status, epochs = verify_chain(gov)
+    assert (status, epochs) == ("verified", 2)
+
+
+def test_chain_linkage_break_is_tampered(tmp_path) -> None:
+    job_root = _legacy_job(tmp_path, "enforcement: blocking\n")
+    migrate_from_constitution(tmp_path, "gov-demo", job_root)
+    gov = governance_dir(tmp_path, "gov-demo")
+    commit_epoch(gov, note="second epoch")
+
+    epochs_path = gov / "epochs.jsonl"
+    rows = [json.loads(line) for line in epochs_path.read_text().splitlines()]
+    rows[0]["note"] = "history rewritten"  # breaks the next row's prev hash
+    epochs_path.write_text(
+        "\n".join(json.dumps(r, sort_keys=True) for r in rows) + "\n"
+    )
+    status, _ = verify_chain(gov)
+    assert status == "tampered"
+
+
+def test_legacy_and_default_paths_unchanged(tmp_path) -> None:
+    # No governance dir: legacy file loads exactly as before.
+    job_root = _legacy_job(tmp_path, "enforcement: blocking\n")
+    doc = load_constitution(job_root)
+    assert doc["source"] == "file"
+    assert doc["enforcement"] == "blocking"
+
+    # Neither governance nor legacy: defaults, advisory.
+    bare = tmp_path / "elsewhere" / "job"
+    bare.mkdir(parents=True)
+    doc = load_constitution(bare)
+    assert doc["source"] == "defaults"
+    assert doc["enforcement"] == DEFAULT_CONSTITUTION["enforcement"]
+
+
+def test_governance_composite_revision_changes_with_any_file(tmp_path) -> None:
+    job_root = _legacy_job(tmp_path, None)
+    migrate_from_constitution(tmp_path, "gov-demo", job_root)
+    first = load_governance(tmp_path, "gov-demo")["revision"]
+    gov = governance_dir(tmp_path, "gov-demo")
+    (gov / AUDIT_POLICY_FILE).write_text("enforcement: blocking\n")
+    commit_epoch(gov)
+    second = load_governance(tmp_path, "gov-demo")["revision"]
+    assert first != second
+
+
+def test_stress_trap_governance_tamper(tmp_path) -> None:
+    from wayfinder_paths.jobs.benchmarks.stress import TRAPS
+
+    outcome = TRAPS["governance_tamper"](tmp_path)
+    assert outcome["held"] is True, outcome


### PR DESCRIPTION
PR 2 of the L3/L4 program. **Stacked on #659** (governance plane) — merge that first.

## The fail-open findings this closes

The review's central safety finding: approval blocked only on an explicit `ready=False` under a blocking constitution. A crashed economic evaluator (`ready: None`), a missing/malformed constitution (advisory defaults), or a constitution edited between evaluation and approval (no freshness check existed) — all promoted freely.

## New semantics

For a **live-capable** job (script loop enabled + recorded forward runs) under **blocking** governance:

| Condition | Old | New |
|---|---|---|
| `ready: True`, revisions match | pass | pass |
| `ready: None` (crashed eval / missing evidence) | **pass** | **ESCALATE** |
| `ready: False` | block | ESCALATE |
| governance changed since evaluation | **pass** | **ESCALATE** (re-run report) |
| governance chain tampered | **pass** | **ESCALATE** (approval AND claim) |

Pre-live and advisory jobs keep the old report-only semantics — research iteration stays cheap and movable; the teeth arrive exactly when real money does.

Supporting changes: proposal crash records carry the real enforcement + constitution revision + `escalate` flag (previously forced "advisory"); the gating unavailable path is marked `escalate`; and every validation-querying op now appends to the protected `audit/<job_id>/evidence_access.jsonl` — the evidence-mining ledger the review called for.

## Verification

7 new tests (None/False escalate for live+blocking; True passes; pre-live and advisory keep old semantics; eval↔approval governance change escalates; tampered chain escalates approval and claim; ledger append + count; op_runner hook records evidence ops only). 92 tests green across proposal/application/approve/store/gating/economics suites. ruff + format clean.

Roll plan: bake+roll after this merges (with #659), then migrate the three live jobs and flip their `audit_policy.enforcement` to `blocking`.