### PR TITLE
Signing - Session-renewal prompt on every transaction path

### DIFF
--- a/wayfinder_paths/core/utils/signing_errors.py
+++ b/wayfinder_paths/core/utils/signing_errors.py
@@ -1,0 +1,18 @@
+class SessionExpiredError(RuntimeError):
+    """Raised when the backend rejects a signature because the wallet's signing
+    session has lapsed. Carries an agent-facing message telling the user how to
+    renew, so the agent surfaces that instead of a raw HTTP error.
+
+    Lives in its own import-free module so both the sign-callback path
+    (wallets.py) and the sponsored-broadcast path (transaction.py) can raise it
+    without the circular import those two modules have with each other."""
+
+
+# The backend 404s a signature request once the session/policy TTL elapses. The
+# agent reads this verbatim, so it's phrased as an instruction to the agent.
+SESSION_EXPIRED_MESSAGE = (
+    "Your wallet signing session has expired, so the transaction was not "
+    "submitted. Do not retry automatically. Send the user a message with this "
+    "link — https://wayfinder.ai/app/shells — asking them to open it, sign in, "
+    "and renew their trading session, then try again once they confirm it's active."
+)

--- a/wayfinder_paths/core/utils/transaction.py
+++ b/wayfinder_paths/core/utils/transaction.py
@@ -20,6 +20,10 @@ from wayfinder_paths.core.constants.chains import (
     MIN_PRIORITY_FEE_BY_CHAIN_ID,
     PRE_EIP_1559_CHAIN_IDS,
 )
+from wayfinder_paths.core.utils.signing_errors import (
+    SESSION_EXPIRED_MESSAGE,
+    SessionExpiredError,
+)
 from wayfinder_paths.core.utils.web3 import (
     _is_gorlami_fork_rpc,
     get_transaction_chain_id,
@@ -312,6 +316,11 @@ async def send_sponsored_transaction(wallet_address: str, transaction: dict) -> 
             wallet_address, _prepare_tx_for_privy(tx)
         )
     except httpx.HTTPStatusError as exc:
+        # 404 is the backend's expired/paused-session signal. The sponsored
+        # path never touches the sign callback, so translate it here too. Lazy
+        # import for the same cycle documented above.
+        if exc.response.status_code == 404:
+            raise SessionExpiredError(SESSION_EXPIRED_MESSAGE) from exc
         # A 4xx means the broadcaster refused the submission (sponsorship
         # disabled, credits depleted, chain not covered, or the daily quota is
         # spent — 429) and nothing reached the chain, so it's safe to retry

--- a/wayfinder_paths/core/utils/wallets.py
+++ b/wayfinder_paths/core/utils/wallets.py
@@ -20,6 +20,10 @@ from wayfinder_paths.core.config import (
     write_wallet_mnemonic,
 )
 from wayfinder_paths.core.constants.chains import SVM_CHAIN_IDS
+from wayfinder_paths.core.utils.signing_errors import (
+    SESSION_EXPIRED_MESSAGE,
+    SessionExpiredError,
+)
 from wayfinder_paths.policies.session import build_session_policy, build_strategy_policy
 
 _DEFAULT_EVM_ACCOUNT_PATH_TEMPLATE = "m/44'/60'/0'/0/{index}"
@@ -235,22 +239,6 @@ def _prepare_tx_for_privy(transaction: dict) -> dict:
     if isinstance(tx.get("to"), bytes) and not tx["to"]:
         del tx["to"]
     return tx
-
-
-class SessionExpiredError(RuntimeError):
-    """Raised when the backend rejects a signature because the wallet's signing
-    session has lapsed. Carries an agent-facing message telling the user how to
-    renew, so the agent surfaces that instead of a raw HTTP error."""
-
-
-# The backend 404s a signature request once the session/policy TTL elapses. The
-# agent reads this verbatim, so it's phrased as an instruction to the agent.
-SESSION_EXPIRED_MESSAGE = (
-    "Your wallet signing session has expired, so the transaction was not "
-    "submitted. Do not retry automatically. Send the user a message with this "
-    "link — https://wayfinder.ai/app/shells — asking them to open it, sign in, "
-    "and renew their trading session, then try again once they confirm it's active."
-)
 
 
 def get_remote_sign_callback(wallet_address: str):

--- a/wayfinder_paths/mcp/tools/execute.py
+++ b/wayfinder_paths/mcp/tools/execute.py
@@ -32,6 +32,7 @@ from wayfinder_paths.core.utils.tokens import (
 from wayfinder_paths.core.utils.transaction import send_transaction
 from wayfinder_paths.core.utils.units import from_erc20_raw
 from wayfinder_paths.core.utils.wallets import (
+    SessionExpiredError,
     find_wallet_leg_for_chain,
     get_wallet_signing_callback_for_chain,
     is_solana_enabled,
@@ -145,6 +146,10 @@ async def _broadcast(
         if explorer_link:
             result["explorer_url"] = explorer_link
         return True, result
+    except SessionExpiredError:
+        # Let the expired-session signal bubble to @catch_errors instead of
+        # collapsing into a generic failed-broadcast tuple.
+        raise
     except Exception as e:
         return False, {"error": sanitize_for_json(str(e)), "chain_id": chain_id}
 
@@ -180,6 +185,10 @@ async def _broadcast_svm(
             result["fee_lamports"] = int(fee_lamports)
             result["fee_sol"] = int(fee_lamports) / 10**SOL_DECIMALS
         return True, result
+    except SessionExpiredError:
+        # Let the expired-session signal bubble to @catch_errors instead of
+        # collapsing into a generic failed-broadcast tuple.
+        raise
     except Exception as e:
         return False, {"error": sanitize_for_json(str(e)), "chain_id": chain_id}
 

--- a/wayfinder_paths/tests/test_session_expired_signing.py
+++ b/wayfinder_paths/tests/test_session_expired_signing.py
@@ -5,12 +5,13 @@ from unittest.mock import AsyncMock, patch
 import httpx
 import pytest
 
-from wayfinder_paths.core.utils import wallets
+from wayfinder_paths.core.utils import transaction, wallets
 from wayfinder_paths.core.utils.wallets import (
     SESSION_EXPIRED_MESSAGE,
     SessionExpiredError,
     get_remote_sign_callback,
 )
+from wayfinder_paths.mcp.tools import execute
 from wayfinder_paths.mcp.utils import catch_errors
 
 
@@ -54,3 +55,37 @@ async def test_catch_errors_surfaces_session_expired_code():
     assert result["ok"] is False
     assert result["error"]["code"] == "session_expired"
     assert "wayfinder.ai/app/shells" in result["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_broadcast_reraises_session_expired_not_swallow():
+    # The broadcast helper swallows most errors into a failed tuple; the
+    # session-expired signal must bubble past it to @catch_errors instead.
+    with patch.object(
+        execute, "send_transaction", AsyncMock(side_effect=SessionExpiredError("x"))
+    ):
+        with pytest.raises(SessionExpiredError):
+            await execute._broadcast(lambda tx: None, {"to": "0x"}, chain_id=8453)
+
+
+@pytest.mark.asyncio
+async def test_broadcast_still_swallows_other_errors():
+    with patch.object(
+        execute, "send_transaction", AsyncMock(side_effect=RuntimeError("nope"))
+    ):
+        ok_flag, result = await execute._broadcast(
+            lambda tx: None, {"to": "0x"}, chain_id=8453
+        )
+    assert ok_flag is False
+    assert "nope" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_sponsored_send_maps_404_to_session_expired():
+    # The gas-sponsored path never touches the sign callback, so the 404 must
+    # be translated where the sponsored broadcast happens.
+    client = AsyncMock()
+    client.send_privy_transaction_sponsored = AsyncMock(side_effect=_http_error(404))
+    with patch.object(transaction, "_wallet_client", lambda: client):
+        with pytest.raises(SessionExpiredError):
+            await transaction.send_sponsored_transaction("0xabc", {"chainId": 8453})


### PR DESCRIPTION
### Summary
Follow-up to #670, which only fired on the non-sponsored local-sign path. Two gaps closed so the renewal prompt reaches the agent for real transactions:

1. **Broadcast swallow.** `_broadcast` / `_broadcast_svm` caught every exception into a failed tuple, hiding `SessionExpiredError` from `@catch_errors`. They now re-raise it. (The approval path via `ensure_allowance` already propagated.)
2. **Gas-sponsored path.** On sponsored chains (Ethereum, Base, Arbitrum, BSC, Polygon, Monad, MegaETH, Plasma, Robinhood) `send_transaction` routes to `send_sponsored_transaction` and never touches the sign callback — so the expired-session 404 was never translated. It now maps that 404 to `SessionExpiredError` at the sponsored-broadcast boundary.

Both converge at `@catch_errors` → `err("session_expired", …)`. Tests cover the callback, broadcast re-raise, and sponsored-path translation.

Note: typed-data / hash signing (Polymarket EIP-712, Hyperliquid actions) still isn't covered — separate follow-up.