### PR TITLE
starters: declare driver lookback_bars — 7 of 11 starters never trade

### DIFF
--- a/wayfinder_paths/jobs/execution/validation.py
+++ b/wayfinder_paths/jobs/execution/validation.py
@@ -533,6 +533,8 @@ def _timing_checks(
     unobservable in a fixture backtest, so they are validated structurally here.
     """
     is_jobs_v1 = str(job_data.get("execution_contract") or "legacy") == "jobs_v1"
+    controller = job_data.get("controller")
+    is_starter = isinstance(controller, Mapping) and bool(controller.get("starter"))
     bar_seconds = bar_interval_seconds(spec.data_contract.get("bar_interval"))
     params = job_data.get("execution_params") or {}
     checks: list[dict[str, Any]] = [
@@ -561,11 +563,13 @@ def _timing_checks(
             # bars); an undeclared lookback means backtests see full history
             # while live sees 200 — path-dependent indicators (Wilder ATR,
             # SuperTrend) will diverge. Declaring it aligns both AND bounds
-            # per-tick backtest cost.
+            # per-tick backtest cost. Blocking for starter jobs: most catalog
+            # starters have warmup_bars > 200, so an undeclared lookback caps
+            # ctx.bar_index below warmup and the job silently never trades.
             "name": "lookback_bars_declared",
             "passed": bool(params.get("lookback_bars")) or not is_jobs_v1,
             "value": params.get("lookback_bars"),
-            "blocking": False,
+            "blocking": is_jobs_v1 and is_starter,
         },
     ]
 

--- a/wayfinder_paths/jobs/starters.py
+++ b/wayfinder_paths/jobs/starters.py
@@ -8,6 +8,7 @@ forward-result machinery owns the user's results.
 from __future__ import annotations
 
 import copy
+import importlib
 import math
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -23,7 +24,7 @@ from wayfinder_paths.jobs.strategies._starter_utils import (
     RANKING_STOP_DEFAULTS,
 )
 
-STARTER_CATALOG_VERSION = "1.6.0"
+STARTER_CATALOG_VERSION = "1.7.0"
 STARTER_STRATEGY_INCEPTION_AT = "2026-08-18T00:00:00+00:00"
 STARTER_EVIDENCE_REVISION = "1.6.0"
 STARTER_LEVERAGE_DEFAULT = 1
@@ -32,6 +33,9 @@ STARTER_LEVERAGE_MAXIMUM = 5
 STARTER_LEVERAGE_STEP = 1
 # Evidence-window owner policy: starter backtests/validation replay 120 days.
 STARTER_DATASET_DAYS = 120
+# Slack on top of the strategy's warmup gate so the live driver's sliding
+# window always clears warmup even when the feed drops a few leading bars.
+STARTER_LOOKBACK_MARGIN_BARS = 20
 
 
 def validate_starter_leverage(value: Any) -> int:
@@ -177,7 +181,10 @@ class StarterDefinition:
 
     def to_dict(self) -> dict[str, Any]:
         payload = asdict(self)
-        payload["params"] = self.configured_params()
+        payload["params"] = {
+            **self.configured_params(),
+            "lookback_bars": starter_lookback_bars(self),
+        }
         payload["risk_limits"] = self.risk_limits()
         payload["risk_controls"] = self.risk_controls()
         payload["leverage_control"] = {
@@ -247,6 +254,35 @@ class StarterDefinition:
             }
         )
         return payload
+
+
+def starter_warmup_bars(definition: StarterDefinition) -> int:
+    """The strategy's own warmup gate, computed from the exact params the
+    launched job will run with. Every starter strategy declares
+    ``warmup_bars`` in ``__init__``; a module that doesn't fails loudly here
+    (and in the catalog test) instead of shipping a starter that never trades.
+    """
+    module = importlib.import_module(definition.module)
+    strategy = module.build_strategy(
+        {**definition.configured_params(), "symbols": list(definition.symbols)}
+    )
+    warmup = int(strategy.warmup_bars)
+    if warmup <= 0:
+        raise ValueError(f"starter {definition.id}: warmup_bars must be positive")
+    return warmup
+
+
+def starter_lookback_bars(definition: StarterDefinition) -> int:
+    """Live-driver window for this starter: strategy warmup plus margin.
+
+    The live/paper driver hands strategies a sliding window of
+    ``lookback_bars`` completed bars (default 200), so ``ctx.bar_index`` is
+    capped at the window length. A window smaller than the strategy's warmup
+    gate means the starter NEVER trades. Deriving the window from the
+    strategy's declared warmup keeps catalog edits from reintroducing the
+    mismatch.
+    """
+    return starter_warmup_bars(definition) + STARTER_LOOKBACK_MARGIN_BARS
 
 
 _RESEARCH_METHOD = {
@@ -1271,6 +1307,9 @@ def create_starter_job(
         "slippage_bps": 3.5,
         "min_trade_notional": 25.0,
         "leverage": selected_leverage,
+        # Without this the driver's default 200-bar window caps ctx.bar_index
+        # below warmup for most starters and they never trade.
+        "lookback_bars": starter_lookback_bars(definition),
     }
     job.controller["starter"] = {
         "id": definition.id,

--- a/wayfinder_paths/tests/test_jobs_starters.py
+++ b/wayfinder_paths/tests/test_jobs_starters.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import json
 import os
 from pathlib import Path
@@ -24,9 +25,12 @@ from wayfinder_paths.jobs.execution.primitives import (
 )
 from wayfinder_paths.jobs.models import WayfinderJob
 from wayfinder_paths.jobs.starters import (
+    STARTER_DEFINITIONS,
     coerce_starter_leverage,
     create_starter_job,
     starter_catalog,
+    starter_lookback_bars,
+    starter_warmup_bars,
     validate_starter_leverage,
 )
 from wayfinder_paths.jobs.store import JobStore
@@ -320,6 +324,63 @@ def test_starter_catalog_has_mixed_maker_and_pair_paper_strategies() -> None:
     )
 
 
+# Live-driver window per starter (strategy warmup_bars + 20-bar margin).
+# The driver windows the handed view to lookback_bars, capping ctx.bar_index;
+# any starter whose warmup gate exceeds the window silently never trades —
+# 7 of 11 entries did exactly that under the old 200-bar driver default.
+# A new/edited starter MUST update this table consciously.
+EXPECTED_STARTER_LOOKBACK_BARS = {
+    "mixed-rsi-snapback-1h": 224,
+    "mixed-bollinger-pullback-1h": 224,
+    "mixed-volume-capitulation-1h": 224,
+    "balanced-passive-capitulation-1h": 224,
+    "mixed-momentum-rank-1h": 360,
+    "mixed-sleeve-momentum-15m": 2904,
+    "mixed-low-vol-rank-15m": 504,
+    "hype-passive-rsi-full-5m": 38,
+    "hype-passive-rsi-staged-5m": 38,
+    "btc-eth-relative-strength-1d": 114,
+    "bch-ltc-relative-strength-1d": 114,
+}
+
+
+def test_every_starter_lookback_clears_its_warmup_gate() -> None:
+    assert set(EXPECTED_STARTER_LOOKBACK_BARS) == {
+        definition.id for definition in STARTER_DEFINITIONS
+    }
+    for definition in STARTER_DEFINITIONS:
+        # Independently rebuild the strategy the way the driver does and read
+        # its warmup gate — the helpers must agree with the real strategy.
+        module = importlib.import_module(definition.module)
+        strategy = module.build_strategy(
+            {**definition.configured_params(), "symbols": list(definition.symbols)}
+        )
+        warmup = int(strategy.warmup_bars)
+        lookback = starter_lookback_bars(definition)
+        assert warmup > 0, definition.id
+        assert lookback > warmup, definition.id
+        assert starter_warmup_bars(definition) == warmup, definition.id
+        assert lookback == EXPECTED_STARTER_LOOKBACK_BARS[definition.id], definition.id
+
+
+def test_starter_catalog_params_expose_lookback_bars() -> None:
+    for item in starter_catalog():
+        assert (
+            item["params"]["lookback_bars"]
+            == EXPECTED_STARTER_LOOKBACK_BARS[item["id"]]
+        )
+
+
+def test_create_starter_sets_driver_lookback_above_warmup(tmp_path) -> None:
+    store = JobStore(repo_root=tmp_path)
+    create_starter_job("mixed-sleeve-momentum-15m", store=store, compile_job=False)
+    job = store.load("mixed-sleeve-momentum-15m")
+    lookback = job.execution_params["lookback_bars"]
+    assert lookback == 2904
+    strategy = MixedSleeveMomentumStrategy(dict(job.execution_params))
+    assert lookback > strategy.warmup_bars  # 2884: momentum_bars 2880 + 4
+
+
 def test_momentum_rank_longs_leaders_and_shorts_laggards() -> None:
     symbols = ["A", "B", "C", "D"]
     strategy = MixedMomentumRankStrategy(
@@ -568,6 +629,7 @@ def test_create_starter_materializes_job_and_forward_inception(tmp_path) -> None
     assert job.controller["initializer_session_id"] == "ses_strategy-labbad"
     assert job.controller["starter"]["selected_leverage"] == 3
     assert job.execution_params["leverage"] == 3
+    assert job.execution_params["lookback_bars"] == 360  # momentum_bars 336 + 4 + 20
     assert result["selected_leverage"] == 3
     assert result["created"] is True
     assert job.execution_spec["data_contract"]["bar_interval"] == "1h"

--- a/wayfinder_paths/tests/test_jobs_view_windowing.py
+++ b/wayfinder_paths/tests/test_jobs_view_windowing.py
@@ -160,7 +160,19 @@ def test_validation_flags_missing_lookback() -> None:
 
     missing = check({"execution_contract": "jobs_v1", "execution_params": {}})
     assert missing["passed"] is False
-    assert missing["blocking"] is False  # warn, never block
+    assert missing["blocking"] is False  # warn-only for hand-built jobs
+
+    starter_missing = check(
+        {
+            "execution_contract": "jobs_v1",
+            "execution_params": {},
+            "controller": {"starter": {"id": "mixed-momentum-rank-1h"}},
+        }
+    )
+    assert starter_missing["passed"] is False
+    # Blocking for starters: most catalog entries have warmup_bars > the
+    # 200-bar driver default, so an undeclared lookback means never trading.
+    assert starter_missing["blocking"] is True
 
     declared = check(
         {"execution_contract": "jobs_v1", "execution_params": {"lookback_bars": 200}}


### PR DESCRIPTION
## Bug (verified in production)

The live/paper driver hands strategies a sliding window of `lookback_bars` completed bars (`jobs/execution/driver.py`: `int(params.get("lookback_bars") or 200)`), so `ctx.bar_index` is capped at the window length. The starter launch path built `execution_params` from `definition.params` and never set `lookback_bars` — every starter ran on the 200-bar default.

**7 of 11 catalog starters have `warmup_bars` above 200**, so `bar_index` stayed below their warmup gate on every tick and they NEVER traded — silently: no error, no journal entry, just `[]` intents forever.

## Fix

- `create_starter_job` now derives the window from the strategy itself: it imports `definition.module`, calls `build_strategy()` on the exact launch params, reads the strategy's declared `warmup_bars`, and sets `lookback_bars = warmup_bars + 20` (margin for feeds dropping a few leading bars). No hand-maintained constants — a catalog param edit automatically moves the window.
- Catalog payloads (`starter_catalog()` / `starter_evidence.json`) now expose `params.lookback_bars`, so what the UI shows matches what the job runs with.
- `STARTER_CATALOG_VERSION` 1.6.0 → 1.7.0.
- The `lookback_bars_declared` validation check (`jobs/execution/validation.py`) is now **blocking for starter jobs** (`controller.starter` present) and stays warn-only for hand-built jobs_v1 jobs. A starter job that somehow loses its lookback can no longer pass validation and silently go dark.
- Backtest/live window alignment: the simulator's `_resolve_compute_window` already honors `params["lookback_bars"]`, so backtests now replay with exactly the live window (previously they fell through to `strategy.warmup_bars`; decisions are unchanged because indicators are precomputed on full frames and the window only gates `bar_index`/cost).

## Per-starter derived windows

| Starter | Warmup basis | warmup_bars | lookback_bars | Traded on 200-bar default? |
|---|---|---:|---:|---|
| mixed-rsi-snapback-1h | SMA(200) + 4 | 204 | 224 | NO |
| mixed-bollinger-pullback-1h | max(z 72, SMA 200) + 4 | 204 | 224 | NO |
| mixed-volume-capitulation-1h | max(SMA 200, vol 24) + 4 | 204 | 224 | NO |
| balanced-passive-capitulation-1h | max(SMA 200, vol 24) + 4 | 204 | 224 | NO |
| mixed-momentum-rank-1h | momentum 336 + 4 | 340 | 360 | NO |
| mixed-sleeve-momentum-15m | momentum 2880 + 4 | 2884 | 2904 | NO |
| mixed-low-vol-rank-15m | volatility 480 + 4 | 484 | 504 | NO |
| hype-passive-rsi-full-5m | max(RSI 14, ATR 14) + 4 | 18 | 38 | yes |
| hype-passive-rsi-staged-5m | max(RSI 14, ATR 14) + 4 | 18 | 38 | yes |
| btc-eth-relative-strength-1d | max(momentum 90, vol 28) + 4 | 94 | 114 | yes |
| bch-ltc-relative-strength-1d | max(momentum 90, vol 28) + 4 | 94 | 114 | yes |

## 15m feed feasibility (sleeve momentum, 2,904 bars)

2,904 × 15m bars ≈ 30.25 days → the driver requests `lookback_hours=726` per symbol per tick through `HyperliquidMarketFeed.get_completed_bars` → `SafeHyperliquidMarketClient.get_candles`. The client passes `start_ms/end_ms` straight through with no window cap, and the **same path already serves the starter dataset fetch at 120 days of 15m bars (11,520 bars — 4× deeper)** when building `results/backtest/input_bars.json`. No cap needed. Per-tick fetch cost grows accordingly (4 symbols × ~2.9k bars every 15 minutes) — that is the unavoidable cost of a 30-day momentum window.

## Tests

- `test_every_starter_lookback_clears_its_warmup_gate` — catalog-wide: independently rebuilds each strategy the way the driver does, asserts `lookback > warmup` for ALL entries, and pins every starter's derived value in `EXPECTED_STARTER_LOOKBACK_BARS` so a new/edited starter must update the table consciously (and can never ship with `warmup > lookback`).
- `test_starter_catalog_params_expose_lookback_bars` — catalog payloads carry the derived window.
- `test_create_starter_sets_driver_lookback_above_warmup` — launch path materializes `execution_params["lookback_bars"] = 2904 > warmup 2884` for the worst-case starter.
- `test_create_starter_materializes_job_and_forward_inception` — extended with the momentum-rank launch value (360).
- `test_validation_flags_missing_lookback` — extended: blocking for starter jobs, still warn-only for hand-built jobs.

`pytest -k "jobs or runner or mcp"`: **1014 passed, 3 skipped** (baseline ~1010/3 + 4 new tests). ruff check + format clean; mypy introduces no new errors on touched files (only pre-existing yaml/croniter stub notes).

## Operator note (existing jobs)

This fixes the **launch path** only. Starter jobs created under catalog ≤ 1.6.0 still carry no `lookback_bars` in their `job.yaml` execution_params and remain dark; with this PR they now **fail validation loudly** instead of ticking silently. Recreating the job from the catalog (or adding the table's `lookback_bars` value to execution_params via the normal proposal/apply flow) repairs them.
