### PR TITLE
opencode agents: grant external_directory for user_vault job paths (1.18.18)

### DIFF
--- a/.opencode/agents/wayfinder-job-auto-worker.md
+++ b/.opencode/agents/wayfinder-job-auto-worker.md
@@ -23,6 +23,19 @@ permission:
     ".wayfinder_runs/**": ask
     ".wayfinder/jobs/**": allow
 
+  # opencode 1.18+ resolves symlinks and classifies vault writes
+  # (.wayfinder -> /wf/user_vault/wayfinder, .wayfinder_runs ->
+  # /wf/user_vault/scripts) as external-directory access; the unmatched
+  # default is "ask", which stalls headless wakes. Allow exactly the vault
+  # trees wakes legitimately touch (job + runner state, run scripts, box
+  # exports) — NEVER a broad /wf/user_vault/** — and keep the governance
+  # plane fail-closed with an explicit deny.
+  external_directory:
+    "/wf/user_vault/wayfinder/**": allow
+    "/wf/user_vault/scripts/**": allow
+    "/wf/user_vault/exports/**": allow
+    "/wf/user_vault/governance/**": deny
+
   bash:
     "*": ask
     "cat > .wayfinder/jobs/**": allow

--- a/.opencode/agents/wayfinder-job-worker.md
+++ b/.opencode/agents/wayfinder-job-worker.md
@@ -27,6 +27,20 @@ permission:
     ".wayfinder_runs/**": ask
     "*": deny
 
+  # opencode 1.18+ resolves symlinks and classifies vault writes
+  # (.wayfinder -> /wf/user_vault/wayfinder, .wayfinder_runs ->
+  # /wf/user_vault/scripts) as external-directory access; the unmatched
+  # default is "ask", which stalls headless wakes on an unanswerable prompt.
+  # Allow exactly the vault trees wakes legitimately touch (job + runner
+  # state, run scripts, box exports) — NEVER a broad /wf/user_vault/** —
+  # and keep the governance plane fail-closed with an explicit deny so it
+  # can never be reached through this class.
+  external_directory:
+    "/wf/user_vault/wayfinder/**": allow
+    "/wf/user_vault/scripts/**": allow
+    "/wf/user_vault/exports/**": allow
+    "/wf/user_vault/governance/**": deny
+
   bash:
     # Provenance guard: the worker cleared a live-mode audit flag by running
     # set-script-mode --by owner — claiming owner identity to satisfy the

--- a/.opencode/agents/wayfinder-strategy-lab.md
+++ b/.opencode/agents/wayfinder-strategy-lab.md
@@ -11,6 +11,18 @@ permission:
     scout: deny
     general: deny
   write: allow
+  # opencode 1.18+ resolves symlinks and classifies vault writes
+  # (.wayfinder -> /wf/user_vault/wayfinder, .wayfinder_runs ->
+  # /wf/user_vault/scripts) as external-directory access with an "ask"
+  # default. Strategy Lab lives in those trees (job bundles, backtest
+  # scratch, box exports) — allow exactly those trees, NEVER a broad
+  # /wf/user_vault/**, and keep the governance plane fail-closed with an
+  # explicit deny.
+  external_directory:
+    "/wf/user_vault/wayfinder/**": allow
+    "/wf/user_vault/scripts/**": allow
+    "/wf/user_vault/exports/**": allow
+    "/wf/user_vault/governance/**": deny
   wayfinder_*: deny
   # core_* — needs scripting + job control for backtests/experiments
   wayfinder_core_*: allow

--- a/wayfinder_paths/tests/test_jobs_live_loose_ends.py
+++ b/wayfinder_paths/tests/test_jobs_live_loose_ends.py
@@ -170,3 +170,35 @@ def test_owner_stamp_launder_trap_and_guards(tmp_path) -> None:
 
     source = Path(worker_module.__file__).read_text()
     assert "OWNER PROVENANCE IS NEVER YOURS TO CLAIM" in source
+
+
+def test_external_directory_grants_cover_vault_but_exclude_governance() -> None:
+    """opencode 1.18+ resolves the .wayfinder / .wayfinder_runs symlinks to
+    /wf/user_vault/** and gates writes behind the external_directory
+    permission (default "ask" — an unanswerable prompt on headless wakes).
+    The job agents must carry narrow allows for exactly the vault trees their
+    edit grants already imply, and the governance plane must stay fail-closed:
+    an explicit external_directory deny, never absorbed by a broad
+    /wf/user_vault/** allow that would undermine the edit-layer deny."""
+    from pathlib import Path
+
+    manifests = [
+        ".opencode/agents/wayfinder-job-worker.md",
+        ".opencode/agents/wayfinder-job-auto-worker.md",
+        ".opencode/agents/wayfinder-strategy-lab.md",
+    ]
+    for path in manifests:
+        manifest = Path(path).read_text()
+        assert "external_directory:" in manifest, path
+        assert '"/wf/user_vault/wayfinder/**": allow' in manifest, path
+        assert '"/wf/user_vault/scripts/**": allow' in manifest, path
+        assert '"/wf/user_vault/exports/**": allow' in manifest, path
+        assert '"/wf/user_vault/governance/**": deny' in manifest, path
+        # A wholesale vault grant would cover governance/ and gut the
+        # capability boundary — the allows must stay enumerated.
+        assert '"/wf/user_vault/**"' not in manifest, path
+
+    # The edit-layer governance deny is a separate, conjunctive check —
+    # external_directory grants must not be mistaken for a reason to drop it.
+    worker = Path(".opencode/agents/wayfinder-job-worker.md").read_text()
+    assert '"governance/**": deny' in worker


### PR DESCRIPTION
## Problem

The boxes rolled from opencode 1.15.5 to 1.18.18, which introduces an `external_directory` permission class. It resolves symlinks before matching, so writes under `/wf/sdk/.wayfinder/**` (symlink to `/wf/user_vault/wayfinder/**`) and `.wayfinder_runs/**` (symlink to `/wf/user_vault/scripts/**`) are now classified as external-directory access. The class defaults to `{"*": "ask"}` when no pattern matches:

```
message=asking id=per_... permission=external_directory patterns=["/wf/user_vault/wayfinder/jobs/<job>/*"]
```

Headless wake sessions (job worker / auto worker) cannot answer an interactive prompt, so research/intervene wakes have been stalled since the roll while script loops trade on fine.

## Fix

Add narrow `external_directory` grants to the three agent manifests whose existing `edit`/`write`/`bash` permissions already operate on vault paths:

- `.opencode/agents/wayfinder-job-worker.md`
- `.opencode/agents/wayfinder-job-auto-worker.md`
- `.opencode/agents/wayfinder-strategy-lab.md`

Each gets the same block:

```yaml
external_directory:
  "/wf/user_vault/wayfinder/**": allow    # jobs + runner state (.wayfinder symlink target)
  "/wf/user_vault/scripts/**": allow      # .wayfinder_runs symlink target
  "/wf/user_vault/exports/**": allow      # box export tree
  "/wf/user_vault/governance/**": deny    # governance plane stays fail-closed
```

This mirrors the on-box hot mitigation (pending owner approval) exactly, so the durable in-repo config and the interim box config converge on the same grants. Deliberately **not** granted: `/wf/user_vault/**` wholesale, `/wf/user_vault/governance/**`, or any audit path. The governance deny is explicit rather than left to the `ask` default so a headless session fails fast instead of hanging if anything ever routes a write there.

Agents left untouched: `wayfinder-quant`, `wayfinder-research`, `wayfinder-sports`, `wayfinder-visual`, `wayfinder-eval-judge` already ship `external_directory: {"*": allow}` (pre-existing, in-repo precedent for the key + pattern-map syntax); `wayfinder`, `wayfinder-baseline`, `wayfinder-mobile`, `wayfinder-planner` are interactive surfaces where the `ask` prompt is answerable, and were not in the stall report.

## Syntax confidence

- Confirmed against the 1.18.18 binary on the box: `external_directory` takes a pattern -> action map (default `{"*": "ask"}`), asks with `<parent-dir>/*` patterns, and pattern matching supports `**`. A global `opencode.jsonc` permission block merges *under* agent frontmatter, so per-agent grants here take precedence and are the narrowest correct surface.
- opencode permission docs additionally confirm allow/deny/ask actions and last-matching-rule-wins evaluation. The four patterns here are disjoint, so ordering is not load-bearing.
- In-repo precedent: five sibling manifests already use the pattern-map form on 1.18.18 boxes (`wayfinder-quant.md` et al.), so the key is known-honored by the loaded surface.
- Shell repo (`opencode.json` on `chore/sdk-override-jobs-v1`) has **no** global `external_directory` config and no per-agent permission overrides — prod has not solved this globally, so the SDK agent manifests (shipped into `/wf/sdk/.opencode/`) are the correct durable surface.

## Governance-bypass analysis

Can an `external_directory` allow undermine the `edit: "governance/**": deny`? No, for three stacked reasons:

1. **Disjoint trees.** The governance plane lives at `<repo_root>/governance/<job_id>/` (`wayfinder_paths/jobs/governance.py`), durably `/wf/user_vault/governance/**` — a *sibling* of `wayfinder/`, `scripts/`, and `exports/`, never contained in any allow. A broad `/wf/user_vault/**` allow WOULD have covered it; that is exactly why the allows are enumerated and the test pins the absence of the broad pattern.
2. **Conjunctive classes.** `edit`/`write` pattern checks and `external_directory` are separate permission gates — an external write must pass both. Granting the external class does not remove the worker's edit-layer `"governance/**": deny` / catch-all `"*": deny`.
3. **Strengthened, not weakened.** `external_directory` matches on symlink-*resolved* paths. A hostile symlink planted inside the agent-writable job tree (e.g. `.wayfinder/jobs/<id>/x -> /wf/user_vault/governance/`) could satisfy the edit-layer allow pattern textually, but the resolved path hits the explicit `"/wf/user_vault/governance/**": deny`. The new class adds a post-resolution defense the edit layer never had.

## Tests

- New `test_external_directory_grants_cover_vault_but_exclude_governance` in `wayfinder_paths/tests/test_jobs_live_loose_ends.py` pins, for all three manifests: the three allows, the governance deny, and the *absence* of a broad `"/wf/user_vault/**"` pattern; plus the worker's edit-layer `"governance/**": deny` staying in place.
- Existing manifest-content guards (owner-stamp launder trap, improve-loop pins, auto-worker bash/edit ordering asserts in `test_eval_wayfinder_jobs.py`) verified compatible — the inserted block contains none of the indexed patterns.
- Full `-k "jobs or runner or mcp"` suite: **980 passed, 3 skipped** (baseline ~979; the +1 is the new guard test). One run saw a single timing-flaky failure in `test_mcp_jobs_background_ops.py::test_background_op_end_to_end_via_echo` (`KeyError: 'exit_code'`, untouched by this change); it passed in isolation and the full re-run was green.

## On-box validation after the next roll

1. Trigger (or wait for) a job wake on a box running 1.18.18 with this SDK build.
2. `grep external_directory` the opencode serve log: expect **no** `message=asking ... permission=external_directory patterns=["/wf/user_vault/wayfinder/..."]` lines for worker sessions; the wake should run to completion and write `reports/<mode>/latest.json`.
3. Negative check: any write attempt resolving into `/wf/user_vault/governance/**` from a worker session should log an immediate deny (not an ask).
4. If a wake still stalls, capture the `patterns=[...]` value from the asking line — it names the exact resolved tree missing from the allow list.
5. Once this ships, the on-box hot mitigation (same grants in box config) can be retired — frontmatter takes precedence over the merged global block, so leaving it temporarily is also harmless.
