### PR TITLE
jobs: starters self-provision their dataset — detached fetch at launch

### DIFF
--- a/wayfinder_paths/jobs/background.py
+++ b/wayfinder_paths/jobs/background.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+from pathlib import Path
 from typing import Any
 
 from wayfinder_paths.jobs.models import utc_now_iso
@@ -27,6 +28,22 @@ def _pid_alive(pid: Any) -> bool:
     except OSError:
         return False
     return True
+
+
+def op_running(job_dir: Path, op: str) -> bool:
+    """True when `op` has a live detached child recorded for the job at
+    `job_dir` — a `running` status file whose pid is still alive. A stale
+    status file from a dead child does not count."""
+    status_path = job_dir / "state" / "background_ops" / f"{op}.json"
+    try:
+        status = json.loads(status_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False
+    return (
+        isinstance(status, dict)
+        and status.get("state") == "running"
+        and _pid_alive(status.get("pid"))
+    )
 
 
 def spawn_detached_op(

--- a/wayfinder_paths/jobs/execution/job.py
+++ b/wayfinder_paths/jobs/execution/job.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import yaml
 
+from wayfinder_paths.jobs.background import op_running
 from wayfinder_paths.jobs.execution.features import (
     load_feature_rows,
     merge_features,
@@ -443,11 +444,14 @@ def _resolve_dataset(
             return PreparedExecutionDataset.from_rows(
                 fixture_bars, {"source": "execution_spec.validation.fixture_bars"}
             )
-    raise FileNotFoundError(
+    message = (
         "No backtest bars found. Provide results/backtest/input_bars.json, "
         "workspace/config/backtest_bars.json, execution_scenario_plan bars, or "
         "execution_spec.validation.fixture_bars."
     )
+    if op_running(root, "fetch_dataset"):
+        message += " — dataset fetch is in progress; retry shortly."
+    raise FileNotFoundError(message)
 
 
 def synthesize_scenario_plan(

--- a/wayfinder_paths/jobs/starters.py
+++ b/wayfinder_paths/jobs/starters.py
@@ -13,6 +13,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
+from wayfinder_paths.jobs.background import spawn_detached_op
 from wayfinder_paths.jobs.models import WayfinderJob, safe_job_id
 from wayfinder_paths.jobs.starter_leverage_evidence import STARTER_LEVERAGE_RESULTS
 from wayfinder_paths.jobs.store import JobStore
@@ -29,6 +30,8 @@ STARTER_LEVERAGE_DEFAULT = 1
 STARTER_LEVERAGE_MINIMUM = 1
 STARTER_LEVERAGE_MAXIMUM = 5
 STARTER_LEVERAGE_STEP = 1
+# Evidence-window owner policy: starter backtests/validation replay 120 days.
+STARTER_DATASET_DAYS = 120
 
 
 def validate_starter_leverage(value: Any) -> int:
@@ -749,6 +752,58 @@ def get_starter(starter_id: str) -> StarterDefinition:
     raise KeyError(f"unknown starter strategy: {starter_id}")
 
 
+def _spawn_starter_dataset_fetch(store: JobStore, job_id: str) -> dict[str, Any]:
+    """Self-provision the starter's market dataset as a detached fetch.
+
+    Launch stays fast (the child fetches bars minutes later into
+    results/backtest/input_bars.json); until then, backtests report the
+    in-progress fetch instead of a bare "no bars" error. Any failure here is
+    journaled and swallowed — dataset provisioning must never fail the launch.
+    """
+    try:
+        bars_path = store.job_dir(job_id) / "results" / "backtest" / "input_bars.json"
+        if bars_path.exists():
+            store.append_journal(
+                job_id,
+                {"type": "starter_dataset_fetch_skipped", "reason": "dataset_exists"},
+            )
+            return {"spawned": False, "reason": "dataset_exists"}
+        status = spawn_detached_op(
+            store,
+            job_id,
+            "fetch_dataset",
+            {"job_id": job_id, "days": STARTER_DATASET_DAYS},
+        )
+        if status.get("already_running"):
+            store.append_journal(
+                job_id,
+                {
+                    "type": "starter_dataset_fetch_skipped",
+                    "reason": "fetch_already_running",
+                },
+            )
+            return {"spawned": False, "reason": "fetch_already_running"}
+        store.append_journal(
+            job_id,
+            {
+                "type": "starter_dataset_fetch_spawned",
+                "op": "fetch_dataset",
+                "days": STARTER_DATASET_DAYS,
+                "pid": status.get("pid"),
+            },
+        )
+        return {"spawned": True, "days": STARTER_DATASET_DAYS, "pid": status.get("pid")}
+    except Exception as exc:  # noqa: BLE001 — never block or fail the launch
+        try:
+            store.append_journal(
+                job_id,
+                {"type": "starter_dataset_fetch_spawn_failed", "error": str(exc)},
+            )
+        except Exception:  # noqa: BLE001
+            pass
+        return {"spawned": False, "error": str(exc)}
+
+
 def create_starter_job(
     starter_id: str,
     *,
@@ -880,4 +935,5 @@ def create_starter_job(
 
         result["compile"] = JobCompiler(store=store).compile(job)
         sync_all_jobs(store=store)
+    result["dataset_fetch"] = _spawn_starter_dataset_fetch(store, job.id)
     return result

--- a/wayfinder_paths/mcp/tools/jobs.py
+++ b/wayfinder_paths/mcp/tools/jobs.py
@@ -368,6 +368,9 @@ async def core_jobs(
       - `starter_strategies` lists the fixed, mixed crypto/equity paper
         starters. `create_starter` with `starter_id` materializes one as a
         normal jobs_v1 job; its own forward inception begins at selection.
+        It also spawns a detached 120-day `fetch_dataset` op — do not re-run
+        `fetch_dataset` right after creating; poll `op_status` if a backtest
+        reports the fetch still in progress.
       - `create` with `agent_mode="monitor"` or `"intervene"` for supervised jobs.
       - `create` with `agent_mode="auto"` and `auto_limits` for agent-only auto jobs.
       - `set_script_mode` with `script_mode="live"` / `"paper"` to flip the

--- a/wayfinder_paths/tests/test_jobs_starters.py
+++ b/wayfinder_paths/tests/test_jobs_starters.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +12,7 @@ import pytest
 
 from wayfinder_paths.jobs.compiler import JobCompiler
 from wayfinder_paths.jobs.execution.features import apply_precompute
+from wayfinder_paths.jobs.execution.job import _resolve_dataset
 from wayfinder_paths.jobs.execution.primitives import (
     CompletedBarsView,
     ExecutionContext,
@@ -94,6 +96,37 @@ def _context(
 
 def _sides(intents: list[dict[str, Any]]) -> dict[str, str]:
     return {intent["symbol"]: intent["side"] for intent in intents}
+
+
+def _journal_events(store: JobStore, job_id: str) -> list[dict[str, Any]]:
+    path = store.job_dir(job_id) / "journal.jsonl"
+    if not path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+@pytest.fixture(autouse=True)
+def dataset_fetch_spawns(monkeypatch) -> list[dict[str, Any]]:
+    """Starter creation spawns a real detached fetch child; stub it so every
+    test stays hermetic, recording the calls for assertions."""
+    calls: list[dict[str, Any]] = []
+
+    def fake_spawn(store, job_id, op, kwargs):  # noqa: ANN001
+        calls.append({"job_id": job_id, "op": op, "kwargs": kwargs})
+        return {
+            "started": True,
+            "op": op,
+            "job_id": job_id,
+            "state": "running",
+            "pid": 4242,
+        }
+
+    monkeypatch.setattr("wayfinder_paths.jobs.starters.spawn_detached_op", fake_spawn)
+    return calls
 
 
 def test_starter_catalog_has_six_mixed_and_two_pair_paper_strategies() -> None:
@@ -472,6 +505,143 @@ def test_create_starter_reuse_tolerates_out_of_range_leverage(tmp_path) -> None:
     assert reused["created"] is False
     assert reused["selected_leverage"] == 5
     assert "clamped to 5" in reused["leverage_warning"]
+
+
+def test_create_starter_spawns_detached_dataset_fetch(
+    tmp_path, dataset_fetch_spawns
+) -> None:
+    store = JobStore(repo_root=tmp_path)
+    result = create_starter_job("mixed-rsi-snapback-1h", store=store, compile_job=False)
+
+    assert dataset_fetch_spawns == [
+        {
+            "job_id": "mixed-rsi-snapback-1h",
+            "op": "fetch_dataset",
+            "kwargs": {"job_id": "mixed-rsi-snapback-1h", "days": 120},
+        }
+    ]
+    assert result["dataset_fetch"] == {"spawned": True, "days": 120, "pid": 4242}
+    events = _journal_events(store, "mixed-rsi-snapback-1h")
+    spawned = next(
+        event for event in events if event["type"] == "starter_dataset_fetch_spawned"
+    )
+    assert spawned["days"] == 120
+    assert spawned["op"] == "fetch_dataset"
+    assert spawned["ts"]
+
+    reused = create_starter_job("mixed-rsi-snapback-1h", store=store, compile_job=False)
+    assert reused["created"] is False
+    assert len(dataset_fetch_spawns) == 1
+
+
+def test_create_starter_skips_dataset_fetch_when_bars_exist(
+    tmp_path, dataset_fetch_spawns
+) -> None:
+    store = JobStore(repo_root=tmp_path)
+    bars_path = (
+        store.job_dir("mixed-rsi-snapback-1h")
+        / "results"
+        / "backtest"
+        / "input_bars.json"
+    )
+    bars_path.parent.mkdir(parents=True)
+    bars_path.write_text("[]", encoding="utf-8")
+
+    result = create_starter_job("mixed-rsi-snapback-1h", store=store, compile_job=False)
+
+    assert result["created"] is True
+    assert result["dataset_fetch"] == {"spawned": False, "reason": "dataset_exists"}
+    assert dataset_fetch_spawns == []
+    skipped = next(
+        event
+        for event in _journal_events(store, "mixed-rsi-snapback-1h")
+        if event["type"] == "starter_dataset_fetch_skipped"
+    )
+    assert skipped["reason"] == "dataset_exists"
+
+
+def test_create_starter_skips_dataset_fetch_when_op_already_running(
+    tmp_path, monkeypatch
+) -> None:
+    store = JobStore(repo_root=tmp_path)
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.starters.spawn_detached_op",
+        lambda store, job_id, op, kwargs: {
+            "already_running": True,
+            "op": op,
+            "job_id": job_id,
+            "state": "running",
+            "pid": 999,
+        },
+    )
+
+    result = create_starter_job("mixed-rsi-snapback-1h", store=store, compile_job=False)
+
+    assert result["created"] is True
+    assert result["dataset_fetch"] == {
+        "spawned": False,
+        "reason": "fetch_already_running",
+    }
+    skipped = next(
+        event
+        for event in _journal_events(store, "mixed-rsi-snapback-1h")
+        if event["type"] == "starter_dataset_fetch_skipped"
+    )
+    assert skipped["reason"] == "fetch_already_running"
+
+
+def test_create_starter_survives_dataset_fetch_spawn_failure(
+    tmp_path, monkeypatch
+) -> None:
+    store = JobStore(repo_root=tmp_path)
+
+    def boom(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise RuntimeError("no child processes")
+
+    monkeypatch.setattr("wayfinder_paths.jobs.starters.spawn_detached_op", boom)
+
+    result = create_starter_job("mixed-rsi-snapback-1h", store=store, compile_job=False)
+
+    assert result["created"] is True
+    assert result["dataset_fetch"] == {"spawned": False, "error": "no child processes"}
+    failed = next(
+        event
+        for event in _journal_events(store, "mixed-rsi-snapback-1h")
+        if event["type"] == "starter_dataset_fetch_spawn_failed"
+    )
+    assert failed["error"] == "no child processes"
+
+
+def test_missing_bars_error_reports_in_progress_dataset_fetch(tmp_path) -> None:
+    store = JobStore(repo_root=tmp_path)
+    create_starter_job("mixed-rsi-snapback-1h", store=store, compile_job=False)
+    root = store.job_dir("mixed-rsi-snapback-1h")
+    spec = ExecutionSpec()
+
+    with pytest.raises(FileNotFoundError) as bare:
+        _resolve_dataset(root, spec, {})
+    assert "dataset fetch is in progress" not in str(bare.value)
+
+    ops_dir = root / "state" / "background_ops"
+    ops_dir.mkdir(parents=True)
+    status_path = ops_dir / "fetch_dataset.json"
+    status_path.write_text(
+        json.dumps({"op": "fetch_dataset", "state": "running", "pid": os.getpid()}),
+        encoding="utf-8",
+    )
+    with pytest.raises(
+        FileNotFoundError, match="dataset fetch is in progress; retry shortly"
+    ):
+        _resolve_dataset(root, spec, {})
+
+    # A stale status file from a dead child must not claim progress.
+    status_path.write_text(
+        json.dumps({"op": "fetch_dataset", "state": "running", "pid": 2**30}),
+        encoding="utf-8",
+    )
+    with pytest.raises(FileNotFoundError) as stale:
+        _resolve_dataset(root, spec, {})
+    assert "dataset fetch is in progress" not in str(stale.value)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

Launching a starter (`create-starter` / MCP `create_starter`) created the job + `starter_evidence.json` but never fetched the market dataset. Every subsequent backtest/validation on a fresh box failed with `No backtest bars found. Provide results/backtest/input_bars.json, ...` until someone manually ran `wayfinder job fetch-dataset <job> --days 120`. This broke the new-user cold start for every starter.

## Fix

After the job is created and compiled, the starter create path spawns the existing `fetch_dataset` op (op_runner already dispatches it to the same `build_live_dataset` the CLI uses) as a **detached** background child via `spawn_detached_op` — launch stays fast (~5-10s), bars arrive minutes later, and the op records its status in `state/background_ops/` so `op_status` / compute_status surface it like any other detached op.

- **Op payload**: `{job_id, days: 120}` (`STARTER_DATASET_DAYS`, the evidence-window owner policy).
- **Idempotent**: skips with a `starter_dataset_fetch_skipped` journal note when `results/backtest/input_bars.json` already exists or a `fetch_dataset` op is already running.
- **Journaled**: `starter_dataset_fetch_spawned` on the job (auto-stamped, like all journal rows).
- **Failure containment**: any spawn failure journals `starter_dataset_fetch_spawn_failed` and the create still succeeds — provisioning never blocks or fails the launch. The result payload carries a `dataset_fetch` key either way.
- **Better error while in flight**: `_resolve_dataset`'s "No backtest bars found" error now appends `— dataset fetch is in progress; retry shortly.` when the job dir shows a RUNNING `fetch_dataset` op with a live pid (new `background.op_running` helper; a stale status file from a dead child does not claim progress).
- MCP `core_jobs` docstring notes the auto-spawn so agents poll `op_status` instead of re-running `fetch_dataset` right after create.

## Tests

`wayfinder_paths/tests/test_jobs_starters.py` (+5, all green):
- create spawns the op with `job_id` + `days=120` and journals it; reuse path does not re-spawn
- idempotent skip when bars exist (no spawn, journal note)
- idempotent skip when a fetch op is already running
- spawn failure does not fail the create (journal + `dataset_fetch.error`)
- missing-bars error gains the in-progress hint only for a live running op (bare error before, stale dead-pid status ignored)

An autouse fixture stubs `spawn_detached_op` in the starter tests so no test forks a real detached child.

Full `-k "jobs or runner or mcp"`: **970 passed, 3 skipped** (baseline ~964 + 5 new). ruff check+format clean on touched files.