### PR TITLE
watchdog: disk-pressure standing check

### DIFF
--- a/wayfinder_paths/conftest.py
+++ b/wayfinder_paths/conftest.py
@@ -1,4 +1,6 @@
+import shutil
 import sys
+from collections import namedtuple
 from pathlib import Path
 
 import pytest
@@ -8,6 +10,22 @@ pytest_plugins = ["wayfinder_paths.testing.gorlami"]
 # Add repo root to path so tests.test_utils can be imported
 _repo_root = Path(__file__).parent.parent
 _repo_root_str = str(_repo_root)
+
+_DiskUsage = namedtuple("_DiskUsage", "total used free")
+_GB = 1024**3
+
+
+@pytest.fixture(autouse=True)
+def _healthy_disk_usage(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin shutil.disk_usage to a healthy 50% volume for every test.
+
+    The watchdog's disk-pressure standing check reads the HOST filesystem —
+    on an actually-full dev box it would leak `disk_pressure` journal events
+    into every unrelated watchdog-pass test. Disk-pressure tests re-patch
+    explicitly and override this pin."""
+    monkeypatch.setattr(
+        shutil, "disk_usage", lambda path: _DiskUsage(100 * _GB, 50 * _GB, 50 * _GB)
+    )
 
 
 def pytest_configure(config):

--- a/wayfinder_paths/jobs/failures.py
+++ b/wayfinder_paths/jobs/failures.py
@@ -16,6 +16,7 @@ gates, refuted hypotheses) still stop the line — that is the system working.
 
 from __future__ import annotations
 
+import shutil
 import time
 from pathlib import Path
 
@@ -54,6 +55,24 @@ def classify_failure(error: str) -> str:
     if any(pattern in text for pattern in INFRASTRUCTURE_PATTERNS):
         return "infrastructure"
     return "evidence"
+
+
+def disk_used_pct(path: str | Path) -> float | None:
+    """Percent of the filesystem holding `path` in use; None on failure.
+
+    The jobs box's 2GB /wf volume silently filled to 100%: boot rsync died
+    half-way, opencode serve crash-looped, runnerd could not start, and live
+    trading loops went dark ~25 minutes with zero alerting. Fill level is
+    the box truth that predicts that failure mode before it lands. Never
+    raises.
+    """
+    try:
+        usage = shutil.disk_usage(path)
+        if usage.total <= 0:
+            return None
+        return 100.0 * usage.used / usage.total
+    except OSError:  # missing path / unmounted volume
+        return None
 
 
 def cpu_steal_pct(sample_seconds: float = 0.2) -> float | None:

--- a/wayfinder_paths/jobs/triggers.py
+++ b/wayfinder_paths/jobs/triggers.py
@@ -30,11 +30,14 @@ DEFAULT_DEBOUNCE_SECONDS = 600
 # runner_loop_gap fires when the watchdog sees a LIVE job's script loop gone
 # dark past 3x its interval — a live book nobody is managing must never wait
 # for the next timer poll.
+# disk_pressure fires when the watchdog sees the jobs volume past its alert
+# threshold — a full disk kills trading exactly like a stalled loop.
 ALWAYS_WAKE_EVENTS = {
     "proposal_restage_requested",
     "verdict_matured",
     "successor_overdue",
     "runner_loop_gap",
+    "disk_pressure",
 }
 
 

--- a/wayfinder_paths/jobs/watchdog.py
+++ b/wayfinder_paths/jobs/watchdog.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shutil
 import signal
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -664,6 +665,86 @@ def _check_loop_gap(store: JobStore, job: Any, now: datetime) -> dict[str, Any] 
     return None
 
 
+# Disk-pressure alerting: the production box's 2GB /wf volume silently filled
+# to 100% — boot rsync died half-way, opencode serve crash-looped, runnerd
+# could not start, and live trading loops went dark ~25 minutes with ZERO
+# alerting at 90/95/100%. The watchdog samples the filesystem holding the
+# jobs repo root every pass and journals (and, for live jobs, wakes the
+# agent) on breach — a full disk kills trading exactly like a stalled loop.
+_DISK_ALERT_PATH = "state/disk_pressure_alert.json"
+DISK_ALERT_PCT_ENV = "WAYFINDER_DISK_ALERT_PCT"
+DEFAULT_DISK_ALERT_PCT = 85
+# One journal entry per pressure episode: re-alert only after this window,
+# or immediately when usage has climbed this much further.
+DISK_REALERT_WINDOW = timedelta(hours=6)
+DISK_REALERT_RISE_PCT = 5.0
+
+
+def _check_disk_usage(
+    store: JobStore, job: Any, now: datetime
+) -> dict[str, Any] | None:
+    usage = shutil.disk_usage(store.repo_root)
+    if usage.total <= 0:
+        return None
+    pct_used = 100.0 * usage.used / usage.total
+    threshold = int(os.environ.get(DISK_ALERT_PCT_ENV) or DEFAULT_DISK_ALERT_PCT)
+    loop = getattr(job, "script_loop", None)
+    mode = (
+        str(getattr(loop, "mode", "") or "")
+        if loop is not None and getattr(loop, "enabled", False)
+        else ""
+    )
+    marker = store.read_json(job.id, _DISK_ALERT_PATH) or {}
+    if pct_used >= threshold:
+        alerted_pct = float(marker.get("pct_used") or 0.0)
+        if (
+            marker
+            and _age(now, marker.get("alerted_at")) < DISK_REALERT_WINDOW
+            and pct_used < alerted_pct + DISK_REALERT_RISE_PCT
+        ):
+            return None  # already alerted for this pressure episode
+        store.write_json(
+            job.id,
+            _DISK_ALERT_PATH,
+            {"pct_used": round(pct_used, 1), "alerted_at": now.isoformat()},
+        )
+        store.append_journal(
+            job.id,
+            {
+                "type": "disk_pressure",
+                "pct_used": round(pct_used, 1),
+                "free_mb": usage.free // (1024 * 1024),
+                "total_mb": usage.total // (1024 * 1024),
+                "threshold_pct": threshold,
+                "mode": mode,
+            },
+        )
+        if mode == "live":
+            # circular import: worker → application → … → triggers
+            from wayfinder_paths.jobs.triggers import fire_triggers
+
+            fire_triggers(store, job, ["disk_pressure"], source="watchdog")
+        return {
+            "action": "disk_pressure",
+            "pct_used": round(pct_used, 1),
+            "threshold_pct": threshold,
+            "mode": mode,
+        }
+    if marker:
+        store.write_json(job.id, _DISK_ALERT_PATH, {})
+        store.append_journal(
+            job.id,
+            {
+                "type": "disk_pressure_recovered",
+                "pct_used": round(pct_used, 1),
+                "threshold_pct": threshold,
+                "mode": mode,
+            },
+        )
+        return {"action": "disk_pressure_recovered", "mode": mode}
+    return None
+
+
 # Lifecycle evaluation is cheap (json reads + arithmetic) but its decisions
 # are consequential — a 6h cadence matches the counterfactual cycle and keeps
 # kill/graduate flips out of the 5-minute noise floor.
@@ -843,6 +924,13 @@ def recover_stalled_applications(
             loop_gap_event = None
         if loop_gap_event is not None:
             recovered.append({"job_id": job.id, **loop_gap_event})
+        try:
+            disk_event = _check_disk_usage(store, job, now)
+        except Exception as exc:
+            errors.append({"job_id": job.id, "error": f"disk: {exc}"})
+            disk_event = None
+        if disk_event is not None:
+            recovered.append({"job_id": job.id, **disk_event})
         try:
             for lifecycle_event in _run_lifecycle_pass(store, job.id, now):
                 recovered.append({"job_id": job.id, **lifecycle_event})

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -11,7 +11,7 @@ from loguru import logger
 
 from wayfinder_paths.core.clients.OpenCodeClient import OPENCODE_CLIENT
 from wayfinder_paths.jobs.derived_features import refresh_derived_features_if_stale
-from wayfinder_paths.jobs.failures import cpu_steal_pct
+from wayfinder_paths.jobs.failures import cpu_steal_pct, disk_used_pct
 from wayfinder_paths.jobs.forward import is_forward_empty
 from wayfinder_paths.jobs.ledger import tail_ledger
 from wayfinder_paths.jobs.memory_hygiene import sanitize_job_memory
@@ -546,6 +546,7 @@ def _compute_status_block(root: Path) -> dict[str, Any]:
     except Exception:  # noqa: BLE001
         last_backtest_ok_at = None
     steal = cpu_steal_pct()
+    disk = disk_used_pct(root)
     try:
         loadavg: list[float] | None = [round(v, 2) for v in os.getloadavg()]
     except OSError:
@@ -553,6 +554,7 @@ def _compute_status_block(root: Path) -> dict[str, Any]:
     return {
         "mem_available_mb": mem_available_mb,
         "cpu_steal_pct": None if steal is None else round(steal, 1),
+        "disk_used_pct": None if disk is None else round(disk, 1),
         "loadavg": loadavg,
         "last_experiment_at": last_experiment_at,
         "last_backtest_ok_at": last_backtest_ok_at,
@@ -568,7 +570,10 @@ def _compute_status_block(root: Path) -> dict[str, Any]:
             "hypervisor is taking most of this box's CPU and local "
             "subprocesses crawl — prefer resident MCP tools for reads, "
             "defer optional heavy compute, and NEVER interpret local "
-            "timeouts (exit 124) as remote outages."
+            "timeouts (exit 124) as remote outages. disk_used_pct above "
+            "~85 means the jobs volume is filling toward the full-disk "
+            "failure mode (dead rsync, crash-looping services) — prune "
+            "stale artifacts before writing anything large."
         ),
     }
 

--- a/wayfinder_paths/tests/test_jobs_fit_the_box.py
+++ b/wayfinder_paths/tests/test_jobs_fit_the_box.py
@@ -1,5 +1,5 @@
-"""Fit-the-box: MCP-first tool-call doctrine, steal-aware load shedding, and
-runner-gap alerting.
+"""Fit-the-box: MCP-first tool-call doctrine, steal-aware load shedding,
+runner-gap alerting, and disk-pressure alerting.
 
 Motivating forensics (production Fly box, ~0.25 sustained vCPU under 81-93%
 CPU steal): agents shelled out to `wayfinder <tool>` CLI wrappers for 1s API
@@ -8,25 +8,34 @@ OOM-killed processes were these; agents then misread their own `timeout`
 kills (exit 124) as "backend DOWN". The watchdog's gate re-stamp ran a full
 backtest under that steal, holding the heavy-compute lock 45-60 min. And
 during the OOM cascade the LIVE job's script loop went dark 65 minutes with
-zero alerting. Under test: the doctrine lands in the worker prompt, the
-watchdog sheds deferrable load under steal, and a dark loop is journaled and
-(for live jobs) wakes the agent.
+zero alerting. Separately, the box's 2GB /wf volume silently filled to 100%
+— boot rsync died half-way, opencode crash-looped, runnerd stayed down, and
+live loops went dark ~25 minutes with no alert at 90/95/100%. Under test:
+the doctrine lands in the worker prompt, the watchdog sheds deferrable load
+under steal, and a dark loop or a filling volume is journaled and (for live
+jobs) wakes the agent.
 """
 
 from __future__ import annotations
 
 import json
+from collections import namedtuple
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
 import pytest
 
-from wayfinder_paths.jobs.failures import classify_failure, cpu_steal_pct
+from wayfinder_paths.jobs.failures import (
+    classify_failure,
+    cpu_steal_pct,
+    disk_used_pct,
+)
 from wayfinder_paths.jobs.models import WayfinderJob
 from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.jobs.triggers import ALWAYS_WAKE_EVENTS
 from wayfinder_paths.jobs.watchdog import (
+    _check_disk_usage,
     _check_loop_gap,
     _recover_stale_gate,
     recover_stalled_applications,
@@ -254,3 +263,144 @@ def test_loop_gap_wired_into_watchdog_pass(
     assert len(gap_events) == 1
     assert gap_events[0]["job_id"] == job.id
     assert not [e for e in result["errors"] if "loop_gap" in str(e.get("error"))]
+
+
+# ── watchdog: disk-pressure alerting ─────────────────────────────────────────
+
+_DiskUsage = namedtuple("_DiskUsage", "total used free")
+
+
+def _patch_disk(
+    monkeypatch: pytest.MonkeyPatch, *, total_mb: int, used_mb: int
+) -> None:
+    total = total_mb * 1024 * 1024
+    used = used_mb * 1024 * 1024
+    monkeypatch.setattr(
+        "shutil.disk_usage", lambda path: _DiskUsage(total, used, total - used)
+    )
+
+
+def test_disk_pressure_journaled_once_with_fields(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    trigger_wakes: list[dict[str, Any]],
+) -> None:
+    store, job = _make_store(tmp_path, "box-disk")
+    now = datetime.now(UTC)
+    _patch_disk(monkeypatch, total_mb=2000, used_mb=1900)  # 95% used
+
+    event = _check_disk_usage(store, job, now)
+    assert event is not None
+    assert event["action"] == "disk_pressure"
+    journaled = _journal_events(store, job.id, "disk_pressure")
+    assert len(journaled) == 1
+    row = journaled[0]
+    assert row["pct_used"] == 95.0
+    assert row["free_mb"] == 100
+    assert row["total_mb"] == 2000
+    assert row["threshold_pct"] == 85
+    assert row["mode"] == "paper"
+    assert not trigger_wakes  # paper mode alerts, never wakes
+
+    # Same pressure next pass → debounced, no second journal entry.
+    assert _check_disk_usage(store, job, now + timedelta(minutes=5)) is None
+    assert len(_journal_events(store, job.id, "disk_pressure")) == 1
+
+
+def test_disk_pressure_realert_on_rise_then_recovery(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job = _make_store(tmp_path, "box-disk-rise")
+    now = datetime.now(UTC)
+    _patch_disk(monkeypatch, total_mb=2000, used_mb=1720)  # 86%
+    assert _check_disk_usage(store, job, now) is not None
+    # +2 points inside the window → same pressure episode, suppressed.
+    _patch_disk(monkeypatch, total_mb=2000, used_mb=1760)  # 88%
+    assert _check_disk_usage(store, job, now + timedelta(hours=1)) is None
+    # A ≥5-point climb re-alerts even inside the window.
+    _patch_disk(monkeypatch, total_mb=2000, used_mb=1840)  # 92%
+    event = _check_disk_usage(store, job, now + timedelta(hours=2))
+    assert event is not None and event["pct_used"] == 92.0
+    assert len(_journal_events(store, job.id, "disk_pressure")) == 2
+    # Past the re-alert window the episode re-alerts without a climb.
+    event = _check_disk_usage(store, job, now + timedelta(hours=9))
+    assert event is not None
+    assert len(_journal_events(store, job.id, "disk_pressure")) == 3
+    # Space freed → recovery journaled once and the marker clears.
+    _patch_disk(monkeypatch, total_mb=2000, used_mb=1000)  # 50%
+    event = _check_disk_usage(store, job, now + timedelta(hours=10))
+    assert event is not None and event["action"] == "disk_pressure_recovered"
+    assert _check_disk_usage(store, job, now + timedelta(hours=10)) is None
+    assert len(_journal_events(store, job.id, "disk_pressure_recovered")) == 1
+
+
+def test_disk_pressure_live_mode_fires_trigger_wake(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    trigger_wakes: list[dict[str, Any]],
+) -> None:
+    store, job = _make_store(tmp_path, "box-disk-live")
+    job.script_loop.mode = "live"
+    store.save(job)
+    _patch_disk(monkeypatch, total_mb=2000, used_mb=1900)
+
+    event = _check_disk_usage(store, job, datetime.now(UTC))
+    assert event is not None and event["mode"] == "live"
+    assert trigger_wakes == [
+        {"job_id": job.id, "events": ["disk_pressure"], "source": "watchdog"}
+    ]
+    assert "disk_pressure" in ALWAYS_WAKE_EVENTS
+
+
+def test_disk_pressure_below_threshold_quiet(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job = _make_store(tmp_path, "box-disk-quiet")
+    _patch_disk(monkeypatch, total_mb=2000, used_mb=1000)  # 50%
+    assert _check_disk_usage(store, job, datetime.now(UTC)) is None
+    assert not _journal_events(store, job.id, "disk_pressure")
+    assert not (store.job_dir(job.id) / "state" / "disk_pressure_alert.json").exists()
+
+
+def test_disk_pressure_env_threshold_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job = _make_store(tmp_path, "box-disk-env")
+    now = datetime.now(UTC)
+    _patch_disk(monkeypatch, total_mb=2000, used_mb=1200)  # 60%
+    assert _check_disk_usage(store, job, now) is None  # default 85 not breached
+    monkeypatch.setenv("WAYFINDER_DISK_ALERT_PCT", "50")
+    event = _check_disk_usage(store, job, now)
+    assert event is not None and event["threshold_pct"] == 50
+    assert _journal_events(store, job.id, "disk_pressure")[0]["threshold_pct"] == 50
+
+
+def test_disk_pressure_wired_into_watchdog_pass(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    trigger_wakes: list[dict[str, Any]],
+) -> None:
+    store, job = _make_store(tmp_path, "box-disk-pass")
+    _patch_disk(monkeypatch, total_mb=2000, used_mb=1900)
+    result = recover_stalled_applications(store=store, now=datetime.now(UTC))
+    disk_events = [e for e in result["recovered"] if e.get("action") == "disk_pressure"]
+    assert len(disk_events) == 1
+    assert disk_events[0]["job_id"] == job.id
+    assert not [e for e in result["errors"] if "disk" in str(e.get("error"))]
+
+
+def test_disk_used_pct_helper_and_compute_status_field(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job = _make_store(tmp_path, "box-disk-status")
+    _patch_disk(monkeypatch, total_mb=2000, used_mb=1500)  # 75%
+    assert disk_used_pct(tmp_path) == 75.0
+    block = _compute_status_block(store.job_dir(job.id))
+    assert block["disk_used_pct"] == 75.0
+    assert "disk_used_pct above" in block["_basis"]
+
+    def _boom(path: Any) -> _DiskUsage:
+        raise OSError("statvfs failed")
+
+    monkeypatch.setattr("shutil.disk_usage", _boom)
+    assert disk_used_pct(tmp_path) is None  # never raises


### PR DESCRIPTION
## Why

The jobs box's 2GB /wf volume silently hit 100%: boot rsync died half-way, opencode serve crash-looped, runnerd couldn't start, and live trading loops went dark ~25 minutes. Nothing alerted at 90/95/100%. We have RSS and CPU-steal standing checks but no disk check.

## What

**`wayfinder_paths/jobs/watchdog.py`** — new `_check_disk_usage` standing check, mirroring `_check_loop_gap`'s structure exactly:

- `shutil.disk_usage(store.repo_root)` every watchdog pass (on boxes that's /wf/sdk, which lives on the /wf volume)
- Threshold from `WAYFINDER_DISK_ALERT_PCT` (default 85, int percent used)
- On breach: journals a `disk_pressure` event (`pct_used`, `free_mb`, `total_mb`, `threshold_pct`, `mode`) and, for live-mode jobs, fires the same trigger-wake escalation `runner_loop_gap` uses — a full disk kills trading exactly like a stalled loop
- Debounce via a `state/disk_pressure_alert.json` marker (same mechanism as loop-gap's `gap_start_ts` marker): re-alerts only after 6h, or immediately if usage climbs ≥5 points; journals `disk_pressure_recovered` once when usage drops back under threshold and clears the marker
- Wired into `recover_stalled_applications` with the same per-job try/except isolation as the sibling checks

**`wayfinder_paths/jobs/triggers.py`** — `disk_pressure` added to `ALWAYS_WAKE_EVENTS` (infrastructure event; wakes regardless of the job's configured trigger list, like `runner_loop_gap`).

**`wayfinder_paths/jobs/failures.py`** — small `disk_used_pct(path)` helper beside `cpu_steal_pct()` (never raises, `None` on failure).

**`wayfinder_paths/jobs/worker.py`** — `_compute_status_block` now carries `disk_used_pct` beside `cpu_steal_pct`, with a one-line interpretation added to `_basis` (natural existing seam; no new surface invented).

## Tests

`wayfinder_paths/tests/test_jobs_fit_the_box.py` (where the loop-gap standing-check tests live), new "watchdog: disk-pressure alerting" section, `shutil.disk_usage` monkeypatched throughout:

- breach journals `disk_pressure` with correct fields; paper mode never wakes; second pass debounced
- ≥5-point rise re-alerts inside the window; past-6h re-alerts without a rise; recovery journals `disk_pressure_recovered` once and clears the marker
- live mode fires the trigger wake (`events=["disk_pressure"]`, `source="watchdog"`) and `disk_pressure` is in `ALWAYS_WAKE_EVENTS`
- below threshold: no journal, no marker
- `WAYFINDER_DISK_ALERT_PCT` override respected
- wired-into-`recover_stalled_applications` pass test
- `disk_used_pct` helper + `_compute_status_block` field; never raises on `OSError`

**`wayfinder_paths/conftest.py`** — autouse fixture pinning `shutil.disk_usage` to a healthy 50% volume for every test: the standing check reads the HOST filesystem, so an actually-full dev box (this one is at 97%) would otherwise leak `disk_pressure` journal events into every unrelated watchdog-pass test. The disk-pressure tests re-patch explicitly and override the pin.

Full `pytest -k "jobs or runner or mcp"`: **991 passed, 9 skipped, 0 failed** (984 pre-existing + 7 new; no regressions). Ruff check + format clean on touched files; scoped mypy: no new errors (5 pre-existing in watchdog/worker, line-shifted only).
