### PR TITLE
Signing - Session-expired renewal prompt

### DIFF
--- a/wayfinder_paths/core/utils/wallets.py
+++ b/wayfinder_paths/core/utils/wallets.py
@@ -3,6 +3,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+import httpx
 from eth_account import Account
 from eth_account.messages import encode_typed_data
 from loguru import logger
@@ -236,12 +237,33 @@ def _prepare_tx_for_privy(transaction: dict) -> dict:
     return tx
 
 
+class SessionExpiredError(RuntimeError):
+    """Raised when the backend rejects a signature because the wallet's signing
+    session has lapsed. Carries an agent-facing message telling the user how to
+    renew, so the agent surfaces that instead of a raw HTTP error."""
+
+
+# The backend 404s a signature request once the session/policy TTL elapses. The
+# agent reads this verbatim, so it's phrased as an instruction to the agent.
+SESSION_EXPIRED_MESSAGE = (
+    "Your wallet signing session has expired, so the transaction was not "
+    "submitted. Do not retry automatically. Send the user a message with this "
+    "link — https://wayfinder.ai/app/shells — asking them to open it, sign in, "
+    "and renew their trading session, then try again once they confirm it's active."
+)
+
+
 def get_remote_sign_callback(wallet_address: str):
     async def sign_callback(transaction: dict) -> bytes:
         transaction["from"] = wallet_address
-        hex_str = await WALLET_CLIENT.sign_transaction(
-            wallet_address, _prepare_tx_for_privy(transaction)
-        )
+        try:
+            hex_str = await WALLET_CLIENT.sign_transaction(
+                wallet_address, _prepare_tx_for_privy(transaction)
+            )
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                raise SessionExpiredError(SESSION_EXPIRED_MESSAGE) from exc
+            raise
         return bytes.fromhex(hex_str.removeprefix("0x"))
 
     # Sign-callback contract: send_transaction() reads this to route
@@ -255,9 +277,14 @@ def get_remote_svm_sign_callback(wallet_address: str):
     """Sign a remote (Privy-backed) Solana wallet's tx via the backend."""
 
     async def sign_callback(tx: VersionedTransaction) -> bytes:
-        signed_b64 = await WALLET_CLIENT.sign_svm_transaction(
-            wallet_address, base64.b64encode(bytes(tx)).decode()
-        )
+        try:
+            signed_b64 = await WALLET_CLIENT.sign_svm_transaction(
+                wallet_address, base64.b64encode(bytes(tx)).decode()
+            )
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                raise SessionExpiredError(SESSION_EXPIRED_MESSAGE) from exc
+            raise
         return base64.b64decode(signed_b64)
 
     sign_callback.wallet_address = wallet_address

--- a/wayfinder_paths/mcp/utils.py
+++ b/wayfinder_paths/mcp/utils.py
@@ -15,6 +15,7 @@ import yaml
 
 from wayfinder_paths.core.clients.MetricsClient import METRICS_CLIENT
 from wayfinder_paths.core.utils.wallets import (  # noqa: F401
+    SessionExpiredError,
     find_wallet_by_label,
     get_local_sign_typed_data_callback,
     get_private_key,
@@ -101,6 +102,8 @@ def _wrap(fn: Callable, prefix: str) -> Callable:
                     f"{prefix} {exc}".strip(),
                     details=exc.details,
                 )
+            except SessionExpiredError as exc:
+                result = err("session_expired", str(exc))
             except Exception as exc:
                 result = err("error", f"{prefix} {exc}".strip())
             _report_tool_metric(
@@ -121,6 +124,8 @@ def _wrap(fn: Callable, prefix: str) -> Callable:
                 f"{prefix} {exc}".strip(),
                 details=exc.details,
             )
+        except SessionExpiredError as exc:
+            result = err("session_expired", str(exc))
         except Exception as exc:
             result = err("error", f"{prefix} {exc}".strip())
         _report_tool_metric(fn.__name__, result, (time.perf_counter() - start) * 1000)

--- a/wayfinder_paths/tests/test_session_expired_signing.py
+++ b/wayfinder_paths/tests/test_session_expired_signing.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from wayfinder_paths.core.utils import wallets
+from wayfinder_paths.core.utils.wallets import (
+    SESSION_EXPIRED_MESSAGE,
+    SessionExpiredError,
+    get_remote_sign_callback,
+)
+from wayfinder_paths.mcp.utils import catch_errors
+
+
+def _http_error(status_code: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://wayfinder.ai/api/v1/wallets/0x/sign")
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError("boom", request=request, response=response)
+
+
+@pytest.mark.asyncio
+async def test_sign_callback_maps_404_to_session_expired():
+    callback = get_remote_sign_callback("0xabc")
+    with patch.object(
+        wallets.WALLET_CLIENT,
+        "sign_transaction",
+        AsyncMock(side_effect=_http_error(404)),
+    ):
+        with pytest.raises(SessionExpiredError):
+            await callback({"to": "0xdef"})
+
+
+@pytest.mark.asyncio
+async def test_sign_callback_reraises_other_http_errors():
+    callback = get_remote_sign_callback("0xabc")
+    with patch.object(
+        wallets.WALLET_CLIENT,
+        "sign_transaction",
+        AsyncMock(side_effect=_http_error(500)),
+    ):
+        with pytest.raises(httpx.HTTPStatusError):
+            await callback({"to": "0xdef"})
+
+
+@pytest.mark.asyncio
+async def test_catch_errors_surfaces_session_expired_code():
+    @catch_errors
+    async def tool() -> dict:
+        raise SessionExpiredError(SESSION_EXPIRED_MESSAGE)
+
+    result = await tool()
+    assert result["ok"] is False
+    assert result["error"]["code"] == "session_expired"
+    assert "wayfinder.ai/app/shells" in result["error"]["message"]


### PR DESCRIPTION
### Summary
When a signature request fails because the wallet's signing session has expired, the transaction tools now return a clear, actionable message telling the user to renew their session in the app — instead of surfacing a raw HTTP error to the agent.

- Remote EVM and Solana signing callbacks detect an expired-session rejection and raise a dedicated `SessionExpiredError`.
- The MCP error wrapper maps it to a `session_expired` result whose message instructs the agent to have the user renew at `wayfinder.ai/app/shells`, then retry.
- Non-expiry errors pass through unchanged.
