### PR TITLE
proposals: don't freeze transient infra failures into candidate reports; add revalidation path

### DIFF
--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -57,7 +57,11 @@ from wayfinder_paths.jobs.models import (
     normalize_agent_mode,
 )
 from wayfinder_paths.jobs.probation import open_paper_probation_leg
-from wayfinder_paths.jobs.proposals import propose_change, restage_proposal
+from wayfinder_paths.jobs.proposals import (
+    propose_change,
+    restage_proposal,
+    revalidate_proposal,
+)
 from wayfinder_paths.jobs.replication import replication_job
 from wayfinder_paths.jobs.research import (
     holdout_check_job,
@@ -1583,6 +1587,21 @@ def restage_cmd(job_id: str, proposal_id: str, candidate_dir: str | None) -> Non
     _echo_json({"ok": True, "result": proposal})
 
 
+@job_cli.command(
+    name="revalidate",
+    help="Re-run validation/comparison for a PENDING proposal against its "
+    "same staged candidate and base revision, replacing the embedded "
+    "candidate_report (recovery for reports frozen by a transient "
+    "infrastructure failure).",
+)
+@click.argument("job_id")
+@click.argument("proposal_id")
+def revalidate_cmd(job_id: str, proposal_id: str) -> None:
+    store = JobStore()
+    proposal = revalidate_proposal(store, job_id, proposal_id)
+    _echo_json({"ok": True, "result": proposal})
+
+
 @job_cli.command(name="reject", help="Reject a pending proposal.")
 @click.argument("job_id")
 @click.argument("proposal_id")
@@ -1630,9 +1649,7 @@ def exhaustion_group() -> None:
 @exhaustion_group.command(name="file", help="File an exhaustion claim (agent-legal).")
 @click.argument("job_id")
 @click.option("--lane", required=True, help="Lane/region claimed exhausted.")
-@click.option(
-    "--evidence", required=True, help="Evidence summary (test counts, refs)."
-)
+@click.option("--evidence", required=True, help="Evidence summary (test counts, refs).")
 @click.option(
     "--provenance",
     type=click.Choice(sorted(CLAIM_PROVENANCES)),
@@ -1733,9 +1750,7 @@ def exhaustion_list_cmd(job_id: str, status: str | None) -> None:
     default="registered kill predicates + mechanical flat-zero floor",
     show_default=True,
 )
-@click.option(
-    "--kill-rules-json", default=None, help="Typed kill predicates as JSON."
-)
+@click.option("--kill-rules-json", default=None, help="Typed kill predicates as JSON.")
 @click.option("--notes", default=None)
 def probation_open_paper_cmd(
     job_id: str,

--- a/wayfinder_paths/jobs/failures.py
+++ b/wayfinder_paths/jobs/failures.py
@@ -20,6 +20,17 @@ import shutil
 import time
 from pathlib import Path
 
+
+class TransientInfrastructureError(RuntimeError):
+    """A box condition (OOM/lock/timeout) interrupted a pipeline step.
+
+    Raised instead of recording a failed artifact so transient box state
+    never freezes into durable evidence: callers abort and retry when the
+    box is quiet rather than staging a "failed" report the approve gate
+    reads forever.
+    """
+
+
 # Deliberately dumb and greppable: case-insensitive substring match against a
 # flat list. No regex cleverness — anyone auditing a recovery decision should
 # be able to grep the error text against this list by eye.

--- a/wayfinder_paths/jobs/proposals.py
+++ b/wayfinder_paths/jobs/proposals.py
@@ -16,6 +16,7 @@ change that gets promoted.
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import uuid
 from pathlib import Path
@@ -24,15 +25,18 @@ from typing import Any
 import yaml
 
 from wayfinder_paths.jobs.application import (
+    _candidate_dir_from_proposal,
     _prepare_candidate_workspace,
     ensure_jobs_v1_contract,
     validate_candidate_bundle,
 )
+from wayfinder_paths.jobs.compute_lock import ComputeLockBusy, heavy_compute_lock
 from wayfinder_paths.jobs.execution.job import (
     backtest_execution_job,
     synthesize_scenario_plan,
 )
 from wayfinder_paths.jobs.execution.primitives import ExecutionSpec
+from wayfinder_paths.jobs.failures import TransientInfrastructureError, classify_failure
 from wayfinder_paths.jobs.gating import (
     compute_workspace_revision,
     evaluate_economic_gate,
@@ -47,10 +51,14 @@ from wayfinder_paths.jobs.improver.spec import (
 from wayfinder_paths.jobs.models import utc_now_iso
 from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.jobs.sync import sync_all_jobs
-from wayfinder_paths.jobs.validation import validation_summary
+from wayfinder_paths.jobs.validation import validation_failure_text, validation_summary
 from wayfinder_paths.jobs.worker import JOB_RESULT_MARKER
 
 PROPOSAL_KINDS = {"code_change", "params_update", "model_update", "improver_change"}
+# Bounded wait for the machine-wide heavy-compute lock before the single
+# propose-time retry of an infrastructure-failed candidate validation.
+PROPOSE_LOCK_WAIT_ENV = "WAYFINDER_PROPOSE_LOCK_WAIT_SECONDS"
+_PROPOSE_LOCK_WAIT_DEFAULT_S = 120.0
 
 
 def propose_change(
@@ -153,9 +161,28 @@ def propose_change(
         memo_path.parent.mkdir(parents=True, exist_ok=True)
         memo_path.write_text(memo.rstrip() + "\n", encoding="utf-8")
 
-    validation, candidate_report = _generate_candidate_report(
-        store, job_id, proposal, candidate_dir, base_revision=base_revision, pid=pid
-    )
+    try:
+        validation, candidate_report = _generate_candidate_report(
+            store, job_id, proposal, candidate_dir, base_revision=base_revision, pid=pid
+        )
+    except TransientInfrastructureError as exc:
+        # Abort BEFORE any proposal file exists: a transient box condition
+        # (OOM/lock/timeout) must never freeze into an immutable
+        # candidate_report that the approve gate then refuses forever.
+        shutil.rmtree(candidate_dir.parent, ignore_errors=True)
+        if memo:
+            memo_path = store.job_dir(job_id) / "proposals" / f"{pid}.md"
+            memo_path.unlink(missing_ok=True)
+        store.append_journal(
+            job_id,
+            {
+                "type": "proposal_propose_aborted",
+                "proposal_id": pid,
+                "failure_kind": "infrastructure",
+                "error": str(exc)[:300],
+            },
+        )
+        raise
     proposal["candidate_report"] = candidate_report
 
     store.write_proposal(job_id, proposal)
@@ -304,6 +331,9 @@ def _generate_candidate_report(
     pid: str,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     validation = validate_candidate_bundle(store, job_id, proposal, candidate_dir)
+    validation = _retry_infrastructure_failure(
+        store, job_id, proposal, candidate_dir, validation
+    )
     candidate_revision = compute_workspace_revision(candidate_dir)
     comparison = _build_comparison(
         store, job_id, candidate_dir, base_revision=base_revision, pid=pid
@@ -370,6 +400,131 @@ def _generate_candidate_report(
         "generated_at": utc_now_iso(),
     }
     return validation, candidate_report
+
+
+def _retry_infrastructure_failure(
+    store: JobStore,
+    job_id: str,
+    proposal: dict[str, Any],
+    candidate_dir: Path,
+    validation: dict[str, Any],
+) -> dict[str, Any]:
+    """Infrastructure failures (ComputeLockBusy, OOM, timeouts) are box
+    conditions, not evidence about the candidate — freezing one into an
+    immutable candidate_report leaves a pending proposal the approve gate
+    refuses forever (verified production dead end). Retry ONCE after a
+    bounded wait for the heavy-compute lock; if the box is still unhealthy,
+    raise so the caller aborts instead of staging a failed report.
+    Evidence-class failures pass through untouched — a real verdict must
+    still stage."""
+    if validation["status"] != "failed":
+        return validation
+    failure_text = validation_failure_text(validation)
+    if classify_failure(failure_text) != "infrastructure":
+        return validation
+    wait_s = float(
+        os.environ.get(PROPOSE_LOCK_WAIT_ENV, "") or _PROPOSE_LOCK_WAIT_DEFAULT_S
+    )
+    if _compute_lock_freed(store, job_id, wait_s):
+        validation = validate_candidate_bundle(store, job_id, proposal, candidate_dir)
+        if validation["status"] != "failed":
+            return validation
+        failure_text = validation_failure_text(validation)
+        if classify_failure(failure_text) != "infrastructure":
+            return validation
+    raise TransientInfrastructureError(
+        "transient infrastructure failure — retry when the box is quiet: "
+        f"{failure_text[:300] or 'unknown'}"
+    )
+
+
+def _compute_lock_freed(store: JobStore, job_id: str, wait_s: float) -> bool:
+    """Bounded wait for the machine-wide heavy-compute lock to come free.
+    Acquire-and-release only — the retry's own backtest re-acquires it.
+    False means the box is still busy after the wait."""
+    try:
+        with heavy_compute_lock(
+            repo_root=store.repo_root,
+            label=f"propose-retry-wait:{job_id}",
+            timeout_s=wait_s,
+        ):
+            return True
+    except ComputeLockBusy:
+        return False
+
+
+def revalidate_proposal(
+    store: JobStore, job_id: str, proposal_id: str
+) -> dict[str, Any]:
+    """Re-run the full validation/comparison for a PENDING proposal against
+    the SAME staged candidate and base revision, replacing the embedded
+    candidate_report.
+
+    Recovery path for reports frozen by a transient infrastructure failure
+    (validation_summary.failure_kind == "infrastructure"): the propose-time
+    snapshot is immutable, so without this the only exit from an
+    infra-failed pending proposal is reject-and-repropose. The candidate and
+    base revision are NOT rebuilt — the same evidence question, asked again
+    on a quiet box. If the job's active revision moved past base_revision
+    the comparison baseline would drift, so refuse: the owner should reject
+    and re-propose against the current workspace instead.
+    """
+    proposal = store.load_proposal(job_id, proposal_id)
+    if proposal["status"] != "pending":
+        raise ValueError(
+            f"Only pending proposals can be revalidated: {proposal_id} is "
+            f"{proposal['status']} (stale approved candidates use "
+            "`wayfinder job restage`)"
+        )
+    candidate_dir = _candidate_dir_from_proposal(store, job_id, proposal)
+    if not candidate_dir.exists():
+        raise FileNotFoundError(
+            f"candidate bundle for {proposal_id} no longer exists at "
+            f"{candidate_dir} — reject the proposal and propose fresh"
+        )
+    root = store.job_dir(job_id)
+    base_revision = str(proposal.get("base_revision") or "")
+    current_revision = compute_workspace_revision(root)
+    if current_revision != base_revision:
+        raise ValueError(
+            f"cannot revalidate {proposal_id}: the job's active revision "
+            f"({current_revision[:12]}) moved past the proposal's base "
+            f"revision ({base_revision[:12]}) — the baseline comparison "
+            "would drift. Reject the proposal and propose fresh against the "
+            "current workspace."
+        )
+    old_summary = (proposal.get("candidate_report") or {}).get(
+        "validation_summary"
+    ) or {}
+    validation, candidate_report = _generate_candidate_report(
+        store,
+        job_id,
+        proposal,
+        candidate_dir,
+        base_revision=base_revision,
+        pid=proposal_id,
+    )
+    proposal["candidate_report"] = candidate_report
+    # Recomputed against the same base: unchanged for an intact candidate,
+    # honest for one that was edited since propose (the regenerated report's
+    # revision covers the current bytes either way).
+    proposal["changed_files"] = _diff_workspaces(root, candidate_dir)
+    proposal["updated_at"] = utc_now_iso()
+    store.write_proposal(job_id, proposal)
+    store.append_journal(
+        job_id,
+        {
+            "type": "proposal_revalidated",
+            "proposal_id": proposal_id,
+            "old_validation_status": old_summary.get("status"),
+            "old_failure_kind": old_summary.get("failure_kind"),
+            "new_validation_status": validation.get("status"),
+            "candidate_revision": candidate_report["revision"],
+        },
+    )
+    store.refresh_scorecard(job_id)
+    sync_all_jobs(store=store)
+    return store.load_proposal(job_id, proposal_id)
 
 
 def restage_proposal(

--- a/wayfinder_paths/jobs/store.py
+++ b/wayfinder_paths/jobs/store.py
@@ -385,9 +385,23 @@ class JobStore:
             )
         if not report.get("revision"):
             raise ValueError("candidate_report is missing its candidate revision")
-        validation_status = (report.get("validation_summary") or {}).get("status")
+        validation_summary = report.get("validation_summary") or {}
+        validation_status = validation_summary.get("status")
         if validation_status != "passed":
-            raise ValueError(f"candidate validation is not passed: {validation_status}")
+            failure_kind = validation_summary.get("failure_kind")
+            kind_note = f" (failure_kind: {failure_kind})" if failure_kind else ""
+            # Wording deliberately avoids INFRASTRUCTURE_PATTERNS terms: this
+            # message rides along in rejection reasons, which classify_failure
+            # re-reads — a pattern word here would flip evidence rejections
+            # into refused-rejection loops.
+            raise ValueError(
+                f"candidate validation is not passed: {validation_status}"
+                f"{kind_note} — if the failure_kind is infrastructure (a "
+                "transient box condition, not a verdict on the change), run: "
+                f"wayfinder job revalidate {safe_job_id(job_id)} "
+                f"{proposal.get('proposal_id')} to re-run validation against "
+                "the same staged candidate"
+            )
         if report.get("mode") == "validation_only":
             self._ensure_candidate_matches_report(job_id, proposal, report)
             return

--- a/wayfinder_paths/jobs/validation.py
+++ b/wayfinder_paths/jobs/validation.py
@@ -23,6 +23,7 @@ from wayfinder_paths.jobs.execution.validation import (
     FORBIDDEN_ORDER_PATTERNS,
     entrypoint_inside_workspace_check,
 )
+from wayfinder_paths.jobs.failures import classify_failure
 from wayfinder_paths.jobs.gating import compute_workspace_revision
 from wayfinder_paths.jobs.models import utc_now_iso
 from wayfinder_paths.jobs.store import JobStore
@@ -635,9 +636,28 @@ def _extract_action(actual: Any) -> Any:
             return None
 
 
+def validation_failure_text(validation: Mapping[str, Any]) -> str:
+    """Aggregate text of every failed check (names + errors + details), for
+    the infrastructure-vs-evidence classification of a failed validation."""
+    parts: list[Any] = [validation.get("error")]
+    for check in validation.get("checks") or []:
+        match check:
+            case Mapping() if not check.get("passed"):
+                parts.extend(
+                    [check.get("name"), check.get("error"), check.get("detail")]
+                )
+    return " | ".join(str(part) for part in parts if part)
+
+
 def validation_summary(validation: Mapping[str, Any]) -> dict[str, Any]:
     checks = validation["checks"]
-    return {
+    summary: dict[str, Any] = {
         "status": validation["status"],
         "failed_checks": [check["name"] for check in checks if not check["passed"]],
     }
+    if summary["status"] == "failed":
+        # infrastructure|evidence: lets the approve gate, the revalidate
+        # flow, and any reader of a residual frozen report distinguish a
+        # transient box condition from a real verdict on the candidate.
+        summary["failure_kind"] = classify_failure(validation_failure_text(validation))
+    return summary

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -1096,6 +1096,11 @@ def _build_worker_prompt_sections(
             "names and fix them in ONE follow-up propose; after 2 failed propose "
             "attempts in a wake, stop and report the blocker instead of "
             "retrying.\n"
+            "- A pending proposal whose candidate_report failed with "
+            "failure_kind 'infrastructure' is a box condition, not evidence: "
+            "run `wayfinder job revalidate <job_id> <proposal_id>` to re-run "
+            "validation on the same candidate instead of rejecting or "
+            "re-proposing.\n"
         )
     )
     # Re-stage tasks are rendered as prompt text, never only inside the JSON

--- a/wayfinder_paths/tests/test_jobs_propose.py
+++ b/wayfinder_paths/tests/test_jobs_propose.py
@@ -7,8 +7,11 @@ the approval gate demands the candidate_report evidence.
 
 from __future__ import annotations
 
+import fcntl
 import json
+import shutil
 from pathlib import Path
+from typing import Any
 
 import pytest
 import yaml
@@ -19,10 +22,16 @@ from wayfinder_paths.jobs.application import (
     validate_application_candidate,
 )
 from wayfinder_paths.jobs.backtest_artifacts import load_backtest_view
+from wayfinder_paths.jobs.failures import TransientInfrastructureError
 from wayfinder_paths.jobs.gating import evaluate_live_gate
 from wayfinder_paths.jobs.models import WayfinderJob
-from wayfinder_paths.jobs.proposals import propose_change, restage_proposal
+from wayfinder_paths.jobs.proposals import (
+    propose_change,
+    restage_proposal,
+    revalidate_proposal,
+)
 from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.jobs.validation import validation_summary
 from wayfinder_paths.tests.test_jobs_application_gate import _patch_runner
 from wayfinder_paths.tests.test_jobs_gating import _make_job
 from wayfinder_paths.tests.test_wayfinder_jobs import _intent_contract
@@ -314,6 +323,10 @@ def test_propose_fails_named_check_when_entrypoint_outside_workspace(
     summary = proposal["candidate_report"]["validation_summary"]
     assert summary["status"] == "failed"
     assert "entrypoint_inside_workspace" in summary["failed_checks"]
+    # Evidence-class failure: staged as a real verdict, machine-tagged.
+    assert summary["failure_kind"] == "evidence"
+    pid = proposal["proposal_id"]
+    assert (root / "proposals" / f"{pid}.json").exists()
 
 
 def test_stale_baseline_apply_restages_with_approval_carryover(
@@ -413,3 +426,218 @@ def test_restage_gate_failure_auto_rejects(
     assert rejected["status"] == "rejected"
     assert rejected["rejection"]["by"] == "agent"
     assert "re-stage gate failed" in str(rejected["rejection"]["reason"])
+
+
+# ── infra-vs-evidence at propose time + revalidation ─────────────────────────
+# Production bug (verified twice): a ComputeLockBusy during the propose-time
+# candidate backtest froze a FAILED validation_summary into the immutable
+# candidate_report; the approve gate then refused forever even though a
+# re-run passed clean. Infra failures must abort propose (retry when quiet),
+# evidence failures must still stage, and pending proposals get a
+# revalidation path that replaces the snapshot in place.
+
+
+def _infra_failed_validation(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+    return {
+        "status": "failed",
+        "checks": [
+            {
+                "name": "candidate_backtest_valid",
+                "passed": False,
+                "error": (
+                    "heavy-compute lock busy after 600s (held by pid=1 "
+                    "label=scan) — another heavy computation is running"
+                ),
+            }
+        ],
+    }
+
+
+def test_validation_summary_tags_failure_kind() -> None:
+    infra = validation_summary(_infra_failed_validation())
+    assert infra["failure_kind"] == "infrastructure"
+
+    evidence = validation_summary(
+        {
+            "status": "failed",
+            "checks": [
+                {
+                    "name": "scenario_entry",
+                    "passed": False,
+                    "error": "expected >= 1 trades, got 0",
+                }
+            ],
+        }
+    )
+    assert evidence["failure_kind"] == "evidence"
+
+    passed = validation_summary(
+        {"status": "passed", "checks": [{"name": "py_compile", "passed": True}]}
+    )
+    assert "failure_kind" not in passed
+
+
+def test_infra_failure_aborts_propose_after_bounded_retry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job_id, root = _make_job(tmp_path)
+    monkeypatch.setenv("WAYFINDER_PROPOSE_LOCK_WAIT_SECONDS", "0.1")
+    calls: list[int] = []
+
+    def busy_validation(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        calls.append(1)
+        return _infra_failed_validation()
+
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.proposals.validate_candidate_bundle", busy_validation
+    )
+
+    with pytest.raises(
+        TransientInfrastructureError, match="retry when the box is quiet"
+    ):
+        _propose_params(store, job_id)
+
+    assert len(calls) == 2, "exactly one bounded retry"
+    assert list((root / "proposals").glob("*.json")) == [], "no proposal staged"
+    assert not list((root / "applications").glob("*/candidate")), "candidate cleaned"
+    journal = (root / "journal.jsonl").read_text(encoding="utf-8")
+    assert "proposal_propose_aborted" in journal
+    assert "proposal_created" not in journal
+
+
+def test_infra_failure_skips_retry_while_lock_still_held(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If the box is still busy after the bounded wait, the retry is
+    pointless — abort with one validation attempt, not two."""
+    store, job_id, root = _make_job(tmp_path)
+    monkeypatch.setenv("WAYFINDER_PROPOSE_LOCK_WAIT_SECONDS", "0.1")
+    calls: list[int] = []
+
+    def busy_validation(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        calls.append(1)
+        return _infra_failed_validation()
+
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.proposals.validate_candidate_bundle", busy_validation
+    )
+    holder = (tmp_path / ".wayfinder" / "compute.lock").open("a+")
+    fcntl.flock(holder.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    try:
+        with pytest.raises(TransientInfrastructureError):
+            _propose_params(store, job_id)
+    finally:
+        fcntl.flock(holder.fileno(), fcntl.LOCK_UN)
+        holder.close()
+
+    assert len(calls) == 1
+    assert list((root / "proposals").glob("*.json")) == []
+
+
+def test_evidence_failure_still_stages_failed_report(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A real verdict on the candidate stages exactly as before — the
+    infra-abort path must never swallow evidence."""
+    store, job_id, root = _make_job(tmp_path)
+
+    def refuted_validation(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {
+            "status": "failed",
+            "checks": [
+                {
+                    "name": "candidate_backtest_valid",
+                    "passed": False,
+                    "error": "execution_valid is False: net_return regressed",
+                }
+            ],
+        }
+
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.proposals.validate_candidate_bundle",
+        refuted_validation,
+    )
+
+    proposal = _propose_params(store, job_id)
+
+    summary = proposal["candidate_report"]["validation_summary"]
+    assert summary["status"] == "failed"
+    assert summary["failure_kind"] == "evidence"
+    pid = proposal["proposal_id"]
+    assert (root / "proposals" / f"{pid}.json").exists()
+    with pytest.raises(ValueError, match="wayfinder job revalidate"):
+        store.approve_proposal(job_id, pid)
+
+
+def test_revalidate_replaces_frozen_report_and_passes_gate(tmp_path: Path) -> None:
+    """The full production recovery: a frozen infra-failed snapshot blocks
+    approval (with the recovery named in the refusal), revalidate re-runs the
+    same candidate at the same base revision and replaces the snapshot, and
+    the gate passes afterward."""
+    store, job_id, root = _make_job(tmp_path)
+    proposal = _propose_params(store, job_id)
+    pid = proposal["proposal_id"]
+
+    # Freeze a pre-fix infra failure into the immutable snapshot.
+    proposal["candidate_report"]["validation_summary"] = {
+        "status": "failed",
+        "failed_checks": ["candidate_backtest_valid"],
+        "failure_kind": "infrastructure",
+    }
+    proposal["candidate_report"]["mode"] = "validation_only"
+    proposal["candidate_report"]["comparison"] = None
+    store.write_proposal(job_id, proposal)
+
+    with pytest.raises(ValueError, match="wayfinder job revalidate"):
+        store.approve_proposal(job_id, pid)
+
+    revalidated = revalidate_proposal(store, job_id, pid)
+
+    report = revalidated["candidate_report"]
+    assert report["validation_summary"]["status"] == "passed"
+    assert "failure_kind" not in report["validation_summary"]
+    assert report["mode"] == "full"
+    assert report["gate"]["live_ready"] is True, report["gate"]["reasons"]
+    assert report["comparison"]["candidate"]["stats"]
+    assert report["base_revision"] == proposal["base_revision"]
+    journal = (root / "journal.jsonl").read_text(encoding="utf-8")
+    assert "proposal_revalidated" in journal
+
+    approved = store.approve_proposal(job_id, pid)
+    assert approved["status"] == "approved"
+
+
+def test_revalidate_refuses_non_pending(tmp_path: Path) -> None:
+    store, job_id, _ = _make_job(tmp_path)
+    proposal = _propose_params(store, job_id)
+    pid = proposal["proposal_id"]
+    store.approve_proposal(job_id, pid)
+
+    with pytest.raises(ValueError, match="Only pending"):
+        revalidate_proposal(store, job_id, pid)
+
+
+def test_revalidate_refuses_drifted_baseline(tmp_path: Path) -> None:
+    """No baseline drift: once the active revision moves past base_revision,
+    the comparison would be against a world the proposal never saw."""
+    store, job_id, root = _make_job(tmp_path)
+    proposal = _propose_params(store, job_id)
+    pid = proposal["proposal_id"]
+
+    script = root / "workspace" / "src" / "strategy.py"
+    script.write_text(
+        script.read_text(encoding="utf-8") + "\n# drift\n", encoding="utf-8"
+    )
+
+    with pytest.raises(ValueError, match="moved past"):
+        revalidate_proposal(store, job_id, pid)
+
+
+def test_revalidate_refuses_missing_candidate(tmp_path: Path) -> None:
+    store, job_id, root = _make_job(tmp_path)
+    proposal = _propose_params(store, job_id)
+    pid = proposal["proposal_id"]
+    shutil.rmtree(root / "applications" / pid / "candidate")
+
+    with pytest.raises(FileNotFoundError, match="no longer exists"):
+        revalidate_proposal(store, job_id, pid)

--- a/wayfinder_paths/tests/test_jobs_self_healing.py
+++ b/wayfinder_paths/tests/test_jobs_self_healing.py
@@ -101,6 +101,9 @@ def test_compute_status_block_in_wake_prompt(tmp_path: Path) -> None:
     # rejections are invitations, not vetoes.
     assert "compute_status" in sections["stable_prefix"]
     assert "INVITATIONS" in sections["stable_prefix"]
+    # Task guidance: infra-failed pending proposals name revalidate as the
+    # remedy (box condition, not evidence).
+    assert "wayfinder job revalidate" in sections["dynamic_context"]
 
 
 def _approved_proposal(error: str | None) -> dict[str, Any]:


### PR DESCRIPTION
## Problem (verified twice on a user box)

At propose time, the candidate backtest runs under `heavy_compute_lock`, which raises `ComputeLockBusy` on contention. The raise short-circuits `_candidate_behavior_checks`: preflight never runs, validation comes back `failed`, `_build_comparison` returns `None`, and that FAILED snapshot is frozen immutably into the proposal's `candidate_report`. The approve gate (`store._ensure_candidate_report_gate`, mirrored in the backend) then refuses forever — "candidate validation is not passed: failed" — even though re-running validation passes clean. `restage` only serves approved proposals, so the user-visible dead end is an un-approvable pending proposal with no recovery except an undiscoverable reject-and-repropose.

The infra-vs-evidence taxonomy from the self-healing work (`failures.classify_failure`) already answers the key question — is this failure about the BOX or about the EVIDENCE? — it just wasn't wired into the propose flow.

## Changes

**1. Propose-time infra handling (`proposals.py`, `failures.py`)**
- When candidate validation fails and `classify_failure(...) == "infrastructure"` (ComputeLockBusy, OOM, timeouts...), propose waits (bounded, default 120s, env-tunable `WAYFINDER_PROPOSE_LOCK_WAIT_SECONDS`) for the heavy-compute lock to come free, then retries validation exactly once. If the box is still busy after the wait, the pointless retry is skipped.
- If the failure is still infrastructure-class, propose ABORTS with a new `TransientInfrastructureError` ("transient infrastructure failure — retry when the box is quiet: ..."), cleans up the staged candidate + memo, and journals `proposal_propose_aborted`. No proposal file is created — a box condition never freezes into an immutable report.
- Evidence-class failures stage the failed report exactly as before: that is a real verdict.

**2. `failure_kind` tagging (`validation.py`)**
- `validation_summary` gains `failure_kind: infrastructure|evidence` whenever `status == "failed"` (classified from failed check names/errors via the shared taxonomy), so any residual infra-failed report is machine-distinguishable.

**3. Revalidation path for pending proposals (`proposals.py`, `cli.py`, `store.py`)**
- New `wayfinder job revalidate <job_id> <proposal_id>`: allowed only for `status=pending` proposals whose candidate dir still exists. Re-runs the full validation/comparison against the SAME staged candidate and the SAME `base_revision`, REPLACES the embedded `candidate_report`, recomputes `changed_files`, and journals `proposal_revalidated`. Refuses with a clear message if the job's active revision moved past `base_revision` (no baseline drift) — reject + re-propose is the right path there.
- The approve gate's refusal for a failed report now names the recovery (`run: wayfinder job revalidate ...`) and surfaces `failure_kind`. Wording deliberately avoids `INFRASTRUCTURE_PATTERNS` terms so the hint can't flip evidence rejections into refused-rejection loops when it rides along in rejection reasons.

**4. Worker guidance (`worker.py`)**
- One line in the intervene/auto task mandate: an infra-failed pending proposal is a box condition, not evidence — revalidate instead of rejecting or re-proposing.

## Tests

- infra failure aborts propose (no proposal file, candidate cleaned, journal event) after exactly one bounded retry
- retry is skipped when the compute lock is still held after the bounded wait
- evidence failure still stages the failed report, tagged `failure_kind: evidence`
- `validation_summary` tagging unit test (infra / evidence / passed)
- revalidate replaces a frozen infra-failed snapshot; gate refusal names the recovery; gate passes after revalidate; `proposal_revalidated` journaled
- revalidate refuses non-pending, drifted baseline, and missing candidate
- worker prompt names `wayfinder job revalidate`

Full `pytest -k "jobs or runner or mcp"`: **1022 passed, 9 skipped**, 2757 deselected in 134s (9 new tests in this PR). ruff clean on changed files; scoped mypy introduces no new errors (identical error set to base, line shifts only).
