### PR TITLE
improver: progress constitution — escalating staleness, successor re-arm, owner-adjudicated exhaustion, probation entry tier

### DIFF
--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -39,6 +39,12 @@ from wayfinder_paths.jobs.execution.preflight import (
 from wayfinder_paths.jobs.execution.reconcile import reconcile_job
 from wayfinder_paths.jobs.execution.validation import validate_execution_job
 from wayfinder_paths.jobs.execution.walk_forward import format_fold_table
+from wayfinder_paths.jobs.exhaustion import (
+    CLAIM_PROVENANCES,
+    adjudicate_exhaustion_claim,
+    file_exhaustion_claim,
+    list_exhaustion_claims,
+)
 from wayfinder_paths.jobs.features import append_feature, list_features
 from wayfinder_paths.jobs.forward_artifacts import load_forward_view
 from wayfinder_paths.jobs.gating import evaluate_live_gate
@@ -50,6 +56,7 @@ from wayfinder_paths.jobs.models import (
     infer_job_kind,
     normalize_agent_mode,
 )
+from wayfinder_paths.jobs.probation import open_paper_probation_leg
 from wayfinder_paths.jobs.proposals import propose_change, restage_proposal
 from wayfinder_paths.jobs.replication import replication_job
 from wayfinder_paths.jobs.research import (
@@ -1608,6 +1615,159 @@ def reject_cmd(
     )
     sync_all_jobs(store=store)
     _echo_json({"ok": True, "result": proposal})
+
+
+@job_cli.group(
+    name="exhaustion",
+    help="Owner-adjudicated exhaustion claims: agents FILE a claim that a "
+    "research lane is exhausted; only the owner may ACCEPT it. A pending or "
+    "accepted claim satisfies the progress constitution for that lane.",
+)
+def exhaustion_group() -> None:
+    pass
+
+
+@exhaustion_group.command(name="file", help="File an exhaustion claim (agent-legal).")
+@click.argument("job_id")
+@click.option("--lane", required=True, help="Lane/region claimed exhausted.")
+@click.option(
+    "--evidence", required=True, help="Evidence summary (test counts, refs)."
+)
+@click.option(
+    "--provenance",
+    type=click.Choice(sorted(CLAIM_PROVENANCES)),
+    required=True,
+    help="What closed the lane. agent-self-rejected can never settle a lane.",
+)
+@click.option(
+    "--next-region",
+    required=True,
+    help="Proposed next region to open if the claim is accepted.",
+)
+@click.option("--ref", "refs", multiple=True, help="Artifact refs (repeatable).")
+def exhaustion_file_cmd(
+    job_id: str,
+    lane: str,
+    evidence: str,
+    provenance: str,
+    next_region: str,
+    refs: tuple[str, ...],
+) -> None:
+    store = JobStore()
+    claim = file_exhaustion_claim(
+        store,
+        job_id,
+        lane=lane,
+        evidence=evidence,
+        provenance=provenance,
+        next_region=next_region,
+        refs=list(refs),
+    )
+    _echo_json({"ok": True, "result": claim})
+
+
+@exhaustion_group.command(
+    name="adjudicate", help="Accept or reject a pending claim (accept is owner-only)."
+)
+@click.argument("job_id")
+@click.argument("claim_id")
+@click.option("--status", type=click.Choice(["accepted", "rejected"]), required=True)
+@click.option(
+    "--by",
+    "adjudicated_by",
+    type=click.Choice(["owner", "agent"]),
+    default="owner",
+    show_default=True,
+    help="Who is adjudicating: accepting a claim requires by='owner'.",
+)
+@click.option("--note", default=None, help="Adjudication note.")
+def exhaustion_adjudicate_cmd(
+    job_id: str, claim_id: str, status: str, adjudicated_by: str, note: str | None
+) -> None:
+    store = JobStore()
+    try:
+        claim = adjudicate_exhaustion_claim(
+            store, job_id, claim_id, status=status, by=adjudicated_by, note=note
+        )
+    except PermissionError as exc:
+        raise click.ClickException(str(exc)) from exc
+    _echo_json({"ok": True, "result": claim})
+
+
+@exhaustion_group.command(name="list", help="List exhaustion claims.")
+@click.argument("job_id")
+@click.option(
+    "--status",
+    type=click.Choice(["pending", "accepted", "rejected"]),
+    default=None,
+    help="Filter by status.",
+)
+def exhaustion_list_cmd(job_id: str, status: str | None) -> None:
+    store = JobStore()
+    _echo_json(
+        {"ok": True, "result": list_exhaustion_claims(store, job_id, status=status)}
+    )
+
+
+@job_cli.command(
+    name="probation-open-paper",
+    help="Open a PAPER probation leg for a candidate that is not clearly "
+    "worse than baseline (regression budget + trade floor checked "
+    "mechanically). Paper only — never live sizing; graduation to live "
+    "keeps the full strict gate + owner approval.",
+)
+@click.argument("job_id")
+@click.option("--name", required=True, help="Leg name (unique per job).")
+@click.option("--symbol", required=True)
+@click.option(
+    "--proposal-id",
+    default=None,
+    help="Source candidate/baseline net_return from this proposal's "
+    "propose-time comparison.",
+)
+@click.option("--candidate-net", type=float, default=None)
+@click.option("--baseline-net", type=float, default=None)
+@click.option("--backtest-trades", type=int, default=None)
+@click.option(
+    "--kill-criterion",
+    default="registered kill predicates + mechanical flat-zero floor",
+    show_default=True,
+)
+@click.option(
+    "--kill-rules-json", default=None, help="Typed kill predicates as JSON."
+)
+@click.option("--notes", default=None)
+def probation_open_paper_cmd(
+    job_id: str,
+    name: str,
+    symbol: str,
+    proposal_id: str | None,
+    candidate_net: float | None,
+    baseline_net: float | None,
+    backtest_trades: int | None,
+    kill_criterion: str,
+    kill_rules_json: str | None,
+    notes: str | None,
+) -> None:
+    store = JobStore()
+    try:
+        leg = open_paper_probation_leg(
+            store,
+            job_id,
+            name=name,
+            symbol=symbol,
+            kill_criterion=kill_criterion,
+            kill_rules=json.loads(kill_rules_json) if kill_rules_json else None,
+            proposal_id=proposal_id,
+            candidate_net=candidate_net,
+            baseline_net=baseline_net,
+            backtest_trades=backtest_trades,
+            notes=notes,
+        )
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+    sync_all_jobs(store=store)
+    _echo_json({"ok": True, "result": leg})
 
 
 @job_cli.command(name="apply-proposal", help="Queue apply for an approved proposal.")

--- a/wayfinder_paths/jobs/evolution_ledger.py
+++ b/wayfinder_paths/jobs/evolution_ledger.py
@@ -207,6 +207,14 @@ def _research_staleness(root: Path, proposals: list[dict[str, Any]]) -> dict[str
     }
 
 
+def research_staleness_report(store: JobStore, job_id: str) -> dict[str, Any]:
+    """Standalone staleness view for mechanical consumers (watchdog impasse
+    check) — same computation the wake context carries, without the cost of
+    the full evolution report."""
+    root = store.job_dir(job_id)
+    return _research_staleness(root, _load_proposals(root))
+
+
 def _opportunity_recall(store: JobStore, job_id: str) -> dict[str, Any] | None:
     """Selection-regret telemetry, CONSTRAINED: a raw net_log_growth max
     flags high-growth candidates the constitution would never promote

--- a/wayfinder_paths/jobs/exhaustion.py
+++ b/wayfinder_paths/jobs/exhaustion.py
@@ -1,0 +1,168 @@
+"""Owner-adjudicated exhaustion claims: closing a research lane is a verdict.
+
+The production stall this fixes: every research lane ended in an agent
+SELF-rejection, the agent's dead map recorded those lanes as FULLY SETTLED,
+and the wake mandate's "state why research is not warranted" hatch let every
+subsequent stale wake cite the settled map — no update in the loop could
+contradict the loop's own confident rejection. Exhaustion is an ESCALATION
+verdict for an authorized reviewer, not a self-grant: agents FILE claims
+(evidence summary, provenance, proposed next region); only the owner may
+ACCEPT one — the same owner-provenance pattern as proposal rejection, script
+mode stamps, and risk-latched halt clears.
+
+A pending or accepted claim satisfies the progress constitution for its lane
+(the escalation is on the record and the decision is with the owner). A claim
+whose provenance is `agent-self-rejected` can never settle a lane, whatever
+its status: self-rejections are development evidence, not verdicts.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from typing import TYPE_CHECKING, Any
+
+from wayfinder_paths.jobs.models import utc_now_iso
+
+if TYPE_CHECKING:
+    from wayfinder_paths.jobs.store import JobStore
+
+CLAIMS_DIR = "research/exhaustion_claims"
+CLAIM_STATUSES = {"pending", "accepted", "rejected"}
+CLAIM_PROVENANCES = {
+    "holdout-refuted",
+    "owner-rejected",
+    "agent-self-rejected",
+    "data-wall",
+}
+
+
+def _claim_path(store: JobStore, job_id: str, claim_id: str) -> str:
+    return f"{CLAIMS_DIR}/{claim_id}.json"
+
+
+def file_exhaustion_claim(
+    store: JobStore,
+    job_id: str,
+    *,
+    lane: str,
+    evidence: str,
+    provenance: str,
+    next_region: str,
+    refs: list[str] | None = None,
+    filed_by: str = "agent",
+) -> dict[str, Any]:
+    """File a claim that a research lane/region is exhausted. Anyone may
+    file; the claim starts `pending` and only the owner can accept it."""
+    lane = str(lane or "").strip()
+    if not lane:
+        raise ValueError("exhaustion claim requires a lane/region name")
+    if provenance not in CLAIM_PROVENANCES:
+        raise ValueError(f"provenance must be one of {sorted(CLAIM_PROVENANCES)}")
+    if not str(evidence or "").strip():
+        raise ValueError("exhaustion claim requires an evidence summary")
+    if not str(next_region or "").strip():
+        raise ValueError(
+            "exhaustion claim requires a proposed next region to open — "
+            "closing a lane without naming a successor is a stall, not a claim"
+        )
+    slug = re.sub(r"[^a-z0-9]+", "-", lane.lower()).strip("-")[:40] or "lane"
+    claim_id = f"claim-{slug}-{uuid.uuid4().hex[:8]}"
+    claim = {
+        "claim_id": claim_id,
+        "job_id": job_id,
+        "lane": lane,
+        "evidence": str(evidence),
+        "refs": [str(ref) for ref in refs or []],
+        "provenance": provenance,
+        "next_region": str(next_region),
+        "status": "pending",
+        "filed_by": filed_by,
+        "filed_at": utc_now_iso(),
+        "adjudication": None,
+    }
+    store.write_json(job_id, _claim_path(store, job_id, claim_id), claim)
+    store.append_journal(
+        job_id,
+        {
+            "type": "exhaustion_claim_filed",
+            "claim_id": claim_id,
+            "lane": lane,
+            "provenance": provenance,
+            "next_region": claim["next_region"],
+        },
+    )
+    store.refresh_scorecard(job_id)
+    return claim
+
+
+def adjudicate_exhaustion_claim(
+    store: JobStore,
+    job_id: str,
+    claim_id: str,
+    *,
+    status: str,
+    by: str,
+    note: str | None = None,
+) -> dict[str, Any]:
+    """Owner adjudication. `accepted` is owner-only (PermissionError for any
+    other actor — agents can FILE, never accept); `rejected` records who."""
+    if status not in {"accepted", "rejected"}:
+        raise ValueError("adjudication status must be accepted or rejected")
+    if status == "accepted" and by != "owner":
+        store.append_journal(
+            job_id,
+            {"type": "exhaustion_claim_accept_refused", "claim_id": claim_id, "by": by},
+        )
+        raise PermissionError(
+            "only the owner may accept an exhaustion claim — agents file "
+            "claims for adjudication, they never adjudicate their own"
+        )
+    claim = store.read_json(job_id, _claim_path(store, job_id, claim_id))
+    if not isinstance(claim, dict):
+        raise FileNotFoundError(f"unknown exhaustion claim: {claim_id}")
+    if claim.get("status") != "pending":
+        raise ValueError(f"claim {claim_id} is already {claim.get('status')}")
+    claim["status"] = status
+    claim["adjudication"] = {"by": by, "note": note, "ts": utc_now_iso()}
+    store.write_json(job_id, _claim_path(store, job_id, claim_id), claim)
+    store.append_journal(
+        job_id,
+        {
+            "type": f"exhaustion_claim_{status}",
+            "claim_id": claim_id,
+            "lane": claim.get("lane"),
+            "by": by,
+        },
+    )
+    store.refresh_scorecard(job_id)
+    return claim
+
+
+def list_exhaustion_claims(
+    store: JobStore, job_id: str, *, status: str | None = None
+) -> list[dict[str, Any]]:
+    claims_dir = store.job_dir(job_id) / CLAIMS_DIR
+    if not claims_dir.is_dir():
+        return []
+    claims: list[dict[str, Any]] = []
+    for path in sorted(claims_dir.glob("*.json")):
+        loaded = store.read_json(job_id, f"{CLAIMS_DIR}/{path.name}")
+        if not isinstance(loaded, dict):
+            continue
+        if status is not None and loaded.get("status") != status:
+            continue
+        claims.append(loaded)
+    claims.sort(key=lambda claim: str(claim.get("filed_at") or ""))
+    return claims
+
+
+def claim_settles_lane(claim: dict[str, Any]) -> bool:
+    """Whether this claim satisfies the progress constitution for its lane.
+
+    Pending and accepted claims settle (the escalation is filed / decided);
+    `agent-self-rejected` provenance NEVER settles — nothing in the loop may
+    control the only evidence used for its own acceptance."""
+    if claim.get("provenance") == "agent-self-rejected":
+        return False
+    return claim.get("status") in {"pending", "accepted"}

--- a/wayfinder_paths/jobs/improver/spec.py
+++ b/wayfinder_paths/jobs/improver/spec.py
@@ -40,7 +40,22 @@ DEFAULT_IMPROVER: dict[str, Any] = {
     # N consecutive neutral/hurt verdicts on same-family refinements => jump
     # basins (new family / universe-scan / archived branch / sizing axis).
     "stuck_rule": {"same_family_non_wins": 2},
-    "probation": {"max_active_legs": 2, "max_size_fraction": 0.5},
+    "probation": {
+        "max_active_legs": 2,
+        "max_size_fraction": 0.5,
+        # Paper entry tier: a candidate "not clearly worse" than baseline
+        # (net_return within max(pct, frac*|baseline|) on the same window,
+        # with a sane backtest trade count) may open a PAPER leg without
+        # beating baseline and without owner approval — probation is the
+        # containment; graduation to live keeps the full strict gate.
+        "paper_max_active_legs": 3,
+        "paper_regression_budget_pct": 0.02,
+        "paper_regression_budget_frac": 0.25,
+        "paper_min_backtest_trades": 10,
+        # Flat-zero retirement floor: past this many closed forward trades,
+        # a paper leg with negative net PnL is retired mechanically.
+        "paper_floor_min_trades": 5,
+    },
     # Evidence tiers rendered into the research-priors prompt; the gate
     # machinery keeps its own enforcement — these are the search policy's
     # triage numbers, one source of truth for the prose.
@@ -125,6 +140,26 @@ class ImproverSpec:
     @property
     def probation_max_size_fraction(self) -> float:
         return float(self.policy["probation"]["max_size_fraction"])
+
+    @property
+    def paper_max_active_legs(self) -> int:
+        return int(self.policy["probation"]["paper_max_active_legs"])
+
+    @property
+    def paper_regression_budget_pct(self) -> float:
+        return float(self.policy["probation"]["paper_regression_budget_pct"])
+
+    @property
+    def paper_regression_budget_frac(self) -> float:
+        return float(self.policy["probation"]["paper_regression_budget_frac"])
+
+    @property
+    def paper_min_backtest_trades(self) -> int:
+        return int(self.policy["probation"]["paper_min_backtest_trades"])
+
+    @property
+    def paper_floor_min_trades(self) -> int:
+        return int(self.policy["probation"]["paper_floor_min_trades"])
 
     @property
     def island_weights(self) -> dict[str, float]:

--- a/wayfinder_paths/jobs/probation.py
+++ b/wayfinder_paths/jobs/probation.py
@@ -16,6 +16,7 @@ from wayfinder_paths.jobs.store import JobStore
 
 PROBATION_PATH = "probation.json"
 PROBATION_STATUSES = {"active", "graduated", "killed"}
+PAPER_TIER = "paper"
 
 
 def load_probation(store: JobStore, job_id: str) -> dict[str, Any]:
@@ -77,6 +78,173 @@ def record_probation_leg(
     store.append_journal(
         job_id,
         {"type": "probation_leg_opened", "leg": name, "proposal_id": proposal_id},
+    )
+    return leg
+
+
+def paper_regression_budget(
+    baseline_net: float, *, budget_pct: float, budget_frac: float
+) -> float:
+    """Allowed net_return giveback for paper entry: the larger of an absolute
+    floor and a fraction of the baseline's own magnitude."""
+    return max(float(budget_pct), float(budget_frac) * abs(float(baseline_net)))
+
+
+def paper_entry_check(
+    *,
+    candidate_net: float,
+    baseline_net: float,
+    backtest_trades: int,
+    spec: ImproverSpec,
+) -> dict[str, Any]:
+    """Mechanical "not clearly worse" test for the paper probation tier."""
+    budget = paper_regression_budget(
+        baseline_net,
+        budget_pct=spec.paper_regression_budget_pct,
+        budget_frac=spec.paper_regression_budget_frac,
+    )
+    min_trades = spec.paper_min_backtest_trades
+    reasons: list[str] = []
+    if int(backtest_trades) < min_trades:
+        reasons.append(
+            f"backtest trade count {backtest_trades} below floor {min_trades}"
+        )
+    floor = float(baseline_net) - budget
+    if float(candidate_net) < floor:
+        reasons.append(
+            f"candidate net_return {candidate_net} clearly worse than baseline "
+            f"{baseline_net} (allowed floor {round(floor, 6)})"
+        )
+    return {
+        "eligible": not reasons,
+        "budget": round(budget, 6),
+        "floor": round(floor, 6),
+        "reasons": reasons,
+    }
+
+
+def _comparison_nets(
+    store: JobStore, job_id: str, proposal_id: str
+) -> tuple[float, float, int]:
+    proposal = store.load_proposal(job_id, proposal_id)
+    comparison = (proposal.get("candidate_report") or {}).get("comparison") or {}
+    candidate_stats = (comparison.get("candidate") or {}).get("stats") or {}
+    baseline_stats = (comparison.get("baseline") or {}).get("stats") or {}
+    if "net_return" not in candidate_stats or "net_return" not in baseline_stats:
+        raise ValueError(
+            f"proposal {proposal_id} has no baseline-vs-candidate net_return "
+            "comparison — paper entry needs the propose-time backtest"
+        )
+    return (
+        float(candidate_stats["net_return"]),
+        float(baseline_stats["net_return"]),
+        int(candidate_stats.get("trade_count") or 0),
+    )
+
+
+def open_paper_probation_leg(
+    store: JobStore,
+    job_id: str,
+    *,
+    name: str,
+    symbol: str,
+    kill_criterion: str,
+    kill_rules: dict[str, Any] | None = None,
+    graduate_criterion: str = "full strict gate + owner approval (unchanged)",
+    graduate_rules: dict[str, Any] | None = None,
+    proposal_id: str | None = None,
+    candidate_net: float | None = None,
+    baseline_net: float | None = None,
+    backtest_trades: int | None = None,
+    notes: str | None = None,
+) -> dict[str, Any]:
+    """Open a PAPER probation leg for a candidate that is "not clearly worse"
+    than baseline — no baseline beat and no owner approval required, because
+    probation is the containment: paper only (size_fraction 0.0, never live
+    sizing), capped concurrency, and outcome-driven retirement (registered
+    kill predicates PLUS the mechanical flat-zero floor the lifecycle
+    controller enforces on every paper leg). Graduation to live is UNCHANGED:
+    a paper leg's results feed a normal proposal through the full strict gate
+    with owner approval — nothing in probation.json confers live execution.
+
+    Entry evidence comes from the proposal's propose-time comparison
+    (`proposal_id`) or explicit candidate/baseline `net_return` figures on
+    the same full-history window.
+    """
+    if proposal_id is not None and candidate_net is None:
+        candidate_net, baseline_net, backtest_trades = _comparison_nets(
+            store, job_id, proposal_id
+        )
+    if candidate_net is None or baseline_net is None:
+        raise ValueError(
+            "paper entry needs candidate/baseline net_return — pass "
+            "proposal_id or explicit figures"
+        )
+    spec = ImproverSpec.load(store.job_dir(job_id))
+    check = paper_entry_check(
+        candidate_net=candidate_net,
+        baseline_net=baseline_net,
+        backtest_trades=int(backtest_trades or 0),
+        spec=spec,
+    )
+    if not check["eligible"]:
+        raise ValueError(
+            "paper probation entry refused: " + "; ".join(check["reasons"])
+        )
+    doc = load_probation(store, job_id)
+    paper_active = [
+        leg
+        for leg in doc["legs"]
+        if leg.get("status") == "active" and leg.get("tier") == PAPER_TIER
+    ]
+    if len(paper_active) >= spec.paper_max_active_legs:
+        raise ValueError(
+            f"max {spec.paper_max_active_legs} concurrent paper probation "
+            "legs — retire one first"
+        )
+    if any(leg.get("name") == name for leg in doc["legs"]):
+        raise ValueError(f"probation leg {name!r} already exists")
+    leg = {
+        "name": name,
+        "symbol": symbol,
+        "status": "active",
+        "tier": PAPER_TIER,
+        "opened_by": "improver",
+        "deployed_at": utc_now_iso(),
+        # Paper legs never carry live sizing; retirement/graduation evidence
+        # is the forward paper stream, adjudicated by the controller.
+        "size_fraction": 0.0,
+        "proposal_id": proposal_id,
+        "entry": {
+            "candidate_net_return": float(candidate_net),
+            "baseline_net_return": float(baseline_net),
+            "backtest_trades": int(backtest_trades or 0),
+            **check,
+        },
+        "graduate": {
+            "criterion": graduate_criterion,
+            "rules": dict(graduate_rules or {}),
+            "progress": None,
+        },
+        "kill": {
+            "criterion": kill_criterion,
+            "rules": dict(kill_rules or {}),
+            "status": None,
+        },
+        "notes": notes,
+        **revision_stamp(store.job_dir(job_id)),
+    }
+    doc["legs"].append(leg)
+    store.write_json(job_id, PROBATION_PATH, doc)
+    store.append_journal(
+        job_id,
+        {
+            "type": "paper_probation_opened",
+            "leg": name,
+            "symbol": symbol,
+            "proposal_id": proposal_id,
+            "entry": leg["entry"],
+        },
     )
     return leg
 

--- a/wayfinder_paths/jobs/proposals.py
+++ b/wayfinder_paths/jobs/proposals.py
@@ -250,6 +250,12 @@ def _validate_improver_payload(improver: dict[str, Any]) -> None:
         raise ValueError("probation.max_active_legs must be >= 1")
     if not 0 < probe.probation_max_size_fraction <= 1:
         raise ValueError("probation.max_size_fraction must be in (0, 1]")
+    if probe.paper_max_active_legs < 1:
+        raise ValueError("probation.paper_max_active_legs must be >= 1")
+    if probe.paper_regression_budget_pct < 0 or probe.paper_regression_budget_frac < 0:
+        raise ValueError("paper regression budget terms must be >= 0")
+    if probe.paper_min_backtest_trades < 1 or probe.paper_floor_min_trades < 1:
+        raise ValueError("paper trade floors must be >= 1")
     weights = probe.island_weights
     if weights and abs(sum(weights.values()) - 1.0) > 0.01:
         raise ValueError(f"island weights must sum to 1.0, got {sum(weights.values())}")

--- a/wayfinder_paths/jobs/store.py
+++ b/wayfinder_paths/jobs/store.py
@@ -792,6 +792,12 @@ class JobStore:
             for proposal in proposals
             if proposal["application"]["status"] == "applying"
         )
+        # circular import: exhaustion annotates via JobStore
+        from wayfinder_paths.jobs.exhaustion import list_exhaustion_claims
+
+        scorecard["pending_exhaustion_claims"] = len(
+            list_exhaustion_claims(self, job_id, status="pending")
+        )
         self.write_json(job_id, "scorecard.json", scorecard)
         return scorecard
 

--- a/wayfinder_paths/jobs/triggers.py
+++ b/wayfinder_paths/jobs/triggers.py
@@ -32,12 +32,16 @@ DEFAULT_DEBOUNCE_SECONDS = 600
 # for the next timer poll.
 # disk_pressure fires when the watchdog sees the jobs volume past its alert
 # threshold — a full disk kills trading exactly like a stalled loop.
+# research_impasse fires when a research-stale job's last K wakes produced
+# zero progress artifacts — the wake it triggers carries the hatch-stripped
+# progress mandate (worker renders it from state/research_impasse.json).
 ALWAYS_WAKE_EVENTS = {
     "proposal_restage_requested",
     "verdict_matured",
     "successor_overdue",
     "runner_loop_gap",
     "disk_pressure",
+    "research_impasse",
 }
 
 

--- a/wayfinder_paths/jobs/watchdog.py
+++ b/wayfinder_paths/jobs/watchdog.py
@@ -57,9 +57,13 @@ RESTAGE_NAG_TIMEOUT = timedelta(minutes=30)
 # past this many failed attempts the owner is escalated instead.
 RESTAGE_MAX_ATTEMPTS = 5
 # A kind=process owner rejection expects a corrected successor proposal.
-# None within this window → wake the agent once per entry.
+# None within this window → wake the agent once per entry ARM.
 SUCCESSOR_OVERDUE_TIMEOUT = timedelta(hours=12)
 _SUCCESSOR_EXPECTED_PATH = "state/successor_expected.json"
+# A successor the agent itself rejected did NOT deliver the invitation — it
+# re-arms the expectation (window restarts at the self-rejection). Bounded:
+# past this many re-arms the thread is journaled as abandoned for the owner.
+SUCCESSOR_MAX_REARMS = 3
 
 
 def _pid_alive(pid: int) -> bool:
@@ -313,6 +317,20 @@ def _recover_restage(
     return event
 
 
+def _staged_after(proposal: dict[str, Any], entry_ts: str) -> bool:
+    """Whether a proposal was staged after the rejection —
+    candidate_report.generated_at is the propose/restage stamp; updated_at is
+    the fallback for report-less proposals."""
+    return (
+        str(
+            (proposal.get("candidate_report") or {}).get("generated_at")
+            or proposal.get("updated_at")
+            or ""
+        )
+        > entry_ts
+    )
+
+
 def _check_successor_overdue(
     store: JobStore,
     job_id: str,
@@ -322,10 +340,15 @@ def _check_successor_overdue(
     """Wake the agent when a process-rejection's expected successor is late.
 
     A kind=process owner rejection (superseded draft, re-stage mechanics) is
-    an INVITATION, not a veto — the owner expects a corrected successor
-    proposal. If none has been created within the window, journal
-    `successor_overdue` once per entry and fire a trigger wake so the
-    invitation cannot silently rot.
+    an INVITATION, not a veto — the owner expects a corrected successor that
+    PROCEEDS TO AUDIT. "Delivered" means: a successor proposal that is alive
+    (or that the owner adjudicated), a staged experiment run, an opened
+    probation leg, or a filed exhaustion claim. A successor the agent itself
+    rejected delivered nothing — one such self-rejection silently terminated
+    an owner-invited thread in production, because the old check counted ANY
+    staged proposal and notified exactly once. Self-rejections now RE-ARM the
+    expectation (bounded at SUCCESSOR_MAX_REARMS, then the thread is
+    journaled `successor_abandoned` for owner review).
     """
     expected = store.read_json(job_id, _SUCCESSOR_EXPECTED_PATH) or []
     if not isinstance(expected, list):
@@ -333,29 +356,106 @@ def _check_successor_overdue(
     events: list[dict[str, Any]] = []
     changed = False
     for entry in expected:
-        if not isinstance(entry, dict) or entry.get("notified"):
-            continue
-        if _age(now, entry.get("ts")) < SUCCESSOR_OVERDUE_TIMEOUT:
+        if not isinstance(entry, dict) or entry.get("delivered") or entry.get(
+            "abandoned"
+        ):
             continue
         entry_ts = str(entry.get("ts") or "")
         rejected_id = str(entry.get("proposal_id") or "")
-        # A successor is any OTHER proposal staged after the rejection —
-        # candidate_report.generated_at is the propose/restage stamp;
-        # updated_at is the fallback for report-less proposals.
-        successor_exists = any(
-            str(p.get("proposal_id")) != rejected_id
-            and str(
-                (p.get("candidate_report") or {}).get("generated_at")
-                or p.get("updated_at")
-                or ""
-            )
-            > entry_ts
+        successors = [
+            p
             for p in proposals
+            if str(p.get("proposal_id")) != rejected_id
+            and _staged_after(p, entry_ts)
+        ]
+        alive = [p for p in successors if p.get("status") != "rejected"]
+        owner_closed = [
+            p
+            for p in successors
+            if p.get("status") == "rejected"
+            and str((p.get("rejection") or {}).get("by") or "")
+            in {"owner", "user", "human"}
+        ]
+        audit_progress = _research_progress_since(
+            store.job_dir(job_id), entry_ts
         )
+        if alive or owner_closed or audit_progress["advanced"]:
+            entry["delivered"] = True
+            entry["notified"] = True
+            changed = True
+            continue
+        self_rejected = [
+            p
+            for p in successors
+            if p.get("status") == "rejected"
+            and str((p.get("rejection") or {}).get("by") or "") == "agent"
+            and str(p.get("proposal_id")) not in (entry.get("rearmed_for") or [])
+        ]
+        if self_rejected:
+            rearms = int(entry.get("rearms") or 0)
+            if rearms >= SUCCESSOR_MAX_REARMS:
+                entry["abandoned"] = True
+                changed = True
+                store.append_journal(
+                    job_id,
+                    {
+                        "type": "successor_abandoned",
+                        "proposal_id": rejected_id,
+                        "rearms": rearms,
+                        "owner_review_required": (
+                            f"the successor invited by the process rejection of "
+                            f"{rejected_id} was agent-self-rejected "
+                            f"{rearms + 1} times — the agent cannot close this "
+                            "thread itself; owner must adjudicate (accept an "
+                            "exhaustion claim or reject the ask)"
+                        ),
+                    },
+                )
+                events.append(
+                    {
+                        "action": "successor_abandoned",
+                        "proposal_id": rejected_id,
+                        "outcome": "owner_review_required",
+                    }
+                )
+                continue
+            newest = max(
+                self_rejected,
+                key=lambda p: str((p.get("rejection") or {}).get("ts") or ""),
+            )
+            rearm_ts = str(
+                (newest.get("rejection") or {}).get("ts") or now.isoformat()
+            )
+            entry["ts"] = rearm_ts
+            entry["notified"] = False
+            entry["rearms"] = rearms + 1
+            entry.setdefault("rearmed_for", []).extend(
+                str(p.get("proposal_id")) for p in self_rejected
+            )
+            changed = True
+            store.append_journal(
+                job_id,
+                {
+                    "type": "successor_rearmed",
+                    "proposal_id": rejected_id,
+                    "self_rejected_successor": str(newest.get("proposal_id")),
+                    "rearms": rearms + 1,
+                },
+            )
+            events.append(
+                {
+                    "action": "successor_rearmed",
+                    "proposal_id": rejected_id,
+                    "outcome": "expectation_rearmed",
+                }
+            )
+            continue
+        if entry.get("notified"):
+            continue
+        if _age(now, entry.get("ts")) < SUCCESSOR_OVERDUE_TIMEOUT:
+            continue
         entry["notified"] = True
         changed = True
-        if successor_exists:
-            continue
         store.append_journal(
             job_id,
             {
@@ -745,6 +845,199 @@ def _check_disk_usage(
     return None
 
 
+# Research-impasse alerting: all three production research jobs froze the
+# same way — staleness computed correctly and the wake mandate fired every
+# wake, but the mandate's "state why research is not warranted" hatch let the
+# agent close every stale wake with prose ("all sub-lanes settled on merit",
+# verbatim across wakes) while staging nothing. Staleness was never a
+# watchdog trigger, so nothing escalated. This check is the escalation: when
+# a research job is stale AND the last K wakes produced zero progress
+# artifacts (experiments, probation legs, staged proposals, exhaustion
+# claims), journal `research_impasse`, write the marker the worker prompt
+# renders as a HATCH-STRIPPED mandate, and fire a trigger wake. Debounced by
+# a re-alert window (mirrors disk_pressure); the marker clears — and journals
+# `research_impasse_resolved` — only when a progress artifact appears.
+_IMPASSE_PATH = "state/research_impasse.json"
+IMPASSE_WAKES_ENV = "WAYFINDER_IMPASSE_WAKES"
+DEFAULT_IMPASSE_WAKES = 3
+IMPASSE_REALERT_WINDOW = timedelta(hours=24)
+# Journal event types that count as research progress: the three legal
+# outcomes of a stale wake plus a staged proposal (which carries its own
+# propose-time backtest audit; self-rejected stagings are filtered out).
+_PROGRESS_JOURNAL_TYPES = {
+    "probation_leg_opened",
+    "paper_probation_opened",
+    "exhaustion_claim_filed",
+}
+
+
+def _journal_rows(root: Path, *, max_lines: int = 20_000) -> list[dict[str, Any]]:
+    path = root / "journal.jsonl"
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines()[-max_lines:]:
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(row, dict):
+            rows.append(row)
+    return rows
+
+
+def _research_progress_since(
+    root: Path,
+    since_ts: str,
+    *,
+    rows: list[dict[str, Any]] | None = None,
+    proposals: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Progress artifacts after `since_ts`: executed experiments, opened
+    probation legs, filed exhaustion claims and (when `proposals` is given)
+    staged proposals that were not agent-self-rejected. Prose does not count."""
+    signals: set[str] = set()
+    for row in rows if rows is not None else _journal_rows(root):
+        if row.get("type") in _PROGRESS_JOURNAL_TYPES and (
+            str(row.get("ts") or "") > since_ts
+        ):
+            signals.add(str(row["type"]))
+    line = _tail_line(root / "results" / "backtest" / "experiments.jsonl")
+    if line:
+        try:
+            if str(json.loads(line).get("ts") or "") > since_ts:
+                signals.add("experiment_run")
+        except ValueError:
+            pass
+    for proposal in proposals or []:
+        if not _staged_after(proposal, since_ts):
+            continue
+        if (
+            proposal.get("status") == "rejected"
+            and str((proposal.get("rejection") or {}).get("by") or "") == "agent"
+        ):
+            continue  # a self-rejected staging delivered nothing
+        signals.add("staged_proposal")
+    return {"advanced": bool(signals), "signals": sorted(signals)}
+
+
+def _check_research_impasse(
+    store: JobStore,
+    job: Any,
+    proposals: list[dict[str, Any]],
+    now: datetime,
+) -> dict[str, Any] | None:
+    loop = getattr(job, "agent_loop", None)
+    if (
+        loop is None
+        or not getattr(loop, "enabled", False)
+        or str(getattr(loop, "mode", "") or "off") == "off"
+    ):
+        return None
+    root = store.job_dir(job.id)
+    rows = _journal_rows(root)
+    wake_ts = [
+        str(row.get("ts") or "") for row in rows if row.get("type") == "agent_wakeup"
+    ]
+    stale_wakes = int(os.environ.get(IMPASSE_WAKES_ENV) or DEFAULT_IMPASSE_WAKES)
+    marker = store.read_json(job.id, _IMPASSE_PATH) or {}
+    if len(wake_ts) < stale_wakes:
+        return None  # startup — not enough wakes to judge
+    basis_ts = sorted(wake_ts)[-stale_wakes]
+    progress = _research_progress_since(
+        root, basis_ts, rows=rows, proposals=proposals
+    )
+    if progress["advanced"]:
+        if marker.get("alerted_at"):
+            store.write_json(job.id, _IMPASSE_PATH, {})
+            store.append_journal(
+                job.id,
+                {
+                    "type": "research_impasse_resolved",
+                    "signals": progress["signals"],
+                },
+            )
+            return {
+                "action": "research_impasse_resolved",
+                "signals": progress["signals"],
+            }
+        return None
+    from wayfinder_paths.jobs.evolution_ledger import research_staleness_report
+
+    staleness = research_staleness_report(store, job.id)
+    if not staleness.get("stale"):
+        return None  # quiet but within policy thresholds — not an impasse
+    if marker.get("alerted_at") and (
+        _age(now, marker.get("alerted_at")) < IMPASSE_REALERT_WINDOW
+    ):
+        return None  # already alerted for this episode
+    store.write_json(
+        job.id,
+        _IMPASSE_PATH,
+        {
+            "alerted_at": now.isoformat(),
+            "basis_wake_ts": basis_ts,
+            "stale_wakes": stale_wakes,
+        },
+    )
+    store.append_journal(
+        job.id,
+        {
+            "type": "research_impasse",
+            "stale_wakes": stale_wakes,
+            "basis_wake_ts": basis_ts,
+            "days_since_last_experiment": staleness.get(
+                "days_since_last_experiment"
+            ),
+            "wakes_since_last_proposal": staleness.get("wakes_since_last_proposal"),
+        },
+    )
+    # circular import: worker → application → … → triggers
+    from wayfinder_paths.jobs.triggers import fire_triggers
+
+    fire_triggers(store, job, ["research_impasse"], source="watchdog")
+    return {
+        "action": "research_impasse",
+        "stale_wakes": stale_wakes,
+        "outcome": "agent_woken",
+    }
+
+
+# Pending exhaustion claims are owner work: surface them on the watchdog
+# cadence (journal on change; the scorecard count refreshes with every
+# scorecard write) so a filed claim cannot silently rot un-adjudicated.
+_CLAIMS_SEEN_PATH = "state/exhaustion_claims_seen.json"
+
+
+def _surface_pending_claims(store: JobStore, job_id: str) -> dict[str, Any] | None:
+    from wayfinder_paths.jobs.exhaustion import list_exhaustion_claims
+
+    pending = list_exhaustion_claims(store, job_id, status="pending")
+    ids = sorted(str(claim.get("claim_id")) for claim in pending)
+    seen = store.read_json(job_id, _CLAIMS_SEEN_PATH) or {}
+    if list(seen.get("pending") or []) == ids:
+        return None
+    store.write_json(
+        job_id, _CLAIMS_SEEN_PATH, {"pending": ids, "checked_at": utc_now_iso()}
+    )
+    if not ids:
+        return None  # a cleared queue needs no alert
+    store.append_journal(
+        job_id,
+        {
+            "type": "exhaustion_claims_pending",
+            "count": len(ids),
+            "claim_ids": ids,
+            "owner_review_required": (
+                "pending exhaustion claims await owner adjudication — accept "
+                "or reject via `wayfinder job exhaustion adjudicate`"
+            ),
+        },
+    )
+    store.refresh_scorecard(job_id)
+    return {"action": "exhaustion_claims_pending", "count": len(ids)}
+
+
 # Lifecycle evaluation is cheap (json reads + arithmetic) but its decisions
 # are consequential — a 6h cadence matches the counterfactual cycle and keeps
 # kill/graduate flips out of the 5-minute noise floor.
@@ -772,6 +1065,9 @@ def _run_lifecycle_pass(
     active = [leg for leg in doc.get("legs") or [] if leg.get("status") == "active"]
     if not active:
         return []
+    from wayfinder_paths.jobs.improver.spec import ImproverSpec
+
+    spec = ImproverSpec.load(store.job_dir(job_id))
     trades_path = store.job_dir(job_id) / "results" / "forward" / "trades.jsonl"
     trades: list[dict[str, Any]] = []
     if trades_path.exists():
@@ -806,11 +1102,30 @@ def _run_lifecycle_pass(
                 f"trades={metrics['closed_trades']} pnl={metrics['net_pnl']}"
             ),
         )
+        # Paper-tier legs carry a mechanical no-strategy-baseline floor on
+        # top of their registered kill rules: a leg that underperforms
+        # flat-zero over its window is retired regardless of what rules the
+        # agent registered — a forced-entry tier without a retirement floor
+        # turns a stall fix into a junk flood.
+        paper_floor: dict[str, Any] | None = None
+        if (
+            leg.get("tier") == "paper"
+            and int(metrics["closed_trades"]) >= spec.paper_floor_min_trades
+            and float(metrics["net_pnl"]) < 0
+        ):
+            paper_floor = {
+                "rule": "paper_flat_zero_floor",
+                "net_pnl": metrics["net_pnl"],
+                "closed_trades": metrics["closed_trades"],
+                "min_trades": spec.paper_floor_min_trades,
+            }
         # Kill outranks graduate: if both fire, the leg dies — pre-registered
         # risk rules are senior to reward rules.
         decision = (
             ("killed", kill)
             if kill["status"] == "met"
+            else ("killed", {"checks": [paper_floor]})
+            if paper_floor is not None
             else ("graduated", graduate)
             if graduate["status"] == "met"
             else None
@@ -931,6 +1246,20 @@ def recover_stalled_applications(
             disk_event = None
         if disk_event is not None:
             recovered.append({"job_id": job.id, **disk_event})
+        try:
+            impasse_event = _check_research_impasse(store, job, proposals, now)
+        except Exception as exc:
+            errors.append({"job_id": job.id, "error": f"impasse: {exc}"})
+            impasse_event = None
+        if impasse_event is not None:
+            recovered.append({"job_id": job.id, **impasse_event})
+        try:
+            claims_event = _surface_pending_claims(store, job.id)
+        except Exception as exc:
+            errors.append({"job_id": job.id, "error": f"claims: {exc}"})
+            claims_event = None
+        if claims_event is not None:
+            recovered.append({"job_id": job.id, **claims_event})
         try:
             for lifecycle_event in _run_lifecycle_pass(store, job.id, now):
                 recovered.append({"job_id": job.id, **lifecycle_event})

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -826,15 +826,26 @@ def _build_worker_prompt_sections(
         "down: verify backend health ONLY via a resident MCP tool result, "
         "and void any agenda/memory claim of 'backend DOWN' that is not "
         "backed by an MCP-tool failure observed THIS wake.\n"
-        "- Research staleness (`evolution.research_staleness`) is visible "
-        "state. When the job is healthy, no verdict is pending, and "
-        "`research_staleness.stale` is true (no experiment in "
+        "- PROGRESS CONSTITUTION: `evolution.research_staleness` is "
+        "visible state. When the job is healthy, no verdict is pending, "
+        "and `research_staleness.stale` is true (no experiment in "
         f">{improver_spec.staleness_experiment_days:g} days, or "
         f">{improver_spec.staleness_wakes} wakes since the last "
-        "proposal), a complete wake MUST advance one research lane "
-        "(signal_scan / experiment grid / holdout_check / analogs) or state "
-        "in the report why research is not warranted. 'Healthy, no change' "
-        "alone is NOT a complete wake when research is stale.\n"
+        "proposal), the wake MUST end in exactly ONE of: (a) a staged AND "
+        "executed experiment, (b) a new probation leg — the paper entry "
+        "tier accepts any candidate not clearly worse than baseline, no "
+        "owner approval needed (wayfinder_paths.jobs.probation."
+        "open_paper_probation_leg / `wayfinder job probation-open-paper`) "
+        "— or (c) an exhaustion claim FILED for owner adjudication "
+        "(`wayfinder job exhaustion file ...`). Stating that research is "
+        "not warranted is NOT a legal outcome of a stale wake — prose "
+        "never satisfies the constitution.\n"
+        "- Self-rejections are development evidence, never verdicts: a "
+        "proposal YOU rejected cannot mark a lane settled in the agenda/"
+        "dead map, and reopening bars ('requires named new evidence') may "
+        "only be set by owner-accepted exhaustion claims or executed-"
+        "experiment results. Any lane marked settled on agent-self-"
+        "rejected provenance is OPEN.\n"
         "- Routine research wakes carry a `search_assignment` (dynamic "
         "context): one island among exploit / adjacent / divergent / "
         "diversification / falsifier / historian, rotated deterministically "
@@ -1107,6 +1118,27 @@ def _build_worker_prompt_sections(
             "it as a strategy failure, but DO NOT report the gate as green. "
             "For any other reason, fixing the gate is a priority this wake.\n\n"
         )
+    # Impasse directive: written by the watchdog when a research-stale job's
+    # last K wakes produced zero progress artifacts, cleared only when one
+    # appears. Rendered as prompt text (never only snapshot JSON) with the
+    # escape hatch stripped — the hatch is how three production jobs closed
+    # every stale wake with "stated-not-advanced" prose for weeks.
+    impasse_directive = ""
+    impasse_marker = store.read_json(job_id, "state/research_impasse.json") or {}
+    if impasse_marker.get("alerted_at"):
+        impasse_directive = (
+            "RESEARCH IMPASSE — the watchdog flagged `research_impasse`: "
+            f"the last {impasse_marker.get('stale_wakes')} wakes staged zero "
+            "experiments, probation legs, staged proposals, or exhaustion "
+            "claims while research is stale.\n"
+            "This wake MUST end in exactly one of: (a) a staged+executed "
+            "experiment, (b) a new probation leg (paper entry tier "
+            "qualifies), (c) an exhaustion claim FILED for owner "
+            "adjudication. No other outcome closes an impasse wake.\n"
+            "It must also make a DIVERSITY move — resurrect an archived/"
+            "historical candidate or recombine signals across lanes. "
+            "Another audit of the incumbent does not count.\n\n"
+        )
     # Ideation is a FORCED session, not a prose suggestion: 130 consecutive
     # "nothing new, agenda stands" wakes proved the agent never consults an
     # external tool unless the wake's task IS the expedition. Stamp-gated on
@@ -1195,6 +1227,7 @@ def _build_worker_prompt_sections(
         f"{DYNAMIC_CONTEXT_MARKER}\n"
         f"{gate_alert}"
         f"{restage_priority}"
+        f"{impasse_directive}"
         f"{ideation_directive}"
         "Current snapshot:\n"
         f"{_canonical_json(dynamic_payload, max_chars=12000)}\n\n"

--- a/wayfinder_paths/tests/test_jobs_progress_constitution.py
+++ b/wayfinder_paths/tests/test_jobs_progress_constitution.py
@@ -1,0 +1,597 @@
+"""Progress constitution: escalating staleness, successor re-arm,
+owner-adjudicated exhaustion, and the paper probation entry tier.
+
+Motivating incident: all three production research jobs' lanes ended in agent
+SELF-rejections, then froze. Staleness computed correctly every wake, but the
+mandate's "state why research is not warranted" hatch let the agent close
+every stale wake with prose; the successor watchdog notified once and counted
+a self-rejected proposal as delivery; and the dead map recorded self-rejected
+lanes as FULLY SETTLED behind a "requires named new evidence" bar while
+experiments — the only generator of such evidence — were withheld. The
+asymmetry under test: nothing inside the loop may control the only evidence
+used for its own acceptance, and a forced-progress quota always ships with a
+retirement floor.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from wayfinder_paths.jobs.exhaustion import (
+    adjudicate_exhaustion_claim,
+    claim_settles_lane,
+    file_exhaustion_claim,
+    list_exhaustion_claims,
+)
+from wayfinder_paths.jobs.models import WayfinderJob, utc_now_iso
+from wayfinder_paths.jobs.probation import (
+    load_probation,
+    open_paper_probation_leg,
+    paper_entry_check,
+)
+from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.jobs.triggers import ALWAYS_WAKE_EVENTS
+from wayfinder_paths.jobs.watchdog import recover_stalled_applications
+from wayfinder_paths.jobs.worker import prepare_job_worker_prompt
+
+
+def _make_store(tmp_path: Path, job_id: str = "progress-demo") -> tuple[JobStore, str]:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        job_id,
+        script="workspace/src/strategy.py",
+        agent_mode="intervene",
+        execution_contract="jobs_v1",
+    )
+    store.save(job)
+    return store, job.id
+
+
+def _journal_events(store: JobStore, job_id: str, event_type: str) -> list[dict]:
+    path = store.job_dir(job_id) / "journal.jsonl"
+    if not path.exists():
+        return []
+    rows = [json.loads(line) for line in path.read_text().splitlines()]
+    return [row for row in rows if row.get("type") == event_type]
+
+
+@pytest.fixture
+def wakes(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+
+    def fake_worker(job_id: str, *, mode: str, **kwargs: Any) -> dict[str, Any]:
+        calls.append({"job_id": job_id, "mode": mode, **kwargs})
+        return {"status": "queued"}
+
+    monkeypatch.setattr("wayfinder_paths.jobs.worker.run_job_worker", fake_worker)
+    return calls
+
+
+def _append_wakes(store: JobStore, job_id: str, count: int) -> None:
+    for _ in range(count):
+        store.append_journal(job_id, {"type": "agent_wakeup"})
+
+
+def _write_experiment_row(store: JobStore, job_id: str, ts: str) -> None:
+    path = store.job_dir(job_id) / "results" / "backtest" / "experiments.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps({"ts": ts, "run_id": "exp-1"}) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Piece 1: escalating staleness — research_impasse standing check
+
+
+def test_research_impasse_fires_once_and_wakes_agent(
+    tmp_path: Path, wakes: list[dict[str, Any]]
+) -> None:
+    store, job_id = _make_store(tmp_path, "impasse-fire")
+    _append_wakes(store, job_id, 3)
+
+    result = recover_stalled_applications(store=store)
+    events = [e for e in result["recovered"] if e.get("action") == "research_impasse"]
+    assert len(events) == 1
+    assert len(_journal_events(store, job_id, "research_impasse")) == 1
+    assert wakes and wakes[0]["job_id"] == job_id
+    assert "research_impasse" in ALWAYS_WAKE_EVENTS
+    marker = store.read_json(job_id, "state/research_impasse.json")
+    assert marker["alerted_at"]
+
+    # Second pass inside the re-alert window: debounced, no duplicate.
+    result = recover_stalled_applications(store=store)
+    assert not [
+        e for e in result["recovered"] if e.get("action") == "research_impasse"
+    ]
+    assert len(_journal_events(store, job_id, "research_impasse")) == 1
+
+
+def test_research_impasse_needs_k_stale_wakes(
+    tmp_path: Path, wakes: list[dict[str, Any]]
+) -> None:
+    store, job_id = _make_store(tmp_path, "impasse-few")
+    _append_wakes(store, job_id, 2)  # below the K=3 default
+    result = recover_stalled_applications(store=store)
+    assert not [
+        e for e in result["recovered"] if e.get("action") == "research_impasse"
+    ]
+    assert not wakes
+
+
+def test_research_impasse_respects_staleness_thresholds(
+    tmp_path: Path, wakes: list[dict[str, Any]]
+) -> None:
+    store, job_id = _make_store(tmp_path, "impasse-fresh")
+    # An experiment BEFORE the recent wakes (no progress since them) but well
+    # inside the staleness window: quiet, not an impasse.
+    _write_experiment_row(
+        store, job_id, (datetime.now(UTC) - timedelta(days=1)).isoformat()
+    )
+    _append_wakes(store, job_id, 3)
+    result = recover_stalled_applications(store=store)
+    assert not [
+        e for e in result["recovered"] if e.get("action") == "research_impasse"
+    ]
+
+
+def test_research_impasse_resolves_on_progress(
+    tmp_path: Path, wakes: list[dict[str, Any]]
+) -> None:
+    store, job_id = _make_store(tmp_path, "impasse-resolve")
+    _append_wakes(store, job_id, 3)
+    recover_stalled_applications(store=store)
+    assert store.read_json(job_id, "state/research_impasse.json")["alerted_at"]
+
+    # A real progress artifact appears (probation leg opened after the wakes).
+    store.append_journal(job_id, {"type": "probation_leg_opened", "leg": "x"})
+    result = recover_stalled_applications(store=store)
+    resolved = [
+        e
+        for e in result["recovered"]
+        if e.get("action") == "research_impasse_resolved"
+    ]
+    assert len(resolved) == 1
+    assert not store.read_json(job_id, "state/research_impasse.json")
+    assert _journal_events(store, job_id, "research_impasse_resolved")
+
+
+def test_impasse_wake_carries_hatch_stripped_mandate(tmp_path: Path) -> None:
+    store, job_id = _make_store(tmp_path, "impasse-prompt")
+    store.write_json(
+        job_id,
+        "state/research_impasse.json",
+        {"alerted_at": utc_now_iso(), "stale_wakes": 3},
+    )
+    sections = prepare_job_worker_prompt(store=store, job_id=job_id, mode="intervene")
+    assert "RESEARCH IMPASSE" in sections["dynamic_context"]
+    assert "DIVERSITY move" in sections["dynamic_context"]
+    assert "exhaustion claim" in sections["dynamic_context"]
+    # No marker → no directive.
+    store.write_json(job_id, "state/research_impasse.json", {})
+    sections = prepare_job_worker_prompt(store=store, job_id=job_id, mode="intervene")
+    assert "RESEARCH IMPASSE" not in sections["dynamic_context"]
+
+
+# ---------------------------------------------------------------------------
+# Piece 2: successor re-arm — a self-rejected successor delivers nothing
+
+
+def _expect_successor(store: JobStore, job_id: str, *, hours_ago: float) -> str:
+    ts = (datetime.now(UTC) - timedelta(hours=hours_ago)).isoformat()
+    store.write_json(
+        job_id,
+        "state/successor_expected.json",
+        [{"proposal_id": "prop-old", "ts": ts, "reason": "superseded"}],
+    )
+    return ts
+
+
+def _self_rejected_successor(
+    store: JobStore, job_id: str, *, pid: str, hours_ago: float
+) -> None:
+    ts = (datetime.now(UTC) - timedelta(hours=hours_ago)).isoformat()
+    store.write_proposal(
+        job_id,
+        {
+            "proposal_id": pid,
+            "status": "rejected",
+            "application": {"status": "not_requested"},
+            "candidate_report": {"generated_at": ts},
+            "rejection": {"by": "agent", "kind": "process", "ts": ts},
+        },
+    )
+
+
+def test_self_rejected_successor_rearms_then_overdue_fires_again(
+    tmp_path: Path, wakes: list[dict[str, Any]]
+) -> None:
+    store, job_id = _make_store(tmp_path, "succ-rearm")
+    _expect_successor(store, job_id, hours_ago=14)
+    _self_rejected_successor(store, job_id, pid="prop-selfrej", hours_ago=13)
+
+    # Pass 1: the self-rejection re-arms the expectation instead of counting
+    # as delivery — the production thread died exactly here.
+    result = recover_stalled_applications(store=store)
+    rearms = [e for e in result["recovered"] if e.get("action") == "successor_rearmed"]
+    assert len(rearms) == 1
+    assert _journal_events(store, job_id, "successor_rearmed")
+    entry = store.read_json(job_id, "state/successor_expected.json")[0]
+    assert entry["rearms"] == 1
+    assert entry["notified"] is False
+    assert entry["rearmed_for"] == ["prop-selfrej"]
+    assert not _journal_events(store, job_id, "successor_overdue")
+
+    # Pass 2: the re-armed window (restarted at the 13h-old rejection) is
+    # already overdue → the invitation wakes the agent again.
+    result = recover_stalled_applications(store=store)
+    overdue = [
+        e for e in result["recovered"] if e.get("action") == "successor_overdue"
+    ]
+    assert len(overdue) == 1
+    assert wakes and wakes[-1]["job_id"] == job_id
+
+    # Pass 3: notified, no new self-rejections → silent.
+    result = recover_stalled_applications(store=store)
+    assert not [
+        e
+        for e in result["recovered"]
+        if e.get("action") in {"successor_overdue", "successor_rearmed"}
+    ]
+
+
+def test_successor_rearm_bounded_then_abandoned(
+    tmp_path: Path, wakes: list[dict[str, Any]]
+) -> None:
+    store, job_id = _make_store(tmp_path, "succ-abandon")
+    _expect_successor(store, job_id, hours_ago=14)
+    expected = store.read_json(job_id, "state/successor_expected.json")
+    expected[0]["rearms"] = 3
+    expected[0]["rearmed_for"] = ["prop-r1", "prop-r2", "prop-r3"]
+    store.write_json(job_id, "state/successor_expected.json", expected)
+    _self_rejected_successor(store, job_id, pid="prop-selfrej-4", hours_ago=1)
+
+    result = recover_stalled_applications(store=store)
+    abandoned = [
+        e for e in result["recovered"] if e.get("action") == "successor_abandoned"
+    ]
+    assert len(abandoned) == 1
+    events = _journal_events(store, job_id, "successor_abandoned")
+    assert len(events) == 1
+    assert "owner" in events[0]["owner_review_required"]
+    assert store.read_json(job_id, "state/successor_expected.json")[0]["abandoned"]
+
+    # Terminal: no duplicate on the next pass.
+    result = recover_stalled_applications(store=store)
+    assert not [
+        e for e in result["recovered"] if e.get("action") == "successor_abandoned"
+    ]
+    assert len(_journal_events(store, job_id, "successor_abandoned")) == 1
+
+
+def test_alive_successor_marks_delivered(
+    tmp_path: Path, wakes: list[dict[str, Any]]
+) -> None:
+    store, job_id = _make_store(tmp_path, "succ-alive")
+    _expect_successor(store, job_id, hours_ago=14)
+    store.write_proposal(
+        job_id,
+        {
+            "proposal_id": "prop-alive",
+            "status": "pending",
+            "application": {"status": "not_requested"},
+            "candidate_report": {"generated_at": datetime.now(UTC).isoformat()},
+        },
+    )
+    result = recover_stalled_applications(store=store)
+    assert not [
+        e for e in result["recovered"] if str(e.get("action", "")).startswith("successor")
+    ]
+    assert store.read_json(job_id, "state/successor_expected.json")[0]["delivered"]
+    assert not wakes
+
+
+def test_audit_progress_counts_as_successor_delivery(
+    tmp_path: Path, wakes: list[dict[str, Any]]
+) -> None:
+    store, job_id = _make_store(tmp_path, "succ-audit")
+    _expect_successor(store, job_id, hours_ago=14)
+    _write_experiment_row(store, job_id, datetime.now(UTC).isoformat())
+    result = recover_stalled_applications(store=store)
+    assert not [
+        e for e in result["recovered"] if str(e.get("action", "")).startswith("successor")
+    ]
+    assert store.read_json(job_id, "state/successor_expected.json")[0]["delivered"]
+    assert not wakes
+
+
+# ---------------------------------------------------------------------------
+# Piece 3: owner-adjudicated exhaustion claims
+
+
+def test_exhaustion_claim_lifecycle_and_owner_only_accept(tmp_path: Path) -> None:
+    store, job_id = _make_store(tmp_path, "claims-demo")
+    claim = file_exhaustion_claim(
+        store,
+        job_id,
+        lane="IMX gap filter",
+        evidence="34 grid cells + 4 WF folds all negative",
+        provenance="holdout-refuted",
+        next_region="cross-asset funding regime",
+        refs=["results/backtest/experiments.jsonl"],
+    )
+    assert claim["status"] == "pending"
+    assert _journal_events(store, job_id, "exhaustion_claim_filed")
+    scorecard = store.read_json(job_id, "scorecard.json")
+    assert scorecard["pending_exhaustion_claims"] == 1
+
+    # Agents can FILE, never accept.
+    with pytest.raises(PermissionError):
+        adjudicate_exhaustion_claim(
+            store, job_id, claim["claim_id"], status="accepted", by="agent"
+        )
+    assert (
+        list_exhaustion_claims(store, job_id, status="pending")[0]["status"]
+        == "pending"
+    )
+    assert _journal_events(store, job_id, "exhaustion_claim_accept_refused")
+
+    accepted = adjudicate_exhaustion_claim(
+        store, job_id, claim["claim_id"], status="accepted", by="owner", note="agreed"
+    )
+    assert accepted["status"] == "accepted"
+    assert accepted["adjudication"]["by"] == "owner"
+    assert _journal_events(store, job_id, "exhaustion_claim_accepted")
+    assert store.read_json(job_id, "scorecard.json")["pending_exhaustion_claims"] == 0
+    # Terminal: cannot re-adjudicate.
+    with pytest.raises(ValueError, match="already accepted"):
+        adjudicate_exhaustion_claim(
+            store, job_id, claim["claim_id"], status="rejected", by="owner"
+        )
+
+
+def test_exhaustion_claim_requires_full_shape(tmp_path: Path) -> None:
+    store, job_id = _make_store(tmp_path, "claims-shape")
+    with pytest.raises(ValueError, match="provenance"):
+        file_exhaustion_claim(
+            store, job_id, lane="x", evidence="e", provenance="vibes", next_region="y"
+        )
+    with pytest.raises(ValueError, match="next region"):
+        file_exhaustion_claim(
+            store,
+            job_id,
+            lane="x",
+            evidence="e",
+            provenance="data-wall",
+            next_region="",
+        )
+    with pytest.raises(ValueError, match="evidence"):
+        file_exhaustion_claim(
+            store, job_id, lane="x", evidence=" ", provenance="data-wall", next_region="y"
+        )
+
+
+def test_agent_self_rejected_provenance_never_settles(tmp_path: Path) -> None:
+    store, job_id = _make_store(tmp_path, "claims-prov")
+    settled = file_exhaustion_claim(
+        store,
+        job_id,
+        lane="lane-a",
+        evidence="holdout negative",
+        provenance="holdout-refuted",
+        next_region="lane-b",
+    )
+    assert claim_settles_lane(settled)  # pending settles
+    self_rej = file_exhaustion_claim(
+        store,
+        job_id,
+        lane="lane-c",
+        evidence="I rejected my own proposals",
+        provenance="agent-self-rejected",
+        next_region="lane-d",
+    )
+    assert not claim_settles_lane(self_rej)
+    accepted = adjudicate_exhaustion_claim(
+        store, job_id, self_rej["claim_id"], status="accepted", by="owner"
+    )
+    # Even owner-accepted, self-rejection provenance cannot settle a lane.
+    assert not claim_settles_lane(accepted)
+
+
+def test_watchdog_surfaces_pending_claims_once(
+    tmp_path: Path, wakes: list[dict[str, Any]]
+) -> None:
+    store, job_id = _make_store(tmp_path, "claims-surface")
+    file_exhaustion_claim(
+        store,
+        job_id,
+        lane="lane-a",
+        evidence="e",
+        provenance="data-wall",
+        next_region="lane-b",
+    )
+    result = recover_stalled_applications(store=store)
+    surfaced = [
+        e for e in result["recovered"] if e.get("action") == "exhaustion_claims_pending"
+    ]
+    assert len(surfaced) == 1 and surfaced[0]["count"] == 1
+    assert len(_journal_events(store, job_id, "exhaustion_claims_pending")) == 1
+    # Unchanged queue → silent next pass.
+    result = recover_stalled_applications(store=store)
+    assert not [
+        e for e in result["recovered"] if e.get("action") == "exhaustion_claims_pending"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Piece 4: paper probation entry tier
+
+
+def test_paper_entry_check_regression_budget() -> None:
+    from wayfinder_paths.jobs.improver.spec import ImproverSpec
+
+    spec = ImproverSpec.load(Path("/nonexistent"))  # defaults
+    # budget = max(0.02, 0.25*|0.10|) = 0.025 → floor 0.075
+    ok = paper_entry_check(
+        candidate_net=0.08, baseline_net=0.10, backtest_trades=30, spec=spec
+    )
+    assert ok["eligible"] and ok["budget"] == 0.025
+    worse = paper_entry_check(
+        candidate_net=0.07, baseline_net=0.10, backtest_trades=30, spec=spec
+    )
+    assert not worse["eligible"]
+    thin = paper_entry_check(
+        candidate_net=0.09, baseline_net=0.10, backtest_trades=3, spec=spec
+    )
+    assert not thin["eligible"] and "floor" in thin["reasons"][0]
+
+
+def _open_paper(
+    store: JobStore, job_id: str, name: str, symbol: str = "HYPE", **overrides: Any
+) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {
+        "candidate_net": 0.09,
+        "baseline_net": 0.10,
+        "backtest_trades": 25,
+        "kill_criterion": "kill on WR<20% after 10",
+        "kill_rules": {"win_rate__lt": 0.2, "min_closed_trades": 10},
+        **overrides,
+    }
+    return open_paper_probation_leg(store, job_id, name=name, symbol=symbol, **kwargs)
+
+
+def test_paper_leg_opens_within_budget_and_caps(tmp_path: Path) -> None:
+    store, job_id = _make_store(tmp_path, "paper-open")
+    leg = _open_paper(store, job_id, "leg-a")
+    assert leg["tier"] == "paper"
+    assert leg["opened_by"] == "improver"
+    assert leg["size_fraction"] == 0.0  # paper only — never live sizing
+    assert _journal_events(store, job_id, "paper_probation_opened")
+    assert load_probation(store, job_id)["legs"][0]["name"] == "leg-a"
+
+    with pytest.raises(ValueError, match="clearly worse"):
+        _open_paper(store, job_id, "leg-worse", candidate_net=0.05)
+    with pytest.raises(ValueError, match="trade count"):
+        _open_paper(store, job_id, "leg-thin", backtest_trades=2)
+
+    _open_paper(store, job_id, "leg-b")
+    _open_paper(store, job_id, "leg-c")
+    with pytest.raises(ValueError, match="concurrent paper"):
+        _open_paper(store, job_id, "leg-d")
+
+
+def test_paper_leg_from_proposal_comparison(tmp_path: Path) -> None:
+    store, job_id = _make_store(tmp_path, "paper-prop")
+    store.write_proposal(
+        job_id,
+        {
+            "proposal_id": "prop-paper",
+            "status": "pending",
+            "application": {"status": "not_requested"},
+            "candidate_report": {
+                "comparison": {
+                    "candidate": {"stats": {"net_return": 0.09, "trade_count": 25}},
+                    "baseline": {"stats": {"net_return": 0.10, "trade_count": 24}},
+                }
+            },
+        },
+    )
+    leg = open_paper_probation_leg(
+        store,
+        job_id,
+        name="leg-prop",
+        symbol="HYPE",
+        kill_criterion="registered rules + flat-zero floor",
+        proposal_id="prop-paper",
+    )
+    assert leg["entry"]["candidate_net_return"] == 0.09
+    assert leg["entry"]["backtest_trades"] == 25
+    # No comparison → refused, never silently opened.
+    store.write_proposal(
+        job_id,
+        {
+            "proposal_id": "prop-bare",
+            "status": "pending",
+            "application": {"status": "not_requested"},
+        },
+    )
+    with pytest.raises(ValueError, match="comparison"):
+        open_paper_probation_leg(
+            store,
+            job_id,
+            name="leg-bare",
+            symbol="HYPE",
+            kill_criterion="x",
+            proposal_id="prop-bare",
+        )
+
+
+def _write_forward_trades(
+    store: JobStore, job_id: str, symbol: str, pnls: list[float]
+) -> None:
+    path = store.job_dir(job_id) / "results" / "forward" / "trades.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(UTC).isoformat()
+    with path.open("a", encoding="utf-8") as handle:
+        for pnl in pnls:
+            handle.write(
+                json.dumps({"symbol": symbol, "net_pnl": pnl, "closed_at": ts}) + "\n"
+            )
+
+
+def test_paper_floor_retires_negative_leg_keeps_positive(
+    tmp_path: Path, wakes: list[dict[str, Any]]
+) -> None:
+    store, job_id = _make_store(tmp_path, "paper-floor")
+    _open_paper(store, job_id, "leg-neg", symbol="NEG")
+    _open_paper(store, job_id, "leg-pos", symbol="POS")
+    # NEG underperforms flat-zero past the floor window; POS is positive.
+    _write_forward_trades(store, job_id, "NEG", [-1.0, -2.0, 1.0, -3.0, -1.0])
+    _write_forward_trades(store, job_id, "POS", [1.0, 2.0, -0.5, 1.5, 0.5])
+
+    recover_stalled_applications(store=store)
+    legs = {leg["name"]: leg for leg in load_probation(store, job_id)["legs"]}
+    assert legs["leg-neg"]["status"] == "killed"
+    assert legs["leg-pos"]["status"] == "active"
+    decisions = _journal_events(store, job_id, "lifecycle_decision")
+    floor_checks = [
+        check
+        for event in decisions
+        for check in event["checks"]
+        if check and check.get("rule") == "paper_flat_zero_floor"
+    ]
+    assert floor_checks and floor_checks[0]["closed_trades"] >= 5
+
+
+def test_paper_floor_waits_for_min_trades(
+    tmp_path: Path, wakes: list[dict[str, Any]]
+) -> None:
+    store, job_id = _make_store(tmp_path, "paper-wait")
+    _open_paper(store, job_id, "leg-early", symbol="EARLY")
+    _write_forward_trades(store, job_id, "EARLY", [-1.0, -2.0])  # below floor window
+    recover_stalled_applications(store=store)
+    legs = {leg["name"]: leg for leg in load_probation(store, job_id)["legs"]}
+    assert legs["leg-early"]["status"] == "active"
+
+
+# ---------------------------------------------------------------------------
+# Piece 5: the wake mandate text is pinned — the escape hatch stays dead
+
+
+def test_wake_mandate_hatch_stripped_and_pinned(tmp_path: Path) -> None:
+    store, job_id = _make_store(tmp_path, "mandate-pin")
+    sections = prepare_job_worker_prompt(store=store, job_id=job_id, mode="intervene")
+    prompt = sections["stable_prefix"]
+    assert "PROGRESS CONSTITUTION" in prompt
+    assert "exactly ONE of" in prompt
+    assert "exhaustion claim FILED for owner adjudication" in prompt
+    assert "Self-rejections are development evidence" in prompt
+    assert "agent-self-" in prompt
+    assert "NOT a legal outcome" in prompt
+    # The escape hatch is gone: prose can no longer close a stale wake.
+    assert "why research is not warranted" not in sections["prompt"]
+    assert "MUST advance one research lane" not in sections["prompt"]

--- a/wayfinder_paths/tests/test_jobs_wake_productivity.py
+++ b/wayfinder_paths/tests/test_jobs_wake_productivity.py
@@ -159,4 +159,8 @@ def test_worker_stable_rules_carry_research_mandate(tmp_path) -> None:
     source = inspect.getsource(worker)
     assert "verdict_matured" in source
     assert "research_staleness" in source
-    assert "NOT a complete wake" in source
+    # Progress constitution: a stale wake ends in an experiment, a probation
+    # leg, or a FILED exhaustion claim — the prose escape hatch is dead.
+    assert "PROGRESS CONSTITUTION" in source
+    assert "NOT a legal outcome" in source
+    assert "why research is not warranted" not in source


### PR DESCRIPTION
## The production stall

All three research jobs' lanes ended in agent self-rejections (Aug 12/17/18), then froze. Forensics showed four interlocking seams:

1. **Staleness computed correctly but never escalated.** `_research_staleness` was fresh every wake and injected into context, but the wake mandate said a stale wake "MUST advance one research lane … **or state in the report why research is not warranted**". The agent used that hatch every wake — "Research stale, stated-not-advanced: all sub-lanes settled on merit", verbatim across wakes. `research_stale` was not a watchdog trigger, so nothing ever forced the issue.
2. **The successor watchdog counted a self-rejected proposal as delivery.** It notified once per entry (`notified=true` unconditionally) and treated ANY staged proposal as the successor — including one the agent self-rejected 47 minutes later. An owner-invited successor thread terminated silently.
3. **Self-rejections settled lanes.** worker.py already stated self-rejections don't bind, but the agent's dead map recorded them as FULLY SETTLED behind a "requires NAMED new evidence" reopening bar — while experiments, the only generator of such evidence, were withheld.
4. **No constitution-legal move existed for a candidate that merely ties baseline**, so "nothing beats the incumbent" ended research instead of narrowing it.

## What this PR builds

**1. Escalating staleness + impasse detector** (`watchdog.py`, `triggers.py`, `evolution_ledger.py`)
New standing check `_check_research_impasse`: if a job is research-stale AND the last K wakes (default 3, `WAYFINDER_IMPASSE_WAKES`) produced zero progress artifacts — executed experiments (`experiments.jsonl` tail), opened probation legs, staged-and-not-self-rejected proposals, filed exhaustion claims — it journals `research_impasse`, writes `state/research_impasse.json`, and fires a trigger wake (`research_impasse` added to `ALWAYS_WAKE_EVENTS`). Debounced by a 24h re-alert window (mirrors the disk-pressure debounce from #683). The marker clears — journaling `research_impasse_resolved` — only when a progress artifact appears. While the marker is up, every wake's dynamic context carries a **hatch-stripped mandate** (see 5) demanding one of the three legal outcomes plus a diversity move (resurrect an archived candidate or cross-lane recombination — another audit of the incumbent does not count).

**2. Successor re-arm** (`watchdog.py`)
"Successor delivered" is redefined as a candidate that **proceeded to audit**: an alive successor proposal (propose-time backtest is the audit), an owner-adjudicated successor, a staged experiment run, an opened probation leg, or a filed exhaustion claim. An agent-self-rejected successor **re-arms** `successor_expected` (window restarts at the rejection timestamp, `notified` reset, journaled `successor_rearmed`), bounded at 3 re-arms — then `successor_abandoned` is journaled with an `owner_review_required` marker.

**3. Owner-adjudicated exhaustion claims** (`exhaustion.py` new, `store.py`, `cli.py`, `watchdog.py`)
`research/exhaustion_claims/<claim-id>.json` — lane, evidence summary, refs, provenance enum (`holdout-refuted | owner-rejected | agent-self-rejected | data-wall`), proposed next region, status `pending|accepted|rejected`. Agents FILE (`wayfinder job exhaustion file`); **accept is owner-only** (`PermissionError` otherwise — same provenance pattern as risk-latched halt clears and script-mode stamps). The watchdog surfaces pending claims (journal on change + `pending_exhaustion_claims` scorecard field). A pending/accepted claim satisfies the constitution for its lane; `agent-self-rejected` provenance can **never** settle a lane, even if accepted (`claim_settles_lane`).

**4. Probation paper entry tier** (`probation.py`, `improver/spec.py`, `proposals.py`, `cli.py`, `watchdog.py`)
`open_paper_probation_leg` / `wayfinder job probation-open-paper`: a candidate whose backtest is *not clearly worse* than baseline — `candidate_net >= baseline_net − max(2%, 0.25·|baseline_net|)` on the same full-history window, with a ≥10-trade backtest floor (all improver-spec tunable) — may open a PAPER probation leg without beating baseline and without owner approval. Paper only: `size_fraction=0.0`, never live sizing; capped at 3 concurrent improver-opened paper legs. Retirement is outcome-driven: registered kill predicates PLUS a mechanical **flat-zero floor** the lifecycle controller enforces (≥5 closed forward trades with negative net PnL → retired, journaled). Graduation to live is UNCHANGED — full strict gate + owner approval; nothing in probation.json confers live execution.

**5. Wake mandate** (`worker.py`)
The escape hatch is dead. A stale wake must end in exactly one of: (a) staged+executed experiment, (b) new probation leg (paper tier qualifies), (c) exhaustion claim FILED for owner adjudication. Added: self-rejections are development evidence and cannot mark lanes settled — only owner-accepted claims or executed-experiment results can; an impasse wake must additionally make a diversity move. Net added prompt text is ~35 lines across the stable prefix and the impasse directive.

## Design grounding (survey)

- *No update should control the only evidence used for its own acceptance* — self-confirmation is symmetric to self-veto: nothing inside the loop can be allowed to contradict-proof a confident rejection. Hence owner-only claim acceptance and the never-settles rule for self-rejected provenance.
- *Exhaustion is an escalation verdict for an authorized reviewer*, not a state an agent can declare about its own search.
- *Loose entry is safe because probation is the containment* (bounded persistence: paper-only, capped, floor-retired) while graduation evidence stays unqueryable by the candidate itself.
- *Forced-experiment quotas need retirement floors* — otherwise a stall fix becomes a junk flood; the flat-zero floor is mechanical, not registered.

## Deferred (documented, not built)

- Lineage-productivity reopen priority (which settled lanes to revisit first).
- Sequential-test multiplicity control across forced-progress experiments.
- Holdout access logging for the paper tier (evidence-access ledger exists; wiring paper-leg adjudication reads into it is follow-up).
- MCP `core_jobs` actions for exhaustion claims — the CLI is the agent surface for job machinery per the mandate; MCP wiring can follow if wake transcripts show friction.

## Tests

New `wayfinder_paths/tests/test_jobs_progress_constitution.py` — 19 tests: impasse fires once/debounces/needs K wakes/respects staleness thresholds/resolves on progress; impasse wake carries the hatch-stripped mandate; self-rejected successor re-arms then re-fires overdue, bounded at 3 → abandoned with owner_review_required, alive successor and audit progress count as delivery; exhaustion claim lifecycle with owner-only accept, shape validation, provenance never-settles, watchdog surfacing; paper entry within/outside regression budget, trade floor, concurrency cap, proposal-comparison sourcing, flat-zero floor retirement (and waits for min trades); mandate text pinned (hatch phrases asserted absent).

Full `pytest -k "jobs or runner or mcp"` green. ruff clean on all touched files; scoped mypy introduces zero new errors (all remaining errors in touched files are pre-existing on base, verified by stash-diff).
