### PR TITLE
runner: warm-path — sync debounce, forkserver tick spawner, resident view server

### DIFF
--- a/wayfinder_paths/jobs/compiler.py
+++ b/wayfinder_paths/jobs/compiler.py
@@ -223,6 +223,9 @@ class JobCompiler:
             "WAYFINDER_FORWARD_DIR": str(root / "results" / "forward"),
             "WAYFINDER_JOB_MODE": str(job.script_loop.mode or "paper"),
             "WAYFINDER_JOB_REVISION": str(job.versioning.get("active_revision") or ""),
+            # The runner daemon gates the warm forkserver tick path on this:
+            # only jobs_v1 script ticks are eligible.
+            "WAYFINDER_JOB_EXECUTION_CONTRACT": str(job.execution_contract or "legacy"),
         }
         spec_path = root / "execution_spec.json"
         if job.execution_spec:

--- a/wayfinder_paths/jobs/forward_artifacts.py
+++ b/wayfinder_paths/jobs/forward_artifacts.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import math
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any
 
@@ -100,6 +100,7 @@ def load_forward_view(
     to_ts: str | None = None,
     max_points: int = 1500,
     include_prices: bool = True,
+    price_fetcher: Callable[..., list[dict[str, Any]]] | None = None,
 ) -> dict[str, Any]:
     """Bounded forward (paper/live) visualization payload for the jobs UI.
 
@@ -127,7 +128,11 @@ def load_forward_view(
     last_closes: dict[str, float] = {}
     if include_prices:
         try:
-            price_series = _fetch_price_series(job_id, ticks, store=store)
+            # `price_fetcher` lets a resident caller (runner view server)
+            # inject a TTL-cached fetch so UI polling cannot hammer the venue;
+            # default is the direct per-call venue fetch.
+            fetch_prices = price_fetcher or _fetch_price_series
+            price_series = fetch_prices(job_id, ticks, store=store)
             series.extend(price_series)
             for entry in price_series:
                 if entry["points"]:

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -7,11 +7,14 @@ import subprocess
 import sys
 import threading
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from wayfinder_paths.runner.warm_spawn import WarmChild
 
 from loguru import logger
 
@@ -39,6 +42,7 @@ from wayfinder_paths.runner.schedule import (
 from wayfinder_paths.runner.script_resolver import resolve_script_path
 
 JOB_RESULT_MARKER = "WAYFINDER_JOB_RESULT "
+DEFAULT_SYNC_DEBOUNCE_SECONDS = 90.0
 JOB_LOCK_TIMEOUT_SECONDS = 3
 JOB_LOCK_BUSY_MSG = (
     "Runner Daemon lock is busy, no operations were completed, please try again later"
@@ -130,6 +134,75 @@ def _kill_process_group(pid: int, *, sig: int) -> None:
         logger.debug(f"Failed to kill process group {pid}: {exc}")
 
 
+def _sync_debounce_seconds() -> float:
+    raw = os.environ.get("WAYFINDER_SYNC_DEBOUNCE_SECONDS")
+    if raw is None or not str(raw).strip():
+        return DEFAULT_SYNC_DEBOUNCE_SECONDS
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning(
+            f"Invalid WAYFINDER_SYNC_DEBOUNCE_SECONDS={raw!r}; "
+            f"using {DEFAULT_SYNC_DEBOUNCE_SECONDS}s"
+        )
+        return DEFAULT_SYNC_DEBOUNCE_SECONDS
+
+
+class _SyncDebouncer:
+    """Trailing-edge coalescer for the backend sync push.
+
+    Every run finish used to fire a full-SDK sync thread; under a busy runner
+    that is almost pure overhead. `request()` arms a single trailing timer:
+    requests that arrive while the timer is pending coalesce into the one fire
+    (the sync reads current state at fire time, so nothing is lost) and the
+    push happens at most `delay_seconds` after the first request. `flush=True`
+    cancels any pending timer and runs the action immediately — control-plane
+    mutations keep their synchronous-feeling sync. A non-positive delay
+    disables debouncing entirely.
+    """
+
+    def __init__(self, *, action: Callable[[], None], delay_seconds: float) -> None:
+        self._action = action
+        self._delay_seconds = float(delay_seconds)
+        self._lock = threading.Lock()
+        self._timer: threading.Timer | None = None
+        self._stopped = False
+
+    def request(self, *, flush: bool = False) -> None:
+        if flush or self._delay_seconds <= 0:
+            self._cancel_pending()
+            self._action()
+            return
+        with self._lock:
+            if self._stopped or self._timer is not None:
+                return
+            timer = threading.Timer(self._delay_seconds, self._fire)
+            timer.name = "wayfinder-sync-debounce"
+            timer.daemon = True
+            self._timer = timer
+            timer.start()
+
+    def _fire(self) -> None:
+        with self._lock:
+            self._timer = None
+            if self._stopped:
+                return
+        self._action()
+
+    def _cancel_pending(self) -> None:
+        with self._lock:
+            if self._timer is not None:
+                self._timer.cancel()
+                self._timer = None
+
+    def stop(self) -> None:
+        with self._lock:
+            self._stopped = True
+            if self._timer is not None:
+                self._timer.cancel()
+                self._timer = None
+
+
 @dataclass
 class RunningProcess:
     run_id: int
@@ -139,7 +212,9 @@ class RunningProcess:
     reason: str
     scheduled_for: int | None
     timeout_seconds: int | None
-    popen: subprocess.Popen[bytes]
+    # Popen for cold workers, WarmChild for forked jobs_v1 ticks — the daemon
+    # only touches the shared duck-typed surface (.pid, .poll(), .returncode).
+    popen: subprocess.Popen[bytes] | WarmChild
     log_path: Path
 
 
@@ -171,7 +246,13 @@ class RunnerDaemon:
         self._running_by_job: dict[int, int] = {}
 
         self._control = None
+        self._view_server: Any | None = None
         self._daemon_log_sink_id: int | None = None
+        self._warm_spawner: Any | None = None
+        self._sync_debouncer = _SyncDebouncer(
+            action=lambda: self._start_backend_sync(),
+            delay_seconds=_sync_debounce_seconds(),
+        )
 
     def _lock_for_job(self, job_id: int) -> threading.Lock:
         lock = self._job_locks.get(job_id)
@@ -211,6 +292,19 @@ class RunnerDaemon:
             f"Runner daemon v{__version__} listening on {self._paths.sock_path}"
         )
 
+        # Warm view endpoint for the jobs UI (starters/backtest/forward).
+        # Best-effort: bind failure or a broken module must never stop the
+        # scheduler — callers fall back to the cold CLI.
+        try:
+            from wayfinder_paths.runner.view_server import RunnerViewServer
+
+            view_server = RunnerViewServer(repo_root=self._paths.repo_root)
+            view_server.start()
+            self._view_server = view_server
+        except Exception:  # noqa: BLE001
+            logger.opt(exception=True).warning("View server failed to start")
+            self._view_server = None
+
         try:
             for sig in (signal.SIGINT, signal.SIGTERM):
                 signal.signal(sig, lambda *_: self.stop())
@@ -220,7 +314,14 @@ class RunnerDaemon:
             self._loop()
         finally:
             self._shutdown.set()
+            self._sync_debouncer.stop()
             self._control.stop()
+            if self._view_server is not None:
+                try:
+                    self._view_server.stop()
+                except Exception:  # noqa: BLE001
+                    pass
+                self._view_server = None
             for rp in self._running.values():
                 _kill_process_group(rp.popen.pid, sig=signal.SIGTERM)
             self._db._conn.close()
@@ -231,6 +332,7 @@ class RunnerDaemon:
                     pass
 
     def stop(self) -> None:
+        self._sync_debouncer.stop()
         self._shutdown.set()
 
     def _loop(self) -> None:
@@ -337,10 +439,12 @@ class RunnerDaemon:
                 ),
             )
 
-        # Refresh the wayfinder-jobs backend after every run so the Strategies
-        # UI (conversations, proposals, reconciled mode) tracks activity instead
-        # of only updating on ~hourly/4-hourly agent wakes.
-        self._sync_to_backend_async()
+        # Refresh the wayfinder-jobs backend after runs so the Strategies UI
+        # (conversations, proposals, reconciled mode) tracks activity instead
+        # of only updating on ~hourly/4-hourly agent wakes. Debounced: a burst
+        # of run finishes coalesces into one push per quiet window instead of
+        # one full-SDK sync thread per run.
+        self._sync_to_backend_async(flush=False)
 
     def _run_side_effect(self, label: str, callback: Callable[[], None]) -> None:
         def _target() -> None:
@@ -406,9 +510,15 @@ class RunnerDaemon:
 
         self._run_side_effect(f"bind-runner-session-{name}", _bind)
 
-    def _sync_to_backend_async(self) -> None:
+    def _sync_to_backend_async(self, *, flush: bool = True) -> None:
+        # flush=True (default) keeps control-plane mutations and direct callers
+        # immediate; only the per-run-finish push opts into the trailing-edge
+        # debounce (flush=False).
         if not is_opencode_instance():
             return
+        self._sync_debouncer.request(flush=flush)
+
+    def _start_backend_sync(self) -> None:
         db_path = self._paths.db_path
 
         def _sync() -> None:
@@ -606,14 +716,30 @@ class RunnerDaemon:
                         f"reason={reason} scheduled_for={scheduled_for}\n"
                     ).encode()
                 )
-                popen = subprocess.Popen(  # noqa: S603
-                    cmd,
-                    cwd=str(self._paths.repo_root),
-                    env=env,
-                    stdout=log_f,
-                    stderr=subprocess.STDOUT,
-                    start_new_session=True,
-                )
+                popen: subprocess.Popen[bytes] | WarmChild | None = None
+                if self._warm_spawn_eligible(job_type=str(job.get("type")), env=env):
+                    # ANY warm-path failure (forkserver dead, import error,
+                    # pickling, ...) must land on the battle-tested Popen path:
+                    # these ticks trade real money.
+                    try:
+                        popen = self._spawn_warm_child(
+                            job_name=job_name, env=env, log_path=log_path
+                        )
+                    except Exception:  # noqa: BLE001
+                        logger.opt(exception=True).warning(
+                            f"Warm spawn failed for job {job_name}; "
+                            "falling back to subprocess"
+                        )
+                        popen = None
+                if popen is None:
+                    popen = subprocess.Popen(  # noqa: S603
+                        cmd,
+                        cwd=str(self._paths.repo_root),
+                        env=env,
+                        stdout=log_f,
+                        stderr=subprocess.STDOUT,
+                        start_new_session=True,
+                    )
         except Exception as exc:  # noqa: BLE001
             err_text = f"spawn failed: {exc}"
             self._db.finish_run(
@@ -691,6 +817,39 @@ class RunnerDaemon:
             return [sys.executable, str(script), *arg_list]
 
         raise ValueError(f"Unsupported job type: {job_type}")
+
+    def _warm_spawn_eligible(self, *, job_type: str, env: Mapping[str, str]) -> bool:
+        """Only jobs_v1 script-loop ticks go warm. Legacy scripts, strategy
+        jobs, and agent wrappers stay on the cold Popen path. `env` is the
+        full run environment (os.environ copy + payload env), so the
+        WAYFINDER_RUNNER_NO_FORK kill-switch works at either the daemon or
+        the per-job level."""
+        if job_type != JOB_TYPE_SCRIPT:
+            return False
+        no_fork = str(env.get("WAYFINDER_RUNNER_NO_FORK") or "").strip().lower()
+        if no_fork not in ("", "0", "false"):
+            return False
+        if env.get("WAYFINDER_JOB_AGENT_MODE"):
+            return False
+        if env.get("WAYFINDER_JOB_EXECUTION_CONTRACT") != "jobs_v1":
+            return False
+        return bool(env.get("WAYFINDER_JOB_DIR"))
+
+    def _spawn_warm_child(
+        self, *, job_name: str, env: dict[str, str], log_path: Path
+    ) -> WarmChild:
+        # Lazy import so a broken warm_spawn module degrades to the Popen
+        # fallback instead of failing daemon startup.
+        from wayfinder_paths.runner.warm_spawn import WarmSpawner
+
+        if self._warm_spawner is None:
+            self._warm_spawner = WarmSpawner()
+        return self._warm_spawner.spawn(
+            job_name=job_name,
+            env=env,
+            log_path=log_path,
+            cwd=self._paths.repo_root,
+        )
 
     # Control-plane methods (called by runnerctl over the local socket)
     def ctl_status(self) -> dict[str, Any]:

--- a/wayfinder_paths/runner/preload.py
+++ b/wayfinder_paths/runner/preload.py
@@ -1,0 +1,30 @@
+"""Forkserver preload for warm jobs_v1 ticks.
+
+Imported once inside the forkserver process (see `runner/warm_spawn.py`), so
+every forked tick starts with pandas and the jobs execution stack already in
+memory instead of cold-importing the full SDK per tick. Imports are
+best-effort: a broken heavy import must degrade to slower forks (the child
+re-imports and surfaces the real error in its own log), never kill the
+forkserver — the daemon would then fall back to cold `subprocess.Popen` ticks
+anyway.
+"""
+
+from __future__ import annotations
+
+import gc
+
+for _module_name in (
+    "pandas",
+    "wayfinder_paths.jobs.execution.primitives",
+    "wayfinder_paths.jobs.execution.engine",
+    "wayfinder_paths.jobs.execution.driver",
+):
+    try:
+        __import__(_module_name)
+    except Exception:  # noqa: BLE001 — degrade to a cold import in the child
+        pass
+
+# Move everything imported so far into the permanent generation: forked ticks
+# share these pages copy-on-write, and freezing keeps the child's first GC from
+# touching (and un-sharing) them.
+gc.freeze()

--- a/wayfinder_paths/runner/view_server.py
+++ b/wayfinder_paths/runner/view_server.py
@@ -1,0 +1,283 @@
+"""Resident HTTP view server inside the runner daemon.
+
+The Strategies UI used to fetch starters/backtest/forward payloads by exec'ing
+a cold `wayfinder` CLI on the box (~90 CPU-s per request under throttle). This
+server keeps those reads warm: a loopback-only ThreadingHTTPServer started by
+the daemon (like `RunnerControlServer`) that serves the exact CLI envelope
+`{"ok": true, "result": ...}` / `{"ok": false, "error": "..."}` so backend
+callers can swap `wayfinder job backtest-view ...` for
+`curl http://127.0.0.1:8646/backtest-view?...` byte-for-byte.
+
+Routes (GET only):
+- /health
+- /starters                                   -> jobs.starters.starter_catalog()
+- /backtest-view?job_id=...&view=...&series=...&from=...&to=...&max_points=...&proposal=...
+- /forward-view?job_id=...&view=...&series=...&from=...&to=...&max_points=...&no_prices=...
+
+Query params mirror the `wayfinder job backtest-view` / `forward-view` CLI
+options 1:1 (same names, same defaults, same coercions). Heavy jobs modules
+are lazy-imported inside handlers so daemon startup stays light. Bind failure
+is warn-and-continue: a box without a free port keeps running the scheduler,
+and the backend falls back to the cold CLI.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, urlsplit
+
+from loguru import logger
+
+from wayfinder_paths import __version__
+
+DEFAULT_VIEW_PORT = 8646
+PRICE_CACHE_TTL_SECONDS = 90.0
+
+
+def _view_port_from_env() -> int:
+    raw = os.environ.get("WAYFINDER_VIEW_PORT")
+    if raw is None or not str(raw).strip():
+        return DEFAULT_VIEW_PORT
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning(
+            f"Invalid WAYFINDER_VIEW_PORT={raw!r}; using {DEFAULT_VIEW_PORT}"
+        )
+        return DEFAULT_VIEW_PORT
+
+
+class _CachedPriceFetcher:
+    """Single-flight, per-job TTL cache around the forward view's venue fetch.
+
+    The UI polls the forward chart; without this every poll re-fetches the
+    OHLC window from the venue. One in-flight fetch per job (concurrent
+    requests wait and reuse the result), successes cached for the TTL,
+    failures propagate uncached so `load_forward_view` degrades with its
+    normal `price_note` and the next poll can retry.
+    """
+
+    def __init__(self, *, ttl_seconds: float = PRICE_CACHE_TTL_SECONDS) -> None:
+        self._ttl_seconds = float(ttl_seconds)
+        self._lock = threading.Lock()
+        self._job_locks: dict[str, threading.Lock] = {}
+        self._entries: dict[str, tuple[float, list[dict[str, Any]]]] = {}
+
+    def _job_lock(self, job_id: str) -> threading.Lock:
+        with self._lock:
+            lock = self._job_locks.get(job_id)
+            if lock is None:
+                lock = threading.Lock()
+                self._job_locks[job_id] = lock
+            return lock
+
+    def __call__(
+        self, job_id: str, ticks: list[dict[str, Any]], *, store: Any
+    ) -> list[dict[str, Any]]:
+        with self._job_lock(str(job_id)):
+            now = time.monotonic()
+            cached = self._entries.get(str(job_id))
+            if cached is not None and now - cached[0] < self._ttl_seconds:
+                return list(cached[1])
+
+            # Late import + module-attribute call: keeps daemon startup light
+            # and the seam monkeypatchable in tests.
+            from wayfinder_paths.jobs import forward_artifacts
+
+            series = forward_artifacts._fetch_price_series(job_id, ticks, store=store)
+            self._entries[str(job_id)] = (time.monotonic(), series)
+            return list(series)
+
+
+class _ViewRequestError(ValueError):
+    """Bad request (missing/invalid query param) -> 400 envelope."""
+
+
+def _scalar(params: dict[str, list[str]], name: str) -> str | None:
+    # Exact query-param names only (job_id, view, from, to, max_points,
+    # proposal, series, no_prices) — the backend builds URLs with precisely
+    # these spellings. Last occurrence wins, matching click's behavior.
+    values = params.get(name)
+    if not values:
+        return None
+    return values[-1]
+
+
+def _int_param(params: dict[str, list[str]], name: str, default: int) -> int:
+    raw = _scalar(params, name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise _ViewRequestError(f"{name} must be an integer, got {raw!r}") from exc
+
+
+def _flag_param(params: dict[str, list[str]], name: str) -> bool:
+    raw = _scalar(params, name)
+    if raw is None:
+        return False
+    return raw.strip().lower() not in ("", "0", "false", "no")
+
+
+def _require_job_id(params: dict[str, list[str]]) -> str:
+    job_id = _scalar(params, "job_id")
+    if not job_id:
+        raise _ViewRequestError("job_id is required")
+    return job_id
+
+
+class _ViewHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler contract
+        view_server: RunnerViewServer = self.server.view_server  # type: ignore[attr-defined]
+        url = urlsplit(self.path)
+        params = parse_qs(url.query, keep_blank_values=True)
+        try:
+            result = view_server.handle_route(url.path, params)
+        except _ViewRequestError as exc:
+            self._respond(400, {"ok": False, "error": str(exc)})
+            return
+        except KeyError:
+            self._respond(404, {"ok": False, "error": f"unknown route: {url.path}"})
+            return
+        except Exception as exc:  # noqa: BLE001 - envelope, never a stack page
+            logger.opt(exception=True).warning(f"View server error on {self.path}")
+            self._respond(500, {"ok": False, "error": str(exc)})
+            return
+        self._respond(200, {"ok": True, "result": result})
+
+    def _respond(self, status: int, payload: dict[str, Any]) -> None:
+        # Same serialization as the CLI's _echo_json -> byte-shape parity.
+        body = json.dumps(payload, indent=2, default=str).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        logger.debug(f"view-server {self.address_string()} {format % args}")
+
+
+class RunnerViewServer:
+    def __init__(
+        self,
+        *,
+        repo_root: Path,
+        host: str = "127.0.0.1",
+        port: int | None = None,
+    ) -> None:
+        self._repo_root = Path(repo_root)
+        self._host = host
+        self._port = _view_port_from_env() if port is None else int(port)
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+        self._price_fetcher = _CachedPriceFetcher()
+
+    @property
+    def port(self) -> int | None:
+        """The bound port (resolves 0 -> ephemeral), or None if not running."""
+        if self._server is None:
+            return None
+        return int(self._server.server_address[1])
+
+    def start(self) -> None:
+        class _Server(ThreadingHTTPServer):
+            daemon_threads = True
+            allow_reuse_address = True
+
+        try:
+            server = _Server((self._host, self._port), _ViewHandler)
+        except OSError as exc:
+            # Warn + continue: the scheduler must keep running without the
+            # warm view endpoint; backend callers fall back to the cold CLI.
+            logger.warning(
+                f"View server failed to bind {self._host}:{self._port}: {exc}; "
+                "continuing without it"
+            )
+            return
+        server.view_server = self  # type: ignore[attr-defined]
+        self._server = server
+
+        def _serve() -> None:
+            server.serve_forever(poll_interval=0.5)
+
+        self._thread = threading.Thread(
+            target=_serve, name="wayfinder-view-server", daemon=True
+        )
+        self._thread.start()
+        logger.info(f"View server listening on http://{self._host}:{self.port}")
+
+    def stop(self) -> None:
+        if self._server is not None:
+            try:
+                self._server.shutdown()
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                self._server.server_close()
+            except Exception:  # noqa: BLE001
+                pass
+            self._server = None
+        if self._thread is not None:
+            self._thread.join(timeout=2)
+            self._thread = None
+
+    # Route handling (called from handler threads)
+    def handle_route(self, path: str, params: dict[str, list[str]]) -> Any:
+        if path == "/health":
+            return {
+                "status": "ok",
+                "version": __version__,
+                "pid": os.getpid(),
+                "repo_root": str(self._repo_root),
+            }
+        if path == "/starters":
+            from wayfinder_paths.jobs.starters import starter_catalog
+
+            return starter_catalog()
+        if path == "/backtest-view":
+            return self._backtest_view(params)
+        if path == "/forward-view":
+            return self._forward_view(params)
+        raise KeyError(path)
+
+    def _store(self) -> Any:
+        from wayfinder_paths.jobs.store import JobStore
+
+        return JobStore(repo_root=self._repo_root)
+
+    def _backtest_view(self, params: dict[str, list[str]]) -> dict[str, Any]:
+        from wayfinder_paths.jobs.backtest_artifacts import load_backtest_view
+
+        return load_backtest_view(
+            _require_job_id(params),
+            store=self._store(),
+            view=_scalar(params, "view") or "all",
+            series_names=list(params.get("series") or []),
+            from_ts=_scalar(params, "from"),
+            to_ts=_scalar(params, "to"),
+            max_points=_int_param(params, "max_points", 1500),
+            proposal_id=_scalar(params, "proposal") or None,
+        )
+
+    def _forward_view(self, params: dict[str, list[str]]) -> dict[str, Any]:
+        from wayfinder_paths.jobs.forward_artifacts import load_forward_view
+
+        return load_forward_view(
+            _require_job_id(params),
+            store=self._store(),
+            view=_scalar(params, "view") or "all",
+            series_names=list(params.get("series") or []),
+            from_ts=_scalar(params, "from"),
+            to_ts=_scalar(params, "to"),
+            max_points=_int_param(params, "max_points", 1500),
+            include_prices=not _flag_param(params, "no_prices"),
+            price_fetcher=self._price_fetcher,
+        )

--- a/wayfinder_paths/runner/warm_spawn.py
+++ b/wayfinder_paths/runner/warm_spawn.py
@@ -1,0 +1,131 @@
+"""Warm forkserver spawner for jobs_v1 script ticks.
+
+Every scheduled jobs_v1 tick used to `subprocess.Popen` a fresh Python that
+cold-imports the full SDK (~30-90 CPU-s under throttle). `WarmSpawner` keeps a
+single forkserver process alive with the heavy modules preloaded
+(`runner/preload.py`) and forks each tick from that warm image instead. The
+fork preserves the daemon's whole bookkeeping contract:
+
+- `WarmChild` duck-types the `subprocess.Popen` surface `_reap` uses
+  (`.pid`, `.poll()`, `.returncode` — including `returncode is None` until an
+  exit has actually been observed, matching Popen after a `killpg`).
+- The child calls `os.setsid()` first, so the daemon's process-group kills
+  (timeout SIGKILL, shutdown/stop SIGTERM) land exactly as they do for Popen
+  workers started with `start_new_session=True`.
+- The child entry mirrors the compiler's jobs_v1 wrapper: log fds redirected
+  to the run's log file, env replaced with the run env the daemon built,
+  workspace on `sys.path`, `run_scheduled_tick(job_dir)`, exit code from
+  `payload["ok"]`.
+
+The daemon treats ANY exception from `WarmSpawner.spawn` as "use the cold
+Popen path" — these ticks trade real money, so the fallback must always be
+reachable (kill-switch: WAYFINDER_RUNNER_NO_FORK=1).
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+import sys
+import threading
+from pathlib import Path
+from typing import Any
+
+PRELOAD_MODULES = ("wayfinder_paths.runner.preload",)
+
+
+def _warm_tick_entry(*, env: dict[str, str], log_path: str, cwd: str) -> None:
+    """Runs inside the forked child. Mirrors the compiler's jobs_v1 wrapper
+    (jobs/compiler.py) plus the process setup Popen did for free."""
+    os.setsid()
+
+    fd = os.open(log_path, os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o644)
+    try:
+        sys.stdout.flush()
+        sys.stderr.flush()
+    except Exception:  # noqa: BLE001
+        pass
+    os.dup2(fd, 1)
+    os.dup2(fd, 2)
+    if fd > 2:
+        os.close(fd)
+
+    # Exact Popen(env=...) parity: the daemon built a full environment
+    # (os.environ copy + per-run keys + job payload env); replace, not merge.
+    os.environ.clear()
+    os.environ.update(env)
+    os.chdir(cwd)
+
+    job_dir = env["WAYFINDER_JOB_DIR"]
+    workspace = str(Path(job_dir) / "workspace")
+    if workspace not in sys.path:
+        sys.path.insert(0, workspace)
+
+    from wayfinder_paths.jobs.execution.driver import run_scheduled_tick
+
+    payload = run_scheduled_tick(job_dir)
+    raise SystemExit(0 if payload.get("ok") else 1)
+
+
+class WarmChild:
+    """Popen-shaped handle over a forked tick, for the daemon's `_reap`."""
+
+    def __init__(self, process: Any) -> None:
+        self._process = process
+        self.returncode: int | None = None
+
+    @property
+    def pid(self) -> int:
+        pid = self._process.pid
+        if pid is None:
+            raise RuntimeError("warm child has no pid (not started)")
+        return int(pid)
+
+    def poll(self) -> int | None:
+        if self.returncode is not None:
+            return self.returncode
+        # is_alive() reaps via the forkserver sentinel; exitcode is negative
+        # for signal deaths, same convention as subprocess.Popen.returncode.
+        if self._process.is_alive():
+            return None
+        exitcode = self._process.exitcode
+        if exitcode is None:
+            return None
+        self.returncode = int(exitcode)
+        return self.returncode
+
+
+class WarmSpawner:
+    def __init__(self, *, preload_modules: tuple[str, ...] = PRELOAD_MODULES) -> None:
+        self._preload_modules = preload_modules
+        self._lock = threading.Lock()
+        self._ctx: Any | None = None
+
+    def _context(self) -> Any:
+        with self._lock:
+            if self._ctx is None:
+                ctx = multiprocessing.get_context("forkserver")
+                ctx.set_forkserver_preload(list(self._preload_modules))
+                self._ctx = ctx
+            return self._ctx
+
+    def spawn(
+        self,
+        *,
+        job_name: str,
+        env: dict[str, str],
+        log_path: str | Path,
+        cwd: str | Path,
+    ) -> WarmChild:
+        process = self._context().Process(
+            target=_warm_tick_entry,
+            kwargs={
+                "env": dict(env),
+                "log_path": str(log_path),
+                "cwd": str(cwd),
+            },
+            name=f"wayfinder-warm-tick-{job_name}",
+            daemon=False,
+        )
+        process.start()
+        return WarmChild(process)

--- a/wayfinder_paths/tests/test_runner_e2e.py
+++ b/wayfinder_paths/tests/test_runner_e2e.py
@@ -178,6 +178,163 @@ def test_runner_daemon_run_once_executes_job_when_not_due(tmp_path: Path) -> Non
         shutil.rmtree(runner_dir, ignore_errors=True)
 
 
+# Executed INSIDE the forked warm child (via _load_strategy): registers an
+# offline replay venue at import time — module import happens before
+# build_adapter in the driver — so a real run_scheduled_tick completes
+# end-to-end with no network.
+_WARM_STRATEGY_SRC = """
+from __future__ import annotations
+
+import pandas as pd
+
+from wayfinder_paths.jobs.execution.preflight import (
+    ReplayAdapter,
+    ReplayBroker,
+    ReplayFeed,
+)
+from wayfinder_paths.jobs.execution.venues import register_venue
+
+
+def _bars() -> list[dict]:
+    end = pd.Timestamp.now(tz="UTC").floor("1h")
+    return [
+        {
+            "timestamp": (end - pd.Timedelta(hours=5 - i)).isoformat(),
+            "symbol": "TEST",
+            "open": 1.0,
+            "high": 1.1,
+            "low": 0.9,
+            "close": 1.0,
+        }
+        for i in range(6)
+    ]
+
+
+def _build_replay_adapter(*, mode, spec, params):
+    feed = ReplayFeed(_bars())
+    feed.cursor = 100  # serve the full dataset
+    return ReplayAdapter(feed=feed, broker=ReplayBroker())
+
+
+register_venue("warm_replay", _build_replay_adapter)
+
+
+def decide(ctx):
+    return None
+"""
+
+
+def test_runner_daemon_runs_warm_forked_jobs_v1_tick_end_to_end(
+    tmp_path: Path,
+) -> None:
+    """A jobs_v1 script tick routed through the forkserver warm path: the REAL
+    run_scheduled_tick executes in the forked child, its JSON payload lands in
+    the run log, the exit code is plumbed through WarmChild, and the daemon
+    reaps the run as OK. The registered script wrapper is a decoy that prints
+    a marker — if the daemon had fallen back to the cold Popen path, the
+    marker (and not the driver payload) would appear in the log."""
+    import json
+
+    from wayfinder_paths.jobs.models import WayfinderJob
+    from wayfinder_paths.jobs.store import JobStore
+
+    runner_dir = _short_runner_dir("wayfinder-runner-warm")
+    if runner_dir.exists():
+        shutil.rmtree(runner_dir, ignore_errors=True)
+    runner_dir.mkdir(parents=True, exist_ok=True)
+
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        "warm-e2e",
+        script="workspace/src/strategy.py",
+        interval_seconds=3600,
+        execution_contract="jobs_v1",
+    )
+    store.create_job(job)
+    root = store.job_dir(job.id)
+    (root / "workspace" / "src").mkdir(parents=True, exist_ok=True)
+    (root / "state").mkdir(parents=True, exist_ok=True)
+    (root / "workspace" / "src" / "strategy.py").write_text(
+        _WARM_STRATEGY_SRC, encoding="utf-8"
+    )
+    (root / "execution_spec.json").write_text(
+        json.dumps(
+            {
+                "data_contract": {
+                    "bar_interval": "1h",
+                    "symbols": ["TEST"],
+                    "market_kind": "swap",
+                },
+                "venues": ["warm_replay"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    runs_dir = tmp_path / ".wayfinder_runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    (runs_dir / "wrapper.py").write_text(
+        "print('POPEN_FALLBACK_MARKER')\n", encoding="utf-8"
+    )
+
+    paths = RunnerPaths(
+        repo_root=tmp_path,
+        runner_dir=runner_dir,
+        db_path=runner_dir / "state.db",
+        logs_dir=runner_dir / "logs",
+        sock_path=runner_dir / "runner.sock",
+    )
+
+    daemon = RunnerDaemon(paths=paths, tick_seconds=0.05, max_workers=2)
+    t = threading.Thread(target=daemon.start, name="runner-e2e-daemon-warm")
+    t.start()
+
+    client = RunnerControlClient(sock_path=paths.sock_path)
+    try:
+        _wait_for_status(client, timeout_s=10.0)
+
+        add = client.call(
+            "add_job",
+            {
+                "name": "warm-e2e-script",
+                "type": "script",
+                "payload": {
+                    "script_path": ".wayfinder_runs/wrapper.py",
+                    "env": {
+                        "WAYFINDER_JOB_EXECUTION_CONTRACT": "jobs_v1",
+                        "WAYFINDER_JOB_DIR": str(root),
+                        "WAYFINDER_JOB_MODE": "paper",
+                    },
+                },
+                "interval_seconds": 3600,
+            },
+        )
+        assert add.get("ok") is True, add
+
+        # Generous timeouts: the first warm spawn starts the forkserver and
+        # pays the preload (pandas + jobs execution stack) once.
+        run_id = _wait_for_job_run_id(client, name="warm-e2e-script", timeout_s=90.0)
+        report = _wait_for_run_finished(client, run_id=run_id, timeout_s=120.0)
+        assert report["result"]["run"]["status"] == RunStatus.OK, report
+        assert report["result"]["run"]["exit_code"] == 0
+        tail = report["result"]["log_tail"]
+        assert isinstance(tail, str)
+        assert "POPEN_FALLBACK_MARKER" not in tail  # warm path, not Popen
+        assert '"ok": true' in tail  # the real driver payload
+        assert '"job_id": "warm-e2e"' in tail
+        # The forked tick really ran the driver: forward artifacts were
+        # written into the job dir by the child.
+        assert (root / "results" / "forward" / "ticks.jsonl").exists()
+    finally:
+        try:
+            client.call("shutdown")
+        except Exception:  # noqa: BLE001
+            daemon.stop()
+        t.join(timeout=10)
+        assert not t.is_alive()
+        shutil.rmtree(runner_dir, ignore_errors=True)
+
+
 def test_detached_daemon_survives_parent_process_group_termination() -> None:
     if os.name == "nt":
         pytest.skip("POSIX-only (relies on process groups via killpg)")

--- a/wayfinder_paths/tests/test_runner_sync_debounce.py
+++ b/wayfinder_paths/tests/test_runner_sync_debounce.py
@@ -1,0 +1,207 @@
+"""The backend sync push is debounced on the run-finish path (trailing edge,
+coalescing) while start() and every ctl_* mutation keep an immediate flush.
+Both pushes (scheduled-jobs bulk_sync + wayfinder-jobs sync_all_jobs) live in
+the same debounced action, so they always fire together."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from wayfinder_paths.runner.constants import JOB_TYPE_SCRIPT, RunStatus
+from wayfinder_paths.runner.daemon import RunnerDaemon, RunningProcess
+from wayfinder_paths.runner.paths import RunnerPaths
+
+
+def _paths(tmp_path: Path) -> RunnerPaths:
+    runner_dir = tmp_path / ".wayfinder" / "runner"
+    return RunnerPaths(
+        repo_root=tmp_path,
+        runner_dir=runner_dir,
+        db_path=runner_dir / "state.db",
+        logs_dir=runner_dir / "logs",
+        sock_path=runner_dir / "runner.sock",
+    )
+
+
+def _wait_for(predicate, timeout_s: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.02)
+    return False
+
+
+def _daemon_with_sync_counter(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    debounce_seconds: str,
+) -> tuple[RunnerDaemon, list[float]]:
+    monkeypatch.setenv("OPENCODE_INSTANCE_ID", "inst-debounce")
+    monkeypatch.setenv("WAYFINDER_SYNC_DEBOUNCE_SECONDS", debounce_seconds)
+    daemon = RunnerDaemon(paths=_paths(tmp_path))
+    calls: list[float] = []
+    monkeypatch.setattr(
+        daemon, "_start_backend_sync", lambda: calls.append(time.monotonic())
+    )
+    return daemon, calls
+
+
+def test_finish_run_syncs_coalesce_on_the_trailing_edge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    daemon, calls = _daemon_with_sync_counter(
+        tmp_path, monkeypatch, debounce_seconds="0.2"
+    )
+
+    for _ in range(5):
+        daemon._sync_to_backend_async(flush=False)
+
+    assert calls == []  # trailing edge: nothing fires inside the window
+    assert _wait_for(lambda: len(calls) == 1)
+    time.sleep(0.3)
+    assert len(calls) == 1  # the burst coalesced into exactly one push
+
+
+def test_flush_runs_immediately_and_cancels_the_pending_timer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    daemon, calls = _daemon_with_sync_counter(
+        tmp_path, monkeypatch, debounce_seconds="0.2"
+    )
+
+    daemon._sync_to_backend_async(flush=False)
+    daemon._sync_to_backend_async(flush=True)
+
+    assert len(calls) == 1
+    time.sleep(0.35)
+    assert len(calls) == 1  # the pending debounced fire was cancelled
+
+
+def test_ctl_mutations_flush_immediately_even_with_a_long_debounce(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    daemon, calls = _daemon_with_sync_counter(
+        tmp_path, monkeypatch, debounce_seconds="600"
+    )
+    runs_dir = tmp_path / ".wayfinder_runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    (runs_dir / "hello.py").write_text("print('hi')\n", encoding="utf-8")
+
+    resp = daemon.ctl_add_job(
+        name="job-a",
+        job_type=JOB_TYPE_SCRIPT,
+        payload={"script_path": ".wayfinder_runs/hello.py"},
+        interval_seconds=60,
+    )
+    assert resp["ok"] is True
+    assert len(calls) == 1
+
+    assert daemon.ctl_pause_job(name="job-a")["ok"] is True
+    assert daemon.ctl_resume_job(name="job-a")["ok"] is True
+    assert daemon.ctl_delete_job(name="job-a")["ok"] is True
+    assert len(calls) == 4
+
+
+def test_finish_run_uses_the_debounced_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    daemon, calls = _daemon_with_sync_counter(
+        tmp_path, monkeypatch, debounce_seconds="0.2"
+    )
+    monkeypatch.setattr(daemon, "_report_finished_run", lambda *a, **k: None)
+    job_id = daemon._db.add_job(
+        name="job-a",
+        job_type=JOB_TYPE_SCRIPT,
+        payload={"script_path": "x.py"},
+        interval_seconds=60,
+        next_run_at=0,
+    )
+    now = int(time.time())
+    run_id = daemon._db.reserve_run(
+        job_id=job_id,
+        started_at=now,
+        next_run_at=now + 60,
+        reason="schedule",
+        scheduled_for=now,
+    )
+    rp = RunningProcess(
+        run_id=run_id,
+        job_id=job_id,
+        job_name="job-a",
+        started_at=now,
+        reason="schedule",
+        scheduled_for=now,
+        timeout_seconds=None,
+        popen=Mock(pid=123),
+        log_path=daemon._paths.logs_dir / "job-a" / f"{run_id}.log",
+    )
+
+    daemon._finish_run(
+        rp, finished_at=now, status=RunStatus.OK, exit_code=0, error_text=None
+    )
+
+    assert calls == []  # debounced, not immediate
+    assert _wait_for(lambda: len(calls) == 1)
+
+
+def test_stop_cancels_the_pending_debounced_sync(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    daemon, calls = _daemon_with_sync_counter(
+        tmp_path, monkeypatch, debounce_seconds="0.2"
+    )
+
+    daemon._sync_to_backend_async(flush=False)
+    daemon.stop()
+    time.sleep(0.35)
+
+    assert calls == []
+
+
+def test_non_positive_debounce_disables_the_delay(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    daemon, calls = _daemon_with_sync_counter(
+        tmp_path, monkeypatch, debounce_seconds="0"
+    )
+
+    daemon._sync_to_backend_async(flush=False)
+
+    assert len(calls) == 1
+
+
+def test_debounced_fire_runs_both_backend_pushes_together(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The action behind the debouncer is the real _start_backend_sync: one
+    fire drives BOTH the scheduled-jobs registry bulk_sync and the
+    wayfinder-jobs sync_all_jobs."""
+    from wayfinder_paths.core.clients.ScheduledJobsClient import SCHEDULED_JOBS_CLIENT
+
+    monkeypatch.setenv("OPENCODE_INSTANCE_ID", "inst-debounce")
+    monkeypatch.setenv("WAYFINDER_SYNC_DEBOUNCE_SECONDS", "0.1")
+    daemon = RunnerDaemon(paths=_paths(tmp_path))
+
+    bulk_calls: list[list[dict]] = []
+    sync_all_calls: list[dict] = []
+    monkeypatch.setattr(
+        SCHEDULED_JOBS_CLIENT, "bulk_sync", lambda jobs: bulk_calls.append(jobs)
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.sync.sync_all_jobs",
+        lambda **kwargs: sync_all_calls.append(kwargs),
+    )
+
+    daemon._sync_to_backend_async(flush=False)
+    daemon._sync_to_backend_async(flush=False)
+
+    assert _wait_for(lambda: len(bulk_calls) == 1 and len(sync_all_calls) == 1)
+    time.sleep(0.2)
+    assert len(bulk_calls) == 1
+    assert len(sync_all_calls) == 1

--- a/wayfinder_paths/tests/test_runner_view_server.py
+++ b/wayfinder_paths/tests/test_runner_view_server.py
@@ -1,0 +1,358 @@
+"""The resident view server must serve the EXACT payloads the cold CLI serves
+(`wayfinder job backtest-view` / `forward-view` / catalog `starters`), in the
+exact CLI envelope {"ok": true, "result": ...} — backend callers swap exec'ing
+the CLI for a loopback curl byte-for-byte. Bind failure is warn-and-continue:
+the daemon scheduler must keep running without it."""
+
+from __future__ import annotations
+
+import json
+import socket
+import threading
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from wayfinder_paths.jobs.backtest_artifacts import load_backtest_view
+from wayfinder_paths.jobs.forward_artifacts import load_forward_view
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.runner.view_server import RunnerViewServer
+
+
+def _get(port: int, path: str) -> tuple[int, dict]:
+    try:
+        with urllib.request.urlopen(f"http://127.0.0.1:{port}{path}") as resp:
+            return resp.status, json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as err:
+        return err.code, json.loads(err.read().decode("utf-8"))
+
+
+@pytest.fixture
+def server(tmp_path: Path):
+    view_server = RunnerViewServer(repo_root=tmp_path, port=0)
+    view_server.start()
+    assert view_server.port is not None
+    yield view_server
+    view_server.stop()
+
+
+def _seed_backtest_job(tmp_path: Path) -> JobStore:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("carry", script="strategy.py", interval_seconds=3600)
+    store.create_job(job)
+    visualization = {
+        "schema_version": "1.0",
+        "symbols": ["TEST"],
+        "series": [
+            {
+                "name": "TEST_price",
+                "kind": "market_price",
+                "symbol": "TEST",
+                "points": [
+                    {
+                        "timestamp": f"2026-07-14T{hour:02d}:00:00+00:00",
+                        "value": 1.0 + hour,
+                    }
+                    for hour in range(24)
+                ],
+            },
+            {
+                "name": "equity",
+                "kind": "equity_curve",
+                "symbol": None,
+                "points": [
+                    {
+                        "timestamp": f"2026-07-14T{hour:02d}:00:00+00:00",
+                        "value": 100.0 + hour,
+                    }
+                    for hour in range(24)
+                ],
+            },
+        ],
+        "markers": [
+            {
+                "timestamp": "2026-07-14T02:00:00+00:00",
+                "symbol": "TEST",
+                "kind": "entry",
+            }
+        ],
+        "validation": {"status": "passed"},
+    }
+    latest = {
+        "run_id": "run-1",
+        "stats": {"net_pnl": 1.5},
+        "trades": [{"symbol": "TEST", "net_pnl": 1.5}],
+        "validation": {"status": "passed"},
+    }
+    store.write_json("carry", "results/backtest/visualization.json", visualization)
+    store.write_json("carry", "results/backtest/latest.json", latest)
+    return store
+
+
+def _seed_forward_job(tmp_path: Path) -> JobStore:
+    """Trimmed version of the forward-view artifact fixture
+    (test_jobs_forward_view): fills + trades + ticks jsonl."""
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("carry", script="strategy.py", interval_seconds=3600)
+    job.execution_params["initial_capital"] = 100.0
+    store.create_job(job)
+    forward = store.job_dir("carry") / "results" / "forward"
+    forward.mkdir(parents=True, exist_ok=True)
+
+    def write_jsonl(name: str, rows: list[dict]) -> None:
+        (forward / name).write_text(
+            "".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8"
+        )
+
+    write_jsonl(
+        "fills.jsonl",
+        [
+            {
+                "kind": "fill",
+                "timestamp": "2026-07-14T05:00:00+00:00",
+                "symbol": "IMX",
+                "side": "sell",
+                "avg_price": 0.130,
+                "filled_size": 700.0,
+                "reduce_only": False,
+                "status": "filled",
+                "mode": "paper",
+            },
+            {
+                "kind": "fill",
+                "timestamp": "2026-07-15T10:00:00+00:00",
+                "symbol": "IMX",
+                "side": "buy",
+                "avg_price": 0.128,
+                "filled_size": 700.0,
+                "reduce_only": True,
+                "status": "filled",
+                "mode": "paper",
+            },
+        ],
+    )
+    write_jsonl(
+        "trades.jsonl",
+        [
+            {
+                "kind": "trade",
+                "symbol": "IMX",
+                "side": "buy",
+                "net_pnl": 1.4,
+                "closed_at": "2026-07-15T10:00:00+00:00",
+                "mode": "paper",
+            }
+        ],
+    )
+    write_jsonl(
+        "ticks.jsonl",
+        [
+            {
+                "kind": "tick",
+                "bar_ts": f"2026-07-14T{hour:02d}:00:00+00:00",
+                "mode": "paper",
+                "ledger": {"realized_pnl": 0.0, "positions": {}},
+            }
+            for hour in range(4)
+        ]
+        + [
+            {
+                "kind": "tick",
+                "bar_ts": "2026-07-15T10:00:00+00:00",
+                "mode": "paper",
+                "ledger": {"realized_pnl": 1.4, "positions": {}},
+            }
+        ],
+    )
+    return store
+
+
+def test_health_route(server: RunnerViewServer) -> None:
+    status, body = _get(server.port, "/health")
+    assert status == 200
+    assert body["ok"] is True
+    assert body["result"]["status"] == "ok"
+
+
+def test_starters_route_serves_the_bare_catalog_list(server: RunnerViewServer) -> None:
+    from wayfinder_paths.jobs.starters import starter_catalog
+
+    status, body = _get(server.port, "/starters")
+    assert status == 200
+    assert body["ok"] is True
+    assert isinstance(body["result"], list)
+    assert body["result"] == json.loads(json.dumps(starter_catalog(), default=str))
+
+
+def test_backtest_view_parity_with_direct_loader(
+    tmp_path: Path, server: RunnerViewServer
+) -> None:
+    _seed_backtest_job(tmp_path)
+    query = (
+        "job_id=carry&view=legs&series=TEST_price&max_points=100"
+        "&from=2026-07-14T01:00:00%2B00:00&to=2026-07-14T20:00:00%2B00:00"
+    )
+
+    status, body = _get(server.port, f"/backtest-view?{query}")
+
+    direct = load_backtest_view(
+        "carry",
+        store=JobStore(repo_root=tmp_path),
+        view="legs",
+        series_names=["TEST_price"],
+        from_ts="2026-07-14T01:00:00+00:00",
+        to_ts="2026-07-14T20:00:00+00:00",
+        max_points=100,
+        proposal_id=None,
+    )
+    assert status == 200
+    assert body == {"ok": True, "result": json.loads(json.dumps(direct, default=str))}
+    assert body["result"]["available"] is True
+    assert [s["name"] for s in body["result"]["visualization"]["series"]] == [
+        "TEST_price"
+    ]
+
+
+def test_forward_view_parity_with_direct_loader(
+    tmp_path: Path, server: RunnerViewServer
+) -> None:
+    _seed_forward_job(tmp_path)
+
+    status, body = _get(server.port, "/forward-view?job_id=carry&view=all&no_prices=1")
+
+    direct = load_forward_view(
+        "carry",
+        store=JobStore(repo_root=tmp_path),
+        view="all",
+        include_prices=False,
+    )
+    assert status == 200
+    assert body == {"ok": True, "result": json.loads(json.dumps(direct, default=str))}
+    assert body["result"]["summary"]["pnl_by_mode"] == {"paper": 1.4, "live": 0.0}
+
+
+def test_forward_view_price_fetch_is_ttl_cached_and_injected(
+    tmp_path: Path, server: RunnerViewServer, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two polls inside the TTL hit the venue exactly once — the server passes
+    its cached single-flight fetcher through load_forward_view's price_fetcher
+    seam."""
+    import wayfinder_paths.jobs.forward_artifacts as forward_artifacts
+
+    _seed_forward_job(tmp_path)
+    calls: list[str] = []
+
+    def _fake_fetch(job_id: str, ticks: list[dict], *, store) -> list[dict]:
+        calls.append(job_id)
+        return [
+            {
+                "name": "IMX_price",
+                "kind": "market_price",
+                "symbol": "IMX",
+                "venue": "fake",
+                "points": [],
+            }
+        ]
+
+    monkeypatch.setattr(forward_artifacts, "_fetch_price_series", _fake_fetch)
+
+    for _ in range(2):
+        status, body = _get(server.port, "/forward-view?job_id=carry")
+        assert status == 200
+        assert body["ok"] is True
+        kinds = {s["kind"] for s in body["result"]["visualization"]["series"]}
+        assert "market_price" in kinds
+
+    assert calls == ["carry"]  # second request served from the 90s TTL cache
+
+
+def test_missing_job_id_is_a_400_envelope(server: RunnerViewServer) -> None:
+    status, body = _get(server.port, "/backtest-view?view=all")
+    assert status == 400
+    assert body["ok"] is False
+    assert "job_id" in body["error"]
+
+
+def test_unknown_route_is_a_404_envelope(server: RunnerViewServer) -> None:
+    status, body = _get(server.port, "/nope")
+    assert status == 404
+    assert body["ok"] is False
+
+
+def test_invalid_max_points_is_a_400_envelope(
+    tmp_path: Path, server: RunnerViewServer
+) -> None:
+    _seed_backtest_job(tmp_path)
+    status, body = _get(server.port, "/backtest-view?job_id=carry&max_points=lots")
+    assert status == 400
+    assert body["ok"] is False
+    assert "max_points" in body["error"]
+
+
+def test_bind_failure_warns_and_continues(tmp_path: Path) -> None:
+    blocker = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    blocker.bind(("127.0.0.1", 0))
+    blocker.listen(1)
+    taken_port = blocker.getsockname()[1]
+    try:
+        view_server = RunnerViewServer(repo_root=tmp_path, port=taken_port)
+        view_server.start()  # must not raise
+        assert view_server.port is None
+        view_server.stop()  # idempotent no-op
+    finally:
+        blocker.close()
+
+
+def test_daemon_starts_and_stops_the_view_server(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Started like RunnerControlServer: alive while the daemon runs, gone
+    after shutdown. WAYFINDER_VIEW_PORT=0 -> ephemeral port for the test."""
+    import shutil
+
+    from wayfinder_paths.runner.client import RunnerControlClient
+    from wayfinder_paths.runner.daemon import RunnerDaemon
+    from wayfinder_paths.runner.paths import RunnerPaths
+
+    monkeypatch.setenv("WAYFINDER_VIEW_PORT", "0")
+    # Short /tmp dir: pytest tmp_path is too long for AF_UNIX socket paths
+    # (same pattern as test_runner_e2e).
+    runner_dir = Path("/tmp") / f"wf-viewsrv-{time.time_ns()}"
+    runner_dir.mkdir(parents=True, exist_ok=True)
+    paths = RunnerPaths(
+        repo_root=tmp_path,
+        runner_dir=runner_dir,
+        db_path=runner_dir / "state.db",
+        logs_dir=runner_dir / "logs",
+        sock_path=runner_dir / "runner.sock",
+    )
+    daemon = RunnerDaemon(paths=paths, tick_seconds=0.05)
+    thread = threading.Thread(target=daemon.start, name="runner-view-daemon")
+    thread.start()
+    client = RunnerControlClient(sock_path=paths.sock_path)
+    try:
+        deadline = time.time() + 10.0
+        while time.time() < deadline:
+            if client.call("status").get("ok"):
+                break
+            time.sleep(0.1)
+        assert daemon._view_server is not None
+        port = daemon._view_server.port
+        assert port is not None
+
+        status, body = _get(port, "/health")
+        assert status == 200
+        assert body["ok"] is True
+    finally:
+        try:
+            client.call("shutdown")
+        except Exception:  # noqa: BLE001
+            daemon.stop()
+        thread.join(timeout=5)
+        shutil.rmtree(runner_dir, ignore_errors=True)
+    assert not thread.is_alive()
+    assert daemon._view_server is None

--- a/wayfinder_paths/tests/test_runner_warm_spawn.py
+++ b/wayfinder_paths/tests/test_runner_warm_spawn.py
@@ -1,0 +1,189 @@
+"""WarmChild must duck-type exactly the Popen surface the daemon's _reap uses
+(.pid, .poll(), .returncode — None until an exit is observed), the daemon's
+process-group kills must land on a setsid'd forked child, and ANY warm-spawn
+failure must fall back to the cold Popen path (these ticks trade real money).
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+import signal
+import time
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from wayfinder_paths.runner.constants import JOB_TYPE_SCRIPT
+from wayfinder_paths.runner.daemon import RunnerDaemon, _kill_process_group
+from wayfinder_paths.runner.paths import RunnerPaths
+from wayfinder_paths.runner.warm_spawn import WarmChild
+
+
+def _forkserver_ctx() -> multiprocessing.context.BaseContext:
+    return multiprocessing.get_context("forkserver")
+
+
+# Module-level targets: the forkserver child imports this test module by name
+# to unpickle them, so they must not be nested.
+def _exit_with_code_7() -> None:
+    raise SystemExit(7)
+
+
+def _setsid_and_sleep() -> None:
+    os.setsid()
+    time.sleep(60)
+
+
+def _wait_for(predicate, timeout_s: float = 30.0) -> bool:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return False
+
+
+def test_warm_child_poll_reports_none_then_the_exit_code() -> None:
+    process = _forkserver_ctx().Process(target=_exit_with_code_7, daemon=False)
+    process.start()
+    child = WarmChild(process)
+
+    assert child.pid == process.pid
+    assert child.returncode is None  # never an exit code before one exists
+    assert _wait_for(lambda: child.poll() is not None)
+    assert child.poll() == 7
+    assert child.returncode == 7
+
+
+def test_warm_child_killpg_timeout_kill_lands_on_the_sleeping_child() -> None:
+    """Exactly what _reap does on timeout: killpg(SIGKILL) against the child's
+    pid — valid only because the warm entry calls os.setsid() first, mirroring
+    Popen(start_new_session=True)."""
+    process = _forkserver_ctx().Process(target=_setsid_and_sleep, daemon=False)
+    process.start()
+    child = WarmChild(process)
+
+    assert _wait_for(lambda: os.getpgid(child.pid) == child.pid)  # setsid has happened
+    assert child.poll() is None
+    _kill_process_group(child.pid, sig=signal.SIGKILL)
+    assert _wait_for(lambda: child.poll() is not None)
+    assert child.poll() == -signal.SIGKILL  # Popen's signal-death convention
+    assert child.returncode == -signal.SIGKILL
+
+
+def _paths(tmp_path: Path) -> RunnerPaths:
+    runner_dir = tmp_path / ".wayfinder" / "runner"
+    return RunnerPaths(
+        repo_root=tmp_path,
+        runner_dir=runner_dir,
+        db_path=runner_dir / "state.db",
+        logs_dir=runner_dir / "logs",
+        sock_path=runner_dir / "runner.sock",
+    )
+
+
+def _jobs_v1_env(job_dir: str = "/tmp/job") -> dict[str, str]:
+    return {
+        "WAYFINDER_JOB_EXECUTION_CONTRACT": "jobs_v1",
+        "WAYFINDER_JOB_DIR": job_dir,
+    }
+
+
+def test_warm_spawn_eligibility_gates(tmp_path: Path) -> None:
+    daemon = RunnerDaemon(paths=_paths(tmp_path))
+    eligible = daemon._warm_spawn_eligible
+
+    assert eligible(job_type=JOB_TYPE_SCRIPT, env=_jobs_v1_env()) is True
+    assert eligible(job_type="strategy", env=_jobs_v1_env()) is False
+    assert (
+        eligible(
+            job_type=JOB_TYPE_SCRIPT,
+            env={**_jobs_v1_env(), "WAYFINDER_RUNNER_NO_FORK": "1"},
+        )
+        is False
+    )
+    assert (
+        eligible(
+            job_type=JOB_TYPE_SCRIPT,
+            env={**_jobs_v1_env(), "WAYFINDER_RUNNER_NO_FORK": "0"},
+        )
+        is True
+    )
+    assert (
+        eligible(
+            job_type=JOB_TYPE_SCRIPT,
+            env={**_jobs_v1_env(), "WAYFINDER_JOB_AGENT_MODE": "monitor"},
+        )
+        is False
+    )
+    assert (
+        eligible(
+            job_type=JOB_TYPE_SCRIPT,
+            env={**_jobs_v1_env(), "WAYFINDER_JOB_EXECUTION_CONTRACT": "legacy"},
+        )
+        is False
+    )
+    assert (
+        eligible(
+            job_type=JOB_TYPE_SCRIPT,
+            env={"WAYFINDER_JOB_EXECUTION_CONTRACT": "jobs_v1"},
+        )
+        is False
+    )  # no WAYFINDER_JOB_DIR
+
+
+def test_warm_spawn_failure_falls_back_to_popen(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runs_dir = tmp_path / ".wayfinder_runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    (runs_dir / "tick.py").write_text("print('hi')\n", encoding="utf-8")
+
+    daemon = RunnerDaemon(paths=_paths(tmp_path))
+    resp = daemon.ctl_add_job(
+        name="warm-job",
+        job_type=JOB_TYPE_SCRIPT,
+        payload={
+            "script_path": ".wayfinder_runs/tick.py",
+            "env": _jobs_v1_env(str(tmp_path / "jobdir")),
+        },
+        interval_seconds=60,
+    )
+    assert resp["ok"] is True
+
+    def _boom(**_kwargs):
+        raise RuntimeError("forkserver is dead")
+
+    monkeypatch.setattr(daemon, "_spawn_warm_child", _boom)
+    popen = Mock()
+    popen.pid = 4242
+    popen_calls: list[tuple] = []
+    monkeypatch.setattr(
+        "subprocess.Popen",
+        lambda *args, **kwargs: popen_calls.append((args, kwargs)) or popen,
+    )
+
+    job, state = daemon._db.get_job(name="warm-job")
+    run_id = daemon._maybe_start_job(
+        job={
+            "id": job.id,
+            "name": job.name,
+            "type": job.type,
+            "payload": job.payload,
+            "interval_seconds": job.interval_seconds,
+            "schedule_kind": job.schedule_kind,
+            "cron_expr": job.cron_expr,
+            "timezone": job.timezone,
+            "next_run_at": int(time.time()),
+        },
+        now=int(time.time()),
+        reason="schedule",
+    )
+
+    assert run_id is not None
+    assert len(popen_calls) == 1  # cold path took over
+    run = daemon._db.get_run(run_id=run_id)
+    assert run is not None and run["pid"] == 4242
+    assert daemon._running[run_id].popen is popen


### PR DESCRIPTION
Implements items 1–3 of the warm-path plan for the jobs box (fit the box in $25/mo: cut sustained CPU that is overhead, not work). Each change is independently safe and degrades to today's behavior.

## 1. Sync debounce (`runner/daemon.py`)

- New `_SyncDebouncer`: trailing-edge `threading.Timer`, default **90s**, env `WAYFINDER_SYNC_DEBOUNCE_SECONDS` (non-positive disables the delay).
- `_finish_run` → debounced `request()`; a burst of run finishes coalesces into one push per quiet window instead of one full-SDK sync thread per run.
- Both pushes (scheduled-jobs registry `bulk_sync` + wayfinder-jobs `sync_all_jobs`) live in the same debounced action, so they always fire together.
- `start()` and every `ctl_*` mutation keep an immediate flush; `stop()` cancels the pending timer.

## 2. Forkserver warm spawner for jobs_v1 ticks (`runner/warm_spawn.py`, `runner/preload.py`)

- `WarmSpawner` forks each jobs_v1 script tick from a single `multiprocessing` **forkserver** with `runner/preload.py` preloaded (pandas + `jobs.execution` primitives/engine/driver, `gc.freeze()`), replacing the cold per-tick Python that re-imports the whole SDK.
- `WarmChild` duck-types exactly the Popen surface `_reap` uses: `.pid`, `.poll()`, `.returncode` (None until an exit is observed — matching Popen after a timeout `killpg`; signal deaths surface as negative codes).
- Child entry mirrors the compiler's jobs_v1 wrapper plus what Popen did for free: `os.setsid()` (so the daemon's `killpg` timeout/shutdown kills land), dup2 of the run log onto stdout/stderr, full env replacement, `chdir(repo_root)`, workspace on `sys.path`, `run_scheduled_tick(job_dir)`, exit code from `payload["ok"]`.
- Gate: script job + `WAYFINDER_JOB_EXECUTION_CONTRACT == "jobs_v1"` (new in `jobs/compiler.py::_job_env`) + `WAYFINDER_JOB_DIR` + not an agent wrapper (`WAYFINDER_JOB_AGENT_MODE`) + kill-switch `WAYFINDER_RUNNER_NO_FORK` unset. Legacy scripts, strategy jobs, and agent wakes stay on Popen.
- **Safety:** ANY exception on the warm path (forkserver dead, import error, pickling…) logs a warning and falls back to the existing Popen path — these ticks trade real money, so the cold path is always reachable.
- Preload imports are individually best-effort: a broken heavy import degrades to slower forks instead of killing the forkserver.

## 3. Resident view server (`runner/view_server.py`)

- `ThreadingHTTPServer` on `127.0.0.1:${WAYFINDER_VIEW_PORT:-8646}`, started/stopped by the daemon exactly like `RunnerControlServer`; **bind failure = warn + continue** (scheduler keeps running, backend falls back to the cold CLI).
- Routes `/health`, `/starters` (bare catalog list), `/backtest-view`, `/forward-view`. Query params are a 1:1 spelling of the CLI flags: `job_id`, `view`, `series` (repeatable), `from`, `to`, `max_points`, `proposal` (backtest), `no_prices` (forward) — same defaults and coercions as `wayfinder job backtest-view` / `forward-view`.
- Responses are the exact CLI envelope `{"ok": true, "result": ...}` / `{"ok": false, "error": "..."}`, serialized with the CLI's `json.dumps(..., indent=2, default=str)`, `application/json`. Bad params → 400 envelope, unknown route → 404 envelope, handler errors → 500 envelope.
- Heavy jobs modules are lazy-imported inside handlers; `JobStore(repo_root=paths.repo_root)` per request.
- `load_forward_view` gains an optional `price_fetcher` kwarg (default = current direct venue fetch); the view server injects a **90s-TTL single-flight per-job cache** so UI polling cannot hammer the venue. Failures propagate uncached (normal `price_note` degradation).

## Tests

`pytest -k "jobs or runner or mcp"`: **919 passed, 3 skipped** (baseline 897 passed, 3 skipped; +22 new, no regressions).

- `test_runner_sync_debounce.py` (7): trailing-edge coalescing, flush-cancels-pending, ctl_* immediate, `_finish_run` debounced, stop cancels, zero-delay disable, both pushes fire together.
- `test_runner_warm_spawn.py` (4): `WarmChild.poll()` semantics (None → exit code; signal death → negative), `killpg` SIGKILL on a setsid'd sleeping forked child, eligibility gates, spawn-failure → Popen fallback with run bookkeeping intact.
- `test_runner_e2e.py` (+1): real forked jobs_v1 tick end-to-end through the daemon — the actual `run_scheduled_tick` runs in the forked child against an offline replay venue (registered at strategy import), run reaped OK with exit 0, driver JSON in the run log, decoy Popen wrapper proves the warm path was taken, forward artifacts written by the child.
- `test_runner_view_server.py` (10): byte-shape parity with direct `load_backtest_view`/`load_forward_view` (including `from`/`to`/`series`/`max_points`), envelope contract (200/400/404), bare starters list, TTL price-fetch caching through the injected seam, bind-failure warn+continue, daemon start/stop integration.

## Notes / deviations from the plan

- Plan line refs for `daemon.py` (:343, :592–:607) and `compiler.py` (:148–170, :219–233) had drifted slightly on current `wayfinder-jobs-v1`; the real seams (`_finish_run`, `_maybe_start_job` spawn block, jobs_v1 wrapper, `_job_env`) were located and used.
- `_sync_to_backend_async` keeps **flush as the default**; only `_finish_run` opts into debouncing. Same call-site mapping as the plan, but existing direct callers (and `test_runner_reconcile.py`) keep immediate semantics.
- The warm e2e uses the driver's real code path with an offline replay venue (`preflight.ReplayFeed/ReplayBroker`) registered from the job's strategy module — a genuinely successful `ok: true` tick with zero network, rather than mocking across the fork boundary (test-process monkeypatches don't cross the forkserver).
- `WarmChild` wraps `multiprocessing`'s forkserver `Process` (sentinel-based `poll`, exit codes delivered via the forkserver pipe) rather than raw fds — same observable semantics as Popen for everything `_reap` touches.

Rollout: bake + roll boxes, then the backend warm-curl fallback PR. `WAYFINDER_RUNNER_NO_FORK=1` reverts ticks to cold Popen without a deploy; unset `WAYFINDER_SYNC_DEBOUNCE_SECONDS`/set `0` reverts sync behavior; the view server is additive.
