### PR TITLE
agents: fix external_directory catch-all ordering (opencode matcher is last-match-wins)

### DIFF
--- a/.opencode/agents/wayfinder-job-auto-worker.md
+++ b/.opencode/agents/wayfinder-job-auto-worker.md
@@ -31,15 +31,23 @@ permission:
   # exports) — NEVER a broad /wf/user_vault/** — and keep the governance
   # plane fail-closed with an explicit deny.
   external_directory:
+    # ORDER IS LOAD-BEARING. opencode's evaluator is last-match-wins over
+    # YAML insertion order (permission/index.ts evaluate() uses findLast;
+    # fromConfig() emits rules in Object.entries order) — NOT specificity
+    # based, and "*"/"**" both compile to ".*" and cross slashes
+    # (util/wildcard.ts). The catch-all deny must come FIRST so the vault
+    # allows below override it; appended last it matched every request and
+    # silently denied all vault writes (observed under opencode 1.18.18).
+    # Catch-all: any other external path (e.g. a depth mistake like
+    # ../../workspace resolving to /workspace) fails fast with a legible
+    # error instead of hanging on the default "ask".
+    "*": deny
     "/wf/user_vault/wayfinder/**": allow
     "/wf/user_vault/scripts/**": allow
     "/wf/user_vault/exports/**": allow
+    # Governance stays LAST so it wins over any overlapping allow ever
+    # added above — fail-closed under last-match-wins.
     "/wf/user_vault/governance/**": deny
-    # Catch-all deny: any other external path (e.g. a depth mistake like
-    # ../../workspace resolving to /workspace) fails fast with a legible
-    # error instead of hanging on the default "ask". The matcher is
-    # specificity-based, so the enumerated allows above still win.
-    "*": deny
 
   bash:
     "*": ask

--- a/.opencode/agents/wayfinder-job-worker.md
+++ b/.opencode/agents/wayfinder-job-worker.md
@@ -36,15 +36,23 @@ permission:
   # and keep the governance plane fail-closed with an explicit deny so it
   # can never be reached through this class.
   external_directory:
+    # ORDER IS LOAD-BEARING. opencode's evaluator is last-match-wins over
+    # YAML insertion order (permission/index.ts evaluate() uses findLast;
+    # fromConfig() emits rules in Object.entries order) — NOT specificity
+    # based, and "*"/"**" both compile to ".*" and cross slashes
+    # (util/wildcard.ts). The catch-all deny must come FIRST so the vault
+    # allows below override it; appended last it matched every request and
+    # silently denied all vault writes (observed under opencode 1.18.18).
+    # Catch-all: any other external path (e.g. a depth mistake like
+    # ../../workspace resolving to /workspace) fails fast with a legible
+    # error instead of hanging on the default "ask".
+    "*": deny
     "/wf/user_vault/wayfinder/**": allow
     "/wf/user_vault/scripts/**": allow
     "/wf/user_vault/exports/**": allow
+    # Governance stays LAST so it wins over any overlapping allow ever
+    # added above — fail-closed under last-match-wins.
     "/wf/user_vault/governance/**": deny
-    # Catch-all deny: any other external path (e.g. a depth mistake like
-    # ../../workspace resolving to /workspace) fails fast with a legible
-    # error instead of hanging on the default "ask". The matcher is
-    # specificity-based, so the enumerated allows above still win.
-    "*": deny
 
   bash:
     # Provenance guard: the worker cleared a live-mode audit flag by running

--- a/.opencode/agents/wayfinder-strategy-lab.md
+++ b/.opencode/agents/wayfinder-strategy-lab.md
@@ -19,15 +19,23 @@ permission:
   # /wf/user_vault/**, and keep the governance plane fail-closed with an
   # explicit deny.
   external_directory:
+    # ORDER IS LOAD-BEARING. opencode's evaluator is last-match-wins over
+    # YAML insertion order (permission/index.ts evaluate() uses findLast;
+    # fromConfig() emits rules in Object.entries order) — NOT specificity
+    # based, and "*"/"**" both compile to ".*" and cross slashes
+    # (util/wildcard.ts). The catch-all deny must come FIRST so the vault
+    # allows below override it; appended last it matched every request and
+    # silently denied all vault writes (observed under opencode 1.18.18).
+    # Catch-all: any other external path (e.g. a depth mistake like
+    # ../../workspace resolving to /workspace) fails fast with a legible
+    # error instead of hanging on the default "ask".
+    "*": deny
     "/wf/user_vault/wayfinder/**": allow
     "/wf/user_vault/scripts/**": allow
     "/wf/user_vault/exports/**": allow
+    # Governance stays LAST so it wins over any overlapping allow ever
+    # added above — fail-closed under last-match-wins.
     "/wf/user_vault/governance/**": deny
-    # Catch-all deny: any other external path (e.g. a depth mistake like
-    # ../../workspace resolving to /workspace) fails fast with a legible
-    # error instead of hanging on the default "ask". The matcher is
-    # specificity-based, so the enumerated allows above still win.
-    "*": deny
   wayfinder_*: deny
   # core_* — needs scripting + job control for backtests/experiments
   wayfinder_core_*: allow

--- a/wayfinder_paths/tests/test_jobs_live_loose_ends.py
+++ b/wayfinder_paths/tests/test_jobs_live_loose_ends.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
+from pathlib import Path
 
 import httpx
 import yaml
@@ -173,41 +175,159 @@ def test_owner_stamp_launder_trap_and_guards(tmp_path) -> None:
     assert "OWNER PROVENANCE IS NEVER YOURS TO CLAIM" in source
 
 
+AGENT_MANIFESTS = [
+    ".opencode/agents/wayfinder-job-worker.md",
+    ".opencode/agents/wayfinder-job-auto-worker.md",
+    ".opencode/agents/wayfinder-strategy-lab.md",
+]
+
+# ORDER IS LOAD-BEARING (see test_external_directory_matcher_semantics for
+# the ported opencode evaluator that proves it): opencode resolves rules
+# last-match-wins over YAML insertion order, so the "*" catch-all deny must
+# come FIRST (every later allow overrides it) and the governance deny LAST
+# (it wins over any overlapping allow ever added above it).
+EXPECTED_EXTERNAL_DIRECTORY = [
+    ("*", "deny"),
+    ("/wf/user_vault/wayfinder/**", "allow"),
+    ("/wf/user_vault/scripts/**", "allow"),
+    ("/wf/user_vault/exports/**", "allow"),
+    ("/wf/user_vault/governance/**", "deny"),
+]
+
+
+def _external_directory_map(manifest_path: str) -> dict[str, str]:
+    manifest = Path(manifest_path).read_text()
+    frontmatter = yaml.safe_load(manifest.split("---\n")[1])
+    return frontmatter["permission"]["external_directory"]
+
+
 def test_external_directory_grants_cover_vault_deny_governance_and_catch_all() -> None:
     """opencode 1.18+ resolves the .wayfinder / .wayfinder_runs symlinks to
-    /wf/user_vault/** and gates writes behind the external_directory
+    /wf/user_vault/** and gates reads/writes behind the external_directory
     permission (default "ask" — an unanswerable prompt on headless wakes).
     The job agents must carry narrow allows for exactly the vault trees their
     edit grants already imply, keep the governance plane fail-closed with an
-    explicit deny (never absorbed by a broad /wf/user_vault/** allow), and end
-    with a "*" catch-all deny: on a headless worker ask == hang, so a path
+    explicit deny (never absorbed by a broad /wf/user_vault/** allow), and
+    carry a "*" catch-all deny: on a headless worker ask == hang, so a path
     mistake outside the vault (observed: ../../workspace from the repo root
     resolving to /workspace) must fail fast with a legible error the agent can
-    self-correct in the same wake. opencode's matcher is specificity-based, so
-    the enumerated allows still win over the catch-all."""
-    from pathlib import Path
+    self-correct in the same wake.
 
-    expected = {
-        "/wf/user_vault/wayfinder/**": "allow",
-        "/wf/user_vault/scripts/**": "allow",
-        "/wf/user_vault/exports/**": "allow",
-        "/wf/user_vault/governance/**": "deny",
-        "*": "deny",
-    }
-    manifests = [
-        ".opencode/agents/wayfinder-job-worker.md",
-        ".opencode/agents/wayfinder-job-auto-worker.md",
-        ".opencode/agents/wayfinder-strategy-lab.md",
-    ]
-    for path in manifests:
-        manifest = Path(path).read_text()
-        frontmatter = yaml.safe_load(manifest.split("---\n")[1])
-        assert frontmatter["permission"]["external_directory"] == expected, path
+    opencode's evaluator is LAST-MATCH-WINS over YAML insertion order — NOT
+    specificity-based (packages/opencode/src/permission/index.ts evaluate()
+    uses findLast; fromConfig() emits rules in Object.entries order). The
+    catch-all therefore must be the FIRST key: when it was appended last
+    (PR #681) it matched every request and silently denied all vault writes.
+    This test pins the exact ordered items, not just the mapping — YAML load
+    preserves key order into the dict, mirroring opencode's parse."""
+    for path in AGENT_MANIFESTS:
+        mapping = _external_directory_map(path)
+        assert list(mapping.items()) == EXPECTED_EXTERNAL_DIRECTORY, path
         # A wholesale vault grant would cover governance/ and gut the
         # capability boundary — the allows must stay enumerated.
-        assert '"/wf/user_vault/**"' not in manifest, path
+        assert '"/wf/user_vault/**"' not in Path(path).read_text(), path
 
     # The edit-layer governance deny is a separate, conjunctive check —
     # external_directory grants must not be mistaken for a reason to drop it.
     worker = Path(".opencode/agents/wayfinder-job-worker.md").read_text()
     assert '"governance/**": deny' in worker
+
+
+def _wildcard_match(string: str, pattern: str) -> bool:
+    """Faithful port of opencode's Wildcard.match
+    (packages/opencode/src/util/wildcard.ts L3-L19 @ v1.18.18, commit
+    31406ccc): escape regex specials EXCEPT * and ?, then * -> ".*"
+    (crosses slashes; "**" has no special meaning — it compiles to
+    ".*.*" == ".*"), ? -> ".", anchored ^...$ with dotall."""
+    string = string.replace("\\", "/")
+    pattern = pattern.replace("\\", "/")
+    escaped = re.sub(r"[.+^${}()|[\]\\]", lambda m: "\\" + m.group(0), pattern)
+    escaped = escaped.replace("*", ".*").replace("?", ".")
+    # "ls *" also matches bare "ls" (trailing-arg wildcard optionality)
+    if escaped.endswith(" .*"):
+        escaped = escaped[:-3] + "( .*)?"
+    return re.match("^" + escaped + "$", string, flags=re.DOTALL) is not None
+
+
+def _evaluate(
+    permission: str, pattern: str, ruleset: list[dict[str, str]]
+) -> dict[str, str]:
+    """Faithful port of opencode's Permission.evaluate
+    (packages/opencode/src/permission/index.ts L28-L38 @ v1.18.18):
+    rulesets.flat().findLast(...) — the LAST matching rule wins, with an
+    {action: "ask", pattern: "*"} fallback when nothing matches."""
+    winner = None
+    for rule in ruleset:
+        if _wildcard_match(permission, rule["permission"]) and _wildcard_match(
+            pattern, rule["pattern"]
+        ):
+            winner = rule
+    return winner or {"permission": permission, "pattern": "*", "action": "ask"}
+
+
+def _from_config(
+    permission_config: dict[str, dict[str, str] | str],
+) -> list[dict[str, str]]:
+    """Faithful port of opencode's Permission.fromConfig
+    (packages/opencode/src/permission/index.ts L186-L198 @ v1.18.18):
+    Object.entries insertion order becomes ruleset order ($HOME/~ expansion
+    omitted — no such patterns in the agent manifests)."""
+    ruleset: list[dict[str, str]] = []
+    for key, value in permission_config.items():
+        if isinstance(value, str):
+            ruleset.append({"permission": key, "pattern": "*", "action": value})
+            continue
+        for pattern, action in value.items():
+            ruleset.append({"permission": key, "pattern": pattern, "action": action})
+    return ruleset
+
+
+def test_external_directory_matcher_semantics() -> None:
+    """Run the actual manifest maps through a faithful Python port of
+    opencode v1.18.18's matcher and pin the outcomes. Requests are shaped
+    exactly as opencode builds them: join(parentDir, "*") — a literal "*"
+    suffix (packages/opencode/src/tool/external-directory.ts L29-L37)."""
+    for path in AGENT_MANIFESTS:
+        ruleset = _from_config({"external_directory": _external_directory_map(path)})
+
+        def action(request: str, ruleset: list[dict[str, str]] = ruleset) -> str:
+            return _evaluate("external_directory", request, ruleset)["action"]
+
+        # Job-dir writes (the production breakage under PR #681) → allow.
+        assert action("/wf/user_vault/wayfinder/jobs/majors-5m-lab/*") == "allow", path
+        assert (
+            action("/wf/user_vault/wayfinder/jobs/majors-5m-lab/research/*") == "allow"
+        ), path
+        assert action("/wf/user_vault/wayfinder/runner/*") == "allow", path
+        assert action("/wf/user_vault/scripts/.scratch/session/*") == "allow", path
+        assert action("/wf/user_vault/exports/*") == "allow", path
+        # Governance plane → deny, at any depth.
+        assert action("/wf/user_vault/governance/*") == "deny", path
+        assert action("/wf/user_vault/governance/owner_targets/*") == "deny", path
+        # Unknown external paths → deny FAST via the catch-all (no ask-hang).
+        assert action("/workspace/*") == "deny", path
+        assert action("/etc/*") == "deny", path
+        # Sibling-prefix escapes do not ride the allow ("wayfinder_evil").
+        assert action("/wf/user_vault/wayfinder_evil/*") == "deny", path
+
+        # Regression pin: the PR #681 ordering (catch-all LAST) denies the
+        # job dir under last-match-wins — the exact production failure.
+        broken = _from_config(
+            {
+                "external_directory": {
+                    "/wf/user_vault/wayfinder/**": "allow",
+                    "/wf/user_vault/scripts/**": "allow",
+                    "/wf/user_vault/exports/**": "allow",
+                    "/wf/user_vault/governance/**": "deny",
+                    "*": "deny",
+                }
+            }
+        )
+        assert (
+            _evaluate(
+                "external_directory",
+                "/wf/user_vault/wayfinder/jobs/majors-5m-lab/*",
+                broken,
+            )["action"]
+            == "deny"
+        )


### PR DESCRIPTION
## Problem

After PR #681 appended `"*": deny` to the agents' `external_directory` maps, production serve logs showed every job-dir write denied by the catch-all:

```
evaluated permission=external_directory pattern=/wf/user_vault/wayfinder/jobs/majors-5m-lab/* action.permission=external_directory action.pattern=* action.action=deny
```

The `#681` comment claimed "the matcher is specificity-based, so the enumerated allows above still win." That is wrong. I read the opencode source at tag `v1.18.18` (commit `31406cc`, the version on the box) to get the real semantics.

## Actual matcher semantics (opencode v1.18.18)

**1. Resolution is last-match-wins — no specificity, no allow/deny precedence.**
`packages/opencode/src/permission/index.ts` L28-38:

```ts
export function evaluate(permission: string, pattern: string, ...rulesets: PermissionV1.Ruleset[]): PermissionV1.Rule {
  return (
    rulesets
      .flat()
      .findLast((rule) => Wildcard.match(permission, rule.permission) && Wildcard.match(pattern, rule.pattern)) ?? {
      action: "ask",
      permission,
      pattern: "*",
    }
  )
}
```

`findLast` — the last rule in the flattened ruleset that matches wins. Nothing sorts by specificity anywhere in this path.

**2. Ruleset order = YAML insertion order.**
`packages/opencode/src/permission/index.ts` L186-198 (`fromConfig`) iterates `Object.entries(value)` — one rule per `(pattern, action)` in map insertion order. `merge` (L200-202) is a flat concat. Agent frontmatter rules are appended after the built-in defaults and user config (`packages/opencode/src/agent/agent.ts` L286-293: `item.permission = Permission.merge(item.permission, Permission.fromConfig(value.permission ?? {}))`), so frontmatter entries override defaults — later beats earlier, everywhere.

**3. `*` crosses slashes; `**` has no special meaning.**
`packages/opencode/src/util/wildcard.ts` L3-19:

```ts
let escaped = pattern
  .replace(/[.+^${}()|[\]\\]/g, "\\$&") // escape special regex chars
  .replace(/\*/g, ".*") // * becomes .*
  .replace(/\?/g, ".") // ? becomes .
...
return new RegExp("^" + escaped + "$", flags).test(str)
```

`*` and `?` are deliberately not escaped; `*` → `.*` which crosses `/`. There is **no globstar handling**: `**` compiles to `.*.*` ≡ `.*`. So `/wf/user_vault/wayfinder/**` and `/wf/user_vault/wayfinder/*` are the same regex.

**4. Requests are parent-dir globs with a literal `*`.**
`packages/opencode/src/tool/external-directory.ts` L29-37: `const glob = path.join(dir, "*")` → `ctx.ask({ permission: "external_directory", patterns: [glob], ... })`. The requested *string* `/wf/user_vault/wayfinder/jobs/majors-5m-lab/*` is matched as plain text against each config pattern's regex. Read/grep/glob/lsp/edit/write/apply_patch all gate external paths through this helper.

## Why #681 broke

`/wf/user_vault/wayfinder/**` **did** match the request — `^/wf/user_vault/wayfinder/.*.*$` matches `/wf/user_vault/wayfinder/jobs/majors-5m-lab/*` fine. But `"*": deny` (regex `^.*$`) **also** matched, and being the last entry in the YAML map it was the `findLast` winner. The log line only prints the winning rule, which made it look like the allow "failed to match". Under #680 (no catch-all) the allow was the last matching rule, so everything worked.

## Fix

Catch-all deny **can** coexist with the allows — it just has to come **first**, so every enumerated rule after it overrides it:

```yaml
external_directory:
  "*": deny
  "/wf/user_vault/wayfinder/**": allow
  "/wf/user_vault/scripts/**": allow
  "/wf/user_vault/exports/**": allow
  "/wf/user_vault/governance/**": deny
```

- Job-dir request `/wf/user_vault/wayfinder/jobs/<job>/*` → matches `*` (deny) and the wayfinder allow; allow is later → **allow**.
- `/wf/user_vault/governance/...` → **deny** (kept last so it beats any overlapping allow ever added above it — fail-closed under last-match-wins).
- Unknown external path (e.g. `/workspace/*`) → only `*` matches → **deny fast**, no ask-hang. The catch-all deny survives.
- Sibling-prefix escape `/wf/user_vault/wayfinder_evil/*` → deny (the allow requires the literal `/` after `wayfinder`).

Applied identically to `wayfinder-job-worker.md`, `wayfinder-job-auto-worker.md`, `wayfinder-strategy-lab.md`. Subagents (e.g. wayfinder-quant via task) inherit the parent's `external_directory` rules in parent order (`packages/opencode/src/agent/subagent-permissions.ts` + `session/prompt.ts` L346), so the corrected ordering propagates.

**Known trade-off** (same as under #681, unchanged by this PR): an agent-level `*` deny sits after opencode's built-in default external whitelists (global tmp, skill dirs, reference dirs — `agent/agent.ts` L109-127), so those default allows are shadowed for these three agents. The tool-output truncation dir stays readable because opencode re-appends its allow *after* frontmatter rules unless explicitly denied (`agent/agent.ts` L295-310).

## Tests

- `test_external_directory_grants_cover_vault_deny_governance_and_catch_all` now pins the **ordered** items (`list(mapping.items())`) — the old dict equality was order-blind, which is how #681 passed the guard while broken in production.
- New `test_external_directory_matcher_semantics`: faithful Python port of `Wildcard.match`, `Permission.evaluate` (findLast), and `Permission.fromConfig` from v1.18.18 (source files/lines cited in docstrings), run against the *actual* manifest maps. Asserts: job-dir requests → allow, governance → deny, `/workspace/*` → deny, sibling escape → deny, and a regression pin that the #681 ordering (catch-all last) denies the job dir.

## Validation

- `pytest -k "jobs or runner or mcp"`: **992 passed, 9 skipped** (baseline 991/9, +1 new test)
- `ruff check` + `ruff format --check`: clean
