### PR TITLE
Jobs - Add Selectable Starter Strategies

### DIFF
--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -60,6 +60,7 @@ from wayfinder_paths.jobs.research import (
     signal_scan_job,
 )
 from wayfinder_paths.jobs.runner_bridge import RunnerBridge
+from wayfinder_paths.jobs.starters import create_starter_job, starter_catalog
 from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.jobs.strategies import library_catalog
 from wayfinder_paths.jobs.sync import (
@@ -215,6 +216,41 @@ def list_cmd() -> None:
             "result": [snapshot_job(job.id, store=store) for job in store.list_jobs()],
         }
     )
+
+
+@job_cli.command(
+    name="starter-strategies",
+    help="List the selectable, paper-only jobs_v1 starter strategies.",
+)
+def starter_strategies_cmd() -> None:
+    _echo_json({"ok": True, "result": starter_catalog()})
+
+
+@job_cli.command(
+    name="create-starter",
+    help="Create a paper jobs_v1 job from a selectable starter definition.",
+)
+@click.argument("starter_id")
+@click.option("--job-id", default=None, help="Override the generated job id.")
+@click.option(
+    "--initializer-session-id",
+    default=None,
+    help="Strategy Lab session that initiated this job.",
+)
+@click.option("--no-compile", is_flag=True, default=False)
+def create_starter_cmd(
+    starter_id: str,
+    job_id: str | None,
+    initializer_session_id: str | None,
+    no_compile: bool,
+) -> None:
+    result = create_starter_job(
+        starter_id,
+        job_id=job_id,
+        initializer_session_id=initializer_session_id,
+        compile_job=not no_compile,
+    )
+    _echo_json({"ok": True, "result": result})
 
 
 @job_cli.command(

--- a/wayfinder_paths/jobs/execution/engine.py
+++ b/wayfinder_paths/jobs/execution/engine.py
@@ -348,6 +348,7 @@ async def _run_tick_inner(
                 {
                     "timestamp": bar_iso,
                     "visible_bar_count": len(view),
+                    "visible_latest_timestamp": _latest_visible_timestamp(view),
                     "guard_event_count": len(result.guard_events),
                 }
             )
@@ -498,10 +499,19 @@ async def _run_tick_inner(
             "timestamp": bar_iso,
             # len(view) == row count; avoids a full DataFrame copy per bar.
             "visible_bar_count": len(ctx.view),
+            # A bounded multi-symbol window can legitimately lose more sparse
+            # rows than it gains at the next timestamp. The latest visible
+            # timestamp is the invariant that actually proves causal replay.
+            "visible_latest_timestamp": _latest_visible_timestamp(ctx.view),
             "guard_event_count": len(result.guard_events),
         }
     )
     return result
+
+
+def _latest_visible_timestamp(view: CompletedBarsView) -> str | None:
+    timestamps = view._ensure_timestamps()
+    return timestamps[-1].isoformat() if timestamps else None
 
 
 def _apply_engine_leverage(

--- a/wayfinder_paths/jobs/execution/validation.py
+++ b/wayfinder_paths/jobs/execution/validation.py
@@ -6,6 +6,7 @@ import py_compile
 import re
 import tokenize
 from collections.abc import Mapping
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -51,11 +52,44 @@ def validate_execution_trace(
     warnings: list[str] = []
     critical_failures: list[str] = []
 
-    visible_counts = [item["visible_bar_count"] for item in trace["runs"]]
-    no_lookahead = visible_counts == sorted(visible_counts)
+    runs = trace["runs"]
+    if runs and all("visible_latest_timestamp" in item for item in runs):
+        replay_times = [_trace_timestamp(item.get("timestamp")) for item in runs]
+        visible_times = [
+            _trace_timestamp(item.get("visible_latest_timestamp")) for item in runs
+        ]
+        parsed_replay_times = [value for value in replay_times if value is not None]
+        parsed_visible_times = [value for value in visible_times if value is not None]
+        timestamps_parse = len(parsed_replay_times) == len(runs) and len(
+            parsed_visible_times
+        ) == len(runs)
+        replay_monotonic = timestamps_parse and parsed_replay_times == sorted(
+            parsed_replay_times
+        )
+        visible_monotonic = timestamps_parse and parsed_visible_times == sorted(
+            parsed_visible_times
+        )
+        visible_not_future = timestamps_parse and all(
+            visible <= replay
+            for visible, replay in zip(
+                parsed_visible_times, parsed_replay_times, strict=True
+            )
+        )
+        no_lookahead = bool(
+            timestamps_parse
+            and replay_monotonic
+            and visible_monotonic
+            and visible_not_future
+        )
+    else:
+        # Backward compatibility for traces recorded before the causal
+        # timestamp marker existed. Counts are valid for growing views, but
+        # not sufficient for new bounded windows containing sparse symbols.
+        visible_counts = [item["visible_bar_count"] for item in runs]
+        no_lookahead = visible_counts == sorted(visible_counts)
     if not no_lookahead:
         critical_failures.append(
-            "visible bar count moved backward or leaked future bars"
+            "visible market data moved backward or leaked future bars"
         )
 
     bracket_events = trace["bracket_events"]
@@ -108,6 +142,16 @@ def validate_execution_trace(
         "critical_failures": critical_failures,
         "auto_fix_suggestions": _suggestions(issues + critical_failures + warnings),
     }
+
+
+def _trace_timestamp(value: Any) -> datetime | None:
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed
 
 
 def validate_execution_job(

--- a/wayfinder_paths/jobs/forward.py
+++ b/wayfinder_paths/jobs/forward.py
@@ -29,11 +29,14 @@ FORWARD_FILES = {
 }
 
 
-def default_forward_summary(job_id: str | None = None) -> dict[str, Any]:
+def default_forward_summary(
+    job_id: str | None = None, *, inception_at: str | None = None
+) -> dict[str, Any]:
     now = utc_now_iso()
     return {
         "schema_version": FORWARD_SCHEMA_VERSION,
         "job_id": job_id,
+        "inception_at": inception_at or now,
         "updated_at": now,
         "runs": {
             "count": 0,

--- a/wayfinder_paths/jobs/models.py
+++ b/wayfinder_paths/jobs/models.py
@@ -212,6 +212,7 @@ class WayfinderJob:
         agent_wake_seconds: int | None = None,
         auto_limits: dict[str, Any] | None = None,
         execution_contract: ExecutionContract = "legacy",
+        initializer_session_id: str | None = None,
     ) -> WayfinderJob:
         jid = safe_job_id(job_id)
         normalized_mode = normalize_agent_mode(agent_mode)
@@ -255,9 +256,13 @@ class WayfinderJob:
         initializer_session = re.sub(
             r"[^A-Za-z0-9_-]",
             "",
-            os.environ.get("OPENCODE_SESSION_ID")
-            or os.environ.get("OPENCODE_SESSIONID")
-            or "",
+            initializer_session_id
+            if initializer_session_id is not None
+            else (
+                os.environ.get("OPENCODE_SESSION_ID")
+                or os.environ.get("OPENCODE_SESSIONID")
+                or ""
+            ),
         )
         controller: dict[str, Any] = (
             {

--- a/wayfinder_paths/jobs/starters.py
+++ b/wayfinder_paths/jobs/starters.py
@@ -1,0 +1,677 @@
+"""Selectable, paper-only jobs_v1 starter strategies.
+
+The catalog owns exact rules and research provenance. Selecting a starter
+creates a normal Wayfinder job; from that point, the standard backtest and
+forward-result machinery owns the user's results.
+"""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from wayfinder_paths.jobs.models import WayfinderJob, safe_job_id
+from wayfinder_paths.jobs.store import JobStore
+
+STARTER_CATALOG_VERSION = "1.2.0"
+STARTER_STRATEGY_INCEPTION_AT = "2026-08-17T00:00:00+00:00"
+
+
+@dataclass(frozen=True)
+class StarterDefinition:
+    id: str
+    name: str
+    family: str
+    summary: str
+    timeframe: str
+    module: str
+    symbols: tuple[str, ...]
+    crypto_assets: tuple[str, ...]
+    tokenized_equities: tuple[str, ...]
+    rules: tuple[str, ...]
+    params: dict[str, Any]
+    research_evidence: dict[str, Any]
+    cautions: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        for key in (
+            "symbols",
+            "crypto_assets",
+            "tokenized_equities",
+            "rules",
+            "cautions",
+        ):
+            payload[key] = list(payload[key])
+        payload.update(
+            {
+                "catalog_version": STARTER_CATALOG_VERSION,
+                "strategy_inception_at": STARTER_STRATEGY_INCEPTION_AT,
+                "execution_contract": "jobs_v1",
+                "default_mode": "paper",
+                "selectable": True,
+                "forward_tracking": {
+                    "starts": "when_selected",
+                    "initial_status": "no_forward_observations",
+                },
+                "risk_notice": (
+                    "Positive historical expectancy is not a guarantee. "
+                    "Start in paper mode and evaluate forward results from "
+                    "the job's own inception before considering live risk."
+                ),
+            }
+        )
+        return payload
+
+
+_RESEARCH_METHOD = {
+    "source": "Hydromancer Reservoir 1-second Hyperliquid/HIP-3 candles",
+    "window_end": "2026-08-16T23:45:00+00:00",
+    "fill_model": "decision on completed close; fill at next bar open",
+    "costs": {"taker_fee_bps_per_side": 4.5, "slippage_bps_per_side": 3.5},
+    "funding": "Hyperliquid hourly historical funding applied by signed exposure",
+    "validation": (
+        "four chronological folds; daily rank strategies also checked at "
+        "neighboring UTC rebalance phases"
+    ),
+}
+
+_PAIR_RESEARCH_METHOD = {
+    "source": "Hyperliquid info API daily candles",
+    "window_start": "2024-08-17T00:00:00+00:00",
+    "window_end": "2026-08-17T00:00:00+00:00",
+    "calendar_days": 730.0,
+    "fill_model": "decision on completed close; fill at next bar open",
+    "costs": {"taker_fee_bps_per_side": 4.5, "slippage_bps_per_side": 3.5},
+    "funding": (
+        "Binance USD-M historical funding used as a two-year carry proxy; "
+        "the jobs_v1 replay excludes funding until the simulator consumes "
+        "funding feature rows as settlement events"
+    ),
+    "validation": (
+        "four chronological folds; conventional Monday rebalance plus all "
+        "seven neighboring weekly phases checked"
+    ),
+}
+
+
+STARTER_DEFINITIONS: tuple[StarterDefinition, ...] = (
+    StarterDefinition(
+        id="mixed-rsi-snapback-1h",
+        name="Mixed RSI Snapback · 1h",
+        family="mean_reversion",
+        summary=(
+            "Buys short, oversold pullbacks only while the asset remains above "
+            "its long trend; otherwise holds cash."
+        ),
+        timeframe="1h",
+        module="wayfinder_paths.jobs.strategies.mixed_rsi_snapback",
+        symbols=("BTC", "HYPE", "xyz:COIN", "xyz:TSLA"),
+        crypto_assets=("BTC", "HYPE"),
+        tokenized_equities=("xyz:COIN", "xyz:TSLA"),
+        rules=(
+            "Enter long when RSI(6) is below 20 and close is above SMA(200).",
+            "Exit when RSI(6) rises above 50 or after 72 completed bars.",
+            "Target 25% per active leg; all four active legs target 100% gross.",
+        ),
+        params={
+            "rsi_period": 6,
+            "entry_rsi": 20.0,
+            "exit_rsi": 50.0,
+            "trend_sma_period": 200,
+            "max_hold_bars": 72,
+            "weight_per_leg": 0.25,
+        },
+        research_evidence={
+            **_RESEARCH_METHOD,
+            "window_start": "2025-11-25T17:00:00+00:00",
+            "calendar_days": 264.2,
+            "return_after_costs_and_funding": 0.0824,
+            "funding_return_contribution": -0.0004,
+            "sharpe": 1.66,
+            "max_drawdown": -0.0279,
+            "chronological_fold_returns": [0.0200, 0.0084, 0.0321, 0.0197],
+            "jobs_v1_engine": {
+                "return_after_fees_and_slippage": 0.0815,
+                "sharpe": 1.63,
+                "max_drawdown": -0.0279,
+                "trade_count": 182,
+                "total_fees_usd": 213.81,
+                "funding_included": False,
+                "trace_valid": True,
+            },
+        },
+    ),
+    StarterDefinition(
+        id="mixed-bollinger-pullback-1h",
+        name="Mixed Bollinger Pullback · 1h",
+        family="mean_reversion",
+        summary=(
+            "Fades unusually stretched moves back toward a three-day mean, "
+            "but only in the direction of the asset's slower trend."
+        ),
+        timeframe="1h",
+        module="wayfinder_paths.jobs.strategies.mixed_bollinger_pullback",
+        symbols=("BTC", "SOL", "xyz:XYZ100", "xyz:TSLA"),
+        crypto_assets=("BTC", "SOL"),
+        tokenized_equities=("xyz:XYZ100", "xyz:TSLA"),
+        rules=(
+            "Standardize log price against its trailing 72-hour mean and volatility.",
+            "Below -2z, buy only above SMA(200); above +2z, short only below SMA(200).",
+            "Exit at the rolling mean or after 12 completed bars; target 25% per leg.",
+        ),
+        params={
+            "zscore_bars": 72,
+            "entry_zscore": 2.0,
+            "exit_zscore": 0.0,
+            "trend_sma_period": 200,
+            "max_hold_bars": 12,
+            "weight_per_leg": 0.25,
+        },
+        research_evidence={
+            **_RESEARCH_METHOD,
+            "window_start": "2025-11-13T14:00:00+00:00",
+            "calendar_days": 276.4,
+            "return_after_costs_and_funding": 0.0690,
+            "funding_return_contribution": -0.0003,
+            "sharpe": 2.13,
+            "max_drawdown": -0.0151,
+            "chronological_fold_returns": [0.0188, 0.0121, 0.0142, 0.0222],
+            "signal_check": {
+                "horizon_hours": 12,
+                "training_events": 66,
+                "training_excess_return": 0.0062,
+                "training_t_stat": 2.85,
+                "reserved_tail_events": 19,
+                "reserved_tail_excess_return": 0.0050,
+                "reserved_tail_t_stat": 1.35,
+            },
+            "jobs_v1_engine": {
+                "return_after_fees_and_slippage": 0.0584,
+                "sharpe": 1.85,
+                "max_drawdown": -0.0162,
+                "trade_count": 164,
+                "total_fees_usd": 190.41,
+                "funding_included": False,
+                "trace_valid": True,
+            },
+        },
+        cautions=(
+            "The 72-hour lookback was materially stronger than nearby lookbacks; treat this as a paper hypothesis and monitor decay.",
+        ),
+    ),
+    StarterDefinition(
+        id="mixed-volume-capitulation-1h",
+        name="Mixed Volume Capitulation · 1h",
+        family="mean_reversion",
+        summary=(
+            "Buys oversold pullbacks in established uptrends only when hourly "
+            "volume confirms that the selloff is unusually active."
+        ),
+        timeframe="1h",
+        module="wayfinder_paths.jobs.strategies.mixed_volume_capitulation",
+        symbols=("BTC", "HYPE", "xyz:COIN", "xyz:TSLA"),
+        crypto_assets=("BTC", "HYPE"),
+        tokenized_equities=("xyz:COIN", "xyz:TSLA"),
+        rules=(
+            "Enter long when RSI(7) is below 20 and close remains above SMA(200).",
+            "Require current hourly volume above its trailing 24-hour median.",
+            "Exit when RSI(7) rises above 50 or after 72 completed bars; target 25% per leg.",
+        ),
+        params={
+            "rsi_period": 7,
+            "entry_rsi": 20.0,
+            "exit_rsi": 50.0,
+            "trend_sma_period": 200,
+            "volume_median_bars": 24,
+            "volume_multiple": 1.0,
+            "max_hold_bars": 72,
+            "weight_per_leg": 0.25,
+        },
+        research_evidence={
+            **_RESEARCH_METHOD,
+            "window_start": "2025-11-25T17:00:00+00:00",
+            "calendar_days": 264.2,
+            "return_after_costs_and_funding": 0.1214,
+            "funding_return_contribution": 0.0006,
+            "sharpe": 3.15,
+            "max_drawdown": -0.0263,
+            "chronological_fold_returns": [0.0377, 0.0158, 0.0344, 0.0284],
+            "signal_check": {
+                "horizon_hours": 8,
+                "training_events": 51,
+                "training_excess_return": 0.0076,
+                "training_t_stat": 3.10,
+                "reserved_tail_events": 5,
+                "reserved_tail_excess_return": -0.0024,
+                "reserved_tail_t_stat": -0.41,
+            },
+            "jobs_v1_engine": {
+                "return_after_fees_and_slippage": 0.1208,
+                "sharpe": 3.11,
+                "max_drawdown": -0.0275,
+                "trade_count": 102,
+                "total_fees_usd": 122.04,
+                "funding_included": False,
+                "trace_valid": True,
+            },
+        },
+        cautions=(
+            "The sparse raw trigger did not independently confirm in the reserved tail; forward evidence is especially important.",
+        ),
+    ),
+    StarterDefinition(
+        id="mixed-momentum-rank-1h",
+        name="Mixed Momentum Rank · 1h",
+        family="cross_sectional_momentum",
+        summary=(
+            "A daily, market-neutral relative-strength basket across two "
+            "crypto and two tokenized-equity markets."
+        ),
+        timeframe="1h",
+        module="wayfinder_paths.jobs.strategies.mixed_momentum_rank",
+        symbols=("BTC", "SOL", "xyz:XYZ100", "xyz:TSLA"),
+        crypto_assets=("BTC", "SOL"),
+        tokenized_equities=("xyz:XYZ100", "xyz:TSLA"),
+        rules=(
+            "Rank all four assets by trailing 14-day return.",
+            "Long the top two and short the bottom two at 25% per leg.",
+            "Re-rank daily on the 12:00 UTC completed bar; gross 100%, net 0%.",
+        ),
+        params={
+            "momentum_bars": 336,
+            "rebalance_bars": 24,
+            "rebalance_offset": 12,
+            "weight_per_leg": 0.25,
+        },
+        research_evidence={
+            **_RESEARCH_METHOD,
+            "window_start": "2025-11-13T14:00:00+00:00",
+            "calendar_days": 276.3,
+            "return_after_costs_and_funding": 0.2924,
+            "funding_return_contribution": -0.0040,
+            "sharpe": 1.76,
+            "max_drawdown": -0.1075,
+            "chronological_fold_returns": [0.0465, 0.0999, 0.0754, 0.0440],
+            "jobs_v1_engine": {
+                "return_after_fees_and_slippage": 0.2675,
+                "sharpe": 1.77,
+                "max_drawdown": -0.0946,
+                "trade_count": 217,
+                "total_fees_usd": 270.95,
+                "funding_included": False,
+                "trace_valid": True,
+            },
+        },
+    ),
+    StarterDefinition(
+        id="mixed-sleeve-momentum-15m",
+        name="Crypto + Equity Sleeve Momentum · 15m",
+        family="cross_sectional_momentum",
+        summary=(
+            "Keeps separate crypto and equity sleeves, long the stronger and "
+            "short the weaker asset inside each sleeve."
+        ),
+        timeframe="15m",
+        module="wayfinder_paths.jobs.strategies.mixed_sleeve_momentum",
+        symbols=("BTC", "HYPE", "xyz:COIN", "xyz:MSTR"),
+        crypto_assets=("BTC", "HYPE"),
+        tokenized_equities=("xyz:COIN", "xyz:MSTR"),
+        rules=(
+            "Rank BTC vs HYPE and COIN vs MSTR by trailing 30-day return.",
+            "Within each sleeve, long the winner and short the loser at 25% each.",
+            "Re-rank daily on the 12:00 UTC completed bar; gross 100%, net 0%.",
+        ),
+        params={
+            "momentum_bars": 2880,
+            "rebalance_bars": 96,
+            "rebalance_offset": 48,
+            "weight_per_leg": 0.25,
+        },
+        research_evidence={
+            **_RESEARCH_METHOD,
+            "window_start": "2025-12-02T15:00:00+00:00",
+            "calendar_days": 257.4,
+            "return_after_costs_and_funding": 0.3375,
+            "funding_return_contribution": -0.0031,
+            "sharpe": 1.97,
+            "max_drawdown": -0.1158,
+            "chronological_fold_returns": [0.1136, -0.0545, 0.1963, 0.0619],
+            "jobs_v1_engine": {
+                "return_after_fees_and_slippage": 0.2587,
+                "sharpe": 1.51,
+                "max_drawdown": -0.1315,
+                "trade_count": 116,
+                "total_fees_usd": 136.39,
+                "funding_included": False,
+                "trace_valid": True,
+            },
+        },
+        cautions=("One of four chronological folds was negative.",),
+    ),
+    StarterDefinition(
+        id="mixed-low-vol-rank-15m",
+        name="Mixed Low-Volatility Rank · 15m",
+        family="low_volatility_ranking",
+        summary=(
+            "A slow-moving defensive factor basket that owns the calmer pair "
+            "and shorts the more volatile pair."
+        ),
+        timeframe="15m",
+        module="wayfinder_paths.jobs.strategies.mixed_low_vol_rank",
+        symbols=("BTC", "SOL", "xyz:XYZ100", "xyz:TSLA"),
+        crypto_assets=("BTC", "SOL"),
+        tokenized_equities=("xyz:XYZ100", "xyz:TSLA"),
+        rules=(
+            "Rank all four assets by trailing 5-day realized volatility.",
+            "Long the two lowest-volatility assets and short the two highest.",
+            "Re-rank daily on the 12:00 UTC completed bar; gross 100%, net 0%.",
+        ),
+        params={
+            "volatility_bars": 480,
+            "rebalance_bars": 96,
+            "rebalance_offset": 48,
+            "weight_per_leg": 0.25,
+        },
+        research_evidence={
+            **_RESEARCH_METHOD,
+            "window_start": "2025-11-13T14:30:00+00:00",
+            "calendar_days": 276.4,
+            "return_after_costs_and_funding": 0.1642,
+            "funding_return_contribution": -0.0070,
+            "sharpe": 1.03,
+            "max_drawdown": -0.1301,
+            "chronological_fold_returns": [0.0085, 0.0699, 0.0457, 0.0318],
+            "jobs_v1_engine": {
+                "return_after_fees_and_slippage": 0.2089,
+                "sharpe": 1.36,
+                "max_drawdown": -0.1010,
+                "trade_count": 141,
+                "total_fees_usd": 173.08,
+                "funding_included": False,
+                "trace_valid": True,
+            },
+        },
+    ),
+    StarterDefinition(
+        id="btc-eth-relative-strength-1d",
+        name="BTC / ETH Relative Strength · 1d",
+        family="relative_value_pair",
+        summary=(
+            "A high-liquidity pair trade that owns the stronger major and "
+            "shorts the weaker one while targeting stable spread risk."
+        ),
+        timeframe="1d",
+        module="wayfinder_paths.jobs.strategies.pair_relative_strength",
+        symbols=("BTC", "ETH"),
+        crypto_assets=("BTC", "ETH"),
+        tokenized_equities=(),
+        rules=(
+            "Compare trailing 90-day BTC and ETH log returns.",
+            "Long the relative-strength leader and short the laggard; rebalance weekly.",
+            "Target 10% annualized spread volatility using 28 days of history; clamp gross exposure to 15–100%.",
+        ),
+        params={
+            "momentum_bars": 90,
+            "volatility_bars": 28,
+            "bars_per_year": 365,
+            "target_volatility": 0.10,
+            "min_gross_exposure": 0.15,
+            "max_gross_exposure": 1.0,
+            "rebalance_bars": 7,
+            "rebalance_offset": 4,
+        },
+        research_evidence={
+            **_PAIR_RESEARCH_METHOD,
+            "strategy_family": "cross-sectional pair momentum",
+            "return_after_costs_and_funding": 0.2185,
+            "funding_return_contribution": -0.0010,
+            "sharpe": 1.10,
+            "max_drawdown": -0.1031,
+            "chronological_fold_returns": [0.1443, 0.0318, 0.0249, 0.0070],
+            "weekly_phase_sharpes_before_funding": [
+                1.00,
+                1.15,
+                1.07,
+                0.92,
+                1.10,
+                0.72,
+                0.46,
+            ],
+            "price_mean_reversion_gate": {
+                "verdict": "REJECT",
+                "failed": [
+                    "engle_granger_both_directions",
+                    "half_life",
+                    "rolling_stability",
+                ],
+                "engle_granger_t_stats": {"btc_on_eth": -2.286, "eth_on_btc": -1.957},
+                "half_life_hours": 2291.1,
+                "rolling_stability_fraction": 0.26,
+                "interpretation": (
+                    "This is deliberately a relative-momentum pair, not a "
+                    "z-score mean-reversion strategy."
+                ),
+            },
+            "jobs_v1_engine": {
+                "return_after_fees_and_slippage": 0.2074,
+                "sharpe": 0.99,
+                "max_drawdown": -0.1103,
+                "trade_count": 182,
+                "total_fees_usd": 56.41,
+                "funding_included": False,
+                "trace_valid": True,
+            },
+        },
+        cautions=(
+            "This is a relative-momentum pair, not a price mean-reversion strategy.",
+        ),
+    ),
+    StarterDefinition(
+        id="bch-ltc-relative-strength-1d",
+        name="BCH / LTC Relative Strength · 1d",
+        family="relative_value_pair",
+        summary=(
+            "A proof-of-work relative-value pair that rotates toward the "
+            "stronger coin and scales down when the spread becomes volatile."
+        ),
+        timeframe="1d",
+        module="wayfinder_paths.jobs.strategies.pair_relative_strength",
+        symbols=("BCH", "LTC"),
+        crypto_assets=("BCH", "LTC"),
+        tokenized_equities=(),
+        rules=(
+            "Compare trailing 90-day BCH and LTC log returns.",
+            "Long the relative-strength leader and short the laggard; rebalance weekly.",
+            "Target 10% annualized spread volatility using 28 days of history; clamp gross exposure to 15–100%.",
+        ),
+        params={
+            "momentum_bars": 90,
+            "volatility_bars": 28,
+            "bars_per_year": 365,
+            "target_volatility": 0.10,
+            "min_gross_exposure": 0.15,
+            "max_gross_exposure": 1.0,
+            "rebalance_bars": 7,
+            "rebalance_offset": 4,
+        },
+        research_evidence={
+            **_PAIR_RESEARCH_METHOD,
+            "strategy_family": "cross-sectional pair momentum",
+            "return_after_costs_and_funding": 0.3054,
+            "funding_return_contribution": 0.0007,
+            "sharpe": 1.43,
+            "max_drawdown": -0.1078,
+            "chronological_fold_returns": [0.0222, 0.0354, 0.0642, 0.1590],
+            "weekly_phase_sharpes_before_funding": [
+                0.93,
+                1.41,
+                1.09,
+                1.15,
+                1.43,
+                1.31,
+                1.16,
+            ],
+            "price_mean_reversion_gate": {
+                "verdict": "REJECT",
+                "failed": [
+                    "engle_granger_both_directions",
+                    "half_life",
+                    "rolling_stability",
+                ],
+                "engle_granger_t_stats": {"bch_on_ltc": -1.235, "ltc_on_bch": -1.479},
+                "half_life_hours": 3064.0,
+                "rolling_stability_fraction": 0.33,
+                "interpretation": (
+                    "This is deliberately a relative-momentum pair, not a "
+                    "z-score mean-reversion strategy."
+                ),
+            },
+            "jobs_v1_engine": {
+                "return_after_fees_and_slippage": 0.2821,
+                "sharpe": 1.25,
+                "max_drawdown": -0.1080,
+                "trade_count": 181,
+                "total_fees_usd": 49.74,
+                "funding_included": False,
+                "trace_valid": True,
+            },
+        },
+        cautions=(
+            "This is a relative-momentum pair, not a price mean-reversion strategy.",
+            "BCH and LTC are materially less liquid than BTC and ETH; keep this starter small and honor live capacity checks.",
+        ),
+    ),
+)
+
+
+def starter_catalog() -> list[dict[str, Any]]:
+    return [definition.to_dict() for definition in STARTER_DEFINITIONS]
+
+
+def get_starter(starter_id: str) -> StarterDefinition:
+    normalized = str(starter_id).strip().lower()
+    for definition in STARTER_DEFINITIONS:
+        if definition.id == normalized:
+            return definition
+    raise KeyError(f"unknown starter strategy: {starter_id}")
+
+
+def create_starter_job(
+    starter_id: str,
+    *,
+    job_id: str | None = None,
+    store: JobStore | None = None,
+    compile_job: bool = True,
+    initializer_session_id: str | None = None,
+) -> dict[str, Any]:
+    """Materialize a selectable starter as an ordinary paper jobs_v1 job."""
+    definition = get_starter(starter_id)
+    store = store or JobStore()
+    resolved_id = safe_job_id(job_id or definition.id)
+    job_path = store.job_dir(resolved_id) / "job.yaml"
+    if job_path.exists():
+        existing = store.load(resolved_id)
+        existing_starter = existing.controller.get("starter") or {}
+        if job_id is not None or existing_starter.get("id") != definition.id:
+            raise FileExistsError(f"job already exists: {resolved_id}")
+        entrypoint = store.resolve_script_entrypoint(existing.id, existing.to_dict())
+        return {
+            "created": False,
+            "job": existing.to_dict(),
+            "job_yaml": str(job_path),
+            "script_entrypoint": str(entrypoint) if entrypoint is not None else None,
+            "starter": definition.to_dict(),
+        }
+
+    from wayfinder_paths.jobs.execution.primitives import bar_interval_seconds
+
+    interval_seconds = bar_interval_seconds(definition.timeframe)
+    if interval_seconds is None:
+        raise ValueError(f"unsupported starter timeframe: {definition.timeframe}")
+    job = WayfinderJob.new(
+        resolved_id,
+        name=definition.name,
+        goal=(
+            f"Paper-track the {definition.name} starter from this job's inception; "
+            "refresh its backtest before any proposal to change risk or go live."
+        ),
+        script="workspace/src/strategy.py",
+        interval_seconds=interval_seconds,
+        timeout_seconds=180,
+        agent_mode="monitor",
+        agent_wake_seconds=3600,
+        execution_contract="jobs_v1",
+        initializer_session_id=initializer_session_id,
+    )
+    job.execution_spec = {
+        "market_kind": "perp",
+        "view_type": "completed_bars",
+        "bar_model": "completed_only",
+        "fill_model": "next_bar_open",
+        "ohlc_rules": {
+            "use_high_low_for_stops": True,
+            "allow_close_only_entries": False,
+            "same_bar_fill": False,
+            "same_bar_policy": "conservative",
+        },
+        "data_contract": {
+            "candles_source": "sdk_only",
+            "no_external_ccxt": True,
+            "rate_limit_safe": True,
+            "bar_interval": definition.timeframe,
+            "symbols": list(definition.symbols),
+            "max_bar_age_intervals": 2,
+            "stale_policy": "skip",
+        },
+        "validation": {"mode": "strict", "require_scenarios": False},
+        "venues": ["hyperliquid"],
+    }
+    job.execution_params = {
+        **copy.deepcopy(definition.params),
+        "symbols": list(definition.symbols),
+        "venue": "hyperliquid",
+        "initial_capital": 10_000.0,
+        "fee_bps": 4.5,
+        "slippage_bps": 3.5,
+        "min_trade_notional": 25.0,
+    }
+    job.controller["starter"] = {
+        "id": definition.id,
+        "catalog_version": STARTER_CATALOG_VERSION,
+        "strategy_inception_at": STARTER_STRATEGY_INCEPTION_AT,
+        "job_tracking_inception_at": job.created_at,
+        "paper_only": True,
+    }
+    job.performance["starter_evidence"] = "results/backtest/starter_evidence.json"
+    job.performance["tracking_inception_at"] = job.created_at
+
+    job_path = store.create_job(job)
+    entrypoint = store.resolve_script_entrypoint(job.id, job.to_dict())
+    if entrypoint is None:
+        raise RuntimeError("starter job has no workspace strategy entrypoint")
+    Path(entrypoint).write_text(
+        f"from {definition.module} import build_strategy\n",
+        encoding="utf-8",
+    )
+    evidence = definition.to_dict()
+    evidence["job_id"] = job.id
+    evidence["job_tracking_inception_at"] = job.created_at
+    store.write_json(job.id, "results/backtest/starter_evidence.json", evidence)
+
+    result: dict[str, Any] = {
+        "created": True,
+        "job": job.to_dict(),
+        "job_yaml": str(job_path),
+        "script_entrypoint": str(entrypoint),
+        "starter": definition.to_dict(),
+    }
+    if compile_job:
+        from wayfinder_paths.jobs.compiler import JobCompiler
+        from wayfinder_paths.jobs.sync import sync_all_jobs
+
+        result["compile"] = JobCompiler(store=store).compile(job)
+        sync_all_jobs(store=store)
+    return result

--- a/wayfinder_paths/jobs/store.py
+++ b/wayfinder_paths/jobs/store.py
@@ -160,7 +160,7 @@ class JobStore:
         self._write_jsonl_if_missing(root / "results" / "forward" / "fills.jsonl")
         self._write_json_if_missing(
             root / "results" / "forward" / "summary.json",
-            default_forward_summary(job.id),
+            default_forward_summary(job.id, inception_at=job.created_at),
         )
         self._write_json_if_missing(
             root / "versions" / "active.json",

--- a/wayfinder_paths/jobs/strategies/_starter_utils.py
+++ b/wayfinder_paths/jobs/strategies/_starter_utils.py
@@ -1,0 +1,111 @@
+"""Small shared helpers for the mixed-asset starter strategies."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import pandas as pd
+
+from wayfinder_paths.jobs.execution.primitives import ExecutionContext
+
+
+def merge_params(
+    defaults: Mapping[str, Any], overrides: Mapping[str, Any] | None
+) -> dict[str, Any]:
+    params = dict(defaults)
+    params.update(dict(overrides or {}))
+    params["symbols"] = [str(symbol) for symbol in params.get("symbols") or []]
+    return params
+
+
+def current_feature_values(
+    ctx: ExecutionContext,
+    symbols: Sequence[str],
+    column: str,
+) -> dict[str, float] | None:
+    """Return one synchronized, finite feature value per symbol.
+
+    A missing/stale leg stands the whole basket down. Ranking a mixture of
+    timestamps would silently turn a data outage into a trading signal.
+    """
+    rows = current_rows(ctx, symbols, required_columns=(column,))
+    if rows is None:
+        return None
+    values: dict[str, float] = {}
+    for symbol, row in rows.items():
+        value = pd.to_numeric(pd.Series([row[column]]), errors="coerce").iloc[0]
+        if pd.isna(value):
+            return None
+        values[symbol] = float(value)
+    return values
+
+
+def current_rows(
+    ctx: ExecutionContext,
+    symbols: Sequence[str],
+    *,
+    required_columns: Sequence[str] = (),
+) -> dict[str, pd.Series] | None:
+    """Return synchronized latest rows or stand the whole basket down."""
+    timestamps = ctx.view.timestamps
+    if not timestamps:
+        return None
+    latest_timestamp = pd.Timestamp(timestamps[-1])
+    required = set(required_columns)
+    rows: dict[str, pd.Series] = {}
+    for symbol in symbols:
+        frame = ctx.view.symbol_frame(symbol)
+        if frame.empty or not required.issubset(frame.columns):
+            return None
+        row = frame.iloc[-1]
+        if pd.Timestamp(row["timestamp"]) != latest_timestamp:
+            return None
+        rows[symbol] = row
+    return rows
+
+
+def trailing_return_features(
+    frames: Mapping[str, pd.DataFrame],
+    *,
+    lookback: int,
+    column: str,
+) -> dict[str, pd.DataFrame]:
+    return {
+        symbol: pd.DataFrame(
+            {
+                column: pd.to_numeric(frame["close"], errors="coerce").pct_change(
+                    lookback
+                )
+            }
+        )
+        for symbol, frame in frames.items()
+    }
+
+
+def ranked_weights(
+    scores: Mapping[str, float], *, weight_per_leg: float
+) -> dict[str, float]:
+    """Long the upper half and short the lower half, deterministically."""
+    ranked = sorted(scores, key=lambda symbol: (scores[symbol], symbol))
+    midpoint = len(ranked) // 2
+    weights = dict.fromkeys(ranked[:midpoint], -weight_per_leg)
+    weights.update(dict.fromkeys(ranked[midpoint:], weight_per_leg))
+    return weights
+
+
+def sleeve_weights(
+    scores: Mapping[str, float],
+    sleeves: Sequence[Sequence[str]],
+    *,
+    weight_per_leg: float,
+) -> dict[str, float]:
+    """Long the winner and short the loser independently in each sleeve."""
+    weights = {symbol: 0.0 for sleeve in sleeves for symbol in sleeve}
+    for sleeve in sleeves:
+        if len(sleeve) != 2:
+            raise ValueError("starter momentum sleeves must contain two symbols")
+        loser, winner = sorted(sleeve, key=lambda symbol: (scores[symbol], symbol))
+        weights[loser] = -weight_per_leg
+        weights[winner] = weight_per_leg
+    return weights

--- a/wayfinder_paths/jobs/strategies/mixed_bollinger_pullback.py
+++ b/wayfinder_paths/jobs/strategies/mixed_bollinger_pullback.py
@@ -1,0 +1,118 @@
+"""One-hour trend-aligned Bollinger pullbacks across mixed perp markets."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from wayfinder_paths.jobs.execution.primitives import ExecutionContext
+from wayfinder_paths.jobs.strategies._starter_utils import current_rows, merge_params
+from wayfinder_paths.jobs.strategies.portfolio import target_weights_to_intents
+
+
+class MixedBollingerPullbackStrategy:
+    default_params: dict[str, Any] = {
+        "symbols": ["BTC", "SOL", "xyz:XYZ100", "xyz:TSLA"],
+        "venue": "hyperliquid",
+        "zscore_bars": 72,
+        "entry_zscore": 2.0,
+        "exit_zscore": 0.0,
+        "trend_sma_period": 200,
+        "max_hold_bars": 12,
+        "weight_per_leg": 0.25,
+        "rebalance_threshold": 0.10,
+        "min_trade_notional": 25.0,
+    }
+
+    def __init__(self, params: dict[str, Any] | None = None) -> None:
+        self.params = merge_params(self.default_params, params)
+        self.warmup_bars = (
+            max(
+                int(self.params["zscore_bars"]),
+                int(self.params["trend_sma_period"]),
+            )
+            + 4
+        )
+
+    def precompute(self, frames: dict[str, pd.DataFrame]) -> dict[str, pd.DataFrame]:
+        zscore_bars = int(self.params["zscore_bars"])
+        trend_bars = int(self.params["trend_sma_period"])
+        derived: dict[str, pd.DataFrame] = {}
+        for symbol, frame in frames.items():
+            close = pd.to_numeric(frame["close"], errors="coerce")
+            log_close = np.log(close)
+            rolling = log_close.rolling(zscore_bars, min_periods=zscore_bars)
+            derived[symbol] = pd.DataFrame(
+                {
+                    "starter_pullback_zscore": (
+                        (log_close - rolling.mean()) / rolling.std()
+                    ),
+                    "starter_trend_sma": close.rolling(
+                        trend_bars, min_periods=trend_bars
+                    ).mean(),
+                }
+            )
+        return derived
+
+    def decide(self, ctx: ExecutionContext) -> list[dict[str, Any]]:
+        symbols = list(self.params["symbols"])
+        if ctx.bar_index < self.warmup_bars:
+            return []
+
+        rows = current_rows(
+            ctx,
+            symbols,
+            required_columns=(
+                "starter_pullback_zscore",
+                "starter_trend_sma",
+            ),
+        )
+        if rows is None:
+            return []
+
+        weights: dict[str, float] = {}
+        entry_zscore = float(self.params["entry_zscore"])
+        exit_zscore = float(self.params["exit_zscore"])
+        weight = float(self.params["weight_per_leg"])
+        max_hold_bars = int(self.params["max_hold_bars"])
+
+        for symbol, row in rows.items():
+            zscore = float(row["starter_pullback_zscore"])
+            close = float(row["close"])
+            trend_sma = float(row["starter_trend_sma"])
+            position = ctx.ledger.positions.get(symbol)
+
+            if position is not None:
+                crossed_mean = (position.side == "long" and zscore >= exit_zscore) or (
+                    position.side == "short" and zscore <= -exit_zscore
+                )
+                timed_out = position.bars_held >= max_hold_bars - 1
+                weights[symbol] = (
+                    0.0
+                    if crossed_mean or timed_out
+                    else weight
+                    if position.side == "long"
+                    else -weight
+                )
+            elif zscore < -entry_zscore and close > trend_sma:
+                weights[symbol] = weight
+            elif zscore > entry_zscore and close < trend_sma:
+                weights[symbol] = -weight
+            else:
+                weights[symbol] = 0.0
+
+        return target_weights_to_intents(
+            ctx,
+            weights,
+            venue=str(self.params["venue"]),
+            rebalance_threshold=float(self.params["rebalance_threshold"]),
+            min_trade_notional=float(self.params["min_trade_notional"]),
+        )
+
+
+def build_strategy(
+    params: dict[str, Any] | None = None,
+) -> MixedBollingerPullbackStrategy:
+    return MixedBollingerPullbackStrategy(params)

--- a/wayfinder_paths/jobs/strategies/mixed_low_vol_rank.py
+++ b/wayfinder_paths/jobs/strategies/mixed_low_vol_rank.py
@@ -1,0 +1,73 @@
+"""Fifteen-minute low-volatility rank across crypto and equity perps."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from wayfinder_paths.jobs.execution.primitives import ExecutionContext
+from wayfinder_paths.jobs.strategies._starter_utils import (
+    current_feature_values,
+    merge_params,
+    ranked_weights,
+)
+from wayfinder_paths.jobs.strategies.portfolio import target_weights_to_intents
+
+
+class MixedLowVolRankStrategy:
+    default_params: dict[str, Any] = {
+        "symbols": ["BTC", "SOL", "xyz:XYZ100", "xyz:TSLA"],
+        "venue": "hyperliquid",
+        "volatility_bars": 480,
+        "rebalance_bars": 96,
+        "rebalance_offset": 48,
+        "weight_per_leg": 0.25,
+        "rebalance_threshold": 0.10,
+        "min_trade_notional": 25.0,
+    }
+
+    def __init__(self, params: dict[str, Any] | None = None) -> None:
+        self.params = merge_params(self.default_params, params)
+        self.warmup_bars = int(self.params["volatility_bars"]) + 4
+
+    def precompute(self, frames: dict[str, pd.DataFrame]) -> dict[str, pd.DataFrame]:
+        lookback = int(self.params["volatility_bars"])
+        derived: dict[str, pd.DataFrame] = {}
+        for symbol, frame in frames.items():
+            close = pd.to_numeric(frame["close"], errors="coerce")
+            realized_volatility = (
+                np.log(close).diff().rolling(lookback, min_periods=lookback).std()
+            )
+            # Higher score is better: the rank helper longs the upper half.
+            derived[symbol] = pd.DataFrame(
+                {"starter_low_vol_score": -realized_volatility}
+            )
+        return derived
+
+    def decide(self, ctx: ExecutionContext) -> list[dict[str, Any]]:
+        if ctx.bar_index < self.warmup_bars or not ctx.every_n_bars(
+            int(self.params["rebalance_bars"]),
+            offset=int(self.params["rebalance_offset"]),
+        ):
+            return []
+        scores = current_feature_values(
+            ctx, list(self.params["symbols"]), "starter_low_vol_score"
+        )
+        if scores is None:
+            return []
+        weights = ranked_weights(
+            scores, weight_per_leg=float(self.params["weight_per_leg"])
+        )
+        return target_weights_to_intents(
+            ctx,
+            weights,
+            venue=str(self.params["venue"]),
+            rebalance_threshold=float(self.params["rebalance_threshold"]),
+            min_trade_notional=float(self.params["min_trade_notional"]),
+        )
+
+
+def build_strategy(params: dict[str, Any] | None = None) -> MixedLowVolRankStrategy:
+    return MixedLowVolRankStrategy(params)

--- a/wayfinder_paths/jobs/strategies/mixed_momentum_rank.py
+++ b/wayfinder_paths/jobs/strategies/mixed_momentum_rank.py
@@ -1,0 +1,65 @@
+"""One-hour cross-asset momentum rank, rebalanced daily at 12:00 UTC."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from wayfinder_paths.jobs.execution.primitives import ExecutionContext
+from wayfinder_paths.jobs.strategies._starter_utils import (
+    current_feature_values,
+    merge_params,
+    ranked_weights,
+    trailing_return_features,
+)
+from wayfinder_paths.jobs.strategies.portfolio import target_weights_to_intents
+
+
+class MixedMomentumRankStrategy:
+    default_params: dict[str, Any] = {
+        "symbols": ["BTC", "SOL", "xyz:XYZ100", "xyz:TSLA"],
+        "venue": "hyperliquid",
+        "momentum_bars": 336,
+        "rebalance_bars": 24,
+        "rebalance_offset": 12,
+        "weight_per_leg": 0.25,
+        "rebalance_threshold": 0.10,
+        "min_trade_notional": 25.0,
+    }
+
+    def __init__(self, params: dict[str, Any] | None = None) -> None:
+        self.params = merge_params(self.default_params, params)
+        self.warmup_bars = int(self.params["momentum_bars"]) + 4
+
+    def precompute(self, frames: dict[str, pd.DataFrame]) -> dict[str, pd.DataFrame]:
+        lookback = int(self.params["momentum_bars"])
+        return trailing_return_features(
+            frames, lookback=lookback, column="starter_momentum"
+        )
+
+    def decide(self, ctx: ExecutionContext) -> list[dict[str, Any]]:
+        if ctx.bar_index < self.warmup_bars or not ctx.every_n_bars(
+            int(self.params["rebalance_bars"]),
+            offset=int(self.params["rebalance_offset"]),
+        ):
+            return []
+        scores = current_feature_values(
+            ctx, list(self.params["symbols"]), "starter_momentum"
+        )
+        if scores is None:
+            return []
+        weights = ranked_weights(
+            scores, weight_per_leg=float(self.params["weight_per_leg"])
+        )
+        return target_weights_to_intents(
+            ctx,
+            weights,
+            venue=str(self.params["venue"]),
+            rebalance_threshold=float(self.params["rebalance_threshold"]),
+            min_trade_notional=float(self.params["min_trade_notional"]),
+        )
+
+
+def build_strategy(params: dict[str, Any] | None = None) -> MixedMomentumRankStrategy:
+    return MixedMomentumRankStrategy(params)

--- a/wayfinder_paths/jobs/strategies/mixed_rsi_snapback.py
+++ b/wayfinder_paths/jobs/strategies/mixed_rsi_snapback.py
@@ -1,0 +1,98 @@
+"""One-hour, long-only RSI snapback across crypto and tokenized equities."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from wayfinder_paths.jobs.execution.primitives import ExecutionContext
+from wayfinder_paths.jobs.indicators import wilder_rsi
+from wayfinder_paths.jobs.strategies._starter_utils import current_rows, merge_params
+from wayfinder_paths.jobs.strategies.portfolio import target_weights_to_intents
+
+
+class MixedRsiSnapbackStrategy:
+    default_params: dict[str, Any] = {
+        "symbols": ["BTC", "HYPE", "xyz:COIN", "xyz:TSLA"],
+        "venue": "hyperliquid",
+        "rsi_period": 6,
+        "entry_rsi": 20.0,
+        "exit_rsi": 50.0,
+        "trend_sma_period": 200,
+        "max_hold_bars": 72,
+        "weight_per_leg": 0.25,
+        "rebalance_threshold": 0.10,
+        "min_trade_notional": 25.0,
+    }
+
+    def __init__(self, params: dict[str, Any] | None = None) -> None:
+        self.params = merge_params(self.default_params, params)
+        self.warmup_bars = int(self.params["trend_sma_period"]) + 4
+
+    def precompute(self, frames: dict[str, pd.DataFrame]) -> dict[str, pd.DataFrame]:
+        period = int(self.params["rsi_period"])
+        sma_period = int(self.params["trend_sma_period"])
+        derived: dict[str, pd.DataFrame] = {}
+        for symbol, frame in frames.items():
+            close = pd.to_numeric(frame["close"], errors="coerce")
+            derived[symbol] = pd.DataFrame(
+                {
+                    "starter_rsi": wilder_rsi(close, period),
+                    "starter_trend_sma": close.rolling(
+                        sma_period, min_periods=sma_period
+                    ).mean(),
+                }
+            )
+        return derived
+
+    def decide(self, ctx: ExecutionContext) -> list[dict[str, Any]]:
+        symbols = list(self.params["symbols"])
+        if ctx.bar_index < self.warmup_bars:
+            return []
+
+        rows = current_rows(
+            ctx,
+            symbols,
+            required_columns=(
+                "starter_rsi",
+                "starter_trend_sma",
+            ),
+        )
+        if rows is None:
+            return []
+
+        weights: dict[str, float] = {}
+        for symbol, row in rows.items():
+            rsi = float(row["starter_rsi"])
+            close = float(row["close"])
+            trend_sma = float(row["starter_trend_sma"])
+            position = ctx.ledger.positions.get(symbol)
+            should_exit = position is not None and (
+                rsi > float(self.params["exit_rsi"])
+                or position.bars_held >= int(self.params["max_hold_bars"]) - 1
+            )
+            should_enter = (
+                position is None
+                and rsi < float(self.params["entry_rsi"])
+                and close > trend_sma
+            )
+            weights[symbol] = (
+                0.0
+                if should_exit
+                else float(self.params["weight_per_leg"])
+                if position is not None or should_enter
+                else 0.0
+            )
+
+        return target_weights_to_intents(
+            ctx,
+            weights,
+            venue=str(self.params["venue"]),
+            rebalance_threshold=float(self.params["rebalance_threshold"]),
+            min_trade_notional=float(self.params["min_trade_notional"]),
+        )
+
+
+def build_strategy(params: dict[str, Any] | None = None) -> MixedRsiSnapbackStrategy:
+    return MixedRsiSnapbackStrategy(params)

--- a/wayfinder_paths/jobs/strategies/mixed_sleeve_momentum.py
+++ b/wayfinder_paths/jobs/strategies/mixed_sleeve_momentum.py
@@ -1,0 +1,72 @@
+"""Fifteen-minute crypto/equity sleeve momentum, rebalanced daily."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from wayfinder_paths.jobs.execution.primitives import ExecutionContext
+from wayfinder_paths.jobs.strategies._starter_utils import (
+    current_feature_values,
+    merge_params,
+    sleeve_weights,
+    trailing_return_features,
+)
+from wayfinder_paths.jobs.strategies.portfolio import target_weights_to_intents
+
+
+class MixedSleeveMomentumStrategy:
+    default_params: dict[str, Any] = {
+        "symbols": ["BTC", "HYPE", "xyz:COIN", "xyz:MSTR"],
+        "sleeves": [["BTC", "HYPE"], ["xyz:COIN", "xyz:MSTR"]],
+        "venue": "hyperliquid",
+        "momentum_bars": 2880,
+        "rebalance_bars": 96,
+        "rebalance_offset": 48,
+        "weight_per_leg": 0.25,
+        "rebalance_threshold": 0.10,
+        "min_trade_notional": 25.0,
+    }
+
+    def __init__(self, params: dict[str, Any] | None = None) -> None:
+        self.params = merge_params(self.default_params, params)
+        self.params["sleeves"] = [
+            [str(symbol) for symbol in sleeve]
+            for sleeve in self.params.get("sleeves") or []
+        ]
+        self.warmup_bars = int(self.params["momentum_bars"]) + 4
+
+    def precompute(self, frames: dict[str, pd.DataFrame]) -> dict[str, pd.DataFrame]:
+        lookback = int(self.params["momentum_bars"])
+        return trailing_return_features(
+            frames, lookback=lookback, column="starter_momentum"
+        )
+
+    def decide(self, ctx: ExecutionContext) -> list[dict[str, Any]]:
+        if ctx.bar_index < self.warmup_bars or not ctx.every_n_bars(
+            int(self.params["rebalance_bars"]),
+            offset=int(self.params["rebalance_offset"]),
+        ):
+            return []
+        scores = current_feature_values(
+            ctx, list(self.params["symbols"]), "starter_momentum"
+        )
+        if scores is None:
+            return []
+        weights = sleeve_weights(
+            scores,
+            self.params["sleeves"],
+            weight_per_leg=float(self.params["weight_per_leg"]),
+        )
+        return target_weights_to_intents(
+            ctx,
+            weights,
+            venue=str(self.params["venue"]),
+            rebalance_threshold=float(self.params["rebalance_threshold"]),
+            min_trade_notional=float(self.params["min_trade_notional"]),
+        )
+
+
+def build_strategy(params: dict[str, Any] | None = None) -> MixedSleeveMomentumStrategy:
+    return MixedSleeveMomentumStrategy(params)

--- a/wayfinder_paths/jobs/strategies/mixed_volume_capitulation.py
+++ b/wayfinder_paths/jobs/strategies/mixed_volume_capitulation.py
@@ -1,0 +1,117 @@
+"""One-hour volume-confirmed RSI capitulation across mixed perp markets."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from wayfinder_paths.jobs.execution.primitives import ExecutionContext
+from wayfinder_paths.jobs.indicators import wilder_rsi
+from wayfinder_paths.jobs.strategies._starter_utils import current_rows, merge_params
+from wayfinder_paths.jobs.strategies.portfolio import target_weights_to_intents
+
+
+class MixedVolumeCapitulationStrategy:
+    default_params: dict[str, Any] = {
+        "symbols": ["BTC", "HYPE", "xyz:COIN", "xyz:TSLA"],
+        "venue": "hyperliquid",
+        "rsi_period": 7,
+        "entry_rsi": 20.0,
+        "exit_rsi": 50.0,
+        "trend_sma_period": 200,
+        "volume_median_bars": 24,
+        "volume_multiple": 1.0,
+        "max_hold_bars": 72,
+        "weight_per_leg": 0.25,
+        "rebalance_threshold": 0.10,
+        "min_trade_notional": 25.0,
+    }
+
+    def __init__(self, params: dict[str, Any] | None = None) -> None:
+        self.params = merge_params(self.default_params, params)
+        self.warmup_bars = (
+            max(
+                int(self.params["trend_sma_period"]),
+                int(self.params["volume_median_bars"]),
+            )
+            + 4
+        )
+
+    def precompute(self, frames: dict[str, pd.DataFrame]) -> dict[str, pd.DataFrame]:
+        rsi_period = int(self.params["rsi_period"])
+        trend_bars = int(self.params["trend_sma_period"])
+        volume_bars = int(self.params["volume_median_bars"])
+        derived: dict[str, pd.DataFrame] = {}
+        for symbol, frame in frames.items():
+            close = pd.to_numeric(frame["close"], errors="coerce")
+            volume = pd.to_numeric(frame["volume"], errors="coerce")
+            derived[symbol] = pd.DataFrame(
+                {
+                    "starter_capitulation_rsi": wilder_rsi(close, rsi_period),
+                    "starter_trend_sma": close.rolling(
+                        trend_bars, min_periods=trend_bars
+                    ).mean(),
+                    "starter_volume_median": volume.rolling(
+                        volume_bars, min_periods=volume_bars
+                    ).median(),
+                }
+            )
+        return derived
+
+    def decide(self, ctx: ExecutionContext) -> list[dict[str, Any]]:
+        symbols = list(self.params["symbols"])
+        if ctx.bar_index < self.warmup_bars:
+            return []
+
+        rows = current_rows(
+            ctx,
+            symbols,
+            required_columns=(
+                "starter_capitulation_rsi",
+                "starter_trend_sma",
+                "starter_volume_median",
+            ),
+        )
+        if rows is None:
+            return []
+
+        weights: dict[str, float] = {}
+        for symbol, row in rows.items():
+            rsi = float(row["starter_capitulation_rsi"])
+            close = float(row["close"])
+            trend_sma = float(row["starter_trend_sma"])
+            volume = float(row["volume"])
+            volume_median = float(row["starter_volume_median"])
+            position = ctx.ledger.positions.get(symbol)
+            should_exit = position is not None and (
+                rsi > float(self.params["exit_rsi"])
+                or position.bars_held >= int(self.params["max_hold_bars"]) - 1
+            )
+            should_enter = (
+                position is None
+                and rsi < float(self.params["entry_rsi"])
+                and close > trend_sma
+                and volume > volume_median * float(self.params["volume_multiple"])
+            )
+            weights[symbol] = (
+                0.0
+                if should_exit
+                else float(self.params["weight_per_leg"])
+                if position is not None or should_enter
+                else 0.0
+            )
+
+        return target_weights_to_intents(
+            ctx,
+            weights,
+            venue=str(self.params["venue"]),
+            rebalance_threshold=float(self.params["rebalance_threshold"]),
+            min_trade_notional=float(self.params["min_trade_notional"]),
+        )
+
+
+def build_strategy(
+    params: dict[str, Any] | None = None,
+) -> MixedVolumeCapitulationStrategy:
+    return MixedVolumeCapitulationStrategy(params)

--- a/wayfinder_paths/jobs/strategies/pair_relative_strength.py
+++ b/wayfinder_paths/jobs/strategies/pair_relative_strength.py
@@ -1,0 +1,165 @@
+"""Volatility-targeted relative-strength trade for one crypto pair."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import pandas as pd
+
+from wayfinder_paths.jobs.execution.primitives import ExecutionContext
+from wayfinder_paths.jobs.strategies._starter_utils import current_rows, merge_params
+from wayfinder_paths.jobs.strategies.portfolio import target_weights_to_intents
+
+
+class PairRelativeStrengthStrategy:
+    """Long the stronger leg and short the weaker leg at equal dollar risk.
+
+    The pair is selected for economic relatedness and liquidity. This is a
+    cross-sectional momentum trade, not a claim that the price ratio is
+    cointegrated. Realized spread volatility scales gross exposure so a
+    volatile relative move automatically reduces risk.
+    """
+
+    default_params: dict[str, Any] = {
+        "symbols": ["BTC", "ETH"],
+        "venue": "hyperliquid",
+        "momentum_bars": 90,
+        "volatility_bars": 28,
+        "bars_per_year": 365,
+        "target_volatility": 0.10,
+        "min_gross_exposure": 0.15,
+        "max_gross_exposure": 1.0,
+        "rebalance_bars": 7,
+        "rebalance_offset": 4,
+        "rebalance_threshold": 0.0,
+        "min_trade_notional": 25.0,
+    }
+
+    def __init__(self, params: dict[str, Any] | None = None) -> None:
+        self.params = merge_params(self.default_params, params)
+        if len(self.params["symbols"]) != 2:
+            raise ValueError("pair relative strength requires exactly two symbols")
+        self.warmup_bars = (
+            max(
+                int(self.params["momentum_bars"]),
+                int(self.params["volatility_bars"]),
+            )
+            + 4
+        )
+
+    def precompute(self, frames: dict[str, pd.DataFrame]) -> dict[str, pd.DataFrame]:
+        symbol_a, symbol_b = self.params["symbols"]
+        frame_a = frames[symbol_a]
+        frame_b = frames[symbol_b]
+        close_a = _timestamped_close(frame_a)
+        close_b = _timestamped_close(frame_b)
+        aligned = pd.concat(
+            [close_a.rename("a"), close_b.rename("b")], axis=1, join="inner"
+        ).dropna()
+
+        formation = int(self.params["momentum_bars"])
+        volatility_bars = int(self.params["volatility_bars"])
+        log_a = aligned["a"].map(math.log)
+        log_b = aligned["b"].map(math.log)
+        relative_momentum = (log_a - log_a.shift(formation)) - (
+            log_b - log_b.shift(formation)
+        )
+        relative_return = log_a.diff() - log_b.diff()
+        spread_volatility = (
+            0.5
+            * relative_return.rolling(volatility_bars).std()
+            * math.sqrt(float(self.params["bars_per_year"]))
+        )
+
+        timestamps = pd.to_datetime(frame_a["timestamp"], utc=True)
+        features = pd.DataFrame(index=frame_a.index)
+        features["pair_relative_momentum"] = timestamps.map(relative_momentum)
+        features["pair_spread_volatility"] = timestamps.map(spread_volatility)
+        return {symbol_a: features}
+
+    def decide(self, ctx: ExecutionContext) -> list[dict[str, Any]]:
+        symbol_a, symbol_b = self.params["symbols"]
+        held = [
+            symbol
+            for symbol in (symbol_a, symbol_b)
+            if ctx.ledger.positions.get(symbol) is not None
+        ]
+        if len(held) == 1:
+            # A pair is one risk unit. Never leave a directional orphan after
+            # a rejected/partial companion order.
+            position = ctx.ledger.positions[held[0]]
+            return [
+                {
+                    "action": "CLOSE",
+                    "venue": str(self.params["venue"]),
+                    "symbol": held[0],
+                    "side": "sell" if position.side == "long" else "buy",
+                    "size": position.size,
+                    "reduce_only": True,
+                    "metadata": {"exit_reason": "orphan_leg_guard"},
+                }
+            ]
+
+        if ctx.bar_index < self.warmup_bars or not ctx.every_n_bars(
+            int(self.params["rebalance_bars"]),
+            offset=int(self.params["rebalance_offset"]),
+        ):
+            return []
+
+        rows = current_rows(ctx, (symbol_a, symbol_b))
+        if rows is None:
+            return []
+        row = rows[symbol_a]
+        momentum = _finite_float(row.get("pair_relative_momentum"))
+        spread_volatility = _finite_float(row.get("pair_spread_volatility"))
+        if momentum is None or spread_volatility is None or spread_volatility <= 0:
+            return []
+
+        if momentum == 0:
+            weights = {symbol_a: 0.0, symbol_b: 0.0}
+        else:
+            gross = float(self.params["target_volatility"]) / spread_volatility
+            gross = min(
+                float(self.params["max_gross_exposure"]),
+                max(float(self.params["min_gross_exposure"]), gross),
+            )
+            direction = 1.0 if momentum > 0 else -1.0
+            weights = {
+                symbol_a: 0.5 * gross * direction,
+                symbol_b: -0.5 * gross * direction,
+            }
+
+        intents = target_weights_to_intents(
+            ctx,
+            weights,
+            venue=str(self.params["venue"]),
+            rebalance_threshold=float(self.params["rebalance_threshold"]),
+            min_trade_notional=float(self.params["min_trade_notional"]),
+        )
+        for intent in intents:
+            if str(intent.get("action", "")).upper() == "CLOSE":
+                intent.setdefault("metadata", {})["exit_reason"] = "weekly_rebalance"
+        return intents
+
+
+def _timestamped_close(frame: pd.DataFrame) -> pd.Series:
+    return pd.Series(
+        pd.to_numeric(frame["close"], errors="coerce").to_numpy(),
+        index=pd.to_datetime(frame["timestamp"], utc=True),
+        dtype=float,
+    )
+
+
+def _finite_float(value: Any) -> float | None:
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
+
+def build_strategy(
+    params: dict[str, Any] | None = None,
+) -> PairRelativeStrengthStrategy:
+    return PairRelativeStrengthStrategy(params)

--- a/wayfinder_paths/mcp/tools/jobs.py
+++ b/wayfinder_paths/mcp/tools/jobs.py
@@ -27,6 +27,7 @@ from wayfinder_paths.jobs.models import (
 )
 from wayfinder_paths.jobs.proposals import propose_change
 from wayfinder_paths.jobs.runner_bridge import RunnerBridge
+from wayfinder_paths.jobs.starters import create_starter_job, starter_catalog
 from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.jobs.strategies import library_catalog
 from wayfinder_paths.jobs.sync import apply_script_mode, snapshot_job, sync_all_jobs
@@ -35,6 +36,8 @@ from wayfinder_paths.mcp.utils import catch_errors, err, ok
 
 JobAction = Literal[
     "list",
+    "starter_strategies",
+    "create_starter",
     "create",
     "status",
     "report",
@@ -276,6 +279,8 @@ async def core_jobs(
     action: JobAction,
     *,
     job_id: str | None = None,
+    starter_id: str | None = None,
+    initializer_session_id: str | None = None,
     name: str | None = None,
     goal: str | None = None,
     script: str | None = None,
@@ -359,6 +364,9 @@ async def core_jobs(
         Jobs default to `execution_contract="jobs_v1"` (decide()/build_strategy
         driven by the SDK tick driver); pass `execution_contract="legacy"` only
         for a real standalone script that runs top-to-bottom.
+      - `starter_strategies` lists the fixed, mixed crypto/equity paper
+        starters. `create_starter` with `starter_id` materializes one as a
+        normal jobs_v1 job; its own forward inception begins at selection.
       - `create` with `agent_mode="monitor"` or `"intervene"` for supervised jobs.
       - `create` with `agent_mode="auto"` and `auto_limits` for agent-only auto jobs.
       - `set_script_mode` with `script_mode="live"` / `"paper"` to flip the
@@ -414,6 +422,22 @@ async def core_jobs(
 
     if action == "list":
         return ok([snapshot_job(job.id, store=store) for job in store.list_jobs()])
+
+    if action == "starter_strategies":
+        return ok(starter_catalog())
+
+    if action == "create_starter":
+        if not starter_id:
+            return err("invalid_request", "create_starter requires starter_id")
+        return ok(
+            create_starter_job(
+                starter_id,
+                job_id=job_id,
+                store=store,
+                compile_job=compile,
+                initializer_session_id=initializer_session_id,
+            )
+        )
 
     if action == "sync":
         # Recompile runner links first: job.yaml is agent-editable (e.g.

--- a/wayfinder_paths/tests/test_execution_timing_validation.py
+++ b/wayfinder_paths/tests/test_execution_timing_validation.py
@@ -12,7 +12,10 @@ from wayfinder_paths.jobs.execution.simulator import (
     run_execution_grid,
     simulate_execution,
 )
-from wayfinder_paths.jobs.execution.validation import validate_execution_job
+from wayfinder_paths.jobs.execution.validation import (
+    validate_execution_job,
+    validate_execution_trace,
+)
 from wayfinder_paths.jobs.models import WayfinderJob
 from wayfinder_paths.jobs.store import JobStore
 
@@ -107,6 +110,41 @@ def _make_job(
 
 def _check(report: dict[str, Any], name: str) -> dict[str, Any]:
     return next(check for check in report["checks"] if check["name"] == name)
+
+
+def test_sparse_bounded_trace_uses_timestamps_for_lookahead_validation() -> None:
+    trace = {
+        "execution_spec": ExecutionSpec().to_dict(),
+        "runs": [
+            {
+                "timestamp": "2026-01-01T00:00:00+00:00",
+                "visible_bar_count": 3,
+                "visible_latest_timestamp": "2026-01-01T00:00:00+00:00",
+            },
+            {
+                "timestamp": "2026-01-01T01:00:00+00:00",
+                "visible_bar_count": 4,
+                "visible_latest_timestamp": "2026-01-01T01:00:00+00:00",
+            },
+            {
+                "timestamp": "2026-01-01T02:00:00+00:00",
+                # A sparse row aged out of the bounded window.
+                "visible_bar_count": 3,
+                "visible_latest_timestamp": "2026-01-01T02:00:00+00:00",
+            },
+        ],
+        "bracket_events": [],
+        "fills": [],
+        "guard_events": [],
+    }
+    result = validate_execution_trace(trace)
+    assert result["data_valid"] is True
+    assert result["execution_valid"] is True
+
+    trace["runs"][1]["visible_latest_timestamp"] = "2026-01-01T03:00:00+00:00"
+    invalid = validate_execution_trace(trace)
+    assert invalid["data_valid"] is False
+    assert invalid["execution_valid"] is False
 
 
 def test_valid_interval_schedule_passes(tmp_path: Path) -> None:

--- a/wayfinder_paths/tests/test_jobs_initializer_session.py
+++ b/wayfinder_paths/tests/test_jobs_initializer_session.py
@@ -27,6 +27,16 @@ def test_new_accepts_legacy_env_spelling(monkeypatch) -> None:
     assert job.controller["initializer_session_id"] == "ses_legacy9"
 
 
+def test_new_accepts_explicit_initializer_session(monkeypatch) -> None:
+    monkeypatch.setenv("OPENCODE_SESSION_ID", "ses_env")
+    job = WayfinderJob.new(
+        "init-explicit",
+        interval_seconds=3600,
+        initializer_session_id="ses_explicit!dirty",
+    )
+    assert job.controller["initializer_session_id"] == "ses_explicitdirty"
+
+
 def test_new_leaves_controller_empty_without_env(monkeypatch) -> None:
     monkeypatch.delenv("OPENCODE_SESSION_ID", raising=False)
     monkeypatch.delenv("OPENCODE_SESSIONID", raising=False)

--- a/wayfinder_paths/tests/test_jobs_starters.py
+++ b/wayfinder_paths/tests/test_jobs_starters.py
@@ -1,0 +1,389 @@
+"""Selectable mixed-asset starter catalog and jobs_v1 implementations."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from wayfinder_paths.jobs.execution.features import apply_precompute
+from wayfinder_paths.jobs.execution.primitives import (
+    CompletedBarsView,
+    ExecutionContext,
+    ExecutionSpec,
+    PositionLedger,
+    PositionRecord,
+    StateSnapshot,
+)
+from wayfinder_paths.jobs.starters import create_starter_job, starter_catalog
+from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.jobs.strategies.mixed_bollinger_pullback import (
+    MixedBollingerPullbackStrategy,
+)
+from wayfinder_paths.jobs.strategies.mixed_low_vol_rank import (
+    MixedLowVolRankStrategy,
+)
+from wayfinder_paths.jobs.strategies.mixed_momentum_rank import (
+    MixedMomentumRankStrategy,
+)
+from wayfinder_paths.jobs.strategies.mixed_rsi_snapback import (
+    MixedRsiSnapbackStrategy,
+)
+from wayfinder_paths.jobs.strategies.mixed_sleeve_momentum import (
+    MixedSleeveMomentumStrategy,
+)
+from wayfinder_paths.jobs.strategies.mixed_volume_capitulation import (
+    MixedVolumeCapitulationStrategy,
+)
+from wayfinder_paths.jobs.strategies.pair_relative_strength import (
+    PairRelativeStrengthStrategy,
+)
+
+
+def _context(
+    strategy: Any,
+    closes: dict[str, list[float]],
+    *,
+    interval: str,
+    volumes: dict[str, list[float]] | None = None,
+) -> ExecutionContext:
+    timestamps = pd.date_range(
+        "2026-01-01T00:00:00Z",
+        periods=len(next(iter(closes.values()))),
+        freq=interval,
+    )
+    rows: list[dict[str, Any]] = []
+    for symbol, values in closes.items():
+        symbol_volumes = (volumes or {}).get(symbol, [1.0] * len(values))
+        for timestamp, close, volume in zip(
+            timestamps, values, symbol_volumes, strict=True
+        ):
+            rows.append(
+                {
+                    "timestamp": timestamp,
+                    "symbol": symbol,
+                    "open": close,
+                    "high": close,
+                    "low": close,
+                    "close": close,
+                    "volume": volume,
+                }
+            )
+    spec = ExecutionSpec()
+    spec.data_contract["bar_interval"] = interval
+    view = apply_precompute(strategy, CompletedBarsView.from_rows(rows))
+    return ExecutionContext(
+        view=view,
+        ledger=PositionLedger(),
+        state_snapshot=StateSnapshot(status="valid"),
+        capacity=None,
+        params={"initial_capital": 10_000.0},
+        timestamp=timestamps[-1].isoformat(),
+        execution_spec=spec,
+    )
+
+
+def _sides(intents: list[dict[str, Any]]) -> dict[str, str]:
+    return {intent["symbol"]: intent["side"] for intent in intents}
+
+
+def test_starter_catalog_has_six_mixed_and_two_pair_paper_strategies() -> None:
+    catalog = starter_catalog()
+    assert len(catalog) == 8
+    assert {item["timeframe"] for item in catalog} == {"15m", "1h", "1d"}
+    assert [item["timeframe"] for item in catalog].count("15m") == 2
+    assert [item["timeframe"] for item in catalog].count("1h") == 4
+    assert [item["timeframe"] for item in catalog].count("1d") == 2
+    for item in catalog:
+        assert item["crypto_assets"]
+        assert set(item["symbols"]) == set(item["crypto_assets"]) | set(
+            item["tokenized_equities"]
+        )
+        assert item["default_mode"] == "paper"
+        assert item["execution_contract"] == "jobs_v1"
+        assert item["family"] in {
+            "cross_sectional_momentum",
+            "mean_reversion",
+            "low_volatility_ranking",
+            "relative_value_pair",
+        }
+        assert isinstance(item["cautions"], list)
+        assert item["strategy_inception_at"]
+        assert item["research_evidence"]["return_after_costs_and_funding"] > 0
+        engine = item["research_evidence"]["jobs_v1_engine"]
+        assert engine["return_after_fees_and_slippage"] > 0
+        assert engine["funding_included"] is False
+        assert engine["trace_valid"] is True
+
+    pairs = {
+        item["id"]: item
+        for item in catalog
+        if item["research_evidence"].get("strategy_family")
+        == "cross-sectional pair momentum"
+    }
+    assert set(pairs) == {
+        "btc-eth-relative-strength-1d",
+        "bch-ltc-relative-strength-1d",
+    }
+    assert all(len(item["symbols"]) == 2 for item in pairs.values())
+    assert all(not item["tokenized_equities"] for item in pairs.values())
+    assert all(
+        item["research_evidence"]["price_mean_reversion_gate"]["verdict"] == "REJECT"
+        for item in pairs.values()
+    )
+
+
+def test_momentum_rank_longs_leaders_and_shorts_laggards() -> None:
+    symbols = ["A", "B", "C", "D"]
+    strategy = MixedMomentumRankStrategy(
+        {
+            "symbols": symbols,
+            "momentum_bars": 2,
+            "rebalance_bars": 1,
+            "min_trade_notional": 0.0,
+        }
+    )
+    ctx = _context(
+        strategy,
+        {
+            "A": [1.0, 1.1, 1.2, 1.3, 1.5, 1.8, 2.2],
+            "B": [1.0, 1.05, 1.1, 1.15, 1.2, 1.3, 1.4],
+            "C": [1.0, 0.98, 0.96, 0.94, 0.92, 0.88, 0.84],
+            "D": [1.0, 0.95, 0.9, 0.85, 0.8, 0.7, 0.6],
+        },
+        interval="1h",
+    )
+    assert _sides(strategy.decide(ctx)) == {
+        "A": "buy",
+        "B": "buy",
+        "C": "sell",
+        "D": "sell",
+    }
+
+
+def test_sleeve_momentum_keeps_crypto_and_equity_sleeves_separate() -> None:
+    strategy = MixedSleeveMomentumStrategy(
+        {
+            "symbols": ["A", "B", "C", "D"],
+            "sleeves": [["A", "B"], ["C", "D"]],
+            "momentum_bars": 2,
+            "rebalance_bars": 1,
+            "min_trade_notional": 0.0,
+        }
+    )
+    ctx = _context(
+        strategy,
+        {
+            "A": [1.0, 1.05, 1.1, 1.2, 1.35, 1.55, 1.8],
+            "B": [1.0, 0.98, 0.95, 0.9, 0.85, 0.78, 0.7],
+            "C": [1.0, 0.97, 0.94, 0.9, 0.84, 0.77, 0.7],
+            "D": [1.0, 1.04, 1.08, 1.15, 1.27, 1.42, 1.6],
+        },
+        interval="15min",
+    )
+    assert _sides(strategy.decide(ctx)) == {
+        "A": "buy",
+        "B": "sell",
+        "C": "sell",
+        "D": "buy",
+    }
+
+
+def test_low_vol_rank_longs_calm_pair_and_shorts_volatile_pair() -> None:
+    strategy = MixedLowVolRankStrategy(
+        {
+            "symbols": ["A", "B", "C", "D"],
+            "volatility_bars": 3,
+            "rebalance_bars": 1,
+            "min_trade_notional": 0.0,
+        }
+    )
+    ctx = _context(
+        strategy,
+        {
+            "A": [1.0, 1.01, 1.02, 1.03, 1.04, 1.05, 1.06, 1.07],
+            "B": [1.0, 1.02, 1.01, 1.03, 1.02, 1.04, 1.03, 1.05],
+            "C": [1.0, 1.20, 0.90, 1.30, 0.80, 1.25, 0.85, 1.20],
+            "D": [1.0, 0.75, 1.25, 0.70, 1.35, 0.65, 1.40, 0.60],
+        },
+        interval="15min",
+    )
+    assert _sides(strategy.decide(ctx)) == {
+        "A": "buy",
+        "B": "buy",
+        "C": "sell",
+        "D": "sell",
+    }
+
+
+def test_rsi_snapback_requires_oversold_reading_and_positive_trend() -> None:
+    strategy = MixedRsiSnapbackStrategy(
+        {
+            "symbols": ["A"],
+            "rsi_period": 2,
+            "entry_rsi": 101.0,
+            "trend_sma_period": 3,
+            "min_trade_notional": 0.0,
+        }
+    )
+    ctx = _context(strategy, {"A": [1.0, 1.0, 1.0, 2.0, 2.1, 2.0, 2.2]}, interval="1h")
+    assert _sides(strategy.decide(ctx)) == {"A": "buy"}
+
+
+def test_bollinger_pullback_fades_extremes_inside_the_slow_trend() -> None:
+    strategy = MixedBollingerPullbackStrategy(
+        {
+            "symbols": ["A", "B"],
+            "zscore_bars": 3,
+            "entry_zscore": 0.5,
+            "trend_sma_period": 5,
+            "min_trade_notional": 0.0,
+        }
+    )
+    ctx = _context(
+        strategy,
+        {
+            "A": [5, 6, 7, 8, 9, 10, 11, 12, 13, 12],
+            "B": [15, 14, 13, 12, 11, 10, 9, 8, 7, 8],
+        },
+        interval="1h",
+    )
+    assert _sides(strategy.decide(ctx)) == {"A": "buy", "B": "sell"}
+
+
+def test_volume_capitulation_requires_above_median_volume() -> None:
+    strategy = MixedVolumeCapitulationStrategy(
+        {
+            "symbols": ["A", "B"],
+            "rsi_period": 2,
+            "entry_rsi": 101.0,
+            "trend_sma_period": 3,
+            "volume_median_bars": 3,
+            "min_trade_notional": 0.0,
+        }
+    )
+    ctx = _context(
+        strategy,
+        {
+            "A": [1.0, 1.0, 1.0, 2.0, 2.1, 2.0, 2.2],
+            "B": [1.0, 1.0, 1.0, 2.0, 2.1, 2.0, 2.2],
+        },
+        volumes={
+            "A": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 2.0],
+            "B": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+        },
+        interval="1h",
+    )
+    assert _sides(strategy.decide(ctx)) == {"A": "buy"}
+
+
+def test_pair_relative_strength_emits_two_opposite_equal_notional_legs() -> None:
+    strategy = PairRelativeStrengthStrategy(
+        {
+            "symbols": ["A", "B"],
+            "momentum_bars": 2,
+            "volatility_bars": 3,
+            "min_gross_exposure": 0.4,
+            "max_gross_exposure": 0.4,
+            "rebalance_bars": 1,
+            "min_trade_notional": 0.0,
+        }
+    )
+    ctx = _context(
+        strategy,
+        {
+            "A": [1.0, 1.01, 1.03, 1.06, 1.10, 1.15, 1.21, 1.28],
+            "B": [1.0, 1.00, 0.99, 1.00, 1.01, 1.00, 1.01, 1.00],
+        },
+        interval="1D",
+    )
+    intents = strategy.decide(ctx)
+    assert _sides(intents) == {"A": "buy", "B": "sell"}
+    assert {round(float(intent["notional"]), 2) for intent in intents} == {2000.0}
+
+
+def test_pair_relative_strength_closes_an_orphan_leg_immediately() -> None:
+    strategy = PairRelativeStrengthStrategy({"symbols": ["A", "B"]})
+    ctx = _context(
+        strategy,
+        {"A": [1.0, 1.1], "B": [1.0, 0.9]},
+        interval="1D",
+    )
+    ctx.ledger.positions["A"] = PositionRecord(
+        symbol="A", side="long", size=2.0, avg_price=1.0
+    )
+    assert strategy.decide(ctx) == [
+        {
+            "action": "CLOSE",
+            "venue": "hyperliquid",
+            "symbol": "A",
+            "side": "sell",
+            "size": 2.0,
+            "reduce_only": True,
+            "metadata": {"exit_reason": "orphan_leg_guard"},
+        }
+    ]
+
+
+def test_create_starter_materializes_job_and_forward_inception(tmp_path) -> None:
+    store = JobStore(repo_root=tmp_path)
+    result = create_starter_job(
+        "mixed-momentum-rank-1h",
+        job_id="my-starter",
+        store=store,
+        compile_job=False,
+        initializer_session_id="ses_strategy-lab!bad",
+    )
+    job = store.load("my-starter")
+    assert job.execution_contract == "jobs_v1"
+    assert job.script_loop.mode == "paper"
+    assert job.controller["starter"]["paper_only"] is True
+    assert job.controller["initializer_session_id"] == "ses_strategy-labbad"
+    assert result["created"] is True
+    assert job.execution_spec["data_contract"]["bar_interval"] == "1h"
+    assert result["script_entrypoint"].endswith("workspace/src/strategy.py")
+    assert "mixed_momentum_rank" in Path(result["script_entrypoint"]).read_text(
+        encoding="utf-8"
+    )
+    summary = json.loads(
+        (store.job_dir(job.id) / "results/forward/summary.json").read_text()
+    )
+    assert summary["inception_at"] == job.created_at
+    assert (store.job_dir(job.id) / "results/backtest/starter_evidence.json").exists()
+
+    pair_result = create_starter_job(
+        "btc-eth-relative-strength-1d",
+        job_id="daily-pair-starter",
+        store=store,
+        compile_job=False,
+    )
+    pair_job = store.load("daily-pair-starter")
+    assert pair_job.script_loop.interval_seconds == 86_400
+    assert pair_job.execution_spec["data_contract"]["bar_interval"] == "1d"
+    assert pair_job.execution_spec["data_contract"]["symbols"] == ["BTC", "ETH"]
+    assert "pair_relative_strength" in Path(pair_result["script_entrypoint"]).read_text(
+        encoding="utf-8"
+    )
+
+
+def test_create_starter_reuses_its_canonical_job_id(tmp_path) -> None:
+    store = JobStore(repo_root=tmp_path)
+    first = create_starter_job(
+        "mixed-rsi-snapback-1h",
+        store=store,
+        compile_job=False,
+        initializer_session_id="ses_first",
+    )
+    second = create_starter_job(
+        "mixed-rsi-snapback-1h",
+        store=store,
+        compile_job=False,
+        initializer_session_id="ses_second",
+    )
+
+    assert first["created"] is True
+    assert second["created"] is False
+    assert second["job"]["id"] == "mixed-rsi-snapback-1h"
+    assert second["job"]["controller"]["initializer_session_id"] == "ses_first"


### PR DESCRIPTION
## Summary

- publish six mixed crypto/equity starters and two relative-strength pair starters
- expose starter discovery and materialization through the jobs CLI and MCP tool
- create normal paper-only `jobs_v1` jobs with persisted parameters, evidence, execution assumptions, initializer-session ownership, and forward inception

## Why

The Jobs frontend needs ready-to-run examples that can be selected by a user and handed to a Strategy Lab agent as a fully configured job.

## User impact

Users can start from a researched public strategy template instead of building every job from scratch. Existing jobs and custom strategy workflows are unchanged.

## Validation

- `uv run pytest wayfinder_paths/tests/test_jobs_starters.py wayfinder_paths/tests/test_execution_timing_validation.py wayfinder_paths/tests/test_jobs_initializer_session.py` — 42 passed
- Ruff lint and format checks on all changed Python files

## Dependency

This PR is intentionally stacked on `wayfinder-jobs-v1`, which is currently proposed for `main` in #444.
