### PR TITLE
opencode agents: fail-fast external_directory catch-all for headless workers

### DIFF
--- a/.opencode/agents/wayfinder-job-auto-worker.md
+++ b/.opencode/agents/wayfinder-job-auto-worker.md
@@ -35,6 +35,11 @@ permission:
     "/wf/user_vault/scripts/**": allow
     "/wf/user_vault/exports/**": allow
     "/wf/user_vault/governance/**": deny
+    # Catch-all deny: any other external path (e.g. a depth mistake like
+    # ../../workspace resolving to /workspace) fails fast with a legible
+    # error instead of hanging on the default "ask". The matcher is
+    # specificity-based, so the enumerated allows above still win.
+    "*": deny
 
   bash:
     "*": ask

--- a/.opencode/agents/wayfinder-job-worker.md
+++ b/.opencode/agents/wayfinder-job-worker.md
@@ -40,6 +40,11 @@ permission:
     "/wf/user_vault/scripts/**": allow
     "/wf/user_vault/exports/**": allow
     "/wf/user_vault/governance/**": deny
+    # Catch-all deny: any other external path (e.g. a depth mistake like
+    # ../../workspace resolving to /workspace) fails fast with a legible
+    # error instead of hanging on the default "ask". The matcher is
+    # specificity-based, so the enumerated allows above still win.
+    "*": deny
 
   bash:
     # Provenance guard: the worker cleared a live-mode audit flag by running

--- a/.opencode/agents/wayfinder-strategy-lab.md
+++ b/.opencode/agents/wayfinder-strategy-lab.md
@@ -23,6 +23,11 @@ permission:
     "/wf/user_vault/scripts/**": allow
     "/wf/user_vault/exports/**": allow
     "/wf/user_vault/governance/**": deny
+    # Catch-all deny: any other external path (e.g. a depth mistake like
+    # ../../workspace resolving to /workspace) fails fast with a legible
+    # error instead of hanging on the default "ask". The matcher is
+    # specificity-based, so the enumerated allows above still win.
+    "*": deny
   wayfinder_*: deny
   # core_* — needs scripting + job control for backtests/experiments
   wayfinder_core_*: allow

--- a/wayfinder_paths/tests/test_jobs_live_loose_ends.py
+++ b/wayfinder_paths/tests/test_jobs_live_loose_ends.py
@@ -9,6 +9,7 @@ import asyncio
 import json
 
 import httpx
+import yaml
 
 from wayfinder_paths.core.clients.WayfinderClient import WayfinderClient
 from wayfinder_paths.jobs.models import WayfinderJob
@@ -172,16 +173,27 @@ def test_owner_stamp_launder_trap_and_guards(tmp_path) -> None:
     assert "OWNER PROVENANCE IS NEVER YOURS TO CLAIM" in source
 
 
-def test_external_directory_grants_cover_vault_but_exclude_governance() -> None:
+def test_external_directory_grants_cover_vault_deny_governance_and_catch_all() -> None:
     """opencode 1.18+ resolves the .wayfinder / .wayfinder_runs symlinks to
     /wf/user_vault/** and gates writes behind the external_directory
     permission (default "ask" — an unanswerable prompt on headless wakes).
     The job agents must carry narrow allows for exactly the vault trees their
-    edit grants already imply, and the governance plane must stay fail-closed:
-    an explicit external_directory deny, never absorbed by a broad
-    /wf/user_vault/** allow that would undermine the edit-layer deny."""
+    edit grants already imply, keep the governance plane fail-closed with an
+    explicit deny (never absorbed by a broad /wf/user_vault/** allow), and end
+    with a "*" catch-all deny: on a headless worker ask == hang, so a path
+    mistake outside the vault (observed: ../../workspace from the repo root
+    resolving to /workspace) must fail fast with a legible error the agent can
+    self-correct in the same wake. opencode's matcher is specificity-based, so
+    the enumerated allows still win over the catch-all."""
     from pathlib import Path
 
+    expected = {
+        "/wf/user_vault/wayfinder/**": "allow",
+        "/wf/user_vault/scripts/**": "allow",
+        "/wf/user_vault/exports/**": "allow",
+        "/wf/user_vault/governance/**": "deny",
+        "*": "deny",
+    }
     manifests = [
         ".opencode/agents/wayfinder-job-worker.md",
         ".opencode/agents/wayfinder-job-auto-worker.md",
@@ -189,11 +201,8 @@ def test_external_directory_grants_cover_vault_but_exclude_governance() -> None:
     ]
     for path in manifests:
         manifest = Path(path).read_text()
-        assert "external_directory:" in manifest, path
-        assert '"/wf/user_vault/wayfinder/**": allow' in manifest, path
-        assert '"/wf/user_vault/scripts/**": allow' in manifest, path
-        assert '"/wf/user_vault/exports/**": allow' in manifest, path
-        assert '"/wf/user_vault/governance/**": deny' in manifest, path
+        frontmatter = yaml.safe_load(manifest.split("---\n")[1])
+        assert frontmatter["permission"]["external_directory"] == expected, path
         # A wholesale vault grant would cover governance/ and gut the
         # capability boundary — the allows must stay enumerated.
         assert '"/wf/user_vault/**"' not in manifest, path


### PR DESCRIPTION
Follow-up to #680. Adds a `"*": deny` catch-all to the `permission.external_directory` blocks of the three headless agent manifests (`wayfinder-job-worker`, `wayfinder-job-auto-worker`, `wayfinder-strategy-lab`).

## Why

opencode 1.18.18's unmatched `external_directory` default is `"*": ask`. For a headless worker, ask == hang: there is no human to answer the prompt. We hit this on-box when a research agent wrote `../../workspace/src` from the repo root — a directory-depth mistake resolving to `/workspace` — and the wake stalled on an unanswerable prompt. With the catch-all deny, the same mistake fails fast with a legible permission error the agent can self-correct in the same wake.

## Notes

- opencode's matcher is **specificity-based**, not first-match — the enumerated `/wf/user_vault/{wayfinder,scripts,exports}/**` allows (and the `governance/**` deny) still win over the `"*"` catch-all. Its last position in the map is purely for readability.
- **Interactive agents are unchanged**: they keep the default ask (a human can answer), and quant/research keep their intentional `"*": allow`.
- Guard test (`test_jobs_live_loose_ends.py`) upgraded from substring checks to parsing the frontmatter and asserting the exact expected `external_directory` map, catch-all included; renamed to `test_external_directory_grants_cover_vault_deny_governance_and_catch_all`.

## Testing

- `pytest -k "jobs or runner or mcp"`: 980 passed, 3 skipped (baseline unchanged)
- manifest-index asserts in `test_eval_wayfinder_jobs.py`: pass
- ruff clean on the touched test file
