### PR TITLE
jobs - Deprioritize detached heavy ops (nice + OOM-first + idle I/O)

### DIFF
--- a/wayfinder_paths/jobs/execution/op_runner.py
+++ b/wayfinder_paths/jobs/execution/op_runner.py
@@ -22,6 +22,8 @@ stderr. Failures propagate as a traceback on stderr with a non-zero exit.
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 import sys
 from typing import Any
 
@@ -153,7 +155,38 @@ def _run_op(op: str, kwargs: dict[str, Any]) -> Any:
     raise ValueError(f"unknown op: {op}")
 
 
+def _lower_priority() -> None:
+    """Deprioritize this heavy op against the long-lived server + agent it
+    shares the box with, on all three contended resources: lowest CPU priority
+    (yields the core the moment the interactive path needs it), first OOM
+    victim (a memory spike kills this child, not the server), and 'idle' I/O
+    class (disk reads yield to interactive reads). All three are unprivileged
+    and best-effort — a platform missing any of them just skips that one.
+    """
+    try:
+        os.nice(19)
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        with open("/proc/self/oom_score_adj", "w") as f:
+            f.write("1000")
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        # 'idle' I/O class via ionice(1). Only bites under an ioprio-aware I/O
+        # scheduler (CFQ/BFQ); a no-op elsewhere. capture_output keeps the
+        # result-only stdout contract intact.
+        subprocess.run(
+            ["ionice", "-c", "3", "-p", str(os.getpid())],
+            check=False,
+            capture_output=True,
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
+
 def main() -> None:
+    _lower_priority()
     request = json.load(sys.stdin)
     result = _run(request["op"], dict(request.get("kwargs") or {}))
     json.dump(result, sys.stdout, default=str)

--- a/wayfinder_paths/tests/test_research_and_pair_check.py
+++ b/wayfinder_paths/tests/test_research_and_pair_check.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import math
+import os
 
 import numpy as np
 import pandas as pd
@@ -408,3 +409,46 @@ def test_rank_check_op_routes(monkeypatch) -> None:
         "stub": "rank",
         "column": "mom",
     }
+
+
+def test_op_runner_lowers_its_priority() -> None:
+    """Every detached heavy op self-deprioritizes at entry so the interactive
+    server + agent on the same box keep their CPU and survive a memory spike.
+    Forked so the change lands in a throwaway child, not the test runner."""
+    import shutil
+    import subprocess
+
+    from wayfinder_paths.jobs.execution import op_runner
+
+    r, w = os.pipe()
+    pid = os.fork()
+    if pid == 0:  # child
+        os.close(r)
+        try:
+            op_runner._lower_priority()
+            nice = os.getpriority(os.PRIO_PROCESS, 0)
+            try:
+                with open("/proc/self/oom_score_adj") as f:
+                    oom = f.read().strip()
+            except OSError:
+                oom = "na"
+            io = "na"
+            if shutil.which("ionice"):
+                io = subprocess.run(
+                    ["ionice", "-p", str(os.getpid())],
+                    capture_output=True,
+                    text=True,
+                ).stdout.strip()
+            os.write(w, f"{nice}|{oom}|{io}".encode())
+        finally:
+            os._exit(0)
+    os.close(w)
+    out = os.read(r, 128).decode()
+    os.close(r)
+    os.waitpid(pid, 0)
+    nice_s, oom_s, io_s = out.split("|")
+    assert int(nice_s) == 19
+    if oom_s != "na":  # /proc present (Linux) — OOM-first-victim marker set
+        assert oom_s == "1000"
+    if io_s != "na":  # ionice present — moved to the idle I/O class
+        assert "idle" in io_s


### PR DESCRIPTION
### Summary

Every heavy op already runs in an isolated child process via `op_runner` (`backtest_job`, `experiments`, `signal_scan`, `holdout_check`, `restamp`, optuna search, …). This has that child **self-deprioritize at entry on all three contended resources**, so it never starves the long-lived server + agent it shares the box with:

- `os.nice(19)` — lowest CPU priority; yields the core the instant the interactive path wants it.
- `oom_score_adj = 1000` — first OOM victim; a memory spike kills the disposable op, not the server.
- `ionice` idle I/O class — its disk reads yield to interactive reads (best-effort; only bites under an ioprio-aware scheduler).

All three are unprivileged raises and best-effort (no caps needed; anything unavailable is skipped). Scheduled `strategy`/`script` ticks don't go through `op_runner`, so live execution is untouched. Verified on the target base image: `nice=19  oom_score_adj=1000  io_class=idle`.

### Benchmark (before vs after)

Measured in a CPU/mem-constrained container (`--cpuset-cpus=0,1 --memory=2g`, i.e. 2 cores / 2 GB) with a latency-sensitive **foreground** and a heavy **background** op. The only variable between arms is the background launch — `before` = normal priority (today), `after` = this change.

| Test | before | after |
| --- | --- | --- |
| Foreground p95 latency under CPU load | **64.3 ms** (2.37× baseline) | **26.6 ms** (0.98× baseline) |
| OOM victim under memory pressure | **foreground** (the interactive process) | **background** (the heavy op) |
| Long-run foreground p95 (6 min continuous load) | — | **23–35 ms, flat** (11.9 ms drift, no creep/leak) |

The change keeps the interactive path at baseline latency (2.4× faster tail) under load, flips the OOM victim to the disposable op, and holds steady over a long run — and it only ever slows the deprioritized op, never live ticks or the interactive path.