### PR TITLE
jobs+core: live loose ends from the majors journal audit

### DIFF
--- a/wayfinder_paths/core/clients/WayfinderClient.py
+++ b/wayfinder_paths/core/clients/WayfinderClient.py
@@ -10,16 +10,40 @@ from wayfinder_paths.core.constants.base import DEFAULT_HTTP_TIMEOUT
 
 
 class WayfinderClient:
+    # Cap for the single polite in-client 429 retry below. Subclasses with
+    # their own retry stack (Gorlami) override this tighter and the base
+    # retry honors it — a hardcoded base cap silently overrode theirs.
+    MAX_RETRY_DELAY_S = 30.0
+
     def __init__(self):
         self.headers = {
             "Content-Type": "application/json",
         }
         self._ensure_api_key_header()
-        self.client = httpx.AsyncClient(
+        self.client = self._build_client()
+        self._client_loop: asyncio.AbstractEventLoop | None = None
+
+    def _build_client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
             timeout=httpx.Timeout(DEFAULT_HTTP_TIMEOUT),
             follow_redirects=True,
             headers=self.headers,
         )
+
+    def _ensure_client_for_running_loop(self) -> None:
+        # Client singletons outlive event loops: every `asyncio.run()` seam
+        # (counterfactual replay, derived features, scripts) creates a fresh
+        # loop, while the httpx connection pool stays bound to the first loop
+        # that used it. Reusing it then dies with "Event loop is closed"
+        # (observed live: majors-5m-lab post-apply shadow dark for 5 days).
+        # Rebuild the client whenever the running loop changed; the old
+        # pool's sockets belong to a dead loop and are abandoned to GC.
+        loop = asyncio.get_running_loop()
+        if self._client_loop is None:
+            self._client_loop = loop
+        elif self._client_loop is not loop:
+            self.client = self._build_client()
+            self._client_loop = loop
 
     def _ensure_api_key_header(self) -> None:
         if self.headers.get("X-API-KEY"):
@@ -38,6 +62,7 @@ class WayfinderClient:
     ) -> httpx.Response:
         logger.debug(f"Making {method} request to {url}")
         start_time = time.time()
+        self._ensure_client_for_running_loop()
 
         # Pass API key to all endpoints (including public ones) for rate limiting
         self._ensure_api_key_header()
@@ -53,10 +78,11 @@ class WayfinderClient:
             # One polite retry honoring Retry-After (capped), then surface the
             # error. Instant hammer-retries are what turned a credit blip into
             # an hours-long 429 storm across every job on the box.
+            cap = float(self.MAX_RETRY_DELAY_S)
             try:
-                delay = min(float(resp.headers.get("Retry-After") or 5.0), 30.0)
+                delay = min(float(resp.headers.get("Retry-After") or 5.0), cap)
             except ValueError:
-                delay = 5.0
+                delay = min(5.0, cap)
             logger.warning(
                 f"HTTP 429 for {method} {url} — retrying once in {delay:.0f}s"
             )

--- a/wayfinder_paths/jobs/execution/driver.py
+++ b/wayfinder_paths/jobs/execution/driver.py
@@ -434,18 +434,32 @@ async def _reconcile(
     venue_positions: dict[str, Any] = {}
     account_values: dict[str, float] = {}
     for name, broker in brokers.items():
-        try:
-            venue_state = await broker.fetch_state(symbols)
-        except Exception as exc:
+        # A transient backend blip must not become a reconcile_mismatch wake:
+        # every ambiguous snapshot journals + triggers the (expensive) agent,
+        # and 13 of 13 recent mismatches on the live canary were one-shot
+        # fetch failures, not state divergence. Retry briefly; a PERSISTENT
+        # failure still goes ambiguous -> reduce-only, unchanged.
+        venue_state = None
+        last_error: Exception | None = None
+        for attempt in range(3):
+            try:
+                venue_state = await broker.fetch_state(symbols)
+                break
+            except Exception as exc:  # noqa: BLE001
+                last_error = exc
+                if attempt < 2:
+                    await asyncio.sleep(1.5 * (attempt + 1))
+        if venue_state is None:
             return (
                 StateSnapshot(
-                    status="ambiguous", reason=f"venue state fetch failed: {exc}"
+                    status="ambiguous",
+                    reason=f"venue state fetch failed: {last_error}",
                 ),
                 [
                     {
                         "kind": "reconcile_fetch_failed",
                         "venue": name,
-                        "reason": str(exc),
+                        "reason": str(last_error),
                     }
                 ],
             )

--- a/wayfinder_paths/jobs/watchdog.py
+++ b/wayfinder_paths/jobs/watchdog.py
@@ -26,6 +26,7 @@ from textwrap import dedent
 from typing import Any
 
 from wayfinder_paths.jobs.application import complete_application
+from wayfinder_paths.jobs.models import utc_now_iso
 from wayfinder_paths.jobs.runner_bridge import RunnerBridge
 from wayfinder_paths.jobs.store import JobStore
 
@@ -611,11 +612,59 @@ def recover_stalled_applications(
                 recovered.append({"job_id": job.id, **lifecycle_event})
         except Exception as exc:
             errors.append({"job_id": job.id, "error": f"lifecycle: {exc}"})
+        try:
+            audit_event = _audit_live_mode(store, job)
+        except Exception as exc:  # noqa: BLE001
+            errors.append({"job_id": job.id, "error": f"live_audit: {exc}"})
+            audit_event = None
+        if audit_event is not None:
+            recovered.append({"job_id": job.id, **audit_event})
     try:
         _refresh_portfolio_report(store, now)
     except Exception as exc:  # noqa: BLE001 — fleet telemetry never blocks recovery
         errors.append({"job_id": "_portfolio", "error": str(exc)})
     return {"scanned": scanned, "recovered": recovered, "errors": errors}
+
+
+_LIVE_AUDIT_PATH = "state/live_mode_audit.json"
+
+
+def _audit_live_mode(store: JobStore, job: Any) -> dict[str, Any] | None:
+    """Flag live-mode misconfiguration the guardrails grandfathered in.
+
+    funding-carry-basket ran mode=live for five weeks with the engine-default
+    wallet label — set before operator-owned mode existed, so nothing was
+    stamped and nothing ever re-audited it. Two conditions, checked every
+    pass, journaled only when the flag set CHANGES:
+    - live with no owner stamp in state/operator.json (unattributed mode)
+    - live with no explicit execution_params.wallet_label (engine default
+      'main' rarely exists on a box — the job cannot actually trade)
+    """
+    loop = getattr(job, "script_loop", None)
+    flags: list[str] = []
+    if (
+        loop is not None
+        and getattr(loop, "enabled", False)
+        and (str(getattr(loop, "mode", "") or "") == "live")
+    ):
+        operator = store.read_json(job.id, "state/operator.json") or {}
+        set_by = ((operator.get("script_mode") or {}).get("set_by")) or None
+        if set_by != "owner":
+            flags.append("unstamped_live_mode")
+        execution_params = dict(getattr(job, "execution_params", None) or {})
+        if not str(execution_params.get("wallet_label") or "").strip():
+            flags.append("live_wallet_label_missing")
+    previous = store.read_json(job.id, _LIVE_AUDIT_PATH) or {}
+    if sorted(previous.get("flags") or []) == sorted(flags):
+        return None
+    store.write_json(
+        job.id, _LIVE_AUDIT_PATH, {"flags": flags, "checked_at": utc_now_iso()}
+    )
+    store.append_journal(
+        job.id,
+        {"type": "live_mode_audit", "flags": flags, "cleared": not flags},
+    )
+    return {"action": "live_mode_audit", "flags": flags} if flags else None
 
 
 _PORTFOLIO_REFRESH_S = 1800

--- a/wayfinder_paths/tests/test_jobs_live_loose_ends.py
+++ b/wayfinder_paths/tests/test_jobs_live_loose_ends.py
@@ -1,0 +1,154 @@
+"""Live loose ends from the majors-5m-lab journal audit: client singletons
+dying across event loops (counterfactual dark for 5 days), transient venue
+fetch blips waking the agent as reconcile mismatches, and live-mode
+misconfiguration that predates the operator-stamp guardrail."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import httpx
+
+from wayfinder_paths.core.clients.WayfinderClient import WayfinderClient
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.store import JobStore
+
+
+def test_client_rebuilds_when_event_loop_changes(monkeypatch) -> None:
+    built: list[httpx.AsyncClient] = []
+    transport = httpx.MockTransport(lambda request: httpx.Response(200, json={}))
+
+    def build(self) -> httpx.AsyncClient:
+        client = httpx.AsyncClient(transport=transport)
+        built.append(client)
+        return client
+
+    monkeypatch.setattr(WayfinderClient, "_build_client", build)
+    client = WayfinderClient()
+
+    async def request() -> None:
+        await client._authed_request("GET", "https://example.test/x")
+
+    # Two asyncio.run calls = two distinct loops (the counterfactual seam).
+    asyncio.run(request())
+    first = client.client
+    asyncio.run(request())
+    assert client.client is not first  # rebuilt for the new loop
+
+    # Same loop, repeated requests: no churn after the first rebuild.
+    async def twice() -> None:
+        await client._authed_request("GET", "https://example.test/x")
+        before = client.client
+        await client._authed_request("GET", "https://example.test/x")
+        await client._authed_request("GET", "https://example.test/x")
+        assert client.client is before
+
+    asyncio.run(twice())
+
+
+class _FlakyBroker:
+    def __init__(self, failures: int) -> None:
+        self.failures = failures
+        self.calls = 0
+
+    async def fetch_state(self, symbols):
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise RuntimeError("Could not fetch Hyperliquid state")
+        from wayfinder_paths.jobs.execution.venues import VenueState
+
+        return VenueState(
+            positions={}, open_orders=[], balances={}, source="test", fetched_at=None
+        )
+
+
+def test_reconcile_retries_transient_fetch_failures(monkeypatch) -> None:
+    from wayfinder_paths.jobs.execution import driver as driver_module
+    from wayfinder_paths.jobs.execution.driver import _reconcile
+    from wayfinder_paths.jobs.execution.engine import EngineState
+
+    monkeypatch.setattr(driver_module.asyncio, "sleep", _instant_sleep, raising=False)
+    flaky = _FlakyBroker(failures=2)
+    snapshot, notes = asyncio.run(
+        _reconcile(
+            mode="live",
+            state=EngineState(),
+            brokers={"hyperliquid": flaky},
+            symbols=["HYPE"],
+            state_file_existed=True,
+        )
+    )
+    assert snapshot.status == "valid"  # two blips absorbed
+    assert flaky.calls == 3
+    assert not [n for n in notes if n.get("kind") == "reconcile_fetch_failed"]
+
+    dead = _FlakyBroker(failures=99)
+    snapshot, notes = asyncio.run(
+        _reconcile(
+            mode="live",
+            state=EngineState(),
+            brokers={"hyperliquid": dead},
+            symbols=["HYPE"],
+            state_file_existed=True,
+        )
+    )
+    assert snapshot.status == "ambiguous"  # persistent failure still bites
+    assert dead.calls == 3
+    assert notes[0]["kind"] == "reconcile_fetch_failed"
+
+
+async def _instant_sleep(_seconds: float) -> None:
+    return None
+
+
+def test_watchdog_flags_unstamped_and_walletless_live_mode(tmp_path) -> None:
+    from wayfinder_paths.jobs.watchdog import _audit_live_mode
+
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        "audit-demo",
+        script="workspace/src/strategy.py",
+        agent_mode="intervene",
+        execution_contract="jobs_v1",
+    )
+    job.script_loop.mode = "live"
+    store.save(job)
+
+    event = _audit_live_mode(store, job)
+    assert sorted(event["flags"]) == [
+        "live_wallet_label_missing",
+        "unstamped_live_mode",
+    ]
+    rows = [
+        json.loads(line)
+        for line in (store.job_dir(job.id) / "journal.jsonl").read_text().splitlines()
+    ]
+    audits = [r for r in rows if r["type"] == "live_mode_audit"]
+    assert len(audits) == 1
+
+    # Unchanged flags on the next pass: no duplicate journal spam.
+    assert _audit_live_mode(store, job) is None
+    rows = (store.job_dir(job.id) / "journal.jsonl").read_text().splitlines()
+    assert sum('"live_mode_audit"' in line for line in rows) == 1
+
+    # Owner stamp + explicit wallet clears the flags (journaled once as clear).
+    store.write_json(
+        job.id, "state/operator.json", {"script_mode": {"set_by": "owner"}}
+    )
+    job.execution_params["wallet_label"] = "majors-wallet"
+    store.save(job)
+    assert _audit_live_mode(store, job) is None  # cleared -> no recovery event
+    rows = (store.job_dir(job.id) / "journal.jsonl").read_text().splitlines()
+    cleared = [json.loads(line) for line in rows if '"live_mode_audit"' in line]
+    assert cleared[-1]["cleared"] is True
+
+    # Paper jobs never flag.
+    paper = WayfinderJob.new(
+        "paper-demo",
+        script="workspace/src/strategy.py",
+        agent_mode="intervene",
+        execution_contract="jobs_v1",
+    )
+    store.save(paper)
+    assert _audit_live_mode(store, paper) is None


### PR DESCRIPTION
Post-rollout audit of the live canary's journal surfaced three production defects. All reproduced in tests and fixed.

## 1. Client singletons die across event loops (counterfactual dark for 5 days)

`WayfinderClient` builds one `httpx.AsyncClient` at construction; its connection pool binds to the first event loop that uses it. Every `asyncio.run()` seam — counterfactual replay, derived features, ad-hoc scripts — creates a fresh loop and inherits dead transports: **"Event loop is closed"**. Observed live: majors-5m-lab's post-apply shadow for the active proposal (`prop-code-change-4e24b85c`, applied Aug 11) failed 8× and has been dark since — the entry-gating adjudication mechanism was blind for the live job's active change. The client now rebuilds itself whenever the running loop changes (same loop → zero churn).

Drive-by in the same file: the base 429-retry's hardcoded 30s cap silently overrode Gorlami's 5s `MAX_RETRY_DELAY_S` — its two tests were red on the branch tip. Cap is now subclass-aware.

## 2. Transient venue blips woke the agent as reconcile mismatches

13/13 recent `reconcile_mismatch` events on majors were one-shot `hyperliquid_get_state` failures (backend 5xx / wallet-service blips), each journaling + firing a trigger wake — LLM spend on nothing. The reconciler now retries 3× with short backoff before declaring ambiguous. A persistent failure still goes ambiguous → reduce-only ticks, unchanged.

## 3. Live-mode misconfiguration audit (the funding-carry-basket lesson)

funding-carry-basket ran `mode=live` for **five weeks** with the engine-default wallet label — set before operator-owned mode existed (#653), so nothing was stamped and nothing ever re-audited it. The watchdog now checks every job each pass and flags: live with no owner stamp (`unstamped_live_mode`) or live with no explicit `execution_params.wallet_label` (`live_wallet_label_missing`). Journals `live_mode_audit` only when the flag set *changes* (no 5-minute spam), including an explicit cleared record.

## Verification

3 new tests (loop-change rebuild + same-loop stability; retry absorbs 2 blips / persistent failure still bites; audit flags, dedupes, clears, ignores paper). Gorlami client tests back to green. Wide suite (jobs+mcp+execution+client): 969 passed. ruff clean.
