### PR TITLE
jobs: self-healing pipeline — failure taxonomy, durable restage, continuation scheduling

### DIFF
--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -1544,12 +1544,23 @@ def restage_cmd(job_id: str, proposal_id: str, candidate_dir: str | None) -> Non
     show_default=True,
     help="Who is rejecting: owner vetoes bind the worker; agent = housekeeping.",
 )
+@click.option(
+    "--kind",
+    type=click.Choice(["process", "substantive"]),
+    default=None,
+    help="process = mechanics (superseded/re-stage), successor expected; "
+    "substantive = verdict on the change. Default: inferred from --reason.",
+)
 def reject_cmd(
-    job_id: str, proposal_id: str, reason: str | None, rejected_by: str
+    job_id: str,
+    proposal_id: str,
+    reason: str | None,
+    rejected_by: str,
+    kind: str | None,
 ) -> None:
     store = JobStore()
     proposal = store.reject_proposal(
-        job_id, proposal_id, reason=reason, rejected_by=rejected_by
+        job_id, proposal_id, reason=reason, rejected_by=rejected_by, kind=kind
     )
     sync_all_jobs(store=store)
     _echo_json({"ok": True, "result": proposal})

--- a/wayfinder_paths/jobs/failures.py
+++ b/wayfinder_paths/jobs/failures.py
@@ -1,0 +1,48 @@
+"""Failure taxonomy: infrastructure vs evidence.
+
+One OOM at 21:04Z (live production) cascaded into 14 hours of frozen
+research: the job-worker agent recorded "OOM-blocked" in its agendas, marked
+research lanes "exhausted", and self-rejected an owner-approved proposal
+whose mechanical re-stage failed inside the OOM window. Every recovery
+required a human operator. The missing primitive was a shared, dumb answer
+to one question: is this failure about the BOX or about the EVIDENCE?
+
+The asymmetry rule: INFRASTRUCTURE failures (OOM, locks, timeouts, dead
+event loops, unreachable services) are transient box conditions — they are
+watchdog-retried, self-repair mechanically, and may never bury approved
+work or close a research lane. EVIDENCE failures (failed validation, red
+gates, refuted hypotheses) still stop the line — that is the system working.
+"""
+
+from __future__ import annotations
+
+# Deliberately dumb and greppable: case-insensitive substring match against a
+# flat list. No regex cleverness — anyone auditing a recovery decision should
+# be able to grep the error text against this list by eye.
+INFRASTRUCTURE_PATTERNS = (
+    "oom",
+    "out of memory",
+    "memory",
+    "killed",
+    "lock busy",
+    "heavy-compute lock",
+    "timeout",
+    "timed out",
+    "408",
+    "429",
+    "502",
+    "503",
+    "event loop is closed",
+    "connection",
+    "opencode-unavailable",
+    "prompt_async",
+    "resource temporarily unavailable",
+)
+
+
+def classify_failure(error: str) -> str:
+    """Classify an error string as "infrastructure" or "evidence"."""
+    text = (error or "").lower()
+    if any(pattern in text for pattern in INFRASTRUCTURE_PATTERNS):
+        return "infrastructure"
+    return "evidence"

--- a/wayfinder_paths/jobs/improver/scheduler.py
+++ b/wayfinder_paths/jobs/improver/scheduler.py
@@ -29,6 +29,7 @@ they exist to handle their event, not to run the rotation.
 from __future__ import annotations
 
 import json
+import os
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -50,6 +51,9 @@ SCHEDULER_STATE_PATH = "state/scheduler.json"
 # A trigger wake stamps state/agent_wake_state.json immediately before the
 # worker runs; a stamp this fresh means THIS wake is the trigger's wake.
 _TRIGGER_WINDOW_S = 180
+# A background op that completed within this window and has not been marked
+# harvested still owns the research thread — do not rotate away from it.
+_CONTINUATION_WINDOW_S = 2 * 3600
 
 ISLAND_DIRECTIVES: dict[str, str] = {
     "exploit": (
@@ -120,6 +124,47 @@ def assign_island(
     }
     total = sum(assigned.values())
 
+    # Continuation beats rotation: an in-flight (or recently completed,
+    # unharvested) background op is a research thread mid-flight — rotating
+    # to a different island strands its results (live incident: a wake
+    # started a grid, the next wake rotated islands and the completed grid
+    # was never read). Deterministic: pure function of on-disk op status.
+    history = state.get("history") or []
+    last_island = ""
+    if history and isinstance(history[-1], dict):
+        last_island = str(history[-1].get("island") or "")
+    continuation_ops = _continuation_ops(root, now=now)
+    if continuation_ops and last_island in ISLANDS:
+        assigned[last_island] += 1
+        reasons = [
+            "continuation: in-flight/unharvested background op — finish the "
+            "thread before rotating"
+        ]
+        state = {
+            "assigned": assigned,
+            "total": total + 1,
+            "history": history[-19:]
+            + [{"island": last_island, "ts": utc_now_iso(), "reason": reasons[0]}],
+        }
+        store.write_json(job_id, SCHEDULER_STATE_PATH, state)
+        store.append_journal(
+            job_id,
+            {
+                "type": "island_assigned",
+                "island": last_island,
+                "reasons": reasons,
+                "continuation_ops": continuation_ops,
+            },
+        )
+        return {
+            "island": last_island,
+            "reasons": reasons,
+            "directive": ISLAND_DIRECTIVES[last_island],
+            "agenda": f"research/islands/{last_island}.md",
+            "assigned_counts": assigned,
+            "continuation_ops": continuation_ops,
+        }
+
     weights = {island: spec.island_weights.get(island, 0.0) for island in ISLANDS}
     boosts: list[str] = []
     if _verdict_stuck_streak(store, job_id, spec.stuck_same_family_non_wins):
@@ -176,6 +221,53 @@ def assign_island(
         "assigned_counts": assigned,
         "target_weights": {k: round(v, 3) for k, v in weights.items()},
     }
+
+
+def _continuation_ops(root: Path, *, now: datetime | None) -> list[str]:
+    """Op names with an in-flight or recently-completed-but-unharvested
+    background op (state/background_ops/<op>.json, written by the MCP
+    detached-op launcher). A running op with a dead pid is a stale marker
+    from a killed run — it must not pin the rotation forever."""
+    ops_dir = root / "state" / "background_ops"
+    if not ops_dir.exists():
+        return []
+    current = now or datetime.now(UTC)
+    ops: list[str] = []
+    for path in sorted(ops_dir.glob("*.json")):
+        if path.name.endswith(".result.json"):
+            continue
+        try:
+            doc = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(doc, dict):
+            continue
+        state = str(doc.get("state") or "")
+        if state == "running":
+            pid = doc.get("pid")
+            if isinstance(pid, int) and pid > 0 and not _pid_alive(pid):
+                continue
+            ops.append(str(doc.get("op") or path.stem))
+            continue
+        if state != "done" or doc.get("harvested"):
+            continue
+        try:
+            finished = datetime.fromisoformat(str(doc.get("finished_at")))
+        except (TypeError, ValueError):
+            continue
+        if finished.tzinfo is None:
+            finished = finished.replace(tzinfo=UTC)
+        if (current - finished).total_seconds() <= _CONTINUATION_WINDOW_S:
+            ops.append(str(doc.get("op") or path.stem))
+    return ops
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
 
 
 def _fresh_trigger(root: Path, *, now: datetime | None) -> list[str] | None:

--- a/wayfinder_paths/jobs/store.py
+++ b/wayfinder_paths/jobs/store.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import yaml
 
+from wayfinder_paths.jobs.failures import classify_failure
 from wayfinder_paths.jobs.forward import default_forward_summary
 from wayfinder_paths.jobs.models import (
     ApplicationStatus,
@@ -26,6 +27,18 @@ APPLICATION_STATUSES = {
     "canceled",
 }
 PROPOSAL_STATUSES = {"pending", "approved", "rejected"}
+REJECTION_KINDS = {"process", "substantive"}
+# Reasons that mark a rejection as process housekeeping (mechanics of the
+# pipeline) rather than a substantive verdict on the change itself.
+_PROCESS_REJECTION_MARKERS = (
+    "superseded",
+    "re-stage",
+    "restage",
+    "oom",
+    "infrastructure",
+    "red gate",
+)
+SUCCESSOR_EXPECTED_PATH = "state/successor_expected.json"
 
 
 class JobStore:
@@ -553,6 +566,7 @@ class JobStore:
         *,
         reason: str | None = None,
         rejected_by: str | None = None,
+        kind: str | None = None,
     ) -> dict[str, Any]:
         proposal = self.load_proposal(job_id, proposal_id)
         application_status = proposal["application"]["status"]
@@ -561,18 +575,67 @@ class JobStore:
                 f"Cannot reject proposal with application status {application_status}: "
                 f"{proposal_id}"
             )
+        by = rejected_by or "owner"
+        # Durable restage: an agent cannot bury owner-approved work over a
+        # transient box failure. When the latest re-stage/validation failure
+        # is infrastructure-class (OOM, lock, timeout), the proposal stays
+        # approved with restage_requested and the watchdog retries — only the
+        # owner may abandon approved work. (Live incident: one OOM during a
+        # mechanical re-stage led the agent to self-reject an owner-approved
+        # proposal, freezing the change until a human noticed.)
+        if proposal["status"] == "approved" and by != "owner":
+            failure_text = _latest_failure_text(proposal, reason)
+            if classify_failure(failure_text) == "infrastructure":
+                proposal["application"]["restage_requested"] = True
+                proposal["updated_at"] = utc_now_iso()
+                self.write_proposal(job_id, proposal)
+                self.append_journal(
+                    job_id,
+                    {
+                        "type": "proposal_reject_refused",
+                        "proposal_id": proposal_id,
+                        "rejected_by": by,
+                        "failure_kind": "infrastructure",
+                    },
+                )
+                raise ValueError(
+                    f"refusing agent rejection of approved proposal "
+                    f"{proposal_id}: its latest re-stage/validation failure "
+                    "is infrastructure-class (OOM/lock/timeout) — a "
+                    "transient box condition, not evidence against the "
+                    "change. The proposal stays approved with "
+                    "restage_requested and the watchdog retries the "
+                    "re-stage; only the owner may abandon approved work."
+                )
+        if kind is not None and kind not in REJECTION_KINDS:
+            raise ValueError(f"rejection kind must be one of {sorted(REJECTION_KINDS)}")
+        rejection_kind = kind or _infer_rejection_kind(reason)
         proposal["status"] = "rejected"
         proposal["approval"]["status"] = "rejected"
         # Provenance is the difference between "the owner said no" (binding —
         # the worker must not re-propose an equivalent change without named
         # new evidence) and the worker's own superseded-draft housekeeping
         # (retry expected). Without it both rejections looked identical and
-        # the worker re-proposed owner-vetoed changes.
+        # the worker re-proposed owner-vetoed changes. `kind` splits owner
+        # rejections further: only kind=substantive binds as a veto;
+        # kind=process (superseded / re-stage mechanics / red-gate
+        # housekeeping) is an invitation to file a corrected successor.
         proposal["rejection"] = {
             "reason": reason,
-            "by": rejected_by or "owner",
+            "by": by,
+            "kind": rejection_kind,
             "ts": utc_now_iso(),
         }
+        if by == "owner" and rejection_kind == "process":
+            # A process rejection from the owner expects a successor
+            # proposal; the watchdog wakes the agent if none appears.
+            expected = self.read_json(job_id, SUCCESSOR_EXPECTED_PATH, default=[])
+            if not isinstance(expected, list):
+                expected = []
+            expected.append(
+                {"proposal_id": proposal_id, "ts": utc_now_iso(), "reason": reason}
+            )
+            self.write_json(job_id, SUCCESSOR_EXPECTED_PATH, expected)
         if application_status == "queued":
             self._set_application_status(proposal, "canceled")
         proposal["updated_at"] = utc_now_iso()
@@ -596,6 +659,7 @@ class JobStore:
                 "proposal_id": proposal_id,
                 "application_status": proposal["application"]["status"],
                 "rejected_by": proposal["rejection"]["by"],
+                "kind": rejection_kind,
                 "reason": reason,
             },
         )
@@ -777,6 +841,33 @@ class JobStore:
                     "ts": utc_now_iso(),
                 }
             )
+
+
+def _infer_rejection_kind(reason: str | None) -> str:
+    text = (reason or "").lower()
+    if any(marker in text for marker in _PROCESS_REJECTION_MARKERS):
+        return "process"
+    return "substantive"
+
+
+def _latest_failure_text(proposal: Mapping[str, Any], reason: str | None) -> str:
+    """Best-effort text of the proposal's most recent failure, for the
+    infrastructure-vs-evidence classification on agent self-rejections."""
+    application = proposal.get("application") or {}
+    latest_validation = application.get("latest_validation") or {}
+    parts: list[Any] = [
+        reason,
+        application.get("error"),
+        application.get("restage_last_error"),
+        latest_validation.get("error"),
+        (application.get("validation") or {}).get("error"),
+    ]
+    for check in latest_validation.get("checks") or []:
+        if isinstance(check, dict) and not check.get("passed"):
+            parts.extend([check.get("name"), check.get("detail"), check.get("error")])
+    summary = (proposal.get("candidate_report") or {}).get("validation_summary") or {}
+    parts.extend(summary.get("failed_checks") or [])
+    return " | ".join(str(part) for part in parts if part)
 
 
 def _validate_applicable_proposal(

--- a/wayfinder_paths/jobs/triggers.py
+++ b/wayfinder_paths/jobs/triggers.py
@@ -25,7 +25,13 @@ DEFAULT_DEBOUNCE_SECONDS = 600
 # (not market conditions the owner opted into watching).
 # verdict_matured fires at most once per promotion — a matured forward
 # verdict is a research event every job should act on, config or not.
-ALWAYS_WAKE_EVENTS = {"proposal_restage_requested", "verdict_matured"}
+# successor_overdue fires when a kind=process owner rejection's expected
+# successor proposal has not appeared within the watchdog window.
+ALWAYS_WAKE_EVENTS = {
+    "proposal_restage_requested",
+    "verdict_matured",
+    "successor_overdue",
+}
 
 
 def fire_triggers(

--- a/wayfinder_paths/jobs/watchdog.py
+++ b/wayfinder_paths/jobs/watchdog.py
@@ -50,6 +50,14 @@ HARD_KILL_TIMEOUT = timedelta(minutes=45)
 # restage wake re-fired (once per window) — one truncated prompt or dead
 # session must not strand an owner-approved change.
 RESTAGE_NAG_TIMEOUT = timedelta(minutes=30)
+# Mechanical re-stages are retried across watchdog passes (one per pass) —
+# an OOM'd backtest must not strand an owner-approved change — but bounded:
+# past this many failed attempts the owner is escalated instead.
+RESTAGE_MAX_ATTEMPTS = 5
+# A kind=process owner rejection expects a corrected successor proposal.
+# None within this window → wake the agent once per entry.
+SUCCESSOR_OVERDUE_TIMEOUT = timedelta(hours=12)
+_SUCCESSOR_EXPECTED_PATH = "state/successor_expected.json"
 
 
 def _pid_alive(pid: int) -> bool:
@@ -216,18 +224,51 @@ def _recover_restage(
     if params:
         if not allow_mechanical:
             return None  # next pass, 5 minutes out
+        attempts = int(application.get("restage_attempts") or 0)
+        if attempts >= RESTAGE_MAX_ATTEMPTS:
+            if application.get("restage_attempts_exhausted"):
+                return None
+            application["restage_attempts_exhausted"] = True
+            store.write_proposal(job_id, proposal)
+            event = {
+                "type": "application_watchdog_recovered",
+                "proposal_id": proposal_id,
+                "stalled_status": "restage_requested",
+                "action": "restage_attempts_exhausted",
+                "outcome": "needs_attention",
+                "attempts": attempts,
+            }
+            store.append_journal(job_id, event)
+            return event
         # circular import: proposals → worker → …driver → triggers → watchdog
         from wayfinder_paths.jobs.proposals import restage_proposal
 
         try:
             result = restage_proposal(store, job_id, proposal_id)
         except Exception as exc:
+            from wayfinder_paths.jobs.failures import classify_failure
+
+            failure_kind = classify_failure(str(exc))
+            # Persist the bounded retry counter on the CURRENT on-disk
+            # proposal — restage_proposal reloads and rewrites it internally,
+            # so our in-memory copy may be stale. An infrastructure-class
+            # failure keeps the re-stage request alive so later passes retry
+            # (the failed restage may have cleared the flag before dying).
+            fresh = store.load_proposal(job_id, proposal_id)
+            fresh_application = fresh["application"]
+            fresh_application["restage_attempts"] = attempts + 1
+            fresh_application["restage_last_error"] = str(exc)[:300]
+            if failure_kind == "infrastructure":
+                fresh_application["restage_requested"] = True
+            store.write_proposal(job_id, fresh)
             store.append_journal(
                 job_id,
                 {
                     "type": "application_watchdog_skipped",
                     "proposal_id": proposal_id,
                     "reason": f"mechanical restage failed: {exc}",
+                    "failure_kind": failure_kind,
+                    "restage_attempts": attempts + 1,
                 },
             )
             return None
@@ -268,6 +309,75 @@ def _recover_restage(
     }
     store.append_journal(job_id, event)
     return event
+
+
+def _check_successor_overdue(
+    store: JobStore,
+    job_id: str,
+    proposals: list[dict[str, Any]],
+    now: datetime,
+) -> list[dict[str, Any]]:
+    """Wake the agent when a process-rejection's expected successor is late.
+
+    A kind=process owner rejection (superseded draft, re-stage mechanics) is
+    an INVITATION, not a veto — the owner expects a corrected successor
+    proposal. If none has been created within the window, journal
+    `successor_overdue` once per entry and fire a trigger wake so the
+    invitation cannot silently rot.
+    """
+    expected = store.read_json(job_id, _SUCCESSOR_EXPECTED_PATH) or []
+    if not isinstance(expected, list):
+        return []
+    events: list[dict[str, Any]] = []
+    changed = False
+    for entry in expected:
+        if not isinstance(entry, dict) or entry.get("notified"):
+            continue
+        if _age(now, entry.get("ts")) < SUCCESSOR_OVERDUE_TIMEOUT:
+            continue
+        entry_ts = str(entry.get("ts") or "")
+        rejected_id = str(entry.get("proposal_id") or "")
+        # A successor is any OTHER proposal staged after the rejection —
+        # candidate_report.generated_at is the propose/restage stamp;
+        # updated_at is the fallback for report-less proposals.
+        successor_exists = any(
+            str(p.get("proposal_id")) != rejected_id
+            and str(
+                (p.get("candidate_report") or {}).get("generated_at")
+                or p.get("updated_at")
+                or ""
+            )
+            > entry_ts
+            for p in proposals
+        )
+        entry["notified"] = True
+        changed = True
+        if successor_exists:
+            continue
+        store.append_journal(
+            job_id,
+            {
+                "type": "successor_overdue",
+                "proposal_id": rejected_id,
+                "rejected_ts": entry_ts,
+                "reason": entry.get("reason"),
+            },
+        )
+        from wayfinder_paths.jobs.triggers import fire_triggers
+
+        fire_triggers(
+            store, store.load(job_id), ["successor_overdue"], source="watchdog"
+        )
+        events.append(
+            {
+                "action": "successor_overdue",
+                "proposal_id": rejected_id,
+                "outcome": "agent_woken",
+            }
+        )
+    if changed:
+        store.write_json(job_id, _SUCCESSOR_EXPECTED_PATH, expected)
+    return events
 
 
 # Matches "backtest is for revision ab12cd34ef56, workspace is 0f1e2d3c4b5a" —
@@ -596,6 +706,13 @@ def recover_stalled_applications(
             pause_event = None
         if pause_event is not None:
             recovered.append({"job_id": job.id, **pause_event})
+        try:
+            for successor_event in _check_successor_overdue(
+                store, job.id, proposals, now
+            ):
+                recovered.append({"job_id": job.id, **successor_event})
+        except Exception as exc:
+            errors.append({"job_id": job.id, "error": f"successor: {exc}"})
         try:
             gate_event = _recover_stale_gate(
                 store, job.id, proposals, allow_restamp=not restamped_this_pass

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -507,6 +507,60 @@ def _standing_checks_block(root: Path) -> dict[str, Any]:
     return block
 
 
+def _compute_status_block(root: Path) -> dict[str, Any]:
+    """Mechanical box truth: is compute healthy RIGHT NOW?
+
+    One production OOM froze research for 14 hours because the agent carried
+    "OOM-blocked" claims in its agendas long after memory recovered — nothing
+    in the context ever contradicted the stale belief. This block is computed
+    from the box on every wake so an infrastructure claim can always be
+    checked against current reality. Best-effort on every field, never
+    raises."""
+    mem_available_mb: int | None = None
+    try:
+        for line in Path("/proc/meminfo").read_text(encoding="utf-8").splitlines():
+            if line.startswith("MemAvailable:"):
+                mem_available_mb = int(line.split()[1]) // 1024
+                break
+    except Exception:  # noqa: BLE001 — non-Linux boxes have no /proc/meminfo
+        mem_available_mb = None
+    last_experiment_at: str | None = None
+    experiments_path = root / "results" / "backtest" / "experiments.jsonl"
+    try:
+        for line in reversed(experiments_path.read_text(encoding="utf-8").splitlines()):
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            if isinstance(row, dict):
+                last_experiment_at = str(row.get("ts") or "") or None
+            break
+    except Exception:  # noqa: BLE001
+        last_experiment_at = None
+    last_backtest_ok_at: str | None = None
+    viz_path = root / "results" / "backtest" / "visualization.json"
+    try:
+        last_backtest_ok_at = dt.datetime.fromtimestamp(
+            viz_path.stat().st_mtime, tz=dt.UTC
+        ).isoformat()
+    except Exception:  # noqa: BLE001
+        last_backtest_ok_at = None
+    return {
+        "mem_available_mb": mem_available_mb,
+        "last_experiment_at": last_experiment_at,
+        "last_backtest_ok_at": last_backtest_ok_at,
+        "_basis": (
+            "Mechanical box truth computed THIS wake. Infrastructure "
+            "failures (OOM, locks, timeouts) are TRANSIENT and "
+            "watchdog-retried — they are FORBIDDEN as reasons to mark a "
+            "research lane blocked or exhausted, in agendas or reports. "
+            "NEVER carry an infrastructure claim from memory when this "
+            "block contradicts it. If this block shows healthy memory and "
+            "recent successful compute, every 'OOM-blocked' qualifier you "
+            "have ever written is void."
+        ),
+    }
+
+
 def _drop_volatile_stable_keys(value: Any) -> Any:
     match value:
         case dict():
@@ -652,6 +706,7 @@ def _build_worker_prompt_sections(
         "post_apply_shadow": _counterfactual_block(store, job_id),
         "research_substrate": _research_substrate_block(root),
         "standing_checks": _standing_checks_block(root),
+        "compute_status": _compute_status_block(root),
         "evolution": _evolution_block(store, job_id),
         "archive": _archive_block(store, job_id),
         "restage_tasks": restage_tasks,
@@ -681,9 +736,14 @@ def _build_worker_prompt_sections(
         "reason='superseded by <new-id>')) so the owner never reviews stale drafts. "
         "ALWAYS pass a reason on self-rejections — an unreasoned rejection is "
         "recorded as an OWNER veto.\n"
-        "- Rejections have provenance (`rejection.by` on the proposal): an "
-        "OWNER rejection is a DECISION, not a formality. NEVER re-propose an "
-        "equivalent change after an owner rejection unless you have NAMED new "
+        "- Rejections have provenance (`rejection.by` + `rejection.kind` on "
+        "the proposal): an OWNER rejection with kind='substantive' is a "
+        "DECISION, not a formality — a binding veto. kind='process' owner "
+        "rejections (superseded drafts, re-stage mechanics, red-gate "
+        "housekeeping) are INVITATIONS, not vetoes: file the corrected "
+        "successor proposal promptly. NEVER re-propose an "
+        "equivalent change after a substantive owner rejection unless you "
+        "have NAMED new "
         "evidence that did not exist at rejection time, and the new proposal "
         "summary must cite both the rejected proposal id and that evidence. "
         "Your own reasoned self-rejections (superseded/stale drafts) do not "
@@ -729,6 +789,13 @@ def _build_worker_prompt_sections(
         "the next candidate, run the next experiment, or record in the "
         "report precisely why not. A neutral verdict means the change did "
         "nothing: that is license to try the next candidate, not to wait.\n"
+        "- Infrastructure failures are BOX conditions, not research "
+        "verdicts: any claim that a lane is OOM-blocked, locked, or "
+        "timed-out must cite the `compute_status` block from THIS wake — "
+        "stale infrastructure beliefs carried from memory, agendas, or "
+        "prior reports are VOID when compute_status contradicts them. "
+        "Completed background operations must be harvested and acted on "
+        "regardless of this wake's island assignment.\n"
         "- Research staleness (`evolution.research_staleness`) is visible "
         "state. When the job is healthy, no verdict is pending, and "
         "`research_staleness.stale` is true (no experiment in "

--- a/wayfinder_paths/mcp/tools/jobs.py
+++ b/wayfinder_paths/mcp/tools/jobs.py
@@ -190,12 +190,22 @@ async def _start_background_op(
     proc.stdin.write(json.dumps({"op": op, "kwargs": kwargs}).encode())
     await proc.stdin.drain()
     proc.stdin.close()
+    # Best-effort island stamp: which research thread started this op, so the
+    # scheduler's continuation check can keep the wake rotation on it.
+    scheduler_state = _load_json_file(
+        store.job_dir(job_id) / "state" / "scheduler.json"
+    )
+    history = (scheduler_state or {}).get("history") or []
+    island = (
+        history[-1].get("island") if history and isinstance(history[-1], dict) else None
+    )
     status = {
         "op": op,
         "job_id": job_id,
         "state": "running",
         "pid": proc.pid,
         "started_at": utc_now_iso(),
+        **({"island": island} if island else {}),
     }
     status_path.write_text(json.dumps(status), encoding="utf-8")
     task = asyncio.get_running_loop().create_task(
@@ -781,11 +791,14 @@ async def core_jobs(
             # attribution is therefore the agent's own housekeeping, a bare
             # one is an owner veto — which binds the worker (no equivalent
             # re-proposal without named new evidence).
+            # `kind` (process|substantive) rides the same param used by
+            # propose: process rejections expect a successor proposal.
             proposal = store.reject_proposal(
                 job_id,
                 proposal_id,
                 reason=reason,
                 rejected_by="agent" if reason else "owner",
+                kind=kind,
             )
             sync_all_jobs(store=store)
             return ok(proposal)

--- a/wayfinder_paths/tests/test_jobs_self_healing.py
+++ b/wayfinder_paths/tests/test_jobs_self_healing.py
@@ -1,0 +1,321 @@
+"""Self-healing pipeline: failure taxonomy, mechanical compute-status truth,
+durable restage (agents cannot bury approved work on infra failures),
+process-vs-substantive rejection kinds with successor expectations, and
+continuation-aware island scheduling.
+
+Motivating incident: one production OOM cascaded into 14h of frozen research
+— "OOM-blocked" agendas, lanes marked exhausted, and an owner-approved
+proposal self-rejected because its mechanical re-stage failed inside the OOM
+window. The asymmetry under test: INFRASTRUCTURE failures self-repair;
+EVIDENCE failures still stop the line.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from wayfinder_paths.jobs.failures import classify_failure
+from wayfinder_paths.jobs.improver.scheduler import (
+    assign_island,
+    load_scheduler_state,
+)
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.jobs.triggers import ALWAYS_WAKE_EVENTS
+from wayfinder_paths.jobs.watchdog import (
+    _recover_restage,
+    recover_stalled_applications,
+)
+
+
+def _make_store(tmp_path: Path, job_id: str = "heal-demo") -> tuple[JobStore, str]:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        job_id,
+        script="workspace/src/strategy.py",
+        agent_mode="intervene",
+        execution_contract="jobs_v1",
+    )
+    store.save(job)
+    return store, job.id
+
+
+def _journal_events(store: JobStore, job_id: str, event_type: str) -> list[dict]:
+    path = store.job_dir(job_id) / "journal.jsonl"
+    if not path.exists():
+        return []
+    rows = [json.loads(line) for line in path.read_text().splitlines()]
+    return [row for row in rows if row.get("type") == event_type]
+
+
+@pytest.fixture
+def wakes(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+
+    def fake_worker(job_id: str, *, mode: str, **kwargs: Any) -> dict[str, Any]:
+        calls.append({"job_id": job_id, "mode": mode, **kwargs})
+        return {"status": "queued"}
+
+    monkeypatch.setattr("wayfinder_paths.jobs.worker.run_job_worker", fake_worker)
+    return calls
+
+
+def test_classify_failure_taxonomy() -> None:
+    infrastructure = [
+        "backtest process was killed (signal 9) — likely out of memory",
+        "OOM while building the grid",
+        "heavy-compute lock busy",
+        "request timed out after 300s",
+        "HTTP 503 from opencode",
+        "Event loop is closed",
+        "opencode-unavailable: prompt_async failed",
+        "Resource temporarily unavailable",
+    ]
+    for text in infrastructure:
+        assert classify_failure(text) == "infrastructure", text
+    evidence = [
+        "candidate validation is not passed: failed",
+        "candidate gate is not live-ready: net_return below baseline",
+        "thesis refuted by walk-forward folds",
+        "",
+    ]
+    for text in evidence:
+        assert classify_failure(text) == "evidence", text
+
+
+def test_compute_status_block_in_wake_prompt(tmp_path: Path) -> None:
+    from wayfinder_paths.jobs.worker import prepare_job_worker_prompt
+
+    store, job_id = _make_store(tmp_path, "heal-prompt")
+    sections = prepare_job_worker_prompt(store=store, job_id=job_id, mode="intervene")
+    assert "compute_status" in sections["prompt"]
+    assert "mem_available_mb" in sections["prompt"]
+    assert "FORBIDDEN as reasons" in sections["prompt"]  # the _basis contract
+    # Stable-prefix rules: infra claims cite compute_status; process
+    # rejections are invitations, not vetoes.
+    assert "compute_status" in sections["stable_prefix"]
+    assert "INVITATIONS" in sections["stable_prefix"]
+
+
+def _approved_proposal(error: str | None) -> dict[str, Any]:
+    return {
+        "proposal_id": "prop-heal",
+        "status": "approved",
+        "proposed_change": {"summary": "x", "execution_params": {"a": 1}},
+        "application": {
+            "status": "failed",
+            "restage_requested": True,
+            "error": error,
+        },
+    }
+
+
+def test_agent_cannot_bury_approved_work_on_infra_failure(tmp_path: Path) -> None:
+    store, job_id = _make_store(tmp_path)
+    store.write_proposal(
+        job_id,
+        _approved_proposal("process was killed (signal 9) — likely out of memory"),
+    )
+    with pytest.raises(ValueError, match="infrastructure-class"):
+        store.reject_proposal(
+            job_id, "prop-heal", reason="re-stage failed", rejected_by="agent"
+        )
+    kept = store.load_proposal(job_id, "prop-heal")
+    assert kept["status"] == "approved"  # approval survives the box failure
+    assert kept["application"]["restage_requested"] is True
+    assert _journal_events(store, job_id, "proposal_reject_refused")
+
+    # The owner may still abandon approved work — the guard binds agents only.
+    rejected = store.reject_proposal(
+        job_id, "prop-heal", reason="no longer wanted", rejected_by="owner"
+    )
+    assert rejected["status"] == "rejected"
+
+
+def test_agent_reject_of_evidence_failure_still_passes(tmp_path: Path) -> None:
+    store, job_id = _make_store(tmp_path)
+    store.write_proposal(
+        job_id, _approved_proposal("candidate gate is not live-ready: worse net_return")
+    )
+    rejected = store.reject_proposal(
+        job_id,
+        "prop-heal",
+        reason="superseded by prop-next",
+        rejected_by="agent",
+    )
+    assert rejected["status"] == "rejected"  # evidence failures stop the line
+    assert rejected["rejection"]["kind"] == "process"  # superseded → process
+
+
+def test_rejection_kind_heuristic_and_successor_expectation(tmp_path: Path) -> None:
+    store, job_id = _make_store(tmp_path)
+    store.write_proposal(
+        job_id,
+        {
+            "proposal_id": "prop-a",
+            "status": "pending",
+            "application": {"status": "not_requested"},
+        },
+    )
+    store.write_proposal(
+        job_id,
+        {
+            "proposal_id": "prop-b",
+            "status": "pending",
+            "application": {"status": "not_requested"},
+        },
+    )
+    # Owner process rejection (re-stage mechanics) → successor expected.
+    rejected = store.reject_proposal(
+        job_id, "prop-a", reason="restage failed under red gate", rejected_by="owner"
+    )
+    assert rejected["rejection"]["kind"] == "process"
+    expected = store.read_json(job_id, "state/successor_expected.json")
+    assert [entry["proposal_id"] for entry in expected] == ["prop-a"]
+
+    # Owner substantive rejection → binding veto, no successor expectation.
+    rejected = store.reject_proposal(
+        job_id, "prop-b", reason="thesis refuted by walk-forward", rejected_by="owner"
+    )
+    assert rejected["rejection"]["kind"] == "substantive"
+    expected = store.read_json(job_id, "state/successor_expected.json")
+    assert [entry["proposal_id"] for entry in expected] == ["prop-a"]
+
+    # Explicit kind overrides the heuristic.
+    store.write_proposal(
+        job_id,
+        {
+            "proposal_id": "prop-c",
+            "status": "pending",
+            "application": {"status": "not_requested"},
+        },
+    )
+    rejected = store.reject_proposal(
+        job_id, "prop-c", reason="try again with tighter stop", kind="process"
+    )
+    assert rejected["rejection"]["kind"] == "process"
+
+
+def test_successor_overdue_journals_once_and_wakes_agent(
+    tmp_path: Path, wakes: list[dict[str, Any]]
+) -> None:
+    store, job_id = _make_store(tmp_path)
+    stale_ts = (datetime.now(UTC) - timedelta(hours=13)).isoformat()
+    store.write_json(
+        job_id,
+        "state/successor_expected.json",
+        [{"proposal_id": "prop-old", "ts": stale_ts, "reason": "superseded"}],
+    )
+
+    result = recover_stalled_applications(store=store)
+    events = [e for e in result["recovered"] if e.get("action") == "successor_overdue"]
+    assert len(events) == 1
+    assert len(_journal_events(store, job_id, "successor_overdue")) == 1
+    assert wakes and wakes[0]["job_id"] == job_id  # trigger wake fired
+    assert "successor_overdue" in ALWAYS_WAKE_EVENTS
+
+    # Second pass: entry is marked notified — no duplicate journal/wake.
+    result = recover_stalled_applications(store=store)
+    assert not [
+        e for e in result["recovered"] if e.get("action") == "successor_overdue"
+    ]
+    assert len(_journal_events(store, job_id, "successor_overdue")) == 1
+    assert len(wakes) == 1
+
+
+def test_successor_overdue_suppressed_when_successor_exists(
+    tmp_path: Path, wakes: list[dict[str, Any]]
+) -> None:
+    store, job_id = _make_store(tmp_path)
+    stale_ts = (datetime.now(UTC) - timedelta(hours=13)).isoformat()
+    store.write_json(
+        job_id,
+        "state/successor_expected.json",
+        [{"proposal_id": "prop-old", "ts": stale_ts, "reason": "superseded"}],
+    )
+    store.write_proposal(
+        job_id,
+        {
+            "proposal_id": "prop-successor",
+            "status": "pending",
+            "application": {"status": "not_requested"},
+            "candidate_report": {"generated_at": datetime.now(UTC).isoformat()},
+        },
+    )
+    result = recover_stalled_applications(store=store)
+    assert not [
+        e for e in result["recovered"] if e.get("action") == "successor_overdue"
+    ]
+    assert not _journal_events(store, job_id, "successor_overdue")
+    assert not wakes
+
+
+def test_watchdog_retries_infra_failed_restage_with_bounded_attempts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job_id = _make_store(tmp_path)
+    store.write_proposal(job_id, _approved_proposal(None))
+
+    def boom(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise RuntimeError("backtest child killed — out of memory")
+
+    monkeypatch.setattr("wayfinder_paths.jobs.proposals.restage_proposal", boom)
+    now = datetime.now(UTC)
+
+    for attempt in range(1, 6):
+        proposal = store.load_proposal(job_id, "prop-heal")
+        event = _recover_restage(store, job_id, proposal, now)
+        assert event is None  # failure journaled, retry left to the next pass
+        proposal = store.load_proposal(job_id, "prop-heal")
+        assert proposal["application"]["restage_attempts"] == attempt
+        assert proposal["application"]["restage_requested"] is True  # kept alive
+
+    # Attempt 6: budget exhausted — escalate once, then stand down.
+    proposal = store.load_proposal(job_id, "prop-heal")
+    event = _recover_restage(store, job_id, proposal, now)
+    assert event is not None
+    assert event["action"] == "restage_attempts_exhausted"
+    proposal = store.load_proposal(job_id, "prop-heal")
+    assert _recover_restage(store, job_id, proposal, now) is None  # no re-escalate
+
+
+def test_scheduler_prefers_continuation_island(tmp_path: Path) -> None:
+    store, job_id = _make_store(tmp_path, "heal-sched")
+    first = assign_island(store, job_id)
+    assert first["island"] is not None
+
+    ops_dir = store.job_dir(job_id) / "state" / "background_ops"
+    ops_dir.mkdir(parents=True, exist_ok=True)
+    op_path = ops_dir / "backtest_job.json"
+    op_status = {
+        "op": "backtest_job",
+        "state": "done",
+        "finished_at": datetime.now(UTC).isoformat(),
+        "island": first["island"],
+    }
+    op_path.write_text(json.dumps(op_status))
+
+    second = assign_island(store, job_id)
+    assert second["island"] == first["island"]  # thread not abandoned
+    assert any("continuation" in reason for reason in second["reasons"])
+    state = load_scheduler_state(store, job_id)
+    assert state["total"] == 2  # counted as a normal assignment
+    assert state["history"][-1]["island"] == first["island"]
+
+    # A running op with a live pid also pins the rotation.
+    op_path.write_text(
+        json.dumps({"op": "backtest_job", "state": "running", "pid": os.getpid()})
+    )
+    third = assign_island(store, job_id)
+    assert third["island"] == first["island"]
+
+    # Harvested (or stale) results release the rotation to normal deficit.
+    op_path.write_text(json.dumps({**op_status, "harvested": True}))
+    fourth = assign_island(store, job_id)
+    assert not any("continuation" in reason for reason in fourth["reasons"])

--- a/wayfinder_paths/tests/test_wayfinder_jobs.py
+++ b/wayfinder_paths/tests/test_wayfinder_jobs.py
@@ -1224,6 +1224,7 @@ def test_reject_proposal_records_provenance(tmp_path: Path) -> None:
     assert agent["rejection"] == {
         "reason": "superseded by v2",
         "by": "agent",
+        "kind": "process",  # inferred: superseded-draft housekeeping
         "ts": agent["rejection"]["ts"],
     }
     journal = (store.job_dir(job.id) / "journal.jsonl").read_text()


### PR DESCRIPTION
## The incident

One OOM at 21:04Z froze research for 14 hours. The cascade: the job-worker agent recorded "OOM-blocked" in its agendas, marked research lanes "exhausted", and self-rejected an OWNER-APPROVED proposal whose mechanical re-stage happened to fail during the OOM window. Every one of those recoveries required a manual operator intervention. Nothing in the pipeline distinguished "the box hiccuped" from "the evidence says no" — so a transient box failure was allowed to make permanent research decisions.

This PR makes those recoveries mechanical, preserving one asymmetry throughout: **INFRASTRUCTURE failures self-repair; EVIDENCE failures still stop the line.**

## The six mechanisms

1. **Failure taxonomy** (`wayfinder_paths/jobs/failures.py`, new): `classify_failure(error) -> "infrastructure" | "evidence"`. Deliberately dumb case-insensitive substring matching (oom, killed, lock busy, timeout, 502/503, event loop is closed, connection, ...) — greppable by eye, no regex cleverness. Everything else is evidence.

2. **Mechanical compute-status block** (`worker.py`): every wake now carries a `compute_status` block computed from the box (`mem_available_mb` from /proc/meminfo, `last_experiment_at` from experiments.jsonl, `last_backtest_ok_at` from the visualization artifact) with a `_basis` contract: infrastructure failures are TRANSIENT and watchdog-retried — FORBIDDEN as reasons to mark a lane blocked or exhausted; stale infra claims that contradict this block are void. A matching stable-prefix rule requires infra claims to cite this block and requires completed background ops to be harvested regardless of the wake's island.

3. **Durable restage** (`store.py` + `watchdog.py`): `reject_proposal` now refuses an agent rejection of an *approved* proposal whose latest re-stage/validation failure classifies as infrastructure — the proposal stays approved with `restage_requested` and the watchdog retries; only the owner may abandon approved work. The watchdog's mechanical restage now retries across passes (keeping the existing one-restage-per-pass budget) with a bounded `restage_attempts` counter (max 5, then a single `restage_attempts_exhausted` escalation), and keeps the restage request alive when the failure was infrastructure-class.

4. **Rejection kinds** (`store.py`, `cli.py --kind`, MCP `kind` pass-through): rejections carry `kind: process | substantive` (explicit, or inferred from the reason — superseded/re-stage/oom/infrastructure/red gate → process). An owner **process** rejection records an entry in `state/successor_expected.json`; the watchdog journals `successor_overdue` once per entry after 12h with no successor proposal and fires a trigger wake (`successor_overdue` added to ALWAYS_WAKE_EVENTS). The worker's stable rule now says only substantive owner rejections bind as vetoes — process rejections are invitations to file the corrected successor promptly.

5. **Continuation-aware island scheduling** (`improver/scheduler.py` + MCP op launcher): before the weighted-deficit rotation, the scheduler scans `state/background_ops/` for op-status files that are running (with a live pid) or completed within 2h and unharvested. If any exist, the wake is assigned the last-assigned island with a `continuation:` reason — finish the thread before rotating — counted and journaled as a normal assignment, still a pure function of on-disk state. New background ops are stamped with the island that started them.

6. **Tests** (`wayfinder_paths/tests/test_jobs_self_healing.py`, new): 9 tests covering the taxonomy, the compute_status block and both new stable-prefix rules in a built wake prompt, the agent-cannot-bury-approved-work guard (and that owner rejection and evidence-class failures still pass), the kind heuristic + successor expectation, successor_overdue journaling once (not twice) with a fired wake and suppression when a successor exists, bounded watchdog restage retries, and scheduler continuation pinning/release.

## Verification

- `pytest wayfinder_paths/tests -k "jobs or mcp"`: **827 passed, 3 skipped** (one pre-existing test updated to expect the new `rejection.kind` field; everything else untouched).
- `ruff check --fix` + `ruff format` on the touched files only.
