### PR TITLE
runner: keep the view server memory-flat — fork-per-request views

### DIFF
--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -43,6 +43,7 @@ from wayfinder_paths.runner.script_resolver import resolve_script_path
 
 JOB_RESULT_MARKER = "WAYFINDER_JOB_RESULT "
 DEFAULT_SYNC_DEBOUNCE_SECONDS = 90.0
+DEFAULT_MAX_RSS_MB = 900.0
 JOB_LOCK_TIMEOUT_SECONDS = 3
 JOB_LOCK_BUSY_MSG = (
     "Runner Daemon lock is busy, no operations were completed, please try again later"
@@ -132,6 +133,31 @@ def _kill_process_group(pid: int, *, sig: int) -> None:
         return
     except Exception as exc:  # noqa: BLE001
         logger.debug(f"Failed to kill process group {pid}: {exc}")
+
+
+def _max_rss_mb_from_env() -> float:
+    """RSS ceiling for the watchdog. Non-positive disables it."""
+    raw = os.environ.get("WAYFINDER_RUNNERD_MAX_RSS_MB")
+    if raw is None or not str(raw).strip():
+        return DEFAULT_MAX_RSS_MB
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning(
+            f"Invalid WAYFINDER_RUNNERD_MAX_RSS_MB={raw!r}; using {DEFAULT_MAX_RSS_MB}"
+        )
+        return DEFAULT_MAX_RSS_MB
+
+
+def _rss_mb() -> float | None:
+    """Resident set size read from /proc/self/statm (Linux). None where /proc
+    is unavailable (macOS dev boxes) — the watchdog is then a no-op."""
+    try:
+        fields = Path("/proc/self/statm").read_text().split()
+        resident_pages = int(fields[1])
+    except (OSError, IndexError, ValueError):
+        return None
+    return resident_pages * os.sysconf("SC_PAGE_SIZE") / (1024 * 1024)
 
 
 def _sync_debounce_seconds() -> float:
@@ -249,6 +275,7 @@ class RunnerDaemon:
         self._view_server: Any | None = None
         self._daemon_log_sink_id: int | None = None
         self._warm_spawner: Any | None = None
+        self._max_rss_mb = _max_rss_mb_from_env()
         self._sync_debouncer = _SyncDebouncer(
             action=lambda: self._start_backend_sync(),
             delay_seconds=_sync_debounce_seconds(),
@@ -293,12 +320,19 @@ class RunnerDaemon:
         )
 
         # Warm view endpoint for the jobs UI (starters/backtest/forward).
+        # Views are computed in short-lived children forked from the SAME warm
+        # spawner the tick path uses, so runnerd itself stays memory-flat.
         # Best-effort: bind failure or a broken module must never stop the
         # scheduler — callers fall back to the cold CLI.
         try:
             from wayfinder_paths.runner.view_server import RunnerViewServer
+            from wayfinder_paths.runner.warm_spawn import WarmSpawner
 
-            view_server = RunnerViewServer(repo_root=self._paths.repo_root)
+            if self._warm_spawner is None:
+                self._warm_spawner = WarmSpawner()
+            view_server = RunnerViewServer(
+                repo_root=self._paths.repo_root, warm_spawner=self._warm_spawner
+            )
             view_server.start()
             self._view_server = view_server
         except Exception:  # noqa: BLE001
@@ -343,6 +377,12 @@ class RunnerDaemon:
             time.sleep(max(0.0, self._tick_seconds - elapsed))
 
     def tick(self) -> None:
+        # Belt-and-braces vs the kernel OOM killer: check at the tick
+        # boundary, where the previous tick's DB writes are complete and
+        # nothing is mid-flight in the scheduler thread, so an os._exit here
+        # cannot corrupt run bookkeeping (restart marks stale RUNNING runs
+        # ABORTED via mark_stale_running_runs_aborted).
+        self._enforce_rss_limit()
         try:
             now = int(time.time())
             self._last_tick_at = now
@@ -351,6 +391,20 @@ class RunnerDaemon:
                 self._maybe_start_job(job=job, now=now, reason="schedule")
         except Exception:  # noqa: BLE001
             logger.exception("Runner tick error")
+
+    def _enforce_rss_limit(self) -> None:
+        if self._max_rss_mb <= 0:
+            return
+        rss_mb = _rss_mb()
+        if rss_mb is None or rss_mb <= self._max_rss_mb:
+            return
+        logger.critical(
+            f"runnerd RSS {rss_mb:.0f}MB exceeds WAYFINDER_RUNNERD_MAX_RSS_MB="
+            f"{self._max_rss_mb:.0f}MB; exiting now so the supervisor restarts "
+            "us cleanly between ticks instead of the kernel OOM-killing us "
+            "mid-write"
+        )
+        os._exit(1)
 
     def _reap(self, *, now: int) -> None:
         for run_id, rp in list(self._running.items()):

--- a/wayfinder_paths/runner/view_server.py
+++ b/wayfinder_paths/runner/view_server.py
@@ -1,4 +1,4 @@
-"""Resident HTTP view server inside the runner daemon.
+"""Memory-flat HTTP view server inside the runner daemon.
 
 The Strategies UI used to fetch starters/backtest/forward payloads by exec'ing
 a cold `wayfinder` CLI on the box (~90 CPU-s per request under throttle). This
@@ -8,25 +8,44 @@ the daemon (like `RunnerControlServer`) that serves the exact CLI envelope
 callers can swap `wayfinder job backtest-view ...` for
 `curl http://127.0.0.1:8646/backtest-view?...` byte-for-byte.
 
-Routes (GET only):
-- /health
-- /starters                                   -> jobs.starters.starter_catalog()
-- /backtest-view?job_id=...&view=...&series=...&from=...&to=...&max_points=...&proposal=...
-- /forward-view?job_id=...&view=...&series=...&from=...&to=...&max_points=...&no_prices=...
+Memory contract (the reason for the fork-per-request shape): runnerd
+supervises LIVE trading loops and must stay small. Computing views in-process
+(pandas + multi-MB JSON graphs per request, across handler threads) grew
+runnerd's RSS past 1.4GB and got it kernel-OOM-killed on a 4GB box. So:
+
+- `/backtest-view` and `/forward-view` are computed in a SHORT-LIVED CHILD
+  forked from the warm forkserver (`runner/warm_spawn.py`, pandas + jobs
+  stack preloaded). The child writes the exact response body bytes to a
+  tempfile and exits; the handler streams the file to the socket through a
+  64KB buffer. runnerd retains nothing per request.
+- At most `MAX_CONCURRENT_VIEW_CHILDREN` children run at once; excess
+  requests get a 503 `{"ok": false}` envelope after a short wait and the
+  backend falls back to the cold CLI.
+- `/starters` and `/health` are tiny and stay in-process; the starters
+  catalog is serialized immediately and the object graph dropped.
+- The forward view's venue price fetch is cached parent-side as FLAT BYTES
+  only (`_PriceSeriesByteCache`): JSON-serialized series, hard-capped per
+  entry and in entry count, TTL'd — so UI polling cannot hammer the venue,
+  and runnerd's retained footprint stays bounded at a few MB of bytes
+  objects (no pandas frames, no dict graphs).
 
 Query params mirror the `wayfinder job backtest-view` / `forward-view` CLI
-options 1:1 (same names, same defaults, same coercions). Heavy jobs modules
-are lazy-imported inside handlers so daemon startup stays light. Bind failure
-is warn-and-continue: a box without a free port keeps running the scheduler,
-and the backend falls back to the cold CLI.
+options 1:1 (same names, same defaults, same coercions), validated in the
+parent so bad requests never cost a fork. Bind failure is warn-and-continue:
+a box without a free port keeps running the scheduler, and the backend falls
+back to the cold CLI.
 """
 
 from __future__ import annotations
 
 import json
 import os
+import shutil
+import tempfile
 import threading
 import time
+from collections.abc import Callable
+from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
@@ -38,6 +57,15 @@ from wayfinder_paths import __version__
 
 DEFAULT_VIEW_PORT = 8646
 PRICE_CACHE_TTL_SECONDS = 90.0
+PRICE_CACHE_MAX_ENTRY_BYTES = 2_000_000
+PRICE_CACHE_MAX_ENTRIES = 8
+MAX_CONCURRENT_VIEW_CHILDREN = 2
+VIEW_CHILD_BUSY_WAIT_SECONDS = 2.0
+VIEW_CHILD_TIMEOUT_SECONDS = 120.0
+
+_CHILD_EXIT_OK = 0
+_CHILD_EXIT_ERROR = 5
+_RESPONSE_STREAM_CHUNK_BYTES = 64 * 1024
 
 
 def _view_port_from_env() -> int:
@@ -53,46 +81,9 @@ def _view_port_from_env() -> int:
         return DEFAULT_VIEW_PORT
 
 
-class _CachedPriceFetcher:
-    """Single-flight, per-job TTL cache around the forward view's venue fetch.
-
-    The UI polls the forward chart; without this every poll re-fetches the
-    OHLC window from the venue. One in-flight fetch per job (concurrent
-    requests wait and reuse the result), successes cached for the TTL,
-    failures propagate uncached so `load_forward_view` degrades with its
-    normal `price_note` and the next poll can retry.
-    """
-
-    def __init__(self, *, ttl_seconds: float = PRICE_CACHE_TTL_SECONDS) -> None:
-        self._ttl_seconds = float(ttl_seconds)
-        self._lock = threading.Lock()
-        self._job_locks: dict[str, threading.Lock] = {}
-        self._entries: dict[str, tuple[float, list[dict[str, Any]]]] = {}
-
-    def _job_lock(self, job_id: str) -> threading.Lock:
-        with self._lock:
-            lock = self._job_locks.get(job_id)
-            if lock is None:
-                lock = threading.Lock()
-                self._job_locks[job_id] = lock
-            return lock
-
-    def __call__(
-        self, job_id: str, ticks: list[dict[str, Any]], *, store: Any
-    ) -> list[dict[str, Any]]:
-        with self._job_lock(str(job_id)):
-            now = time.monotonic()
-            cached = self._entries.get(str(job_id))
-            if cached is not None and now - cached[0] < self._ttl_seconds:
-                return list(cached[1])
-
-            # Late import + module-attribute call: keeps daemon startup light
-            # and the seam monkeypatchable in tests.
-            from wayfinder_paths.jobs import forward_artifacts
-
-            series = forward_artifacts._fetch_price_series(job_id, ticks, store=store)
-            self._entries[str(job_id)] = (time.monotonic(), series)
-            return list(series)
+def _envelope_bytes(payload: dict[str, Any]) -> bytes:
+    # Same serialization as the CLI's _echo_json -> byte-shape parity.
+    return json.dumps(payload, indent=2, default=str).encode("utf-8")
 
 
 class _ViewRequestError(ValueError):
@@ -133,33 +124,257 @@ def _require_job_id(params: dict[str, list[str]]) -> str:
     return job_id
 
 
+def _common_request(params: dict[str, list[str]]) -> dict[str, Any]:
+    return {
+        "job_id": _require_job_id(params),
+        "view": _scalar(params, "view") or "all",
+        "series_names": list(params.get("series") or []),
+        "from_ts": _scalar(params, "from"),
+        "to_ts": _scalar(params, "to"),
+        "max_points": _int_param(params, "max_points", 1500),
+    }
+
+
+def _backtest_request(params: dict[str, list[str]]) -> dict[str, Any]:
+    return {
+        **_common_request(params),
+        "proposal_id": _scalar(params, "proposal") or None,
+    }
+
+
+def _forward_request(params: dict[str, list[str]]) -> dict[str, Any]:
+    return {
+        **_common_request(params),
+        "include_prices": not _flag_param(params, "no_prices"),
+    }
+
+
+def _replay_price_fetcher(
+    cached_prices: bytes,
+) -> Callable[..., list[dict[str, Any]]]:
+    def _replay(
+        job_id: str, ticks: list[dict[str, Any]], *, store: Any
+    ) -> list[dict[str, Any]]:
+        series: list[dict[str, Any]] = json.loads(cached_prices)
+        return series
+
+    return _replay
+
+
+def _write_price_sidecar(path: str, series: list[dict[str, Any]]) -> None:
+    """Serialize the freshly fetched price series for the parent's byte cache.
+
+    Oversize or unserializable series are simply not written — the parent then
+    caches nothing and the next poll re-fetches, which is the safe default.
+    """
+    try:
+        data = json.dumps(series, default=str).encode("utf-8")
+    except (TypeError, ValueError):
+        return
+    if len(data) > PRICE_CACHE_MAX_ENTRY_BYTES:
+        return
+    try:
+        Path(path).write_bytes(data)
+    except OSError:
+        pass
+
+
+def _view_child_entry(
+    *,
+    route: str,
+    repo_root: str,
+    out_path: str,
+    request: dict[str, Any],
+    cached_prices: bytes | None = None,
+    prices_out_path: str | None = None,
+) -> int:
+    """Compute one view payload. Normally runs inside a short-lived forked
+    child (via `_view_child_main`); also runnable inline, which is how tests
+    exercise the parent<->child contract without a forkserver.
+
+    Writes the exact HTTP body bytes (CLI envelope) to `out_path` and returns
+    the child exit code: `_CHILD_EXIT_OK` for a 200 payload, `_CHILD_EXIT_ERROR`
+    for a 500 error envelope.
+    """
+    try:
+        from wayfinder_paths.jobs.store import JobStore
+
+        store = JobStore(repo_root=Path(repo_root))
+        if route == "/backtest-view":
+            from wayfinder_paths.jobs.backtest_artifacts import load_backtest_view
+
+            result = load_backtest_view(
+                request["job_id"],
+                store=store,
+                view=request["view"],
+                series_names=request["series_names"],
+                from_ts=request["from_ts"],
+                to_ts=request["to_ts"],
+                max_points=request["max_points"],
+                proposal_id=request["proposal_id"],
+            )
+        elif route == "/forward-view":
+            from wayfinder_paths.jobs.forward_artifacts import load_forward_view
+
+            captured: list[dict[str, Any]] | None = None
+            price_fetcher: Callable[..., list[dict[str, Any]]] | None = None
+            if request["include_prices"]:
+                if cached_prices is not None:
+                    price_fetcher = _replay_price_fetcher(cached_prices)
+                else:
+
+                    def _capturing_fetch(
+                        job_id: str, ticks: list[dict[str, Any]], *, store: Any
+                    ) -> list[dict[str, Any]]:
+                        nonlocal captured
+                        # Module-attribute call keeps the seam monkeypatchable
+                        # when the entry runs inline in tests.
+                        from wayfinder_paths.jobs import forward_artifacts
+
+                        captured = forward_artifacts._fetch_price_series(
+                            job_id, ticks, store=store
+                        )
+                        return captured
+
+                    price_fetcher = _capturing_fetch
+            result = load_forward_view(
+                request["job_id"],
+                store=store,
+                view=request["view"],
+                series_names=request["series_names"],
+                from_ts=request["from_ts"],
+                to_ts=request["to_ts"],
+                max_points=request["max_points"],
+                include_prices=request["include_prices"],
+                price_fetcher=price_fetcher,
+            )
+            if captured is not None and prices_out_path is not None:
+                _write_price_sidecar(prices_out_path, captured)
+        else:
+            raise KeyError(route)
+        Path(out_path).write_bytes(_envelope_bytes({"ok": True, "result": result}))
+        return _CHILD_EXIT_OK
+    except Exception as exc:  # noqa: BLE001 — envelope, never a stack page
+        try:
+            Path(out_path).write_bytes(
+                _envelope_bytes({"ok": False, "error": str(exc)})
+            )
+        except OSError:
+            pass
+        return _CHILD_EXIT_ERROR
+
+
+def _view_child_main(**kwargs: Any) -> None:
+    """Forkserver Process target: run the entry, exit with its code."""
+    raise SystemExit(_view_child_entry(**kwargs))
+
+
+class _PriceSeriesByteCache:
+    """Bytes-only TTL cache of the forward view's fetched venue price series.
+
+    The UI polls /forward-view every few seconds and each poll runs in a fresh
+    child, so without parent-side state every poll would re-fetch the OHLC
+    window from the venue. The parent keeps ONLY the JSON-serialized series
+    bytes — hard-capped per entry and in entry count — so runnerd's retained
+    footprint is a few flat bytes objects, never pandas frames or dict graphs.
+    Failures are never cached: the child only writes a sidecar after a
+    successful fetch, so degraded responses retry on the next poll.
+    """
+
+    def __init__(
+        self,
+        *,
+        ttl_seconds: float = PRICE_CACHE_TTL_SECONDS,
+        max_entry_bytes: int = PRICE_CACHE_MAX_ENTRY_BYTES,
+        max_entries: int = PRICE_CACHE_MAX_ENTRIES,
+    ) -> None:
+        self._ttl_seconds = float(ttl_seconds)
+        self._max_entry_bytes = int(max_entry_bytes)
+        self._max_entries = int(max_entries)
+        self._lock = threading.Lock()
+        self._entries: dict[str, tuple[float, bytes]] = {}
+
+    def get(self, job_id: str) -> bytes | None:
+        with self._lock:
+            entry = self._entries.get(job_id)
+            if entry is None:
+                return None
+            if time.monotonic() - entry[0] >= self._ttl_seconds:
+                del self._entries[job_id]
+                return None
+            return entry[1]
+
+    def put(self, job_id: str, data: bytes) -> None:
+        if len(data) > self._max_entry_bytes:
+            return
+        with self._lock:
+            now = time.monotonic()
+            self._entries = {
+                key: value
+                for key, value in self._entries.items()
+                if now - value[0] < self._ttl_seconds
+            }
+            while len(self._entries) >= self._max_entries:
+                oldest = min(self._entries, key=lambda key: self._entries[key][0])
+                del self._entries[oldest]
+            self._entries[job_id] = (now, data)
+
+
+@dataclass
+class _ViewResponse:
+    status: int
+    body_bytes: bytes | None = None
+    # Child-written body streamed to the socket, then unlinked by the handler.
+    body_path: Path | None = None
+
+
 class _ViewHandler(BaseHTTPRequestHandler):
     def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler contract
         view_server: RunnerViewServer = self.server.view_server  # type: ignore[attr-defined]
         url = urlsplit(self.path)
         params = parse_qs(url.query, keep_blank_values=True)
         try:
-            result = view_server.handle_route(url.path, params)
+            response = view_server.render(url.path, params)
         except _ViewRequestError as exc:
-            self._respond(400, {"ok": False, "error": str(exc)})
+            self._respond_bytes(400, _envelope_bytes({"ok": False, "error": str(exc)}))
             return
         except KeyError:
-            self._respond(404, {"ok": False, "error": f"unknown route: {url.path}"})
+            self._respond_bytes(
+                404,
+                _envelope_bytes({"ok": False, "error": f"unknown route: {url.path}"}),
+            )
             return
         except Exception as exc:  # noqa: BLE001 - envelope, never a stack page
             logger.opt(exception=True).warning(f"View server error on {self.path}")
-            self._respond(500, {"ok": False, "error": str(exc)})
+            self._respond_bytes(500, _envelope_bytes({"ok": False, "error": str(exc)}))
             return
-        self._respond(200, {"ok": True, "result": result})
+        if response.body_path is not None:
+            self._respond_file(response.status, response.body_path)
+        else:
+            self._respond_bytes(response.status, response.body_bytes or b"")
 
-    def _respond(self, status: int, payload: dict[str, Any]) -> None:
-        # Same serialization as the CLI's _echo_json -> byte-shape parity.
-        body = json.dumps(payload, indent=2, default=str).encode("utf-8")
+    def _respond_bytes(self, status: int, body: bytes) -> None:
         self.send_response(status)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
+
+    def _respond_file(self, status: int, path: Path) -> None:
+        # Stream the child-written body straight to the socket: runnerd never
+        # holds a multi-MB view payload, only a 64KB copy buffer.
+        try:
+            size = path.stat().st_size
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(size))
+            self.end_headers()
+            with path.open("rb") as body:
+                shutil.copyfileobj(
+                    body, self.wfile, length=_RESPONSE_STREAM_CHUNK_BYTES
+                )
+        finally:
+            path.unlink(missing_ok=True)
 
     def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
         logger.debug(f"view-server {self.address_string()} {format % args}")
@@ -172,13 +387,25 @@ class RunnerViewServer:
         repo_root: Path,
         host: str = "127.0.0.1",
         port: int | None = None,
+        warm_spawner: Any | None = None,
+        max_view_children: int = MAX_CONCURRENT_VIEW_CHILDREN,
+        busy_wait_seconds: float = VIEW_CHILD_BUSY_WAIT_SECONDS,
+        child_timeout_seconds: float = VIEW_CHILD_TIMEOUT_SECONDS,
     ) -> None:
         self._repo_root = Path(repo_root)
         self._host = host
         self._port = _view_port_from_env() if port is None else int(port)
         self._server: ThreadingHTTPServer | None = None
         self._thread: threading.Thread | None = None
-        self._price_fetcher = _CachedPriceFetcher()
+        # Shared with the daemon's warm tick spawner when running inside
+        # runnerd — one forkserver image (same preload) serves both tick forks
+        # and view forks. Created lazily when standalone.
+        self._warm_spawner = warm_spawner
+        self._spawner_lock = threading.Lock()
+        self._children = threading.BoundedSemaphore(int(max_view_children))
+        self._busy_wait_seconds = float(busy_wait_seconds)
+        self._child_timeout_seconds = float(child_timeout_seconds)
+        self._price_cache = _PriceSeriesByteCache()
 
     @property
     def port(self) -> int | None:
@@ -230,54 +457,145 @@ class RunnerViewServer:
             self._thread = None
 
     # Route handling (called from handler threads)
-    def handle_route(self, path: str, params: dict[str, list[str]]) -> Any:
+    def render(self, path: str, params: dict[str, list[str]]) -> _ViewResponse:
         if path == "/health":
-            return {
-                "status": "ok",
-                "version": __version__,
-                "pid": os.getpid(),
-                "repo_root": str(self._repo_root),
-            }
+            return _ViewResponse(
+                200,
+                body_bytes=_envelope_bytes(
+                    {
+                        "ok": True,
+                        "result": {
+                            "status": "ok",
+                            "version": __version__,
+                            "pid": os.getpid(),
+                            "repo_root": str(self._repo_root),
+                        },
+                    }
+                ),
+            )
         if path == "/starters":
             from wayfinder_paths.jobs.starters import starter_catalog
 
-            return starter_catalog()
+            catalog = starter_catalog()
+            body = _envelope_bytes({"ok": True, "result": catalog})
+            # Serialize immediately and drop the object graph — the resident
+            # daemon retains nothing between requests.
+            del catalog
+            return _ViewResponse(200, body_bytes=body)
         if path == "/backtest-view":
-            return self._backtest_view(params)
+            return self._forked_view(path, _backtest_request(params))
         if path == "/forward-view":
-            return self._forward_view(params)
+            return self._forked_view(path, _forward_request(params))
         raise KeyError(path)
 
-    def _store(self) -> Any:
-        from wayfinder_paths.jobs.store import JobStore
+    def _forked_view(self, route: str, request: dict[str, Any]) -> _ViewResponse:
+        if not self._children.acquire(timeout=self._busy_wait_seconds):
+            return _ViewResponse(
+                503,
+                body_bytes=_envelope_bytes(
+                    {
+                        "ok": False,
+                        "error": "view server busy: too many concurrent view builds",
+                    }
+                ),
+            )
+        try:
+            out_path = _view_tempfile("wayfinder-view-")
+            prices_out: Path | None = None
+            try:
+                kwargs: dict[str, Any] = {
+                    "route": route,
+                    "repo_root": str(self._repo_root),
+                    "out_path": str(out_path),
+                    "request": request,
+                }
+                if route == "/forward-view" and request["include_prices"]:
+                    cached = self._price_cache.get(request["job_id"])
+                    if cached is not None:
+                        kwargs["cached_prices"] = cached
+                    else:
+                        prices_out = _view_tempfile("wayfinder-view-prices-")
+                        kwargs["prices_out_path"] = str(prices_out)
 
-        return JobStore(repo_root=self._repo_root)
+                exitcode = self._run_child(kwargs)
 
-    def _backtest_view(self, params: dict[str, list[str]]) -> dict[str, Any]:
-        from wayfinder_paths.jobs.backtest_artifacts import load_backtest_view
+                if prices_out is not None:
+                    self._absorb_price_sidecar(request["job_id"], prices_out)
+                    prices_out = None
+                if exitcode is None:
+                    return self._child_failure(
+                        out_path,
+                        f"view child timed out after "
+                        f"{self._child_timeout_seconds:.0f}s",
+                    )
+                if exitcode not in (_CHILD_EXIT_OK, _CHILD_EXIT_ERROR):
+                    return self._child_failure(
+                        out_path, f"view child failed (exit={exitcode})"
+                    )
+                if not out_path.exists() or out_path.stat().st_size == 0:
+                    return self._child_failure(
+                        out_path, f"view child wrote no output (exit={exitcode})"
+                    )
+                status = 200 if exitcode == _CHILD_EXIT_OK else 500
+                return _ViewResponse(status, body_path=out_path)
+            except Exception:
+                out_path.unlink(missing_ok=True)
+                raise
+            finally:
+                if prices_out is not None:
+                    prices_out.unlink(missing_ok=True)
+        finally:
+            self._children.release()
 
-        return load_backtest_view(
-            _require_job_id(params),
-            store=self._store(),
-            view=_scalar(params, "view") or "all",
-            series_names=list(params.get("series") or []),
-            from_ts=_scalar(params, "from"),
-            to_ts=_scalar(params, "to"),
-            max_points=_int_param(params, "max_points", 1500),
-            proposal_id=_scalar(params, "proposal") or None,
+    @staticmethod
+    def _child_failure(out_path: Path, message: str) -> _ViewResponse:
+        out_path.unlink(missing_ok=True)
+        return _ViewResponse(
+            500, body_bytes=_envelope_bytes({"ok": False, "error": message})
         )
 
-    def _forward_view(self, params: dict[str, list[str]]) -> dict[str, Any]:
-        from wayfinder_paths.jobs.forward_artifacts import load_forward_view
+    def _run_child(self, kwargs: dict[str, Any]) -> int | None:
+        """Fork the view child from the warm forkserver and wait for it.
 
-        return load_forward_view(
-            _require_job_id(params),
-            store=self._store(),
-            view=_scalar(params, "view") or "all",
-            series_names=list(params.get("series") or []),
-            from_ts=_scalar(params, "from"),
-            to_ts=_scalar(params, "to"),
-            max_points=_int_param(params, "max_points", 1500),
-            include_prices=not _flag_param(params, "no_prices"),
-            price_fetcher=self._price_fetcher,
+        Returns the child's exit code, or None if it exceeded the timeout and
+        was killed. Tests monkeypatch this seam to run `_view_child_entry`
+        inline or to simulate crashes/stalls.
+        """
+        process = self._spawn_context().Process(
+            target=_view_child_main,
+            kwargs=kwargs,
+            name="wayfinder-view-child",
+            daemon=False,
         )
+        process.start()
+        process.join(self._child_timeout_seconds)
+        if process.is_alive():
+            process.kill()
+            process.join(5)
+            return None
+        exitcode = process.exitcode
+        return None if exitcode is None else int(exitcode)
+
+    def _spawn_context(self) -> Any:
+        with self._spawner_lock:
+            if self._warm_spawner is None:
+                from wayfinder_paths.runner.warm_spawn import WarmSpawner
+
+                self._warm_spawner = WarmSpawner()
+            return self._warm_spawner.context()
+
+    def _absorb_price_sidecar(self, job_id: str, path: Path) -> None:
+        try:
+            data = path.read_bytes()
+        except OSError:
+            return
+        finally:
+            path.unlink(missing_ok=True)
+        if data:
+            self._price_cache.put(job_id, data)
+
+
+def _view_tempfile(prefix: str) -> Path:
+    fd, name = tempfile.mkstemp(prefix=prefix, suffix=".json")
+    os.close(fd)
+    return Path(name)

--- a/wayfinder_paths/runner/warm_spawn.py
+++ b/wayfinder_paths/runner/warm_spawn.py
@@ -101,7 +101,10 @@ class WarmSpawner:
         self._lock = threading.Lock()
         self._ctx: Any | None = None
 
-    def _context(self) -> Any:
+    def context(self) -> Any:
+        """The preloaded forkserver context. Shared surface: warm tick spawns
+        (below) and the view server's per-request children fork from the SAME
+        forkserver image, so the preload cost is paid once per daemon."""
         with self._lock:
             if self._ctx is None:
                 ctx = multiprocessing.get_context("forkserver")
@@ -117,7 +120,7 @@ class WarmSpawner:
         log_path: str | Path,
         cwd: str | Path,
     ) -> WarmChild:
-        process = self._context().Process(
+        process = self.context().Process(
             target=_warm_tick_entry,
             kwargs={
                 "env": dict(env),

--- a/wayfinder_paths/tests/test_runner_view_server.py
+++ b/wayfinder_paths/tests/test_runner_view_server.py
@@ -1,8 +1,13 @@
-"""The resident view server must serve the EXACT payloads the cold CLI serves
+"""The view server must serve the EXACT payloads the cold CLI serves
 (`wayfinder job backtest-view` / `forward-view` / catalog `starters`), in the
 exact CLI envelope {"ok": true, "result": ...} — backend callers swap exec'ing
-the CLI for a loopback curl byte-for-byte. Bind failure is warn-and-continue:
-the daemon scheduler must keep running without it."""
+the CLI for a loopback curl byte-for-byte. Views are computed in short-lived
+children forked from the warm forkserver so runnerd stays memory-flat: the
+parent retains nothing per request beyond a capped bytes-only price cache.
+Excess concurrency 503s, child failures become {"ok": false} envelopes (never
+hangs), and bind failure is warn-and-continue: the daemon scheduler must keep
+running without it. A parent-side RSS watchdog exits runnerd cleanly between
+ticks before the kernel OOM killer can take the live loops down mid-write."""
 
 from __future__ import annotations
 
@@ -20,24 +25,51 @@ from wayfinder_paths.jobs.backtest_artifacts import load_backtest_view
 from wayfinder_paths.jobs.forward_artifacts import load_forward_view
 from wayfinder_paths.jobs.models import WayfinderJob
 from wayfinder_paths.jobs.store import JobStore
-from wayfinder_paths.runner.view_server import RunnerViewServer
+from wayfinder_paths.runner.view_server import (
+    RunnerViewServer,
+    _PriceSeriesByteCache,
+    _view_child_entry,
+)
+from wayfinder_paths.runner.warm_spawn import WarmSpawner
 
 
 def _get(port: int, path: str) -> tuple[int, dict]:
     try:
-        with urllib.request.urlopen(f"http://127.0.0.1:{port}{path}") as resp:
+        with urllib.request.urlopen(
+            f"http://127.0.0.1:{port}{path}", timeout=60
+        ) as resp:
             return resp.status, json.loads(resp.read().decode("utf-8"))
     except urllib.error.HTTPError as err:
         return err.code, json.loads(err.read().decode("utf-8"))
 
 
+@pytest.fixture(scope="module")
+def shared_spawner() -> WarmSpawner:
+    # One forkserver (with the pandas/jobs preload) for the whole module —
+    # exactly how the daemon shares its tick spawner with the view server.
+    return WarmSpawner()
+
+
 @pytest.fixture
-def server(tmp_path: Path):
-    view_server = RunnerViewServer(repo_root=tmp_path, port=0)
+def server(tmp_path: Path, shared_spawner: WarmSpawner):
+    view_server = RunnerViewServer(
+        repo_root=tmp_path, port=0, warm_spawner=shared_spawner
+    )
     view_server.start()
     assert view_server.port is not None
     yield view_server
     view_server.stop()
+
+
+def _inline_children(
+    view_server: RunnerViewServer, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Run view children inline (no fork) so monkeypatched seams inside the
+    jobs modules are visible to the 'child' — the parent<->child contract
+    (request kwargs, out file, price sidecar, exit codes) stays fully real."""
+    monkeypatch.setattr(
+        view_server, "_run_child", lambda kwargs: _view_child_entry(**kwargs)
+    )
 
 
 def _seed_backtest_job(tmp_path: Path) -> JobStore:
@@ -191,6 +223,8 @@ def test_starters_route_serves_the_bare_catalog_list(server: RunnerViewServer) -
 def test_backtest_view_parity_with_direct_loader(
     tmp_path: Path, server: RunnerViewServer
 ) -> None:
+    """Served through a REAL forked child — the response must still match the
+    direct loader byte-for-byte after JSON parsing."""
     _seed_backtest_job(tmp_path)
     query = (
         "job_id=carry&view=legs&series=TEST_price&max_points=100"
@@ -235,12 +269,13 @@ def test_forward_view_parity_with_direct_loader(
     assert body["result"]["summary"]["pnl_by_mode"] == {"paper": 1.4, "live": 0.0}
 
 
-def test_forward_view_price_fetch_is_ttl_cached_and_injected(
-    tmp_path: Path, server: RunnerViewServer, monkeypatch: pytest.MonkeyPatch
+def test_forward_view_price_fetch_is_byte_cached_across_children(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Two polls inside the TTL hit the venue exactly once — the server passes
-    its cached single-flight fetcher through load_forward_view's price_fetcher
-    seam."""
+    """Two polls inside the TTL hit the venue exactly once: the first child
+    hands the serialized series back through the sidecar file, the parent
+    caches ONLY those bytes, and the second child replays them without
+    fetching. Children run inline so the fake venue fetch is visible."""
     import wayfinder_paths.jobs.forward_artifacts as forward_artifacts
 
     _seed_forward_job(tmp_path)
@@ -260,14 +295,138 @@ def test_forward_view_price_fetch_is_ttl_cached_and_injected(
 
     monkeypatch.setattr(forward_artifacts, "_fetch_price_series", _fake_fetch)
 
-    for _ in range(2):
-        status, body = _get(server.port, "/forward-view?job_id=carry")
-        assert status == 200
-        assert body["ok"] is True
-        kinds = {s["kind"] for s in body["result"]["visualization"]["series"]}
-        assert "market_price" in kinds
+    view_server = RunnerViewServer(repo_root=tmp_path, port=0)
+    _inline_children(view_server, monkeypatch)
+    view_server.start()
+    try:
+        for _ in range(2):
+            status, body = _get(view_server.port, "/forward-view?job_id=carry")
+            assert status == 200
+            assert body["ok"] is True
+            kinds = {s["kind"] for s in body["result"]["visualization"]["series"]}
+            assert "market_price" in kinds
 
-    assert calls == ["carry"]  # second request served from the 90s TTL cache
+        assert calls == ["carry"]  # second request replayed the cached bytes
+        assert view_server._price_cache.get("carry") is not None
+    finally:
+        view_server.stop()
+
+
+def test_price_cache_is_bytes_only_with_hard_caps() -> None:
+    """runnerd's only per-request retention: flat bytes, capped per entry and
+    in entry count, TTL'd."""
+    cache = _PriceSeriesByteCache(ttl_seconds=0.05, max_entry_bytes=8, max_entries=2)
+
+    cache.put("big", b"123456789")  # over the entry cap -> silently dropped
+    assert cache.get("big") is None
+
+    cache.put("a", b"aa")
+    cache.put("b", b"bb")
+    cache.put("c", b"cc")  # entry-count cap evicts the oldest
+    assert cache.get("a") is None
+    assert cache.get("b") == b"bb"
+    assert cache.get("c") == b"cc"
+
+    time.sleep(0.06)
+    assert cache.get("b") is None  # TTL expired
+
+
+def test_third_concurrent_view_request_gets_a_503_envelope(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """At most 2 view children run at once; a third concurrent request gets a
+    quick 503 {"ok": false} so the backend can fall back to the cold CLI."""
+    _seed_backtest_job(tmp_path)
+    view_server = RunnerViewServer(repo_root=tmp_path, port=0, busy_wait_seconds=0.2)
+    release = threading.Event()
+    started: list[str] = []
+
+    def _blocking_child(kwargs: dict) -> int:
+        Path(kwargs["out_path"]).write_bytes(
+            json.dumps({"ok": True, "result": None}).encode("utf-8")
+        )
+        started.append(kwargs["route"])
+        release.wait(timeout=30)
+        return 0
+
+    monkeypatch.setattr(view_server, "_run_child", _blocking_child)
+    view_server.start()
+    results: list[tuple[int, dict]] = []
+    threads = [
+        threading.Thread(
+            target=lambda: results.append(
+                _get(view_server.port, "/backtest-view?job_id=carry")
+            )
+        )
+        for _ in range(2)
+    ]
+    try:
+        for thread in threads:
+            thread.start()
+        deadline = time.time() + 10
+        while len(started) < 2 and time.time() < deadline:
+            time.sleep(0.02)
+        assert len(started) == 2  # both semaphore slots held
+
+        status, body = _get(view_server.port, "/backtest-view?job_id=carry")
+        assert status == 503
+        assert body["ok"] is False
+        assert "busy" in body["error"]
+    finally:
+        release.set()
+        for thread in threads:
+            thread.join(timeout=10)
+        view_server.stop()
+    assert sorted(status for status, _ in results) == [200, 200]
+
+
+def test_child_crash_is_a_500_envelope_not_a_hang(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A child that dies without writing its output file (signal death, OOM)
+    must surface as {"ok": false} immediately."""
+    _seed_backtest_job(tmp_path)
+    view_server = RunnerViewServer(repo_root=tmp_path, port=0)
+    monkeypatch.setattr(view_server, "_run_child", lambda kwargs: 1)
+    view_server.start()
+    try:
+        status, body = _get(view_server.port, "/backtest-view?job_id=carry")
+        assert status == 500
+        assert body["ok"] is False
+        assert "exit=1" in body["error"]
+    finally:
+        view_server.stop()
+
+
+def test_child_timeout_is_a_500_envelope(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_backtest_job(tmp_path)
+    view_server = RunnerViewServer(repo_root=tmp_path, port=0)
+    monkeypatch.setattr(view_server, "_run_child", lambda kwargs: None)
+    view_server.start()
+    try:
+        status, body = _get(view_server.port, "/backtest-view?job_id=carry")
+        assert status == 500
+        assert body["ok"] is False
+        assert "timed out" in body["error"]
+    finally:
+        view_server.stop()
+
+
+def test_forked_child_loader_error_is_a_500_envelope(
+    tmp_path: Path, server: RunnerViewServer
+) -> None:
+    """Real fork path: a loader exception inside the child (corrupt artifact)
+    comes back as the same 500 envelope the in-process server produced."""
+    store = _seed_forward_job(tmp_path)
+    ticks = store.job_dir("carry") / "results" / "forward" / "ticks.jsonl"
+    ticks.write_text('{"kind": "tick", not json\n', encoding="utf-8")
+
+    status, body = _get(server.port, "/forward-view?job_id=carry&no_prices=1")
+    assert status == 500
+    assert body["ok"] is False
+    assert body["error"]
 
 
 def test_missing_job_id_is_a_400_envelope(server: RunnerViewServer) -> None:
@@ -343,6 +502,9 @@ def test_daemon_starts_and_stops_the_view_server(
         assert daemon._view_server is not None
         port = daemon._view_server.port
         assert port is not None
+        # The view server shares the daemon's warm spawner: one forkserver
+        # image serves both tick forks and view forks.
+        assert daemon._view_server._warm_spawner is daemon._warm_spawner
 
         status, body = _get(port, "/health")
         assert status == 200
@@ -356,3 +518,73 @@ def test_daemon_starts_and_stops_the_view_server(
         shutil.rmtree(runner_dir, ignore_errors=True)
     assert not thread.is_alive()
     assert daemon._view_server is None
+
+
+def _daemon_paths(tmp_path: Path):
+    from wayfinder_paths.runner.paths import RunnerPaths
+
+    runner_dir = tmp_path / ".wayfinder" / "runner"
+    return RunnerPaths(
+        repo_root=tmp_path,
+        runner_dir=runner_dir,
+        db_path=runner_dir / "state.db",
+        logs_dir=runner_dir / "logs",
+        sock_path=runner_dir / "runner.sock",
+    )
+
+
+def test_memory_watchdog_exits_cleanly_when_rss_exceeds_limit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """RSS over WAYFINDER_RUNNERD_MAX_RSS_MB -> os._exit(1) at the tick
+    boundary, where no run bookkeeping is mid-flight, so the supervisor
+    restarts runnerd cleanly instead of the kernel OOM-killing it."""
+    import os as os_module
+
+    from wayfinder_paths.runner import daemon as daemon_module
+
+    monkeypatch.setenv("WAYFINDER_RUNNERD_MAX_RSS_MB", "900")
+    daemon = daemon_module.RunnerDaemon(paths=_daemon_paths(tmp_path))
+    exits: list[int] = []
+    monkeypatch.setattr(daemon_module, "_rss_mb", lambda: 1200.0)
+    monkeypatch.setattr(os_module, "_exit", lambda code: exits.append(code))
+
+    daemon.tick()
+    assert exits == [1]
+
+
+def test_memory_watchdog_stays_quiet_below_limit_and_without_procfs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import os as os_module
+
+    from wayfinder_paths.runner import daemon as daemon_module
+
+    monkeypatch.delenv("WAYFINDER_RUNNERD_MAX_RSS_MB", raising=False)
+    daemon = daemon_module.RunnerDaemon(paths=_daemon_paths(tmp_path))
+    assert daemon._max_rss_mb == daemon_module.DEFAULT_MAX_RSS_MB
+    exits: list[int] = []
+    monkeypatch.setattr(os_module, "_exit", lambda code: exits.append(code))
+
+    monkeypatch.setattr(daemon_module, "_rss_mb", lambda: 100.0)
+    daemon.tick()  # well below the limit
+    monkeypatch.setattr(daemon_module, "_rss_mb", lambda: None)
+    daemon.tick()  # no /proc (macOS) -> watchdog disabled
+    assert exits == []
+
+
+def test_memory_watchdog_disabled_by_non_positive_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import os as os_module
+
+    from wayfinder_paths.runner import daemon as daemon_module
+
+    monkeypatch.setenv("WAYFINDER_RUNNERD_MAX_RSS_MB", "0")
+    daemon = daemon_module.RunnerDaemon(paths=_daemon_paths(tmp_path))
+    exits: list[int] = []
+    monkeypatch.setattr(daemon_module, "_rss_mb", lambda: 4096.0)
+    monkeypatch.setattr(os_module, "_exit", lambda code: exits.append(code))
+
+    daemon.tick()
+    assert exits == []


### PR DESCRIPTION
## Incident

The warm-path PR (#673) put a resident view server thread + forkserver preload inside runnerd. On the 4GB box runnerd's RSS grew to 1.36GB / 1.46GB and the kernel OOM-killed it twice in ~4 hours (dmesg pids 842, 3835, anon-rss ~1.4GB) — each kill takes the LIVE trading loops down until the supervisor restarts it. Root cause: `load_backtest_view` (30MB visualization.json) and `load_forward_view` (multi-MB JSONL + pandas venue fetch) ran in handler threads inside runnerd; per-request allocations, per-thread state, and fragmentation accumulate and never return to the floor.

## Fix: fork-per-request views

- **`/backtest-view` and `/forward-view` run in a short-lived child** forked from the SAME warm forkserver the tick path already uses (the daemon now passes its `WarmSpawner` into `RunnerViewServer`; `WarmSpawner.context()` is the shared surface, same preload — one warm image, no second forkserver). The child computes the payload, writes the exact CLI-envelope body bytes to a tempfile, and exits. The handler streams the file to the socket through a 64KB buffer — runnerd never holds a view payload and retains nothing per request.
- **Bounded concurrency**: at most 2 concurrent view children (semaphore). Excess requests wait briefly then get `503 {"ok": false, ...}` — the backend falls back to the cold CLI. Child crash → `500 {"ok": false, "error": "view child failed (exit=N)"}`; child stall → SIGKILL after 120s and a `{"ok": false}` timeout envelope. Never a hang.
- **Response contract unchanged**: same `{"ok": true, "result": ...}` byte shape (`json.dumps(..., indent=2, default=str)` written by the child), same query params (`job_id/view/series/from/to/max_points/proposal/no_prices`), same coercions. Params are validated in the parent so bad requests 400 without costing a fork.
- **`/starters` and `/health` stay in-process** (tiny); the starters catalog object graph is `del`'d immediately after serialization.
- **RSS watchdog (belt-and-braces)**: every daemon tick reads `/proc/self/statm`; if RSS > `WAYFINDER_RUNNERD_MAX_RSS_MB` (default 900, non-positive disables), log critical and `os._exit(1)` at the tick boundary — previous tick's DB writes are complete, nothing mid-flight, and restart recovery already marks stale RUNNING runs ABORTED. A clean supervisor restart between ticks instead of a kernel OOM kill mid-write. No-op where `/proc` is absent (macOS).

## Price-cache decision

The 90s single-flight price cache existed because the UI polls `/forward-view` every few seconds and each poll re-fetched up to `_MAX_PRICE_BARS=2000` OHLC bars per symbol from the venue. Dropping it would turn every poll into a fresh venue fetch (rate-limit pressure + added child latency); keeping the old cache would retain per-job series object graphs in runnerd — the exact retention class that caused the incident.

**Chosen: keep the cache in the parent, but as flat bytes only** (`_PriceSeriesByteCache`): JSON-serialized series, hard caps of 2MB/entry and 8 entries, 90s TTL. On a cache miss the child fetches and hands the serialized series back through a sidecar tempfile (skipped if over the cap); on a hit the parent passes the bytes into the child, which replays them through `load_forward_view`'s existing `price_fetcher` seam. Worst-case parent retention is ~16MB of flat `bytes` objects (typically far less) — no pandas frames, no dict graphs, no fragmentation-prone object churn. Failures are never cached (the sidecar only exists after a successful fetch), preserving the old degrade-and-retry behavior. Trade-off vs the old single-flight lock: two concurrent cold polls for the same job can both fetch — bounded at 2 by the child semaphore, acceptable.

## Tests

`wayfinder_paths/tests/test_runner_view_server.py` (10 → 18 tests):
- backtest/forward parity vs the direct loaders now exercised through REAL forked children (module-shared `WarmSpawner`, mirroring the daemon)
- real forked-child loader error (corrupt `ticks.jsonl`) → `500 {"ok": false}`
- byte-cache round trip across two children (venue hit exactly once; children run inline via the `_run_child` seam so the fake fetch is visible; sidecar → parent bytes → replay all real)
- `_PriceSeriesByteCache` caps: entry-size drop, entry-count eviction, TTL expiry
- concurrency: 2 children in flight, 3rd concurrent request → quick `503 {"ok": false}`
- child crash (no output file) and child timeout → `{"ok": false}` envelopes, no hang
- RSS watchdog: over-limit → `os._exit(1)` (patched statm read + `os._exit`); below-limit / no-procfs / disabled-via-env → quiet
- daemon start/stop test also asserts the view server shares the daemon's `WarmSpawner`

Full `-k "jobs or runner or mcp"`: **927 passed, 9 skipped** (baseline before change: 919 passed, 9 skipped). Mypy on touched files: no new errors (3 pre-existing `daemon.py` errors unchanged). Ruff check + format clean on touched files.
