### PR TITLE
Notify - Surface the daily text budget to the agent

### DIFF
--- a/wayfinder_paths/mcp/tools/notify.py
+++ b/wayfinder_paths/mcp/tools/notify.py
@@ -21,12 +21,12 @@ async def notification_send(
     cap 500 chars. Quiet hours and a daily budget gate unprompted texts: a
     blocked call returns a warning instead of sending, and only a repeat call
     with override=true pushes through — do that only for genuinely urgent
-    information. A successful sms send reports the user's daily budget, how many
-    texts remain today, and the average spacing between them (daily_budget,
-    remaining_budget, avg_seconds_between_messages) — spread unprompted texts
-    across the day rather than spending the budget all at once. Replies while
-    the user is actively texting are never rate-limited, and near-duplicates of
-    texts you already sent are rejected, so answering the user is always safe.
+    information. A successful sms send reports the remaining daily budget and
+    average spacing (daily_budget, remaining_budget,
+    avg_seconds_between_messages) — pace unprompted texts across the day rather
+    than spending the budget at once. Replies while the user is actively texting
+    are never rate-limited, and near-duplicates of texts you already sent are
+    rejected, so answering the user is always safe.
 
     delivery="email" (default) requires a verified email address and renders
     Markdown into a themed HTML email.

--- a/wayfinder_paths/mcp/tools/notify.py
+++ b/wayfinder_paths/mcp/tools/notify.py
@@ -18,12 +18,15 @@ async def notification_send(
 
     delivery="sms" sends `message` as a text to the user's phone — for
     finished, user-facing updates only, never progress notes. Plain text, hard
-    cap 500 chars. Quiet hours and a frequency budget gate unprompted texts: a
+    cap 500 chars. Quiet hours and a daily budget gate unprompted texts: a
     blocked call returns a warning instead of sending, and only a repeat call
     with override=true pushes through — do that only for genuinely urgent
-    information. Replies while the user is actively texting are never
-    rate-limited, and near-duplicates of texts you already sent are rejected,
-    so answering the user is always safe.
+    information. A successful sms send reports the user's daily budget, how many
+    texts remain today, and the average spacing between them (daily_budget,
+    remaining_budget, avg_seconds_between_messages) — spread unprompted texts
+    across the day rather than spending the budget all at once. Replies while
+    the user is actively texting are never rate-limited, and near-duplicates of
+    texts you already sent are rejected, so answering the user is always safe.
 
     delivery="email" (default) requires a verified email address and renders
     Markdown into a themed HTML email.


### PR DESCRIPTION
### Summary

A successful `notification_send(delivery="sms")` now returns the user's daily budget, how many texts remain today, and the average spacing between them (`daily_budget`, `remaining_budget`, `avg_seconds_between_messages`). Documents these in the tool contract so the agent spreads unprompted texts across the day rather than spending the budget all at once.