### PR TITLE
jobs: surface dataset-fetch state in the job snapshot

### DIFF
--- a/wayfinder_paths/jobs/background.py
+++ b/wayfinder_paths/jobs/background.py
@@ -46,6 +46,37 @@ def op_running(job_dir: Path, op: str) -> bool:
     )
 
 
+def op_status_summary(job_dir: Path, op: str) -> dict[str, Any] | None:
+    """Compact snapshot view of a detached op: status collapsed to
+    running/done/failed plus timestamps. None when no run is recorded.
+
+    Read-only (safe from the fork-per-request view server). A `running`
+    status whose pid is dead is resolved the way op_status does — a
+    parseable result file means the detached child finished anyway,
+    otherwise the run is lost and reported failed."""
+    ops_dir = job_dir / "state" / "background_ops"
+    try:
+        status = json.loads((ops_dir / f"{op}.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(status, dict):
+        return None
+    state = status.get("state")
+    if state == "running" and not _pid_alive(status.get("pid")):
+        try:
+            json.loads((ops_dir / f"{op}.result.json").read_text(encoding="utf-8"))
+            state = "done"
+        except (OSError, ValueError):
+            state = "failed"
+    if state not in ("running", "done"):
+        state = "failed"
+    summary: dict[str, Any] = {"status": state}
+    for key in ("started_at", "finished_at"):
+        if status.get(key):
+            summary[key] = status[key]
+    return summary
+
+
 def spawn_detached_op(
     store: JobStore, job_id: str, op: str, kwargs: dict[str, Any]
 ) -> dict[str, Any]:

--- a/wayfinder_paths/jobs/sync.py
+++ b/wayfinder_paths/jobs/sync.py
@@ -12,6 +12,7 @@ from wayfinder_paths.core.config import (
     get_opencode_instance_id,
     is_opencode_instance,
 )
+from wayfinder_paths.jobs.background import op_status_summary
 from wayfinder_paths.jobs.backtest_artifacts import summarize_backtest_artifacts
 from wayfinder_paths.jobs.compiler import JobCompiler
 from wayfinder_paths.jobs.execution.features import summarize_features
@@ -107,6 +108,28 @@ def _engine_mode(store: JobStore, job_id: str) -> str | None:
     return None
 
 
+def _dataset_fetch_state(store: JobStore, job_id: str) -> dict[str, Any] | None:
+    """Dataset-provisioning state for the UI: starters self-provision their
+    bars via a detached fetch_dataset op (~minutes), during which charts are
+    empty and backtests gate — without this key the FE can't tell "data on
+    the way" from an ordinary job. Reports the op status file when one exists
+    (running/done/failed); `needed` marks a starter (evidence file present)
+    whose bars never arrived and has no op recorded. None — the common case,
+    bars present and no op — omits the key so existing job snapshots stay
+    byte-identical."""
+    job_dir = store.job_dir(job_id)
+    summary = op_status_summary(job_dir, "fetch_dataset")
+    if summary is not None:
+        return summary
+    backtest_dir = job_dir / "results" / "backtest"
+    if (
+        not (backtest_dir / "input_bars.json").exists()
+        and (backtest_dir / "starter_evidence.json").exists()
+    ):
+        return {"status": "needed"}
+    return None
+
+
 def _runtime_reconciliation(job: Any, store: JobStore) -> dict[str, Any]:
     """Overlay the live runner/engine truth onto the scorecard so the UI shows
     what's ACTUALLY running, not the declared job.yaml. The driver executes the
@@ -175,6 +198,9 @@ def snapshot_job(job_id: str, *, store: JobStore | None = None) -> dict[str, Any
     runtime = _runtime_reconciliation(job, store)
     if runtime:
         scorecard = {**scorecard, **runtime}
+    dataset_fetch = _dataset_fetch_state(store, job_id)
+    if dataset_fetch is not None:
+        scorecard = {**scorecard, "dataset_fetch": dataset_fetch}
     runner_links = store.read_json(job_id, "runner_links.json", default={}) or {}
     latest_monitor = _report_with_session(store, job_id, "monitor")
     latest_intervene = _report_with_session(store, job_id, "intervene", "improve")

--- a/wayfinder_paths/tests/test_jobs_starters.py
+++ b/wayfinder_paths/tests/test_jobs_starters.py
@@ -10,6 +10,7 @@ from typing import Any
 import pandas as pd
 import pytest
 
+from wayfinder_paths.jobs import sync as sync_mod
 from wayfinder_paths.jobs.compiler import JobCompiler
 from wayfinder_paths.jobs.execution.features import apply_precompute
 from wayfinder_paths.jobs.execution.job import _resolve_dataset
@@ -21,6 +22,7 @@ from wayfinder_paths.jobs.execution.primitives import (
     PositionRecord,
     StateSnapshot,
 )
+from wayfinder_paths.jobs.models import WayfinderJob
 from wayfinder_paths.jobs.starters import (
     coerce_starter_leverage,
     create_starter_job,
@@ -49,6 +51,7 @@ from wayfinder_paths.jobs.strategies.mixed_volume_capitulation import (
 from wayfinder_paths.jobs.strategies.pair_relative_strength import (
     PairRelativeStrengthStrategy,
 )
+from wayfinder_paths.jobs.sync import snapshot_job
 
 
 def _context(
@@ -642,6 +645,138 @@ def test_missing_bars_error_reports_in_progress_dataset_fetch(tmp_path) -> None:
     with pytest.raises(FileNotFoundError) as stale:
         _resolve_dataset(root, spec, {})
     assert "dataset fetch is in progress" not in str(stale.value)
+
+
+class _DownRunnerBridge:
+    """Runner unreachable — snapshot degrades to the declared scorecard."""
+
+    def __init__(self, *, repo_root=None):  # noqa: ANN001
+        pass
+
+    def job_states(self) -> dict[str, Any]:
+        return {}
+
+
+def _snapshot_scorecard(store: JobStore, job_id: str, monkeypatch) -> dict[str, Any]:
+    monkeypatch.setattr(sync_mod, "RunnerBridge", _DownRunnerBridge)
+    return snapshot_job(job_id, store=store)["scorecard"]
+
+
+def _write_fetch_status(store: JobStore, job_id: str, status: dict[str, Any]) -> Path:
+    ops_dir = store.job_dir(job_id) / "state" / "background_ops"
+    ops_dir.mkdir(parents=True, exist_ok=True)
+    (ops_dir / "fetch_dataset.json").write_text(json.dumps(status), encoding="utf-8")
+    return ops_dir
+
+
+def test_snapshot_reports_dataset_needed_before_fetch_op_exists(
+    tmp_path, monkeypatch
+) -> None:
+    # Spawn is stubbed by the autouse fixture, so no op status file exists —
+    # exactly the window between create and the child writing its status.
+    store = JobStore(repo_root=tmp_path)
+    create_starter_job("mixed-rsi-snapback-1h", store=store, compile_job=False)
+    scorecard = _snapshot_scorecard(store, "mixed-rsi-snapback-1h", monkeypatch)
+    assert scorecard["dataset_fetch"] == {"status": "needed"}
+
+
+def test_snapshot_reports_running_dataset_fetch(tmp_path, monkeypatch) -> None:
+    store = JobStore(repo_root=tmp_path)
+    create_starter_job("mixed-rsi-snapback-1h", store=store, compile_job=False)
+    _write_fetch_status(
+        store,
+        "mixed-rsi-snapback-1h",
+        {
+            "op": "fetch_dataset",
+            "state": "running",
+            "pid": os.getpid(),
+            "started_at": "2026-08-19T00:00:00+00:00",
+        },
+    )
+    scorecard = _snapshot_scorecard(store, "mixed-rsi-snapback-1h", monkeypatch)
+    assert scorecard["dataset_fetch"] == {
+        "status": "running",
+        "started_at": "2026-08-19T00:00:00+00:00",
+    }
+
+
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [("done", "done"), ("failed", "failed"), ("killed", "failed"), ("lost", "failed")],
+)
+def test_snapshot_reports_finished_dataset_fetch(
+    tmp_path, monkeypatch, state: str, expected: str
+) -> None:
+    store = JobStore(repo_root=tmp_path)
+    create_starter_job("mixed-rsi-snapback-1h", store=store, compile_job=False)
+    _write_fetch_status(
+        store,
+        "mixed-rsi-snapback-1h",
+        {
+            "op": "fetch_dataset",
+            "state": state,
+            "pid": 4242,
+            "started_at": "2026-08-19T00:00:00+00:00",
+            "finished_at": "2026-08-19T00:02:30+00:00",
+        },
+    )
+    scorecard = _snapshot_scorecard(store, "mixed-rsi-snapback-1h", monkeypatch)
+    assert scorecard["dataset_fetch"] == {
+        "status": expected,
+        "started_at": "2026-08-19T00:00:00+00:00",
+        "finished_at": "2026-08-19T00:02:30+00:00",
+    }
+
+
+def test_snapshot_resolves_stale_running_fetch_via_result_file(
+    tmp_path, monkeypatch
+) -> None:
+    # A `running` status from a dead child means the reaper is gone: a
+    # parseable result file proves the detached fetch finished; without one
+    # the run is lost and reported failed.
+    store = JobStore(repo_root=tmp_path)
+    create_starter_job("mixed-rsi-snapback-1h", store=store, compile_job=False)
+    ops_dir = _write_fetch_status(
+        store,
+        "mixed-rsi-snapback-1h",
+        {"op": "fetch_dataset", "state": "running", "pid": 2**30},
+    )
+    scorecard = _snapshot_scorecard(store, "mixed-rsi-snapback-1h", monkeypatch)
+    assert scorecard["dataset_fetch"] == {"status": "failed"}
+
+    (ops_dir / "fetch_dataset.result.json").write_text("{}", encoding="utf-8")
+    scorecard = _snapshot_scorecard(store, "mixed-rsi-snapback-1h", monkeypatch)
+    assert scorecard["dataset_fetch"] == {"status": "done"}
+
+
+def test_snapshot_omits_dataset_fetch_when_bars_exist_and_no_op(
+    tmp_path, monkeypatch
+) -> None:
+    # The common case — dataset present, nothing in flight — must not grow a
+    # key: existing snapshots stay byte-identical.
+    store = JobStore(repo_root=tmp_path)
+    create_starter_job("mixed-rsi-snapback-1h", store=store, compile_job=False)
+    bars_path = (
+        store.job_dir("mixed-rsi-snapback-1h")
+        / "results"
+        / "backtest"
+        / "input_bars.json"
+    )
+    bars_path.write_text("[]", encoding="utf-8")
+    scorecard = _snapshot_scorecard(store, "mixed-rsi-snapback-1h", monkeypatch)
+    assert "dataset_fetch" not in scorecard
+
+
+def test_snapshot_omits_dataset_fetch_for_ordinary_jobs(tmp_path, monkeypatch) -> None:
+    # A non-starter job without bars has no evidence file — "needed" is a
+    # starter-only signal, ordinary jobs keep their snapshot unchanged.
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        "carry", script="strategy.py", interval_seconds=3600, agent_mode="monitor"
+    )
+    store.create_job(job)
+    scorecard = _snapshot_scorecard(store, job.id, monkeypatch)
+    assert "dataset_fetch" not in scorecard
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Launching a starter now spawns a detached ~2-3 min `fetch_dataset` op
(#677), but the job snapshot said nothing about it — the FE showed empty
charts and a confusing gate error while the data pulled. The snapshot's
scorecard now carries a `dataset_fetch` key the UI can render:

- `running` / `done` / `failed` mirror the op status file
  (`state/background_ops/fetch_dataset.json`), with `started_at` /
  `finished_at` when present. A stale `running` file from a dead child is
  resolved the way `op_status` does: parseable result file = done,
  otherwise failed. New read-only `background.op_status_summary` helper —
  safe from the fork-per-request view server, never rewrites the status
  file.
- `needed` marks a starter (starter_evidence.json present) with no bars
  and no op recorded — the window between create and the child writing
  its status, or a box where the spawn failed — so the FE can distinguish
  "no data yet" from an ordinary job.
- Omitted entirely for the common case (bars present, no op): existing
  job snapshots stay byte-identical.

No backend change needed: the sync path stores the scorecard verbatim and
`_serialize_job` returns it untouched, so the key rides through to the FE
as-is.

Tests: snapshot state matrix (needed / running / done / failed / killed /
lost / stale-pid resolution via result file / omitted with bars / omitted
for ordinary jobs) in test_jobs_starters.py.
