### PR TITLE
jobs: deterministic search-island scheduler + quant subagent dispatch (L3/L4 PR 5)

### DIFF
--- a/.opencode/agents/wayfinder-job-worker.md
+++ b/.opencode/agents/wayfinder-job-worker.md
@@ -6,6 +6,10 @@ temperature: 0.1
 steps: 64
 permission:
   task:
+    # Quant subagent dispatch (L3c): heavy grids/scans/analytics run in a
+    # bounded subagent; the wake stays the orchestrator. Everything else
+    # stays denied.
+    "wayfinder-quant": allow
     "*": deny
   question: deny
 

--- a/wayfinder_paths/jobs/improver/scheduler.py
+++ b/wayfinder_paths/jobs/improver/scheduler.py
@@ -1,0 +1,239 @@
+"""Deterministic search-island scheduler (L3c).
+
+One worker, one wake at a time — but WHICH kind of search a wake runs was
+left to the model's mood, and observed behavior collapsed to exploit-only:
+refine the incumbent, report healthy, sleep. The scheduler makes allocation
+a property of the SYSTEM: each routine research wake is assigned one island
+by weighted-deficit rotation against the ImproverSpec's allocation weights.
+No RNG — the assignment is a pure function of on-disk state, so any
+sequence is auditable and replayable.
+
+Islands:
+- exploit         — refine the incumbent's neighborhood (grids, exits, params)
+- adjacent        — validated family, new cell (regime, symbol, timeframe)
+- divergent       — new basin (family not in dead map, universe, sizing axis)
+- diversification — behaviorally different candidates from the live book
+- falsifier       — attack the incumbent; a confirmed refutation is a WIN
+- historian       — mine the archive (revive frontier branches, autopsy dead)
+
+Boosts are deterministic weight multipliers derived from visible state:
+verdict stuck-streak -> divergent; opportunity_recall.missed -> historian;
+high fleet correlation (portfolio report, PR 6) -> diversification. The
+exploration floor guarantees the non-exploit islands can never be starved
+below the spec's minimum share.
+
+Trigger wakes (verdict_matured, restage, risk events) bypass assignment —
+they exist to handle their event, not to run the rotation.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from wayfinder_paths.jobs.improver.spec import ImproverSpec
+from wayfinder_paths.jobs.models import utc_now_iso
+from wayfinder_paths.jobs.store import JobStore
+
+ISLANDS = (
+    "exploit",
+    "adjacent",
+    "divergent",
+    "diversification",
+    "falsifier",
+    "historian",
+)
+EXPLORE_ISLANDS = ("divergent", "diversification", "falsifier", "historian")
+SCHEDULER_STATE_PATH = "state/scheduler.json"
+# A trigger wake stamps state/agent_wake_state.json immediately before the
+# worker runs; a stamp this fresh means THIS wake is the trigger's wake.
+_TRIGGER_WINDOW_S = 180
+
+ISLAND_DIRECTIVES: dict[str, str] = {
+    "exploit": (
+        "Refine the incumbent's neighborhood: parameter/exit-structure "
+        "experiments on the ACTIVE families (grid for attribution, optuna "
+        "for wide spaces), promote-params on validated winners. Cite the "
+        "trial lineage before sampling — re-running a flat region is spent "
+        "budget."
+    ),
+    "adjacent": (
+        "Extend a VALIDATED family to a new cell: another regime "
+        "(--condition-regime), symbol, or timeframe. The family's evidence "
+        "transfers as a prior, not as a result — the new cell earns its own "
+        "scan + walk-forward before any proposal."
+    ),
+    "divergent": (
+        "Jump basins: a family not in the dead map, a universe-scan, or the "
+        "sizing/leverage axis. Wide typed search spaces with "
+        "optimizer=optuna (multi-objective for structural sweeps). Do NOT "
+        "refine the incumbent this wake — that is exploit's job."
+    ),
+    "diversification": (
+        "Hunt candidates whose BEHAVIOR differs from the live book: holding "
+        "period, direction bias, entry frequency (trial behavior "
+        "descriptors + archive behavior fields). A book of clones is one "
+        "bet wearing several names — score candidates by behavioral "
+        "distance, not just return."
+    ),
+    "falsifier": (
+        "Attack the incumbent: re-run replication, probe regime-slice decay "
+        "(t_recent within active cells), re-test the weakest live "
+        "assumption on fresh data. You are trying to REFUTE — a confirmed "
+        "refutation (with a revert/kill proposal) is a successful wake."
+    ),
+    "historian": (
+        "Mine the archive: investigate opportunity_recall.missed candidates "
+        "FIRST (cite candidate_id), autopsy refuted branches for the "
+        "condition that killed them, map flat regions from trial lineage. "
+        "Output: revive with evidence, or bury with a written reason."
+    ),
+}
+
+
+def load_scheduler_state(store: JobStore, job_id: str) -> dict[str, Any]:
+    doc = store.read_json(job_id, SCHEDULER_STATE_PATH) or {}
+    if not isinstance(doc, dict) or not isinstance(doc.get("assigned"), dict):
+        return {"assigned": {}, "history": [], "total": 0}
+    return doc
+
+
+def assign_island(
+    store: JobStore,
+    job_id: str,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Assign this wake's island and persist the rotation state. Returns a
+    bypass marker (island=None) for trigger wakes."""
+    root = store.job_dir(job_id)
+    trigger = _fresh_trigger(root, now=now)
+    if trigger:
+        return {"island": None, "bypass": trigger}
+
+    spec = ImproverSpec.load(root)
+    state = load_scheduler_state(store, job_id)
+    assigned: dict[str, int] = {
+        island: int(state["assigned"].get(island, 0)) for island in ISLANDS
+    }
+    total = sum(assigned.values())
+
+    weights = {island: spec.island_weights.get(island, 0.0) for island in ISLANDS}
+    boosts: list[str] = []
+    if _verdict_stuck_streak(store, job_id, spec.stuck_same_family_non_wins):
+        weights["divergent"] *= 2.0
+        boosts.append("stuck: recent verdicts all neutral/hurt -> divergent x2")
+    if _opportunity_recall_missed(store, job_id):
+        weights["historian"] *= 2.0
+        boosts.append("opportunity_recall.missed -> historian x2")
+    if _fleet_correlation_high(store, job_id):
+        weights["diversification"] *= 2.0
+        boosts.append("fleet correlation high -> diversification x2")
+    scale = sum(weights.values()) or 1.0
+    weights = {island: value / scale for island, value in weights.items()}
+
+    # Weighted deficit: the island furthest below its target share goes next.
+    # Ties break on fixed ISLANDS order — fully deterministic.
+    def deficit(island: str) -> float:
+        return (total + 1) * weights[island] - assigned[island]
+
+    candidates = list(ISLANDS)
+    explore_assigned = sum(assigned[island] for island in EXPLORE_ISLANDS)
+    floor = spec.exploration_floor
+    floored = total > 0 and (explore_assigned / total) < floor
+    if floored:
+        candidates = list(EXPLORE_ISLANDS)
+
+    island = max(candidates, key=lambda name: (deficit(name), -ISLANDS.index(name)))
+
+    reasons = [f"weighted-deficit rotation (target {weights[island]:.0%})"]
+    if floored:
+        reasons.insert(
+            0,
+            f"exploration floor: explore share {explore_assigned}/{total} "
+            f"< {floor:.0%} — restricted to explore islands",
+        )
+    reasons.extend(boosts)
+
+    assigned[island] += 1
+    state = {
+        "assigned": assigned,
+        "total": total + 1,
+        "history": (state.get("history") or [])[-19:]
+        + [{"island": island, "ts": utc_now_iso(), "reason": reasons[0]}],
+    }
+    store.write_json(job_id, SCHEDULER_STATE_PATH, state)
+    store.append_journal(
+        job_id, {"type": "island_assigned", "island": island, "reasons": reasons}
+    )
+    return {
+        "island": island,
+        "reasons": reasons,
+        "directive": ISLAND_DIRECTIVES[island],
+        "agenda": f"research/islands/{island}.md",
+        "assigned_counts": assigned,
+        "target_weights": {k: round(v, 3) for k, v in weights.items()},
+    }
+
+
+def _fresh_trigger(root: Path, *, now: datetime | None) -> list[str] | None:
+    path = root / "state" / "agent_wake_state.json"
+    if not path.exists():
+        return None
+    try:
+        state = json.loads(path.read_text(encoding="utf-8"))
+        last = datetime.fromisoformat(str(state.get("last_triggered_wake_ts")))
+    except (ValueError, TypeError):
+        return None
+    current = now or datetime.now(UTC)
+    if last.tzinfo is None:
+        last = last.replace(tzinfo=UTC)
+    if (current - last).total_seconds() < _TRIGGER_WINDOW_S:
+        return [str(t) for t in state.get("triggers") or []] or ["trigger"]
+    return None
+
+
+def _verdict_stuck_streak(store: JobStore, job_id: str, streak: int) -> bool:
+    """True when the last `streak` matured verdicts are all neutral/hurt —
+    the local basin is flat or hostile; boost the jump island."""
+    verdicts = store.read_json(job_id, "state/promotion_verdicts.json") or {}
+    if not isinstance(verdicts, dict):
+        return False
+    matured = [
+        record
+        for record in verdicts.values()
+        if isinstance(record, dict)
+        and record.get("verdict") in {"beat", "neutral", "hurt"}
+    ]
+    matured.sort(key=lambda record: str(record.get("recorded_at") or ""))
+    if len(matured) < streak:
+        return False
+    return all(
+        record.get("verdict") in {"neutral", "hurt"} for record in matured[-streak:]
+    )
+
+
+def _opportunity_recall_missed(store: JobStore, job_id: str) -> bool:
+    try:
+        from wayfinder_paths.jobs.evolution_ledger import _opportunity_recall
+
+        recall = _opportunity_recall(store, job_id)
+        return bool(recall and recall.get("missed"))
+    except Exception:  # noqa: BLE001 — telemetry input, never blocks rotation
+        return False
+
+
+def _fleet_correlation_high(store: JobStore, job_id: str) -> bool:
+    """Portfolio hook (PR 6 writes the report): this job's average forward
+    correlation to the rest of the fleet above 0.7 raises diversification."""
+    path = store.repo_root / ".wayfinder" / "portfolio" / "report.json"
+    if not path.exists():
+        return False
+    try:
+        report = json.loads(path.read_text(encoding="utf-8"))
+        value = ((report.get("jobs") or {}).get(job_id) or {}).get("avg_correlation")
+        return value is not None and float(value) > 0.7
+    except (ValueError, TypeError):
+        return False

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -610,6 +610,17 @@ def _build_worker_prompt_sections(
         )
 
     restage_tasks = _restage_block(root)
+    # Island rotation: routine research wakes get a deterministic search
+    # assignment; apply/restage wakes and trigger wakes (bypass inside)
+    # handle their event instead. Never blocks the wake.
+    search_assignment = None
+    if mode == "intervene" and apply_proposal_id is None and not restage_tasks:
+        try:
+            from wayfinder_paths.jobs.improver.scheduler import assign_island
+
+            search_assignment = assign_island(store, job_id)
+        except Exception:  # noqa: BLE001
+            search_assignment = None
     dynamic_payload = {
         "scorecard": snapshot.get("scorecard") or {},
         "forward": forward_block,
@@ -635,6 +646,7 @@ def _build_worker_prompt_sections(
         "evolution": _evolution_block(store, job_id),
         "archive": _archive_block(store, job_id),
         "restage_tasks": restage_tasks,
+        "search_assignment": search_assignment,
     }
 
     stable_prefix = (
@@ -709,6 +721,19 @@ def _build_worker_prompt_sections(
         "(signal_scan / experiment grid / holdout_check / analogs) or state "
         "in the report why research is not warranted. 'Healthy, no change' "
         "alone is NOT a complete wake when research is stale.\n"
+        "- Routine research wakes carry a `search_assignment` (dynamic "
+        "context): one island among exploit / adjacent / divergent / "
+        "diversification / falsifier / historian, rotated deterministically "
+        "by the improver's allocation weights. The island's directive says "
+        "WHAT KIND of search this wake advances — follow it. Maintain the "
+        "island's persistent agenda (`research/islands/<island>.md`): read "
+        "it first, append what you did and learned. If ops consume the wake "
+        "(halt, errors), say so in the report — the rotation still counts "
+        "this island as served.\n"
+        "- Heavy quant work (signal scans, grids, walk-forwards, bulk "
+        "analytics) SHOULD be delegated to the `wayfinder-quant` subagent "
+        "with a bounded brief; you stay the orchestrator — synthesize its "
+        "results, decide, and keep this session light.\n"
         "- The improver is a VERSIONED artifact: the stable spec's `improver` "
         "block is the active search policy (staleness thresholds, tier "
         "numbers, probation caps, island weights) and every artifact you "

--- a/wayfinder_paths/tests/test_jobs_island_scheduler.py
+++ b/wayfinder_paths/tests/test_jobs_island_scheduler.py
@@ -1,0 +1,166 @@
+"""Island scheduler: deterministic weighted-deficit rotation, protected
+exploration floor, stuck/recall boosts, trigger-wake bypass, and the wake
+context integration (search_assignment block + quant dispatch rule)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import yaml
+
+from wayfinder_paths.jobs.improver.scheduler import (
+    EXPLORE_ISLANDS,
+    ISLANDS,
+    assign_island,
+    load_scheduler_state,
+)
+from wayfinder_paths.jobs.improver.spec import IMPROVER_FILENAME
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.store import JobStore
+
+
+def _job(tmp_path, job_id="isl-demo"):
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        job_id,
+        script="workspace/src/strategy.py",
+        agent_mode="intervene",
+        execution_contract="jobs_v1",
+    )
+    store.save(job)
+    return store, job.id
+
+
+def test_rotation_is_deterministic_and_tracks_weights(tmp_path) -> None:
+    sequences = []
+    for run in ("a", "b"):
+        store, job_id = _job(tmp_path / run)
+        sequence = [assign_island(store, job_id)["island"] for _ in range(40)]
+        sequences.append(sequence)
+    assert sequences[0] == sequences[1]  # pure function of on-disk state
+
+    counts = {island: sequences[0].count(island) for island in ISLANDS}
+    assert sequences[0][0] == "exploit"  # highest target share leads
+    assert 12 <= counts["exploit"] <= 18  # ~40% of 40
+    explore = sum(counts[i] for i in EXPLORE_ISLANDS)
+    assert explore / 40 >= 0.25  # spec floor holds in aggregate
+    assert all(counts[island] > 0 for island in ISLANDS)  # nobody starves
+
+
+def test_exploration_floor_binds_under_skewed_weights(tmp_path) -> None:
+    store, job_id = _job(tmp_path)
+    (store.job_dir(job_id) / IMPROVER_FILENAME).write_text(
+        yaml.safe_dump(
+            {
+                "islands": {
+                    "weights": {
+                        "exploit": 0.90,
+                        "adjacent": 0.05,
+                        "divergent": 0.02,
+                        "diversification": 0.01,
+                        "falsifier": 0.01,
+                        "historian": 0.01,
+                    },
+                    "exploration_floor": 0.3,
+                }
+            }
+        )
+    )
+    sequence = [assign_island(store, job_id) for _ in range(20)]
+    islands = [entry["island"] for entry in sequence]
+    explore = sum(1 for island in islands if island in EXPLORE_ISLANDS)
+    assert explore / 20 >= 0.25  # floor overrides the skew
+    floored = [e for e in sequence if any("floor" in r for r in e["reasons"])]
+    assert floored, "floor restriction must be visible in reasons"
+
+    state = load_scheduler_state(store, job_id)
+    assert state["total"] == 20
+    assert sum(state["assigned"].values()) == 20
+
+
+def test_stuck_streak_boosts_divergent(tmp_path) -> None:
+    store, job_id = _job(tmp_path)
+    store.write_json(
+        job_id,
+        "state/promotion_verdicts.json",
+        {
+            "prop-1": {"verdict": "neutral", "recorded_at": "2026-08-01T00:00:00Z"},
+            "prop-2": {"verdict": "hurt", "recorded_at": "2026-08-02T00:00:00Z"},
+        },
+    )
+    result = assign_island(store, job_id)
+    assert any("stuck" in reason for reason in result["reasons"])
+    assert result["target_weights"]["divergent"] > 0.2  # 0.15 doubled, renormed
+
+    # A beat verdict at the tail clears the streak.
+    store.write_json(
+        job_id,
+        "state/promotion_verdicts.json",
+        {
+            "prop-1": {"verdict": "hurt", "recorded_at": "2026-08-01T00:00:00Z"},
+            "prop-2": {"verdict": "beat", "recorded_at": "2026-08-02T00:00:00Z"},
+        },
+    )
+    result = assign_island(store, job_id)
+    assert not any("stuck" in reason for reason in result["reasons"])
+
+
+def test_trigger_wake_bypasses_rotation(tmp_path) -> None:
+    store, job_id = _job(tmp_path)
+    wake_path = store.job_dir(job_id) / "state" / "agent_wake_state.json"
+    wake_path.parent.mkdir(parents=True, exist_ok=True)
+    wake_path.write_text(
+        json.dumps(
+            {
+                "last_triggered_wake_ts": datetime.now(UTC).isoformat(),
+                "triggers": ["verdict_matured"],
+            }
+        )
+    )
+    result = assign_island(store, job_id)
+    assert result == {"island": None, "bypass": ["verdict_matured"]}
+    assert load_scheduler_state(store, job_id)["total"] == 0  # no state burn
+
+    # A stale trigger stamp (old wake) does not bypass.
+    wake_path.write_text(
+        json.dumps(
+            {
+                "last_triggered_wake_ts": "2026-08-01T00:00:00+00:00",
+                "triggers": ["verdict_matured"],
+            }
+        )
+    )
+    assert assign_island(store, job_id)["island"] is not None
+
+
+def test_assignment_journaled_and_stamped(tmp_path) -> None:
+    store, job_id = _job(tmp_path)
+    result = assign_island(store, job_id)
+    rows = [
+        json.loads(line)
+        for line in (store.job_dir(job_id) / "journal.jsonl").read_text().splitlines()
+    ]
+    events = [row for row in rows if row["type"] == "island_assigned"]
+    assert events and events[-1]["island"] == result["island"]
+    assert events[-1]["improver_revision"]  # PR 3 stamp rides along
+
+
+def test_wake_context_carries_assignment_and_quant_rule(tmp_path) -> None:
+    from wayfinder_paths.jobs.worker import prepare_job_worker_prompt
+
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("isl-prompt", agent_mode="intervene")
+    store.save(job)
+    sections = prepare_job_worker_prompt(store=store, job_id=job.id, mode="intervene")
+    assert "search_assignment" in sections["prompt"]
+    assert "research/islands/" in sections["prompt"]
+    assert "wayfinder-quant" in sections["stable_prefix"]
+    assert load_scheduler_state(store, job.id)["total"] == 1
+
+    # Monitor wakes are ops, not research: no assignment, no state burn.
+    store2 = JobStore(repo_root=tmp_path / "b")
+    job2 = WayfinderJob.new("isl-monitor", agent_mode="monitor")
+    store2.save(job2)
+    prepare_job_worker_prompt(store=store2, job_id=job2.id, mode="monitor")
+    assert load_scheduler_state(store2, job2.id)["total"] == 0


### PR DESCRIPTION
PR 5 of the L3/L4 program — off the merged tip.

## The allocation gap

Which KIND of search a wake ran was the model's choice, and observed behavior collapsed to exploit-only (refine incumbent → report healthy → sleep). The reviewer's island architecture, fitted to the single-worker wake model: allocation becomes a **property of the system**, not a mood.

## What ships

- **`jobs/improver/scheduler.py`** — each routine research wake gets one island: `exploit / adjacent / divergent / diversification / falsifier / historian`, assigned by weighted-deficit rotation against the ImproverSpec allocation weights. **No RNG** — a pure function of on-disk state (auditable, replayable), persisted in `state/scheduler.json`, journaled as `island_assigned` (carrying the PR 3 provenance stamps).
- **Deterministic boosts** from visible state: verdict stuck-streak (spec's `same_family_non_wins`) doubles `divergent`; `opportunity_recall.missed` doubles `historian`; high fleet correlation (reads the PR 6 portfolio report when it exists) doubles `diversification`.
- **Protected exploration floor**: when the explore islands' served share drops below the spec minimum, selection restricts to them — a skewed spec cannot starve exploration (test proves it at 90% exploit weight).
- **Trigger bypass**: a fresh `agent_wake_state.json` stamp (verdict_matured etc.) means this wake exists to handle its event — no rotation burn. Apply/restage wakes excluded at the worker seam; monitor wakes never assign.
- **Wake context**: dynamic `search_assignment` block (island, reasons, operator directive, persistent agenda path `research/islands/<island>.md`) + stable-prefix rules: follow the island's directive, maintain its agenda.
- **Quant subagent dispatch**: worker manifest `task` permission now allows `wayfinder-quant` (blanket deny retained for everything else); prompt rule: delegate heavy grids/scans/analytics, stay the orchestrator.

## Verification

6 new tests: rotation determinism + share tracking, floor binding under skewed weights, stuck-boost on/off, trigger bypass (fresh vs stale stamp), journal + stamp, wake-context integration (assignment present on intervene, absent on monitor). Full jobs+mcp suite 808 passed. ruff clean.