### PR TITLE
jobs: fleet portfolio awareness (L3/L4 PR 6)

### DIFF
--- a/wayfinder_paths/jobs/portfolio.py
+++ b/wayfinder_paths/jobs/portfolio.py
@@ -1,0 +1,181 @@
+"""Fleet-level portfolio awareness (P2-lite).
+
+Every job optimizes its own book blind: two jobs long the same majors are
+one bet wearing two names, and neither wake can see it. This module builds
+one deterministic cross-job report from the forward books — pairwise daily
+PnL correlation, shared-symbol overlap, gross notional by symbol — written
+to ``.wayfinder/portfolio/report.json`` on the watchdog cadence. Each wake
+reads its own slice (``portfolio`` context block) and the island scheduler
+raises the diversification weight when a job's average correlation to the
+rest of the fleet runs high.
+
+Pure stdlib math on trade rows — no pandas, no venue calls; the report is a
+function of on-disk state like everything else the improver reads.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from wayfinder_paths.jobs.models import utc_now_iso
+from wayfinder_paths.jobs.store import JobStore
+
+PORTFOLIO_REPORT_RELPATH = Path(".wayfinder") / "portfolio" / "report.json"
+_MIN_SHARED_DAYS = 5
+_RECENT_TRADES = 2000  # per job: bounds the scan on multi-MB books
+HIGH_CORRELATION = 0.7
+
+
+def portfolio_report_path(store: JobStore) -> Path:
+    return store.repo_root / PORTFOLIO_REPORT_RELPATH
+
+
+def build_portfolio_report(store: JobStore) -> dict[str, Any]:
+    books: dict[str, dict[str, float]] = {}
+    symbols: dict[str, dict[str, float]] = {}
+    for job in store.list_jobs():
+        daily, gross = _forward_book(store.job_dir(job.id))
+        if daily:
+            books[job.id] = daily
+            symbols[job.id] = gross
+
+    correlations: dict[str, dict[str, float]] = {job_id: {} for job_id in books}
+    for a in books:
+        for b in books:
+            if a >= b:
+                continue
+            r = _pearson_on_shared_days(books[a], books[b])
+            if r is not None:
+                correlations[a][b] = r
+                correlations[b][a] = r
+
+    shared_symbols: dict[str, list[str]] = {}
+    for job_id, gross in symbols.items():
+        for symbol in gross:
+            shared_symbols.setdefault(symbol, []).append(job_id)
+    shared_symbols = {
+        symbol: sorted(job_ids)
+        for symbol, job_ids in shared_symbols.items()
+        if len(job_ids) > 1
+    }
+
+    jobs_block = {}
+    for job_id in books:
+        pairwise = correlations[job_id]
+        jobs_block[job_id] = {
+            "avg_correlation": (
+                round(sum(pairwise.values()) / len(pairwise), 4) if pairwise else None
+            ),
+            "correlations": {k: round(v, 4) for k, v in sorted(pairwise.items())},
+            "gross_notional_by_symbol": {
+                k: round(v, 2) for k, v in sorted(symbols[job_id].items())
+            },
+            "daily_pnl_days": len(books[job_id]),
+        }
+
+    return {
+        "jobs": jobs_block,
+        "shared_symbols": shared_symbols,
+        "min_shared_days": _MIN_SHARED_DAYS,
+        "generated_at": utc_now_iso(),
+    }
+
+
+def write_portfolio_report(store: JobStore) -> Path:
+    report = build_portfolio_report(store)
+    path = portfolio_report_path(store)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return path
+
+
+def portfolio_block(store: JobStore, job_id: str) -> dict[str, Any] | None:
+    """This job's slice of the fleet report for the wake context. None when
+    no report exists or the job has no forward book yet. Never raises."""
+    try:
+        path = portfolio_report_path(store)
+        if not path.exists():
+            return None
+        report = json.loads(path.read_text(encoding="utf-8"))
+        me = (report.get("jobs") or {}).get(job_id)
+        if not me:
+            return None
+        shared = {
+            symbol: [other for other in job_ids if other != job_id]
+            for symbol, job_ids in (report.get("shared_symbols") or {}).items()
+            if job_id in job_ids
+        }
+        avg = me.get("avg_correlation")
+        block: dict[str, Any] = {
+            "avg_correlation_to_fleet": avg,
+            "correlations": me.get("correlations") or {},
+            "shared_symbols": shared,
+            "generated_at": report.get("generated_at"),
+            "_basis": (
+                "Fleet view over every job's forward book (daily net_pnl "
+                "correlation + symbol overlap), computed mechanically on the "
+                "watchdog cadence. Cite it when choosing candidates."
+            ),
+        }
+        if avg is not None and float(avg) > HIGH_CORRELATION:
+            block["diversification_directive"] = (
+                f"Average correlation to the rest of the fleet is {avg} — your "
+                "candidates are largely redundant with other jobs' books. The "
+                "diversification island weight is raised; prefer candidates "
+                "whose behavior descriptors and symbols diverge from the "
+                "shared exposure above."
+            )
+        return block
+    except Exception:  # noqa: BLE001 — telemetry never breaks a wake
+        return None
+
+
+def _forward_book(root: Path) -> tuple[dict[str, float], dict[str, float]]:
+    """(daily net_pnl by close date, gross notional by symbol) from the
+    forward trade book; empty dicts when there is no book."""
+    trades_path = root / "results" / "forward" / "trades.jsonl"
+    if not trades_path.exists():
+        return {}, {}
+    daily: dict[str, float] = {}
+    gross: dict[str, float] = {}
+    lines = trades_path.read_text(encoding="utf-8").splitlines()[-_RECENT_TRADES:]
+    for line in lines:
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        day = str(row.get("closed_at") or "")[:10]
+        if not day:
+            continue
+        try:
+            pnl = float(row.get("net_pnl") or 0.0)
+            notional = abs(float(row.get("size") or 0.0)) * float(
+                row.get("price") or 0.0
+            )
+        except (TypeError, ValueError):
+            continue
+        daily[day] = daily.get(day, 0.0) + pnl
+        symbol = str(row.get("symbol") or "?")
+        gross[symbol] = gross.get(symbol, 0.0) + notional
+    return daily, gross
+
+
+def _pearson_on_shared_days(a: dict[str, float], b: dict[str, float]) -> float | None:
+    days = sorted(set(a) & set(b))
+    if len(days) < _MIN_SHARED_DAYS:
+        return None
+    xs = [a[day] for day in days]
+    ys = [b[day] for day in days]
+    n = len(days)
+    mean_x = sum(xs) / n
+    mean_y = sum(ys) / n
+    cov = sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys, strict=False))
+    var_x = sum((x - mean_x) ** 2 for x in xs)
+    var_y = sum((y - mean_y) ** 2 for y in ys)
+    if var_x == 0 or var_y == 0:
+        return None
+    return cov / (var_x**0.5 * var_y**0.5)

--- a/wayfinder_paths/jobs/watchdog.py
+++ b/wayfinder_paths/jobs/watchdog.py
@@ -16,10 +16,10 @@ failed after a longer window; claim allows retry from "failed".
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import signal
-import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from textwrap import dedent
@@ -505,8 +505,10 @@ def _run_lifecycle_pass(
         # Kill outranks graduate: if both fire, the leg dies — pre-registered
         # risk rules are senior to reward rules.
         decision = (
-            ("killed", kill) if kill["status"] == "met"
-            else ("graduated", graduate) if graduate["status"] == "met"
+            ("killed", kill)
+            if kill["status"] == "met"
+            else ("graduated", graduate)
+            if graduate["status"] == "met"
             else None
         )
         if decision is None:
@@ -609,7 +611,37 @@ def recover_stalled_applications(
                 recovered.append({"job_id": job.id, **lifecycle_event})
         except Exception as exc:
             errors.append({"job_id": job.id, "error": f"lifecycle: {exc}"})
+    try:
+        _refresh_portfolio_report(store, now)
+    except Exception as exc:  # noqa: BLE001 — fleet telemetry never blocks recovery
+        errors.append({"job_id": "_portfolio", "error": str(exc)})
     return {"scanned": scanned, "recovered": recovered, "errors": errors}
+
+
+_PORTFOLIO_REFRESH_S = 1800
+
+
+def _refresh_portfolio_report(store: JobStore, now: datetime) -> None:
+    """Fleet portfolio report on the watchdog cadence, rate-limited to
+    ~30min: pure on-disk aggregation, but no reason to re-scan every book
+    each 5-minute pass."""
+    from wayfinder_paths.jobs.portfolio import (
+        portfolio_report_path,
+        write_portfolio_report,
+    )
+
+    path = portfolio_report_path(store)
+    if path.exists():
+        try:
+            generated = json.loads(path.read_text(encoding="utf-8")).get("generated_at")
+            stamp = datetime.fromisoformat(str(generated))
+            if stamp.tzinfo is None:
+                stamp = stamp.replace(tzinfo=UTC)
+            if (now - stamp).total_seconds() < _PORTFOLIO_REFRESH_S:
+                return
+        except (ValueError, TypeError):
+            pass
+    write_portfolio_report(store)
 
 
 def ensure_application_watchdog(

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -540,6 +540,15 @@ def _render_research_priors(text: str, spec) -> str:
     return text
 
 
+def _portfolio_context(store: JobStore, job_id: str):
+    try:
+        from wayfinder_paths.jobs.portfolio import portfolio_block
+
+        return portfolio_block(store, job_id)
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def _build_worker_prompt_sections(
     *,
     store: JobStore,
@@ -647,6 +656,7 @@ def _build_worker_prompt_sections(
         "archive": _archive_block(store, job_id),
         "restage_tasks": restage_tasks,
         "search_assignment": search_assignment,
+        "portfolio": _portfolio_context(store, job_id),
     }
 
     stable_prefix = (

--- a/wayfinder_paths/tests/test_jobs_portfolio.py
+++ b/wayfinder_paths/tests/test_jobs_portfolio.py
@@ -1,0 +1,139 @@
+"""Fleet portfolio awareness: correlation/overlap report from forward
+books, the per-job wake block with its diversification directive, the
+scheduler boost, and the watchdog cadence hook."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.portfolio import (
+    build_portfolio_report,
+    portfolio_block,
+    portfolio_report_path,
+    write_portfolio_report,
+)
+from wayfinder_paths.jobs.store import JobStore
+
+
+def _job_with_book(store, job_id, daily_pnl, symbol="HYPE"):
+    job = WayfinderJob.new(
+        job_id,
+        script="workspace/src/strategy.py",
+        agent_mode="intervene",
+        execution_contract="jobs_v1",
+    )
+    store.save(job)
+    trades = store.job_dir(job_id) / "results" / "forward" / "trades.jsonl"
+    trades.parent.mkdir(parents=True, exist_ok=True)
+    with trades.open("w", encoding="utf-8") as handle:
+        for day, pnl in daily_pnl.items():
+            handle.write(
+                json.dumps(
+                    {
+                        "closed_at": f"{day}T12:00:00+00:00",
+                        "net_pnl": pnl,
+                        "symbol": symbol,
+                        "size": 10.0,
+                        "price": 2.5,
+                    }
+                )
+                + "\n"
+            )
+    return job_id
+
+
+DAYS = [f"2026-08-{d:02d}" for d in range(1, 9)]
+
+
+def test_correlation_and_overlap(tmp_path) -> None:
+    store = JobStore(repo_root=tmp_path)
+    series = {day: float(i + 1) for i, day in enumerate(DAYS)}
+    _job_with_book(store, "alpha", series, symbol="HYPE")
+    _job_with_book(store, "beta", series, symbol="HYPE")  # identical book
+    _job_with_book(
+        store,
+        "gamma",
+        {day: -value for day, value in series.items()},
+        symbol="BTC",
+    )
+    _job_with_book(store, "sparse", {DAYS[0]: 1.0}, symbol="ETH")  # < min days
+
+    report = build_portfolio_report(store)
+    jobs = report["jobs"]
+    assert jobs["alpha"]["correlations"]["beta"] == 1.0
+    assert jobs["alpha"]["correlations"]["gamma"] == -1.0
+    assert "sparse" not in jobs["alpha"]["correlations"]  # below shared-day floor
+    assert report["shared_symbols"] == {"HYPE": ["alpha", "beta"]}
+    assert jobs["alpha"]["gross_notional_by_symbol"]["HYPE"] == 200.0  # 8*10*2.5
+
+
+def test_block_and_scheduler_boost_on_high_correlation(tmp_path) -> None:
+    store = JobStore(repo_root=tmp_path)
+    series = {day: float(i + 1) for i, day in enumerate(DAYS)}
+    _job_with_book(store, "alpha", series)
+    _job_with_book(store, "beta", series)
+    write_portfolio_report(store)
+
+    block = portfolio_block(store, "alpha")
+    assert block["avg_correlation_to_fleet"] == 1.0
+    assert block["shared_symbols"] == {"HYPE": ["beta"]}
+    assert "diversification_directive" in block
+
+    from wayfinder_paths.jobs.improver.scheduler import assign_island
+
+    result = assign_island(store, "alpha")
+    assert any("correlation" in reason for reason in result["reasons"])
+    assert result["target_weights"]["diversification"] > 0.1  # doubled, renormed
+
+    # No report for an unknown job -> no block, never raises.
+    assert portfolio_block(store, "nope") is None
+
+
+def test_watchdog_refresh_is_rate_limited(tmp_path) -> None:
+    from wayfinder_paths.jobs.watchdog import _refresh_portfolio_report
+
+    store = JobStore(repo_root=tmp_path)
+    series = {day: float(i + 1) for i, day in enumerate(DAYS)}
+    _job_with_book(store, "alpha", series)
+    now = datetime(2026, 8, 17, 12, 0, tzinfo=UTC)
+    _refresh_portfolio_report(store, now)
+    path = portfolio_report_path(store)
+    first = path.read_text()
+
+    # Fresh report: a pass minutes later leaves it untouched.
+    _job_with_book(store, "beta", series)
+    _refresh_portfolio_report(store, now)
+    assert path.read_text() == first
+
+    # Stale report: the next pass past the window rebuilds with the new job.
+    stale = json.loads(first)
+    stale["generated_at"] = "2026-08-17T10:00:00+00:00"
+    path.write_text(json.dumps(stale))
+    _refresh_portfolio_report(store, now)
+    assert "beta" in json.loads(path.read_text())["jobs"]
+
+
+def test_watchdog_pass_writes_report_end_to_end(tmp_path) -> None:
+    from wayfinder_paths.jobs.watchdog import recover_stalled_applications
+
+    store = JobStore(repo_root=tmp_path)
+    series = {day: float(i + 1) for i, day in enumerate(DAYS)}
+    _job_with_book(store, "alpha", series)
+    outcome = recover_stalled_applications(store=store)
+    assert not [e for e in outcome["errors"] if e.get("job_id") == "_portfolio"]
+    assert portfolio_report_path(store).exists()
+
+
+def test_wake_context_carries_portfolio_block(tmp_path) -> None:
+    from wayfinder_paths.jobs.worker import prepare_job_worker_prompt
+
+    store = JobStore(repo_root=tmp_path)
+    series = {day: float(i + 1) for i, day in enumerate(DAYS)}
+    _job_with_book(store, "alpha", series)
+    _job_with_book(store, "beta", series)
+    write_portfolio_report(store)
+    sections = prepare_job_worker_prompt(store=store, job_id="alpha", mode="intervene")
+    assert "avg_correlation_to_fleet" in sections["prompt"]
+    assert "diversification_directive" in sections["prompt"]


### PR DESCRIPTION
PR 6 — the last of the L3/L4 program. **Stacked on #663** (island scheduler) — merge that first; if it squash-merges I'll rebase this one clean.

## The blindness this closes

Every job optimizes its own book in isolation: two jobs long the same majors are one bet wearing two names, and neither wake can see it. The reviewer's P2, scoped to the single-box fleet.

## What ships

- **`jobs/portfolio.py`** — one deterministic cross-job report from the forward books: pairwise daily `net_pnl` correlation (minimum shared-days floor so sparse books don't fake precision), shared-symbol overlap, gross notional by symbol. Pure stdlib math on on-disk state — no pandas, no venue calls. Written to `.wayfinder/portfolio/report.json` (user_vault-persisted on the box).
- **Watchdog cadence**: the 5-minute recovery pass refreshes the report, rate-limited to ~30 minutes; failures land in the pass errors without blocking recovery.
- **Wake context `portfolio` block**: avg correlation to fleet, pairwise table, shared symbols, and an explicit `diversification_directive` above 0.7 ("your candidates are redundant with job X's book").
- **Scheduler loop closed**: PR 5's fleet-correlation hook now has a writer — high correlation deterministically doubles the `diversification` island weight.

Deferred (as planned): per-user portfolio coordinator meta-job + marginal-portfolio-utility target — needs the islands running to have budgets to allocate.

## Verification

5 new tests (correlation math: identical → 1.0, inverted → −1.0, sparse excluded; block + scheduler boost end-to-end; watchdog rate limiting; full pass writes report; wake context carries block). Full jobs+mcp suite 813 passed. ruff clean.
