### PR TITLE
jobs: active archive + multi-objective search (L3/L4 PR 4)

### DIFF
--- a/wayfinder_paths/jobs/application.py
+++ b/wayfinder_paths/jobs/application.py
@@ -670,7 +670,9 @@ def _record_promoted_revision(
     try:
         from wayfinder_paths.jobs.archive import set_incumbent
 
-        set_incumbent(store, job_id, proposal_id)
+        # Content id first; set_incumbent's resolver falls back to the
+        # proposal UUID for legacy entries recorded before content ids.
+        set_incumbent(store, job_id, f"cand-{revision}" if revision else proposal_id)
     except Exception:  # noqa: BLE001 — archive bookkeeping never breaks promotion
         pass
     revisions_path = root / "versions" / "revisions.jsonl"

--- a/wayfinder_paths/jobs/archive.py
+++ b/wayfinder_paths/jobs/archive.py
@@ -47,6 +47,8 @@ def record_candidate(
     objective: dict[str, Any] | None,
     revision: str | None = None,
     parent_id: str | None = None,
+    parent_candidate_ids: list[str] | None = None,
+    proposal_id: str | None = None,
     behavior: dict[str, Any] | None = None,
     evidence: str | None = None,
 ) -> dict[str, Any]:
@@ -71,6 +73,19 @@ def record_candidate(
                 "updated_at": utc_now_iso(),
             }
         )
+        # Content-derived IDs dedup re-proposals of the same workspace: the
+        # entry accumulates every proposal UUID and parent edge instead of
+        # duplicating. Behavior is content-derived too — fill it once.
+        if proposal_id:
+            ids = existing.setdefault("proposal_ids", [])
+            if proposal_id not in ids:
+                ids.append(proposal_id)
+        for parent in parent_candidate_ids or []:
+            parents = existing.setdefault("parent_candidate_ids", [])
+            if parent and parent not in parents:
+                parents.append(parent)
+        if behavior and not existing.get("behavior"):
+            existing["behavior"] = behavior
         entry = existing
     else:
         entry = {
@@ -81,6 +96,8 @@ def record_candidate(
             "objective": objective,
             "revision": revision,
             "parent_id": parent_id,
+            "parent_candidate_ids": [p for p in (parent_candidate_ids or []) if p],
+            "proposal_ids": [proposal_id] if proposal_id else [],
             "behavior": behavior or {},
             "evidence": evidence,
             "created_at": utc_now_iso(),
@@ -117,9 +134,11 @@ def set_candidate_status(
 
 def set_incumbent(store: JobStore, job_id: str, candidate_id: str) -> None:
     """Promote one entry to incumbent; previous incumbents become archived
-    branches (still ranked on the frontier — that is the point)."""
+    branches (still ranked on the frontier — that is the point). The id
+    resolves as content id first, then proposal UUID, then raw revision —
+    promotion callers hold different handles across archive generations."""
     doc = load_archive(store, job_id)
-    promoted = _find(doc, candidate_id)
+    promoted = _resolve(doc, candidate_id)
     if promoted is None:
         return
     for entry in doc.get("candidates") or []:
@@ -170,6 +189,43 @@ def archive_snapshot_block(store: JobStore, job_id: str) -> dict[str, Any]:
             "revival candidate before any novel divergent search."
         ),
     }
+
+
+def lineage_of(store: JobStore, job_id: str, candidate_id: str) -> list[dict[str, Any]]:
+    """Ancestry walk over parent_candidate_ids (legacy parent_id as
+    fallback edge), nearest parent first. Cycle-safe; unknown parents end
+    the walk — the DAG only knows what was archived."""
+    doc = load_archive(store, job_id)
+    entry = _resolve(doc, candidate_id)
+    lineage: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    frontier = list((entry or {}).get("parent_candidate_ids") or []) or [
+        str((entry or {}).get("parent_id") or "")
+    ]
+    while frontier:
+        parent_id = frontier.pop(0)
+        if not parent_id or parent_id in seen:
+            continue
+        seen.add(parent_id)
+        parent = _resolve(doc, parent_id)
+        if parent is None:
+            continue
+        lineage.append(parent)
+        frontier.extend(parent.get("parent_candidate_ids") or [parent.get("parent_id")])
+    return lineage
+
+
+def _resolve(doc: dict[str, Any], candidate_id: str) -> dict[str, Any] | None:
+    exact = _find(doc, candidate_id)
+    if exact is not None:
+        return exact
+    for entry in doc.get("candidates") or []:
+        if candidate_id in (entry.get("proposal_ids") or []):
+            return entry
+    for entry in doc.get("candidates") or []:
+        if entry.get("revision") and entry["revision"] == candidate_id:
+            return entry
+    return None
 
 
 def _find(doc: dict[str, Any], candidate_id: str) -> dict[str, Any] | None:

--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -440,6 +440,15 @@ def tick_cmd(job_id: str, mode: str | None, dry_run: bool) -> None:
     show_default=True,
     help="Optuna sampler seed for reproducible searches.",
 )
+@click.option(
+    "--objectives",
+    default=None,
+    help=(
+        "Comma-separated grid metrics for multi-objective search (NSGA-II "
+        "Pareto front), e.g. net_return,max_drawdown_pct. Requires "
+        "--optimizer optuna; --rank-by becomes the tie-break."
+    ),
+)
 def experiments_cmd(
     job_id: str,
     grid_path: str | None,
@@ -456,6 +465,7 @@ def experiments_cmd(
     optimizer: str,
     n_trials: int,
     seed: int,
+    objectives: str | None,
 ) -> None:
     store = JobStore()
     if list_only or not grid_path:
@@ -474,8 +484,20 @@ def experiments_cmd(
             "anchored": wf_anchored,
         }
     optuna_options = (
-        {"n_trials": n_trials, "seed": seed} if optimizer == "optuna" else None
+        {
+            "n_trials": n_trials,
+            "seed": seed,
+            **(
+                {"objectives": [x.strip() for x in objectives.split(",") if x.strip()]}
+                if objectives
+                else {}
+            ),
+        }
+        if optimizer == "optuna"
+        else None
     )
+    if objectives and optimizer != "optuna":
+        raise click.UsageError("--objectives requires --optimizer optuna")
     result = run_experiment(
         job_id,
         grid_path,

--- a/wayfinder_paths/jobs/evolution_ledger.py
+++ b/wayfinder_paths/jobs/evolution_ledger.py
@@ -208,11 +208,15 @@ def _research_staleness(root: Path, proposals: list[dict[str, Any]]) -> dict[str
 
 
 def _opportunity_recall(store: JobStore, job_id: str) -> dict[str, Any] | None:
-    """Selection-regret telemetry: does the archive hold a LIVE candidate that
-    outscores the current incumbent but was never promoted? A yes is a
-    measured missed opportunity, not a vibe."""
+    """Selection-regret telemetry, CONSTRAINED: a raw net_log_growth max
+    flags high-growth candidates the constitution would never promote
+    (drawdown/tail violators) as missed opportunities. Filter by the hard
+    constraints, score with the constitution's utility weights, and flag
+    missed only when the best passing candidate utility-beats or
+    Pareto-dominates the incumbent."""
     try:
-        from wayfinder_paths.jobs.archive import load_archive
+        from wayfinder_paths.jobs.archive import _dominates, load_archive
+        from wayfinder_paths.jobs.constitution import load_constitution
 
         doc = load_archive(store, job_id)
         candidates = [
@@ -223,21 +227,54 @@ def _opportunity_recall(store: JobStore, job_id: str) -> dict[str, Any] | None:
         ]
         if not candidates:
             return None
+        constitution = load_constitution(store.job_dir(job_id))
+        hard = constitution.get("hard_constraints") or {}
+        weights = (constitution.get("objective") or {}).get("weights") or {}
+
+        def _violates(entry: dict[str, Any]) -> bool:
+            vector = entry["objective"]
+            checks = (
+                ("max_drawdown_pct", hard.get("max_drawdown_pct")),
+                ("tail_loss", hard.get("max_tail_loss")),
+            )
+            for axis, ceiling in checks:
+                value = vector.get(axis)
+                if ceiling is not None and value is not None:
+                    if float(value) > float(ceiling):
+                        return True
+            return False
+
+        def _utility(entry: dict[str, Any]) -> float:
+            vector = entry["objective"]
+
+            def axis(name: str) -> float:
+                return float(vector.get(name) or 0.0)
+
+            return (
+                axis("net_log_growth")
+                - float(weights.get("downside", 0.0)) * axis("downside_deviation")
+                - float(weights.get("tail", 0.0)) * axis("tail_loss")
+                - float(weights.get("turnover", 0.0)) * axis("fee_load")
+            )
+
         incumbent = next(
             (e for e in candidates if e.get("status") == "incumbent"), None
         )
-
-        def growth(entry: dict[str, Any]) -> float:
-            return float(entry["objective"].get("net_log_growth") or 0.0)
-
-        best = max(candidates, key=growth)
+        passing = [e for e in candidates if not _violates(e)]
+        excluded = len(candidates) - len(passing)
+        if not passing:
+            return {"missed": False, "violating_excluded": excluded}
+        best = max(passing, key=_utility)
         if incumbent is None or best is incumbent:
-            return {"missed": False}
-        gap = growth(best) - growth(incumbent)
+            return {"missed": False, "violating_excluded": excluded}
+        utility_gap = _utility(best) - _utility(incumbent)
+        missed = utility_gap > 0 or _dominates(best, incumbent)
         return {
-            "missed": gap > 0,
+            "missed": missed,
             "best_candidate_id": best.get("candidate_id"),
-            "growth_gap": round(gap, 6),
+            "utility_gap": round(utility_gap, 6),
+            "violating_excluded": excluded,
+            "basis": "constitution_utility+pareto over constraint-passing candidates",
         }
     except Exception:  # noqa: BLE001 — telemetry never breaks the report
         return None

--- a/wayfinder_paths/jobs/execution/experiments.py
+++ b/wayfinder_paths/jobs/execution/experiments.py
@@ -62,6 +62,7 @@ def record_trial_lineage(
                 "run_id": run.get("run_id"),
                 "params": run.get("params"),
                 "rank_metric": stats.get(result.get("rank_by") or "net_return"),
+                "pareto": run.get("pareto"),
                 "behavior": _behavior_descriptor(stats),
             }
         )

--- a/wayfinder_paths/jobs/execution/optimize.py
+++ b/wayfinder_paths/jobs/execution/optimize.py
@@ -58,6 +58,10 @@ def is_search_space(payload: Any) -> bool:
             return False
 
 
+# Grid-row axes where smaller is better; every other rank key maximizes.
+_MINIMIZE_AXES = frozenset({"max_drawdown_pct"})
+
+
 def run_optuna_search(
     script_entrypoint: str | Path,
     dataset: PreparedExecutionDataset,
@@ -70,7 +74,14 @@ def run_optuna_search(
     timeout: float | None = None,
     sampler: str = "tpe",
     top_n_artifacts: int = 10,
+    objectives: list[str] | None = None,
 ) -> ExecutionGridResult:
+    """Single-objective TPE by default. Pass ``objectives=[axis, ...]`` (2+
+    grid rank keys) for multi-objective search: NSGA-II over the requested
+    axes, ``ranked`` leads with the Pareto front (rank_by breaks ties inside
+    it), every run row carries ``pareto: bool``. A search ranked on one
+    scalar collapses the risk/return trade-off the constitution actually
+    scores — MOO returns the frontier and lets the economic gate choose."""
     try:
         import optuna  # lazy: optional --with ml dep; grid path never pays it
     except ImportError as exc:
@@ -79,6 +90,14 @@ def run_optuna_search(
         ) from exc
 
     check_rank_key(rank_by)
+    objectives = list(objectives or [])
+    if len(objectives) == 1:
+        raise ValueError(
+            "objectives needs 2+ axes for multi-objective search; for a "
+            "single axis pass rank_by instead"
+        )
+    for axis in objectives:
+        check_rank_key(axis)
     dimensions = {
         name: dict(value)
         for name, value in search_space.items()
@@ -96,7 +115,7 @@ def run_optuna_search(
 
     run_rows: list[dict[str, Any]] = []
 
-    def objective(trial: Any) -> float:
+    def objective(trial: Any) -> float | tuple[float, ...]:
         params = dict(constants)
         for name, dim in dimensions.items():
             params[name] = _suggest(trial, name, dim)
@@ -106,17 +125,47 @@ def run_optuna_search(
         run_rows.append(row)
         if not row["validation"]["execution_valid"]:
             raise optuna.TrialPruned("execution trace invalid for these params")
+        if objectives:
+            return tuple(float(row.get(axis) or 0) for axis in objectives)
         return float(row[rank_by] or 0)  # same coercion as grid ranking
 
     optuna.logging.set_verbosity(optuna.logging.WARNING)
-    match sampler:
-        case "tpe":
-            sampler_impl = optuna.samplers.TPESampler(seed=seed)
-        case "random":
-            sampler_impl = optuna.samplers.RandomSampler(seed=seed)
-        case _:
-            raise ValueError(f"sampler must be tpe or random, got {sampler!r}")
-    study = optuna.create_study(direction="maximize", sampler=sampler_impl)
+    if objectives:
+        # NSGA-II handles mixed int/float/categorical spaces; an explicit
+        # sampler="motpe" opts into optuna's multi-objective TPE instead.
+        match sampler:
+            case "tpe" | "nsga2":
+                sampler_name = "nsga2"
+                sampler_impl = optuna.samplers.NSGAIISampler(seed=seed)
+            case "motpe":
+                sampler_name = "motpe"
+                sampler_impl = optuna.samplers.TPESampler(seed=seed)
+            case "random":
+                sampler_name = "random"
+                sampler_impl = optuna.samplers.RandomSampler(seed=seed)
+            case _:
+                raise ValueError(
+                    f"sampler must be nsga2, motpe, or random for multi-"
+                    f"objective search, got {sampler!r}"
+                )
+        study = optuna.create_study(
+            directions=[
+                "minimize" if axis in _MINIMIZE_AXES else "maximize"
+                for axis in objectives
+            ],
+            sampler=sampler_impl,
+        )
+    else:
+        match sampler:
+            case "tpe":
+                sampler_name = "tpe"
+                sampler_impl = optuna.samplers.TPESampler(seed=seed)
+            case "random":
+                sampler_name = "random"
+                sampler_impl = optuna.samplers.RandomSampler(seed=seed)
+            case _:
+                raise ValueError(f"sampler must be tpe or random, got {sampler!r}")
+        study = optuna.create_study(direction="maximize", sampler=sampler_impl)
     # n_jobs=1 is REQUIRED (see module docstring), not a performance choice.
     study.optimize(objective, n_trials=n_trials, timeout=timeout, n_jobs=1)
 
@@ -124,7 +173,22 @@ def run_optuna_search(
         run_rows, rank_by=rank_by, top_n=top_n_artifacts
     )
     best_trial = None
-    if ranked:  # study.best_trial raises when every trial was pruned/invalid
+    pareto = None
+    if objectives:
+        front_numbers = {trial.number for trial in study.best_trials}
+        for row in run_rows:
+            row["pareto"] = row["trial"] in front_numbers
+        # Pareto members lead the ranking; rank_by orders inside each part.
+        ranked = sorted(ranked, key=lambda row: bool(row.get("pareto")), reverse=True)
+        pareto = [
+            {
+                "number": trial.number,
+                "values": list(trial.values),
+                "params": dict(trial.params),
+            }
+            for trial in study.best_trials[:top_n_artifacts]
+        ]
+    elif ranked:  # study.best_trial raises when every trial was pruned/invalid
         best_trial = {
             "number": study.best_trial.number,
             "value": study.best_trial.value,
@@ -136,12 +200,15 @@ def run_optuna_search(
         runs=run_rows,
         ranked=ranked,
         invalid=invalid,
-        optimizer="optuna",
+        optimizer="nsga2" if sampler_name == "nsga2" else "optuna",
         search={
             "n_trials": len(run_rows),
             "seed": seed,
-            "sampler": sampler,
+            "sampler": sampler_name,
             "best_trial": best_trial,
+            **(
+                {"objectives": objectives, "pareto_front": pareto} if objectives else {}
+            ),
         },
     )
 

--- a/wayfinder_paths/jobs/prompts/research_priors.md
+++ b/wayfinder_paths/jobs/prompts/research_priors.md
@@ -103,6 +103,12 @@ block's archetype counts and pick the family that treats YOUR disease.
   coarse lattice cannot, on the same budget. A search that only ever runs
   3x3 grids is a local optimizer by construction; TPE-first on wide spaces
   is how the search stays global. Rank with walk-forward either way.
+  For STRUCTURAL sweeps (exit structure, sizing overlays, leverage — anything
+  that reshapes risk, not just return) default to MULTI-OBJECTIVE:
+  `objectives=["net_return","max_drawdown_pct"]` (CLI `--objectives`) runs
+  NSGA-II and returns the Pareto FRONT instead of a single scalar winner —
+  a one-metric ranking silently collapses the risk/return trade-off the
+  constitution actually scores. Trial rows record `pareto: true/false`.
 - **Compound experiments** (second-order treatments): express a
   multi-intervention causal story as 2-4 pre-registered factors (boolean
   gates / structural params), run the factorial via the experiments grid.

--- a/wayfinder_paths/jobs/proposals.py
+++ b/wayfinder_paths/jobs/proposals.py
@@ -171,14 +171,30 @@ def propose_change(
         },
     )
     try:
-        from wayfinder_paths.jobs.archive import record_candidate
+        from wayfinder_paths.jobs.archive import load_archive, record_candidate
+        from wayfinder_paths.jobs.execution.experiments import _behavior_descriptor
 
         change = proposal.get("proposed_change") or {}
         economic = candidate_report.get("economic") or {}
+        candidate_revision = str(candidate_report.get("revision") or "")
+        # Content-derived id: the same workspace content re-proposed lands on
+        # the SAME entry (dedup + sticky refutation), while every proposal
+        # UUID accumulates on it. Parent edge resolves base_revision to the
+        # archived candidate it points at, falling back to the raw revision.
+        candidate_id = f"cand-{candidate_revision}" if candidate_revision else pid
+        parent_entry = next(
+            (
+                entry
+                for entry in load_archive(store, job_id).get("candidates") or []
+                if entry.get("revision") == base_revision
+            ),
+            None,
+        )
+        comparison = candidate_report.get("comparison") or {}
         record_candidate(
             store,
             job_id,
-            candidate_id=pid,
+            candidate_id=candidate_id,
             family=(
                 "probation"
                 if change.get("probation")
@@ -189,8 +205,13 @@ def propose_change(
             summary=str(summary or ""),
             status="probation" if change.get("probation") else "archived",
             objective=(economic.get("objective") or {}).get("candidate"),
-            revision=candidate_report.get("revision"),
+            revision=candidate_revision or None,
             parent_id=base_revision,
+            parent_candidate_ids=[
+                parent_entry["candidate_id"] if parent_entry else base_revision
+            ],
+            proposal_id=pid,
+            behavior=_behavior_descriptor(comparison.get("candidate") or {}),
         )
     except Exception:  # noqa: BLE001 — archive bookkeeping never breaks propose
         pass

--- a/wayfinder_paths/tests/test_execution_ccxt_feed.py
+++ b/wayfinder_paths/tests/test_execution_ccxt_feed.py
@@ -350,7 +350,7 @@ def test_build_live_dataset_chains_derived_features(
 
     calls: list[tuple[str, int]] = []
 
-    def fake_refresh(job_id, *, store, max_age_seconds):
+    def fake_refresh(job_id, *, store, max_age_seconds, **kwargs):
         calls.append((job_id, max_age_seconds))
         return {"refreshed": True, "rows_appended": 3}
 

--- a/wayfinder_paths/tests/test_jobs_active_archive.py
+++ b/wayfinder_paths/tests/test_jobs_active_archive.py
@@ -1,0 +1,151 @@
+"""Active archive: content-derived candidate IDs dedup re-proposals onto one
+entry (accumulating proposal UUIDs and parent edges), lineage walks the DAG,
+promotion resolves legacy handles, and opportunity recall is constrained by
+the constitution instead of flagging drawdown violators as missed wins."""
+
+from __future__ import annotations
+
+from wayfinder_paths.jobs.archive import (
+    lineage_of,
+    load_archive,
+    record_candidate,
+    set_candidate_status,
+    set_incumbent,
+)
+from wayfinder_paths.jobs.evolution_ledger import _opportunity_recall
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.store import JobStore
+
+
+def _job(tmp_path):
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        "arch-demo",
+        script="workspace/src/strategy.py",
+        agent_mode="intervene",
+        execution_contract="jobs_v1",
+    )
+    store.save(job)
+    return store, job.id
+
+
+def _record(store, job_id, cid, **kwargs):
+    defaults = dict(
+        family="params",
+        summary=f"candidate {cid}",
+        status="archived",
+        objective={"net_log_growth": 0.01},
+    )
+    defaults.update(kwargs)
+    return record_candidate(store, job_id, candidate_id=cid, **defaults)
+
+
+def test_content_id_dedup_accumulates_proposals_and_parents(tmp_path) -> None:
+    store, job_id = _job(tmp_path)
+    _record(
+        store,
+        job_id,
+        "cand-aaa",
+        proposal_id="prop-1",
+        parent_candidate_ids=["cand-root"],
+    )
+    entry = _record(
+        store,
+        job_id,
+        "cand-aaa",
+        proposal_id="prop-2",
+        parent_candidate_ids=["cand-root"],
+    )
+    assert entry["proposal_ids"] == ["prop-1", "prop-2"]
+    assert entry["parent_candidate_ids"] == ["cand-root"]
+    assert len(load_archive(store, job_id)["candidates"]) == 1
+
+    # Sticky refutation survives content-id re-proposal.
+    set_candidate_status(store, job_id, "cand-aaa", "refuted", evidence="dead")
+    entry = _record(store, job_id, "cand-aaa", proposal_id="prop-3")
+    assert entry["status"] == "refuted"
+    assert "prop-3" in entry["proposal_ids"]
+
+
+def test_lineage_walks_parent_dag(tmp_path) -> None:
+    store, job_id = _job(tmp_path)
+    _record(store, job_id, "cand-a")
+    _record(store, job_id, "cand-b", parent_candidate_ids=["cand-a"])
+    _record(store, job_id, "cand-c", parent_candidate_ids=["cand-b"])
+    lineage = lineage_of(store, job_id, "cand-c")
+    assert [e["candidate_id"] for e in lineage] == ["cand-b", "cand-a"]
+
+    # Cycle-safe: a->b->a terminates.
+    _record(store, job_id, "cand-x", parent_candidate_ids=["cand-y"])
+    _record(store, job_id, "cand-y", parent_candidate_ids=["cand-x"])
+    ids = [e["candidate_id"] for e in lineage_of(store, job_id, "cand-x")]
+    assert ids == ["cand-y", "cand-x"]
+
+
+def test_set_incumbent_resolves_proposal_uuid_and_revision(tmp_path) -> None:
+    store, job_id = _job(tmp_path)
+    _record(store, job_id, "cand-abc", proposal_id="prop-9", revision="abc123")
+    # Legacy handle: promotion by proposal UUID still lands on the entry.
+    set_incumbent(store, job_id, "prop-9")
+    doc = load_archive(store, job_id)
+    assert doc["candidates"][0]["status"] == "incumbent"
+    # Content handle: cand-<revision> misses exact id, resolves via revision.
+    _record(store, job_id, "cand-def", revision="def456")
+    set_incumbent(store, job_id, "def456")
+    by_id = {e["candidate_id"]: e for e in load_archive(store, job_id)["candidates"]}
+    assert by_id["cand-def"]["status"] == "incumbent"
+    assert by_id["cand-abc"]["status"] == "archived"
+
+
+def test_opportunity_recall_is_constraint_aware(tmp_path) -> None:
+    store, job_id = _job(tmp_path)
+    root = store.job_dir(job_id)
+    (root / "constitution.yaml").write_text(
+        "objective:\n  weights:\n    downside: 0.5\n    tail: 1.0\n"
+        "hard_constraints:\n  max_drawdown_pct: 0.25\n  max_tail_loss: 0.15\n"
+    )
+    _record(
+        store,
+        job_id,
+        "cand-incumbent",
+        status="incumbent",
+        objective={
+            "net_log_growth": 0.02,
+            "downside_deviation": 0.01,
+            "tail_loss": 0.01,
+            "max_drawdown_pct": 0.05,
+        },
+    )
+    # Higher growth but blows the drawdown ceiling: NOT a missed opportunity.
+    _record(
+        store,
+        job_id,
+        "cand-violator",
+        objective={
+            "net_log_growth": 0.10,
+            "downside_deviation": 0.02,
+            "tail_loss": 0.02,
+            "max_drawdown_pct": 0.60,
+        },
+    )
+    recall = _opportunity_recall(store, job_id)
+    assert recall["missed"] is False
+    assert recall["violating_excluded"] == 1
+
+    # A passing candidate that utility-beats the incumbent IS missed.
+    _record(
+        store,
+        job_id,
+        "cand-better",
+        objective={
+            "net_log_growth": 0.05,
+            "downside_deviation": 0.01,
+            "tail_loss": 0.01,
+            "max_drawdown_pct": 0.04,
+        },
+    )
+    recall = _opportunity_recall(store, job_id)
+    assert recall["missed"] is True
+    assert recall["best_candidate_id"] == "cand-better"
+    assert recall["utility_gap"] > 0
+    assert "constraint-passing" in recall["basis"]

--- a/wayfinder_paths/tests/test_jobs_multiobjective.py
+++ b/wayfinder_paths/tests/test_jobs_multiobjective.py
@@ -1,0 +1,65 @@
+"""Multi-objective optuna search: NSGA-II over 2+ grid axes returns the
+Pareto front (ranked leads with it, rows carry pareto flags), the grid
+contract is preserved, and bad inputs fail loudly. Reuses the HoldK peaked
+fixture from the single-objective optuna tests."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("optuna")
+
+from wayfinder_paths.tests.test_jobs_optuna import _search  # noqa: E402
+
+
+def test_multiobjective_returns_pareto_front() -> None:
+    result = _search(n_trials=12, objectives=["net_return", "max_drawdown_pct"], seed=7)
+    assert result.optimizer == "nsga2"
+    assert result.search["sampler"] == "nsga2"
+    assert result.search["objectives"] == ["net_return", "max_drawdown_pct"]
+
+    front = result.search["pareto_front"]
+    assert front, "peaked fixture must produce a non-empty Pareto front"
+    for member in front:
+        assert set(member) == {"number", "values", "params"}
+        assert len(member["values"]) == 2
+
+    flagged = [row for row in result.runs if row.get("pareto")]
+    assert {row["trial"] for row in flagged} >= {m["number"] for m in front}
+    # ranked leads with Pareto members; no non-member outranks a member.
+    seen_non_pareto = False
+    for row in result.ranked:
+        if row.get("pareto"):
+            assert not seen_non_pareto, "Pareto member ranked below non-member"
+        else:
+            seen_non_pareto = True
+    # Front dominance sanity: no member dominates another on the raw axes.
+    for a in front:
+        for b in front:
+            if a is b:
+                continue
+            dominates = (
+                a["values"][0] >= b["values"][0]
+                and a["values"][1] <= b["values"][1]
+                and (a["values"][0] > b["values"][0] or a["values"][1] < b["values"][1])
+            )
+            assert not dominates
+
+
+def test_multiobjective_determinism_and_validation() -> None:
+    first = _search(n_trials=8, objectives=["net_return", "max_drawdown_pct"])
+    second = _search(n_trials=8, objectives=["net_return", "max_drawdown_pct"])
+    assert [r["params"] for r in first.runs] == [r["params"] for r in second.runs]
+
+    with pytest.raises(ValueError, match="2\\+ axes"):
+        _search(objectives=["net_return"])
+    with pytest.raises(ValueError, match="rank_by"):
+        _search(objectives=["net_return", "not_a_metric"])
+
+
+def test_single_objective_contract_unchanged() -> None:
+    result = _search(n_trials=8)
+    assert result.optimizer == "optuna"
+    assert result.search["best_trial"] is not None
+    assert "objectives" not in result.search
+    assert all("pareto" not in row for row in result.runs)


### PR DESCRIPTION
PR 4 of the L3/L4 program — off the merged tip, no stacking this time.

## Quality-diversity archive (active, not a diary)

- **Content-derived candidate ids** (`cand-<workspace revision>`): the same content re-proposed lands on the SAME entry — proposal UUIDs and parent edges accumulate, dedup is real, and **sticky refutation now actually fires** on resubmitted dead ideas (previously every proposal was a fresh UUID entry, so the resubmit-a-dead-idea guard never matched). `set_incumbent` resolves content id → proposal UUID → raw revision, so promotion keeps working across archive generations.
- **Parent DAG**: `parent_candidate_ids` resolved from `base_revision` to the archived ancestor entry; `lineage_of()` walks the ancestry (cycle-safe).
- **Behavior descriptors** populate from candidate-report comparison stats at record time — the behavioral-diversity axis the island scheduler (PR 5) will read.
- **Constrained opportunity recall**: the old recall flagged the highest `net_log_growth` candidate even when it blew the drawdown ceiling. Now: hard-constraint violators filtered, survivors scored with the constitution's utility weights, `missed` only on utility-beat or Pareto domination (reuses `archive._dominates`). Reports the basis and the excluded count.

## Multi-objective search

`run_optuna_search(objectives=["net_return","max_drawdown_pct"])` → NSGA-II over the requested grid axes (`motpe`/`random` opt-in), `ranked` leads with the Pareto front, every run row and trial-lineage row carries `pareto: true/false`, and `search.pareto_front` records the front. Single-objective contract byte-identical. CLI: `--objectives net_return,max_drawdown_pct`; MCP experiments op passes it through existing kwargs untouched. Priors doc now recommends MOO as the default for structural sweeps (exit structure / sizing / leverage).

## Drive-by fix

`test_execution_ccxt_feed` was red on the branch tip — the `fake_refresh` fixture didn't accept the new `refresh_dataset` kwarg. One-line fix included so CI is green again.

## Verification

7 new tests across `test_jobs_active_archive.py` (dedup + sticky + DAG + incumbent resolution + constrained recall) and `test_jobs_multiobjective.py` (Pareto front + determinism + validation + single-objective contract unchanged); full jobs+mcp+execution suite 886 passed. ruff clean.