### PR TITLE
jobs: fit the box — MCP-first tool calls, steal-aware load shedding, runner-gap alerting

### DIFF
--- a/wayfinder_paths/jobs/failures.py
+++ b/wayfinder_paths/jobs/failures.py
@@ -16,6 +16,9 @@ gates, refuted hypotheses) still stop the line — that is the system working.
 
 from __future__ import annotations
 
+import time
+from pathlib import Path
+
 # Deliberately dumb and greppable: case-insensitive substring match against a
 # flat list. No regex cleverness — anyone auditing a recovery decision should
 # be able to grep the error text against this list by eye.
@@ -28,6 +31,11 @@ INFRASTRUCTURE_PATTERNS = (
     "heavy-compute lock",
     "timeout",
     "timed out",
+    # `timeout`-killed subprocesses: under CPU steal a local CLI dies at its
+    # deadline with exit 124 — box starvation, never a remote outage.
+    "exit 124",
+    "exit status 124",
+    "command timed out",
     "408",
     "429",
     "502",
@@ -46,3 +54,30 @@ def classify_failure(error: str) -> str:
     if any(pattern in text for pattern in INFRASTRUCTURE_PATTERNS):
         return "infrastructure"
     return "evidence"
+
+
+def cpu_steal_pct(sample_seconds: float = 0.2) -> float | None:
+    """CPU steal share (%) over a short /proc/stat sample; None off-Linux.
+
+    On a shared-CPU box the hypervisor's steal is the single number that
+    predicts whether local subprocesses will crawl (81-93% steal turned
+    ~90s SDK cold-imports into OOM-killed multi-minute hangs). Two reads
+    ~sample_seconds apart, steal delta over total delta. Never raises.
+    """
+    try:
+
+        def _sample() -> tuple[int, int]:
+            first = Path("/proc/stat").read_text(encoding="utf-8").splitlines()[0]
+            values = [int(v) for v in first.split()[1:]]
+            steal = values[7] if len(values) > 7 else 0
+            return steal, sum(values)
+
+        steal_a, total_a = _sample()
+        time.sleep(sample_seconds)
+        steal_b, total_b = _sample()
+        total_delta = total_b - total_a
+        if total_delta <= 0:
+            return None
+        return 100.0 * (steal_b - steal_a) / total_delta
+    except Exception:  # noqa: BLE001 — non-Linux boxes have no /proc/stat
+        return None

--- a/wayfinder_paths/jobs/prompts/research_priors.md
+++ b/wayfinder_paths/jobs/prompts/research_priors.md
@@ -124,8 +124,12 @@ block's archetype counts and pick the family that treats YOUR disease.
   owner rejections bind on the change, not its neighborhood.
 - **Long runs detach**: `backtest_job` via MCP runs detached by default —
   kick it, poll `op_status`, keep working. Grids/experiments via CLI
-  in-session detach with a log the same way. Never sit synchronously on a
-  heavy run.
+  in-session detach with a log the same way (wrap CLI launches in
+  `timeout 300` minimum, one at a time). Never sit synchronously on a
+  heavy run. READS are the opposite: API/research lookups (funding,
+  prices, sentiment, perp screens) go through the session's resident MCP
+  tools — never `wayfinder <tool>` CLI wrappers, which cold-import the
+  whole SDK per call.
 
 **Post-apply shadow (mechanical counterfactual).** After any applied proposal the harness replays the pre-apply strategy over the forward bars and diffs it against the actual book (`post_apply_shadow` in the wake context; `wayfinder job counterfactual <job_id>` on demand). Entry-gating changes are adjudicated HERE — a filter's cost is invisible in the live book because skipped trades never print. Shadow sustainably ahead => revert/adjust proposal citing the block; active ahead => log the forward validation in the decisions ledger. Never hand-recompute counterfactuals.
 

--- a/wayfinder_paths/jobs/triggers.py
+++ b/wayfinder_paths/jobs/triggers.py
@@ -27,10 +27,14 @@ DEFAULT_DEBOUNCE_SECONDS = 600
 # verdict is a research event every job should act on, config or not.
 # successor_overdue fires when a kind=process owner rejection's expected
 # successor proposal has not appeared within the watchdog window.
+# runner_loop_gap fires when the watchdog sees a LIVE job's script loop gone
+# dark past 3x its interval — a live book nobody is managing must never wait
+# for the next timer poll.
 ALWAYS_WAKE_EVENTS = {
     "proposal_restage_requested",
     "verdict_matured",
     "successor_overdue",
+    "runner_loop_gap",
 }
 
 

--- a/wayfinder_paths/jobs/watchdog.py
+++ b/wayfinder_paths/jobs/watchdog.py
@@ -26,6 +26,7 @@ from textwrap import dedent
 from typing import Any
 
 from wayfinder_paths.jobs.application import complete_application
+from wayfinder_paths.jobs.failures import cpu_steal_pct
 from wayfinder_paths.jobs.models import utc_now_iso
 from wayfinder_paths.jobs.runner_bridge import RunnerBridge
 from wayfinder_paths.jobs.store import JobStore
@@ -388,6 +389,12 @@ _REVISION_MISMATCH_RE = re.compile(
     r"is for revision [0-9a-f]{6,}, workspace is [0-9a-f]{6,}"
 )
 _GATE_RESTAMP_MARKER = "state/gate_restamp.json"
+# A gate re-stamp is a full 120d backtest. Under heavy hypervisor CPU steal
+# (observed 81-93% on the production box) that backtest held the
+# heavy-compute lock 45-60 minutes — starving everything else for a repair
+# that is merely housekeeping. Deferral is safe-closed: the gate stays red a
+# little longer; the next 5-minute pass retries when the box breathes again.
+RESTAMP_STEAL_THRESHOLD_PCT = 60.0
 
 
 def _recover_stale_gate(
@@ -447,6 +454,17 @@ def _recover_stale_gate(
         return None
     if not allow_restamp:
         return None  # one re-stamp (a backtest) per pass; next pass retries
+    steal = cpu_steal_pct()
+    if steal is not None and steal > RESTAMP_STEAL_THRESHOLD_PCT:
+        event = {
+            "type": "restamp_deferred_load",
+            "stalled_status": "stale_gate",
+            "action": "restamp_deferred_load",
+            "cpu_steal_pct": round(steal, 1),
+            "revision": revision,
+        }
+        store.append_journal(job_id, event)
+        return event  # safe-closed: gate stays red; next pass retries
 
     from wayfinder_paths.jobs.compute_lock import ComputeLockBusy
     from wayfinder_paths.jobs.execution.job import backtest_execution_job
@@ -550,6 +568,100 @@ def _recover_orphaned_pause(
     }
     store.append_journal(job_id, event)
     return event
+
+
+# Runner-gap alerting: during one OOM cascade the LIVE job's script loop went
+# dark for 65 minutes with ZERO alerting — the runner daemon was wedged, so
+# nothing that depends on the runner could notice. The watchdog is the
+# independent observer: it compares the newest forward run/tick timestamp
+# against the loop's own interval and journals (and, for live jobs, wakes the
+# agent) when the loop has missed several beats.
+_LOOP_GAP_ALERT_PATH = "state/loop_gap_alert.json"
+LOOP_GAP_INTERVAL_MULTIPLIER = 3
+DEFAULT_LOOP_INTERVAL_SECONDS = 300
+
+
+def _tail_line(path: Path, *, chunk_bytes: int = 2048) -> str | None:
+    """Last non-empty line of a possibly multi-MB file, tail-read only."""
+    try:
+        with path.open("rb") as fh:
+            fh.seek(0, os.SEEK_END)
+            size = fh.tell()
+            fh.seek(max(0, size - chunk_bytes))
+            chunk = fh.read().decode("utf-8", errors="replace")
+    except OSError:
+        return None
+    lines = [line for line in chunk.splitlines() if line.strip()]
+    return lines[-1] if lines else None
+
+
+def _last_forward_ts(root: Path) -> datetime | None:
+    newest: datetime | None = None
+    for name in ("runs.jsonl", "ticks.jsonl"):
+        line = _tail_line(root / "results" / "forward" / name)
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+            parsed = datetime.fromisoformat(str(row.get("ts")))
+        except (ValueError, TypeError, AttributeError):
+            continue  # partial/foreign last line — the other file may serve
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        if newest is None or parsed > newest:
+            newest = parsed
+    return newest
+
+
+def _check_loop_gap(store: JobStore, job: Any, now: datetime) -> dict[str, Any] | None:
+    loop = getattr(job, "script_loop", None)
+    if loop is None or not getattr(loop, "enabled", False):
+        return None
+    interval = int(
+        getattr(loop, "interval_seconds", None) or DEFAULT_LOOP_INTERVAL_SECONDS
+    )
+    last_ts = _last_forward_ts(store.job_dir(job.id))
+    if last_ts is None:
+        return None  # never ran — startup state, not an outage
+    gap = (now - last_ts).total_seconds()
+    mode = str(getattr(loop, "mode", "") or "")
+    marker = store.read_json(job.id, _LOOP_GAP_ALERT_PATH) or {}
+    if gap > LOOP_GAP_INTERVAL_MULTIPLIER * interval:
+        if str(marker.get("gap_start_ts") or "") == last_ts.isoformat():
+            return None  # already alerted for this outage
+        store.write_json(
+            job.id,
+            _LOOP_GAP_ALERT_PATH,
+            {"gap_start_ts": last_ts.isoformat(), "alerted_at": now.isoformat()},
+        )
+        store.append_journal(
+            job.id,
+            {
+                "type": "runner_loop_gap",
+                "gap_seconds": int(gap),
+                "interval": interval,
+                "mode": mode,
+            },
+        )
+        if mode == "live":
+            # circular import: worker → application → … → triggers
+            from wayfinder_paths.jobs.triggers import fire_triggers
+
+            fire_triggers(store, job, ["runner_loop_gap"], source="watchdog")
+        return {
+            "action": "runner_loop_gap",
+            "gap_seconds": int(gap),
+            "interval": interval,
+            "mode": mode,
+        }
+    if marker:
+        store.write_json(job.id, _LOOP_GAP_ALERT_PATH, {})
+        store.append_journal(
+            job.id,
+            {"type": "runner_loop_recovered", "interval": interval, "mode": mode},
+        )
+        return {"action": "runner_loop_recovered", "mode": mode}
+    return None
 
 
 # Lifecycle evaluation is cheap (json reads + arithmetic) but its decisions
@@ -724,6 +836,13 @@ def recover_stalled_applications(
             recovered.append({"job_id": job.id, **gate_event})
             if gate_event.get("action") == "gate_restamp":
                 restamped_this_pass = True
+        try:
+            loop_gap_event = _check_loop_gap(store, job, now)
+        except Exception as exc:
+            errors.append({"job_id": job.id, "error": f"loop_gap: {exc}"})
+            loop_gap_event = None
+        if loop_gap_event is not None:
+            recovered.append({"job_id": job.id, **loop_gap_event})
         try:
             for lifecycle_event in _run_lifecycle_pass(store, job.id, now):
                 recovered.append({"job_id": job.id, **lifecycle_event})

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -11,6 +11,7 @@ from loguru import logger
 
 from wayfinder_paths.core.clients.OpenCodeClient import OPENCODE_CLIENT
 from wayfinder_paths.jobs.derived_features import refresh_derived_features_if_stale
+from wayfinder_paths.jobs.failures import cpu_steal_pct
 from wayfinder_paths.jobs.forward import is_forward_empty
 from wayfinder_paths.jobs.ledger import tail_ledger
 from wayfinder_paths.jobs.memory_hygiene import sanitize_job_memory
@@ -544,8 +545,15 @@ def _compute_status_block(root: Path) -> dict[str, Any]:
         ).isoformat()
     except Exception:  # noqa: BLE001
         last_backtest_ok_at = None
+    steal = cpu_steal_pct()
+    try:
+        loadavg: list[float] | None = [round(v, 2) for v in os.getloadavg()]
+    except OSError:
+        loadavg = None
     return {
         "mem_available_mb": mem_available_mb,
+        "cpu_steal_pct": None if steal is None else round(steal, 1),
+        "loadavg": loadavg,
         "last_experiment_at": last_experiment_at,
         "last_backtest_ok_at": last_backtest_ok_at,
         "_basis": (
@@ -556,7 +564,11 @@ def _compute_status_block(root: Path) -> dict[str, Any]:
             "NEVER carry an infrastructure claim from memory when this "
             "block contradicts it. If this block shows healthy memory and "
             "recent successful compute, every 'OOM-blocked' qualifier you "
-            "have ever written is void."
+            "have ever written is void. cpu_steal_pct above ~60 means the "
+            "hypervisor is taking most of this box's CPU and local "
+            "subprocesses crawl — prefer resident MCP tools for reads, "
+            "defer optional heavy compute, and NEVER interpret local "
+            "timeouts (exit 124) as remote outages."
         ),
     }
 
@@ -796,6 +808,19 @@ def _build_worker_prompt_sections(
         "prior reports are VOID when compute_status contradicts them. "
         "Completed background operations must be harvested and acted on "
         "regardless of this wake's island assignment.\n"
+        "- TOOL CALLS ARE MCP-FIRST: API/research reads (research_*, "
+        "hyperliquid_*, onchain_*, core_web_search, delta lab, funding "
+        "history, prices) MUST use this session's resident MCP tools — "
+        "NEVER `wayfinder <tool-name>` CLI subprocesses, which cold-import "
+        "the whole SDK (~90s CPU and 150-250MB per call under load; the "
+        "box's OOM cascade was mostly these). The `wayfinder job ...` CLI "
+        "remains correct ONLY for job machinery and detached heavy ops "
+        "(backtests, experiments, scans) — wrap those in `timeout 300` "
+        "minimum and run them one at a time. An `exit 124` from a LOCAL "
+        "CLI command is LOCAL CPU STARVATION, never evidence a backend is "
+        "down: verify backend health ONLY via a resident MCP tool result, "
+        "and void any agenda/memory claim of 'backend DOWN' that is not "
+        "backed by an MCP-tool failure observed THIS wake.\n"
         "- Research staleness (`evolution.research_staleness`) is visible "
         "state. When the job is healthy, no verdict is pending, and "
         "`research_staleness.stale` is true (no experiment in "

--- a/wayfinder_paths/tests/test_jobs_fit_the_box.py
+++ b/wayfinder_paths/tests/test_jobs_fit_the_box.py
@@ -1,0 +1,256 @@
+"""Fit-the-box: MCP-first tool-call doctrine, steal-aware load shedding, and
+runner-gap alerting.
+
+Motivating forensics (production Fly box, ~0.25 sustained vCPU under 81-93%
+CPU steal): agents shelled out to `wayfinder <tool>` CLI wrappers for 1s API
+reads — each cold-imports the whole SDK (~90s CPU, 150-250MB) and 24 of 29
+OOM-killed processes were these; agents then misread their own `timeout`
+kills (exit 124) as "backend DOWN". The watchdog's gate re-stamp ran a full
+backtest under that steal, holding the heavy-compute lock 45-60 min. And
+during the OOM cascade the LIVE job's script loop went dark 65 minutes with
+zero alerting. Under test: the doctrine lands in the worker prompt, the
+watchdog sheds deferrable load under steal, and a dark loop is journaled and
+(for live jobs) wakes the agent.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from wayfinder_paths.jobs.failures import classify_failure, cpu_steal_pct
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.jobs.triggers import ALWAYS_WAKE_EVENTS
+from wayfinder_paths.jobs.watchdog import (
+    _check_loop_gap,
+    _recover_stale_gate,
+    recover_stalled_applications,
+)
+from wayfinder_paths.jobs.worker import _compute_status_block
+
+
+def _make_store(
+    tmp_path: Path, job_id: str = "box-demo", *, interval_seconds: int | None = 300
+) -> tuple[JobStore, WayfinderJob]:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        job_id,
+        script="workspace/src/strategy.py",
+        interval_seconds=interval_seconds,
+        agent_mode="intervene",
+        execution_contract="jobs_v1",
+    )
+    store.save(job)
+    return store, job
+
+
+def _journal_events(store: JobStore, job_id: str, event_type: str) -> list[dict]:
+    path = store.job_dir(job_id) / "journal.jsonl"
+    if not path.exists():
+        return []
+    rows = [json.loads(line) for line in path.read_text().splitlines()]
+    return [row for row in rows if row.get("type") == event_type]
+
+
+def _write_forward_runs(store: JobStore, job_id: str, ts: datetime) -> None:
+    path = store.job_dir(job_id) / "results" / "forward" / "runs.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"ts": ts.isoformat(), "status": "ok"}) + "\n")
+
+
+# ── failure taxonomy ─────────────────────────────────────────────────────────
+
+
+def test_exit_124_is_infrastructure() -> None:
+    for text in (
+        "wayfinder research: exit 124",
+        "subprocess returned exit status 124",
+        "command timed out after 300 seconds",
+    ):
+        assert classify_failure(text) == "infrastructure", text
+    assert classify_failure("thesis refuted by walk-forward") == "evidence"
+
+
+def test_cpu_steal_pct_never_raises() -> None:
+    steal = cpu_steal_pct(sample_seconds=0.01)
+    # Linux: a float percentage; macOS/no-procfs: None. Never an exception.
+    assert steal is None or 0.0 <= steal <= 100.0
+
+
+# ── compute_status: box truth carries steal + load ───────────────────────────
+
+
+def test_compute_status_block_has_steal_and_loadavg(tmp_path: Path) -> None:
+    store, job = _make_store(tmp_path, "box-status")
+    block = _compute_status_block(store.job_dir(job.id))
+    assert "cpu_steal_pct" in block  # None off-Linux, float share on Linux
+    assert "loadavg" in block
+    basis = block["_basis"]
+    assert "cpu_steal_pct above ~60" in basis
+    assert "NEVER interpret local timeouts" in basis
+
+
+def test_worker_prompt_carries_mcp_first_doctrine(tmp_path: Path) -> None:
+    from wayfinder_paths.jobs.worker import prepare_job_worker_prompt
+
+    store, job = _make_store(tmp_path, "box-prompt")
+    sections = prepare_job_worker_prompt(store=store, job_id=job.id, mode="intervene")
+    stable = sections["stable_prefix"]
+    assert "MCP-FIRST" in stable
+    assert "cold-import" in stable
+    assert "NEVER `wayfinder <tool-name>` CLI subprocesses" in stable
+    assert "LOCAL CPU STARVATION" in stable
+    # Dynamic context carries the mechanical steal/load numbers.
+    assert "cpu_steal_pct" in sections["prompt"]
+    assert "loadavg" in sections["prompt"]
+
+
+# ── watchdog: steal-aware gate-restamp deferral ──────────────────────────────
+
+
+@pytest.fixture
+def stale_gate(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Force a red gate that is PURELY revision mismatch, and record any
+    restamp (backtest chain) attempts."""
+    attempts: list[str] = []
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.gating.evaluate_live_gate",
+        lambda job_id, store=None: {
+            "live_ready": False,
+            "reasons": ["backtest is for revision aabbccdd11, workspace is ffeedd22"],
+        },
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.gating.compute_workspace_revision",
+        lambda root: "ffeedd22",
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.execution.job.backtest_execution_job",
+        lambda job_id, store=None: attempts.append("backtest"),
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.execution.preflight.run_preflight",
+        lambda job_id, store=None: attempts.append("preflight"),
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.execution.validation.validate_execution_job",
+        lambda job_id, store=None: attempts.append("validate"),
+    )
+    return attempts
+
+
+def test_restamp_deferred_under_cpu_steal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, stale_gate: list[str]
+) -> None:
+    store, job = _make_store(tmp_path, "box-steal-hi")
+    monkeypatch.setattr("wayfinder_paths.jobs.watchdog.cpu_steal_pct", lambda: 90.0)
+    event = _recover_stale_gate(store, job.id, [], allow_restamp=True)
+    assert event is not None
+    assert event["action"] == "restamp_deferred_load"
+    assert event["cpu_steal_pct"] == 90.0
+    assert stale_gate == []  # no backtest launched under load
+    journaled = _journal_events(store, job.id, "restamp_deferred_load")
+    assert len(journaled) == 1
+    assert journaled[0]["cpu_steal_pct"] == 90.0
+
+
+def test_restamp_proceeds_when_steal_low(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, stale_gate: list[str]
+) -> None:
+    store, job = _make_store(tmp_path, "box-steal-lo")
+    monkeypatch.setattr("wayfinder_paths.jobs.watchdog.cpu_steal_pct", lambda: 10.0)
+    event = _recover_stale_gate(store, job.id, [], allow_restamp=True)
+    assert event is not None
+    assert event["action"] == "gate_restamp"
+    assert stale_gate == ["backtest", "preflight", "validate"]
+    assert not _journal_events(store, job.id, "restamp_deferred_load")
+
+
+# ── watchdog: runner-gap alerting ────────────────────────────────────────────
+
+
+@pytest.fixture
+def trigger_wakes(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+
+    def fake_fire(store: Any, job: Any, events: list[str], *, source: str) -> None:
+        calls.append({"job_id": job.id, "events": events, "source": source})
+
+    monkeypatch.setattr("wayfinder_paths.jobs.triggers.fire_triggers", fake_fire)
+    return calls
+
+
+def test_loop_gap_journaled_once_per_outage(
+    tmp_path: Path, trigger_wakes: list[dict[str, Any]]
+) -> None:
+    store, job = _make_store(tmp_path, "box-gap")
+    now = datetime.now(UTC)
+    _write_forward_runs(store, job.id, now - timedelta(seconds=3600))
+
+    event = _check_loop_gap(store, job, now)
+    assert event is not None
+    assert event["action"] == "runner_loop_gap"
+    assert event["gap_seconds"] >= 3 * 300
+    assert event["interval"] == 300
+    assert _check_loop_gap(store, job, now) is None  # deduped second pass
+    journaled = _journal_events(store, job.id, "runner_loop_gap")
+    assert len(journaled) == 1
+    assert journaled[0]["mode"] == "paper"
+    assert not trigger_wakes  # paper mode alerts, never wakes
+
+    # Loop resumes: recovery journaled once and the marker clears.
+    _write_forward_runs(store, job.id, now)
+    event = _check_loop_gap(store, job, now)
+    assert event is not None and event["action"] == "runner_loop_recovered"
+    assert _check_loop_gap(store, job, now) is None
+    assert len(_journal_events(store, job.id, "runner_loop_recovered")) == 1
+
+
+def test_loop_gap_live_mode_fires_trigger_wake(
+    tmp_path: Path, trigger_wakes: list[dict[str, Any]]
+) -> None:
+    store, job = _make_store(tmp_path, "box-gap-live")
+    job.script_loop.mode = "live"
+    store.save(job)
+    now = datetime.now(UTC)
+    _write_forward_runs(store, job.id, now - timedelta(hours=2))
+
+    event = _check_loop_gap(store, job, now)
+    assert event is not None and event["mode"] == "live"
+    assert trigger_wakes == [
+        {"job_id": job.id, "events": ["runner_loop_gap"], "source": "watchdog"}
+    ]
+    assert "runner_loop_gap" in ALWAYS_WAKE_EVENTS
+
+
+def test_loop_gap_quiet_paths(tmp_path: Path) -> None:
+    # Fresh telemetry → no event; no telemetry at all → startup, no event.
+    store, job = _make_store(tmp_path, "box-gap-quiet")
+    now = datetime.now(UTC)
+    assert _check_loop_gap(store, job, now) is None
+    _write_forward_runs(store, job.id, now - timedelta(seconds=60))
+    assert _check_loop_gap(store, job, now) is None
+    # Disabled script loop is never scanned.
+    agent_only = WayfinderJob.new("box-agent-only", agent_mode="intervene")
+    store.save(agent_only)
+    assert _check_loop_gap(store, agent_only, now) is None
+
+
+def test_loop_gap_wired_into_watchdog_pass(
+    tmp_path: Path, trigger_wakes: list[dict[str, Any]]
+) -> None:
+    store, job = _make_store(tmp_path, "box-gap-pass")
+    now = datetime.now(UTC)
+    _write_forward_runs(store, job.id, now - timedelta(hours=1))
+    result = recover_stalled_applications(store=store, now=now)
+    gap_events = [
+        e for e in result["recovered"] if e.get("action") == "runner_loop_gap"
+    ]
+    assert len(gap_events) == 1
+    assert gap_events[0]["job_id"] == job.id
+    assert not [e for e in result["errors"] if "loop_gap" in str(e.get("error"))]


### PR DESCRIPTION
Production forensics on the jobs box (Fly shared-cpu-4x, ~0.25 sustained vCPU under 81–93% CPU steal) found three compounding failure modes. This PR fixes all three.

## What happened on the box

- Agents shelled out to auto-generated `wayfinder <tool>` CLI wrappers for 1-second API reads. Each wrapper cold-imports the whole SDK (~90s CPU, 150–250MB under load); 24 of 29 OOM-killed processes were these. Agents then misread their own `timeout` kills (exit 124) as "backend DOWN" and wrote false lore into agendas.
- The watchdog's gate re-stamp runs a full 120d backtest on any revision mismatch — under steal these held the heavy-compute lock 45–60 minutes each.
- During the OOM cascade, the LIVE job's script loop went dark for 65 minutes with zero alerting.

## Changes

### 1. MCP-first tool-call doctrine (`worker.py`, `prompts/research_priors.md`)
New stable-prefix rule: API/research reads (`research_*`, `hyperliquid_*`, `onchain_*`, `core_web_search`, delta lab, funding, prices) MUST use the session's resident MCP tools — never `wayfinder <tool>` CLI subprocesses. The `wayfinder job ...` CLI stays correct only for job machinery and detached heavy ops (backtests/experiments/scans), wrapped in `timeout 300` minimum, one at a time. An `exit 124` from a local CLI is local CPU starvation, never backend-down evidence — backend health is verified only via a resident MCP tool result, and unbacked "backend DOWN" agenda/memory claims are void. `research_priors.md`'s "Long runs detach" bullet aligned with the same doctrine.

### 2. CPU steal telemetry + steal-aware load shedding (`failures.py`, `worker.py`, `watchdog.py`)
- `failures.cpu_steal_pct()`: steal share over a ~0.2s `/proc/stat` sample; `None` off-Linux; never raises. Shared by worker and watchdog.
- `_compute_status_block` now carries `cpu_steal_pct` and `loadavg`, and its `_basis` tells the agent: steal above ~60% means local subprocesses crawl — prefer MCP tools, defer optional heavy compute, never interpret local timeouts as remote outages.
- `_recover_stale_gate`: before launching a restamp backtest, measure steal; above 60% the restamp is deferred with a journaled `restamp_deferred_load` event (steal value included) and the next 5-minute pass retries. Safe-closed: only this housekeeping path defers — the gate just stays red slightly longer.

### 3. Runner-gap alerting (`watchdog.py`, `triggers.py`)
New `_check_loop_gap` in the watchdog per-job pass: for jobs with `script_loop.enabled`, tail-read (binary seek, last ~2KB — never the whole multi-MB file) the newest `results/forward/runs.jsonl` / `ticks.jsonl` timestamp. Gap > 3× `interval_seconds` (default 300s) journals `runner_loop_gap` {gap_seconds, interval, mode}, deduped per outage via `state/loop_gap_alert.json` keyed on gap-start; recovery clears the marker and journals `runner_loop_recovered`. LIVE-mode jobs additionally fire a trigger wake, and `runner_loop_gap` is in `ALWAYS_WAKE_EVENTS`. Never raises — errors land in the pass error list.

### 4. Failure taxonomy (`failures.py`)
`classify_failure` now maps "exit 124", "exit status 124", "command timed out" → infrastructure.

## Tests

New `wayfinder_paths/tests/test_jobs_fit_the_box.py` (10 tests): compute_status keys + basis contract, prompt doctrine markers, restamp deferral at steal 90 vs normal path at steal 10 (restamp chain observed via monkeypatch), loop-gap journal-once/recovery/live-wake/quiet paths + full watchdog-pass wiring, exit-124 classification, `cpu_steal_pct` never-raises.

Full jobs/mcp suite: 849 passed, 3 skipped.
