### PR TITLE
Fix instance-scoped remote wallet creation

### DIFF
--- a/CONFIG_GUIDE.md
+++ b/CONFIG_GUIDE.md
@@ -112,7 +112,7 @@ Newly generated mnemonics are 12 words by default.
 | `address` | Ethereum address |
 | `private_key_hex` | Private key (hex format with `0x` prefix) |
 
-**Remote wallets** (Privy server wallets) are fetched automatically from the vault backend when `system.api_key` is configured. They don't require `private_key_hex` — signing happens via API. Create them with `create_remote_wallet(label="my_agent")` or `make_wallets.py --remote`.
+**Remote wallets** (Privy server wallets) are fetched automatically from the vault backend when `system.api_key` is configured. They don't require `private_key_hex` — signing happens via API. On a Wayfinder Shell, create them with `create_remote_wallet(label="my_agent", wallet_type="session")` or `make_wallets.py --remote`; the instance binding is inferred from `OPENCODE_INSTANCE_ID`. Outside a Shell, pass `instance_id=` or `--instance-id` explicitly.
 
 Both wallet types work transparently with `get_wallet_signing_callback(label)` and `get_adapter()`.
 

--- a/scripts/make_wallets.py
+++ b/scripts/make_wallets.py
@@ -82,6 +82,14 @@ async def main():
         default="session",
         help="Remote wallet type: session (default, 1h TTL), strategy (7d TTL), or policy (custom)",
     )
+    parser.add_argument(
+        "--instance-id",
+        default=None,
+        help=(
+            "OpenCode instance to bind a remote wallet to. Inferred from "
+            "OPENCODE_INSTANCE_ID when run on a Shell."
+        ),
+    )
     args = parser.parse_args()
 
     # --default means "ensure main wallet exists" (and do nothing otherwise).
@@ -168,7 +176,10 @@ async def main():
         for label in labels_to_create:
             policies = json.loads(args.policies)
             result = await create_remote_wallet(
-                label=label, wallet_type=args.wallet_type, policies=policies
+                label=label,
+                wallet_type=args.wallet_type,
+                policies=policies,
+                instance_id=args.instance_id,
             )
             evm, svm = result["evm"], result["svm"]
             print(

--- a/wayfinder_paths/core/clients/WalletClient.py
+++ b/wayfinder_paths/core/clients/WalletClient.py
@@ -27,7 +27,7 @@ class WalletClient(WayfinderClient):
         self,
         policies: list[dict],
         wallet_type: str,
-        label: str,
+        instance_id: str,
         *,
         chain_type: str = "ethereum",
     ) -> dict[str, Any]:
@@ -36,7 +36,7 @@ class WalletClient(WayfinderClient):
             "policies": policies,
             "wallet_type": wallet_type,
             "chain_type": chain_type,
-            "label": label,
+            "instance_id": instance_id,
         }
         resp = await self._authed_request("POST", url, json=body)
         return resp.json()

--- a/wayfinder_paths/core/utils/wallets.py
+++ b/wayfinder_paths/core/utils/wallets.py
@@ -408,6 +408,7 @@ async def create_remote_wallet(
     wallet_type: str,
     chain_type: str = "ethereum",
     policies: list[dict] = [],  # noqa: B006
+    instance_id: str | None = None,
 ) -> dict[str, Any]:
     if not label.strip():
         raise ValueError("label is required")
@@ -422,18 +423,21 @@ async def create_remote_wallet(
             policies = [build_session_policy()]
         else:
             raise ValueError("policies is required when wallet_type=policy")
+    if instance_id is None:
+        if not is_opencode_instance():
+            raise ValueError(
+                "instance_id is required when creating a remote wallet outside "
+                "an OpenCode instance"
+            )
+        instance_id = get_opencode_instance_id()
     result = await WALLET_CLIENT.create_wallet(
         chain_type=chain_type,
         policies=policies,
-        label=label,
         wallet_type=wallet_type,
+        instance_id=instance_id,
     )
-    # A create provisions an EVM + SVM wallet pair ({"evm": ..., "svm": ...});
-    # the instance binds to the EVM wallet.
-    if is_opencode_instance():
-        await WALLET_CLIENT.bind_to_instance(
-            result["evm"]["wallet_address"], get_opencode_instance_id()
-        )
+    # The backend creates the EVM + SVM pair and binds it atomically; no
+    # follow-up bind is needed.
     return result
 
 

--- a/wayfinder_paths/core/utils/wallets.py
+++ b/wayfinder_paths/core/utils/wallets.py
@@ -430,6 +430,9 @@ async def create_remote_wallet(
                 "an OpenCode instance"
             )
         instance_id = get_opencode_instance_id()
+    instance_id = str(instance_id).strip()
+    if not instance_id:
+        raise ValueError("instance_id must be non-empty")
     result = await WALLET_CLIENT.create_wallet(
         chain_type=chain_type,
         policies=policies,

--- a/wayfinder_paths/tests/test_wallet_creation.py
+++ b/wayfinder_paths/tests/test_wallet_creation.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from wayfinder_paths.core.clients.WalletClient import WalletClient
+from wayfinder_paths.core.utils import wallets as wallets_mod
+
+
+@pytest.mark.asyncio
+async def test_wallet_client_sends_instance_scoped_create(monkeypatch) -> None:
+    client = WalletClient()
+    request = AsyncMock(
+        return_value=SimpleNamespace(json=lambda: {"evm": {}, "svm": {}})
+    )
+    monkeypatch.setattr(client, "_authed_request", request)
+    monkeypatch.setattr(
+        "wayfinder_paths.core.clients.WalletClient.get_api_base_url",
+        lambda: "https://api.test/api/v1",
+    )
+
+    try:
+        await client.create_wallet(
+            policies=[{"name": "TTL"}],
+            wallet_type="strategy",
+            instance_id="oc-test",
+        )
+    finally:
+        await client.client.aclose()
+
+    request.assert_awaited_once_with(
+        "POST",
+        "https://api.test/api/v1/wallets/",
+        json={
+            "policies": [{"name": "TTL"}],
+            "wallet_type": "strategy",
+            "chain_type": "ethereum",
+            "instance_id": "oc-test",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_remote_wallet_create_uses_atomic_backend_binding(monkeypatch) -> None:
+    create = AsyncMock(return_value={"evm": {"wallet_address": "0xabc"}, "svm": {}})
+    bind = AsyncMock()
+    monkeypatch.setattr(wallets_mod.WALLET_CLIENT, "create_wallet", create)
+    monkeypatch.setattr(wallets_mod.WALLET_CLIENT, "bind_to_instance", bind)
+    monkeypatch.setattr(wallets_mod, "is_opencode_instance", lambda: True)
+    monkeypatch.setattr(wallets_mod, "get_opencode_instance_id", lambda: "oc-test")
+
+    result = await wallets_mod.create_remote_wallet("strategy", "strategy")
+
+    assert result["evm"]["wallet_address"] == "0xabc"
+    assert create.await_args.kwargs["instance_id"] == "oc-test"
+    assert create.await_args.kwargs["wallet_type"] == "strategy"
+    bind.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_remote_wallet_create_requires_instance_outside_shell(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(wallets_mod, "is_opencode_instance", lambda: False)
+
+    with pytest.raises(ValueError, match="instance_id is required"):
+        await wallets_mod.create_remote_wallet("strategy", "strategy")

--- a/wayfinder_paths/tests/test_wallet_creation.py
+++ b/wayfinder_paths/tests/test_wallet_creation.py
@@ -54,6 +54,7 @@ async def test_remote_wallet_create_uses_atomic_backend_binding(monkeypatch) -> 
     result = await wallets_mod.create_remote_wallet("strategy", "strategy")
 
     assert result["evm"]["wallet_address"] == "0xabc"
+    assert create.await_args is not None
     assert create.await_args.kwargs["instance_id"] == "oc-test"
     assert create.await_args.kwargs["wallet_type"] == "strategy"
     bind.assert_not_awaited()
@@ -67,3 +68,6 @@ async def test_remote_wallet_create_requires_instance_outside_shell(
 
     with pytest.raises(ValueError, match="instance_id is required"):
         await wallets_mod.create_remote_wallet("strategy", "strategy")
+
+    with pytest.raises(ValueError, match="instance_id must be non-empty"):
+        await wallets_mod.create_remote_wallet("strategy", "strategy", instance_id="  ")


### PR DESCRIPTION
## Summary
- send the required OpenCode instance ID when creating a managed wallet ring
- rely on the backend atomic create-and-bind operation instead of issuing a redundant second bind
- expose an explicit instance override for off-Shell wallet tooling

## Validation
- Ruff clean on all changed Python files
- 55 wallet, signing, and MCP profile tests passed
- live contract probe on tester-2 confirms the backend requires instance_id