### PR TITLE
Jobs: automate exhaustion coverage audits

### DIFF
--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -41,9 +41,12 @@ from wayfinder_paths.jobs.execution.validation import validate_execution_job
 from wayfinder_paths.jobs.execution.walk_forward import format_fold_table
 from wayfinder_paths.jobs.exhaustion import (
     CLAIM_PROVENANCES,
+    CLAIM_STATUSES,
     adjudicate_exhaustion_claim,
+    audit_and_adjudicate_exhaustion_claim,
     file_exhaustion_claim,
     list_exhaustion_claims,
+    reopen_exhaustion_claim,
 )
 from wayfinder_paths.jobs.features import append_feature, list_features
 from wayfinder_paths.jobs.forward_artifacts import load_forward_view
@@ -1294,6 +1297,16 @@ def report_cmd(job_id: str) -> None:
     click.echo(
         f"Pending proposals: {sum(1 for p in proposals if p['status'] == 'pending')}"
     )
+    efficiency = scorecard.get("process_efficiency") or {}
+    if efficiency:
+        ratio = efficiency.get("wakes_per_valid_learning")
+        click.echo(
+            "Research efficiency: "
+            f"{efficiency.get('wakes_with_valid_learning', 0)}/"
+            f"{efficiency.get('wakes_total', 0)} learning wakes; "
+            f"{efficiency.get('activity_only_wakes', 0)} activity-only; "
+            f"{ratio if ratio is not None else 'n/a'} wakes/valid-learning"
+        )
     latest_summary = scorecard.get("last_agent_summary")
     if latest_summary:
         click.echo("")
@@ -1639,9 +1652,9 @@ def reject_cmd(
 
 @job_cli.group(
     name="exhaustion",
-    help="Owner-adjudicated exhaustion claims: agents FILE a claim that a "
-    "research lane is exhausted; only the owner may ACCEPT it. A pending or "
-    "accepted claim satisfies the progress constitution for that lane.",
+    help="Evidence-adjudicated exhaustion claims: agents FILE; the watchdog "
+    "audits structured coverage and applies pass/narrow/reject. Manual "
+    "acceptance and audit reopen remain owner-only.",
 )
 def exhaustion_group() -> None:
     pass
@@ -1712,11 +1725,48 @@ def exhaustion_adjudicate_cmd(
     _echo_json({"ok": True, "result": claim})
 
 
+@exhaustion_group.command(
+    name="audit", help="Run and apply the mechanical coverage audit immediately."
+)
+@click.argument("job_id")
+@click.argument("claim_id")
+def exhaustion_audit_cmd(job_id: str, claim_id: str) -> None:
+    store = JobStore()
+    claim = audit_and_adjudicate_exhaustion_claim(store, job_id, claim_id)
+    _echo_json({"ok": True, "result": claim})
+
+
+@exhaustion_group.command(
+    name="reopen", help="Owner override of an audit-settled claim within 48 hours."
+)
+@click.argument("job_id")
+@click.argument("claim_id")
+@click.option(
+    "--by",
+    "reopened_by",
+    type=click.Choice(["owner", "agent"]),
+    default="owner",
+    show_default=True,
+)
+@click.option("--reason", required=True, help="Why the audited closure is reversed.")
+def exhaustion_reopen_cmd(
+    job_id: str, claim_id: str, reopened_by: str, reason: str
+) -> None:
+    store = JobStore()
+    try:
+        claim = reopen_exhaustion_claim(
+            store, job_id, claim_id, by=reopened_by, reason=reason
+        )
+    except PermissionError as exc:
+        raise click.ClickException(str(exc)) from exc
+    _echo_json({"ok": True, "result": claim})
+
+
 @exhaustion_group.command(name="list", help="List exhaustion claims.")
 @click.argument("job_id")
 @click.option(
     "--status",
-    type=click.Choice(["pending", "accepted", "rejected"]),
+    type=click.Choice(sorted(CLAIM_STATUSES)),
     default=None,
     help="Filter by status.",
 )

--- a/wayfinder_paths/jobs/coverage.py
+++ b/wayfinder_paths/jobs/coverage.py
@@ -1,0 +1,782 @@
+"""Mechanical research-coverage certificates and exhaustion verdicts.
+
+The certificate is reconstructed from controller-owned ledgers. Agent prose is
+not evidence: an absent, blocked, invalid, or underpowered cell remains a gap
+and can never be counted as a negative result.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from itertools import product
+from statistics import median
+from typing import Any
+
+from wayfinder_paths.jobs.execution.experiments import experiment_semantic_hash
+from wayfinder_paths.jobs.models import utc_now_iso
+from wayfinder_paths.jobs.research import read_scan_ledger
+from wayfinder_paths.jobs.store import JobStore
+
+CELL_OUTCOMES = {"negative", "positive", "near_miss"}
+CRITICAL_CELL_STATUSES = {
+    "blocked_infrastructure",
+    "invalid_harness",
+    "underpowered",
+    "not_run",
+}
+CELL_COUNT_KEYS = (
+    "completed_valid",
+    "negative",
+    "positive",
+    "near_miss",
+    "blocked_infrastructure",
+    "invalid_harness",
+    "underpowered",
+    "not_run",
+)
+_CANDIDATE_VERDICTS = {"probation", "promote"}
+_SCAN_LEDGER_PATH = "results/research/signal_scan/ledger.jsonl"
+_EXPERIMENTS_PATH = "results/backtest/experiments.jsonl"
+_LEGACY_SCAN_WRITE_WINDOW_SECONDS = 600
+
+
+def _cell_key(row: Mapping[str, Any]) -> tuple[str, str, str, int, str]:
+    return (
+        str(row.get("symbol") or ""),
+        str(row.get("signal") or ""),
+        str(row.get("timeframe") or ""),
+        int(row.get("horizon") or 0),
+        str(row.get("regime") or "base"),
+    )
+
+
+def _coordinate(key: tuple[str, str, str, int, str]) -> dict[str, Any]:
+    symbol, signal, timeframe, horizon, regime = key
+    return {
+        "symbol": symbol,
+        "signal": signal,
+        "timeframe": timeframe,
+        "horizon": horizon,
+        "regime": regime,
+    }
+
+
+def _cell_id(key: tuple[str, str, str, int, str]) -> str:
+    return ":".join(str(part) for part in key)
+
+
+def _timestamp(value: Any) -> datetime | None:
+    try:
+        stamp = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+    if stamp.tzinfo is None:
+        stamp = stamp.replace(tzinfo=UTC)
+    return stamp.astimezone(UTC)
+
+
+def _at_or_after(value: Any, baseline: Any) -> bool:
+    baseline_ts = _timestamp(baseline)
+    value_ts = _timestamp(value)
+    return baseline_ts is None or (value_ts is not None and value_ts >= baseline_ts)
+
+
+def _rows_for_scan(
+    rows: list[dict[str, Any]], meta: dict[str, Any]
+) -> list[dict[str, Any]]:
+    scan_id = str(meta.get("scan_id") or "")
+    if scan_id:
+        exact = [
+            row
+            for row in rows
+            if row.get("kind") in {"scan_test", "scan_cell"}
+            and str(row.get("scan_id") or "") == scan_id
+        ]
+        if exact:
+            return exact
+
+    # Legacy rows predate scan_id on cells. Prefer the contiguous rows after
+    # the declaration; compacted ledgers fall back to coordinate filtering.
+    meta_index = next(
+        (index for index, row in enumerate(rows) if row is meta),
+        None,
+    )
+    if meta_index is not None:
+        contiguous: list[dict[str, Any]] = []
+        meta_ts = _timestamp(meta.get("ts") or meta.get("scan_id"))
+        for row in rows[meta_index + 1 :]:
+            if row.get("kind") == "scan_meta":
+                break
+            if row.get("kind") in {"scan_test", "scan_cell"}:
+                if scan_id:
+                    # PR-3 cells carry scan_id. Untagged PR-2 cells are
+                    # accepted only when they were written beside this meta;
+                    # after ledger compaction, unrelated latest cells sit at
+                    # the tail and must not be attributed to an old scan.
+                    row_ts = _timestamp(row.get("ts"))
+                    write_delay = (
+                        (row_ts - meta_ts).total_seconds()
+                        if meta_ts is not None and row_ts is not None
+                        else None
+                    )
+                    if (
+                        row.get("scan_id")
+                        or write_delay is None
+                        or not 0 <= write_delay <= _LEGACY_SCAN_WRITE_WINDOW_SECONDS
+                    ):
+                        continue
+                contiguous.append(row)
+        if contiguous:
+            return contiguous
+    if scan_id:
+        return []
+
+    symbols = {str(value) for value in meta.get("symbols") or []}
+    timeframes = {str(value) for value in meta.get("timeframes") or []}
+    filtered = [
+        row
+        for row in rows
+        if row.get("kind") in {"scan_test", "scan_cell"}
+        and (not symbols or str(row.get("symbol") or "") in symbols)
+        and (not timeframes or str(row.get("timeframe") or "") in timeframes)
+    ]
+    latest: dict[tuple[str, str, str, int, str], dict[str, Any]] = {}
+    for row in filtered:
+        latest[_cell_key(row)] = row
+    return list(latest.values())
+
+
+def _selected_scan(
+    rows: list[dict[str, Any]], lane: str, refs: list[str]
+) -> tuple[dict[str, Any] | None, list[dict[str, Any]]]:
+    metas = [row for row in rows if row.get("kind") == "scan_meta"]
+    if not metas:
+        return None, []
+    ref_text = " ".join(refs)
+    matches = [
+        row
+        for row in metas
+        if str(row.get("campaign") or "").strip().casefold() == lane.strip().casefold()
+        or (row.get("scan_id") and str(row["scan_id"]) in ref_text)
+    ]
+    meta = (matches or metas)[-1]
+    return meta, _rows_for_scan(rows, meta)
+
+
+def _declared_keys(
+    meta: Mapping[str, Any] | None, observed: list[dict[str, Any]]
+) -> set[tuple[str, str, str, int, str]]:
+    if meta is None:
+        return {_cell_key(row) for row in observed}
+    symbols = [str(value) for value in meta.get("symbols") or []]
+    signals = [str(value) for value in meta.get("declared_signals") or []]
+    if not signals:
+        signals = sorted(
+            {str(row.get("signal") or "") for row in observed if row.get("signal")}
+        )
+    timeframes = [str(value) for value in meta.get("timeframes") or []]
+    regimes = [str(value) for value in meta.get("declared_regimes") or ["base"]]
+    horizons_by_symbol = meta.get("horizons") or {}
+    declared: set[tuple[str, str, str, int, str]] = set()
+    for symbol in symbols:
+        raw_by_tf = (
+            horizons_by_symbol.get(symbol, {})
+            if isinstance(horizons_by_symbol, Mapping)
+            else {}
+        )
+        for timeframe in timeframes:
+            raw_horizons = (
+                raw_by_tf.get(timeframe, []) if isinstance(raw_by_tf, Mapping) else []
+            )
+            for horizon in raw_horizons:
+                for signal in signals:
+                    for regime in regimes:
+                        declared.add((symbol, signal, timeframe, int(horizon), regime))
+    return declared or {_cell_key(row) for row in observed}
+
+
+def _minimum_detectable_edge(row: Mapping[str, Any]) -> float | None:
+    value = row.get("min_detectable_edge_bps")
+    if isinstance(value, (int, float)):
+        return float(value)
+    # Legacy PR-2 rows have enough information to recover SEM:
+    # abs(t_gross) - t_net = round_trip_cost / SEM.
+    try:
+        gross_t = abs(float(row.get("t") or row.get("t_stat_vs_drift") or 0.0))
+        t_net = float(row["t_net"])
+        cost_bps = float(row["round_trip_cost_bps"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    denominator = gross_t - t_net
+    if denominator <= 0 or cost_bps <= 0:
+        return None
+    return 2.0 * (cost_bps / denominator)
+
+
+def _classify_cell(row: Mapping[str, Any]) -> str:
+    explicit = str(row.get("status") or "")
+    if explicit in CRITICAL_CELL_STATUSES:
+        return explicit
+    verdict = str(row.get("verdict") or "")
+    if verdict == "promote":
+        return "positive"
+    if verdict in {"probation", "candidate"}:
+        return "near_miss"
+    return "negative"
+
+
+def _coverage_gap_rows(
+    journal: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    resolved = {
+        str(row.get("gap_id"))
+        for row in journal
+        if row.get("type") == "research_coverage_gap_resolved" and row.get("gap_id")
+    }
+    return [
+        row
+        for row in journal
+        if row.get("type") == "research_coverage_gap"
+        and str(row.get("gap_id") or "") not in resolved
+        and str(row.get("status") or "") in CRITICAL_CELL_STATUSES
+    ]
+
+
+def _requirement_satisfied(
+    requirement: Mapping[str, Any],
+    *,
+    note_ts: str,
+    scan_rows: list[dict[str, Any]],
+    holdouts: list[dict[str, Any]],
+    journal: list[dict[str, Any]],
+) -> bool:
+    kind = str(requirement.get("kind") or "")
+    if kind == "signal_scan":
+        symbols = {str(value) for value in requirement.get("symbols") or []}
+        timeframes = {str(value) for value in requirement.get("timeframes") or []}
+        signals = {str(value) for value in requirement.get("signals") or []}
+        metas = [row for row in scan_rows if row.get("kind") == "scan_meta"]
+        for meta in metas:
+            if not _at_or_after(meta.get("ts") or meta.get("scan_id"), note_ts):
+                continue
+            if not symbols.issubset({str(v) for v in meta.get("symbols") or []}):
+                continue
+            if not timeframes.issubset({str(v) for v in meta.get("timeframes") or []}):
+                continue
+            measured = [
+                row
+                for row in _rows_for_scan(scan_rows, meta)
+                if row.get("kind") == "scan_test"
+            ]
+            available_signals = {
+                str(value) for value in meta.get("declared_signals") or []
+            } | {str(row.get("signal")) for row in measured if row.get("signal")}
+            if signals and not signals.issubset(available_signals):
+                continue
+            required_symbols = symbols or {
+                str(value) for value in meta.get("symbols") or []
+            }
+            required_timeframes = timeframes or {
+                str(value) for value in meta.get("timeframes") or []
+            }
+            required_signals: set[str | None] = set(signals)
+            if not required_signals:
+                required_signals.add(None)
+            if (
+                measured
+                and required_symbols
+                and required_timeframes
+                and all(
+                    any(
+                        row.get("symbol") == symbol
+                        and row.get("timeframe") == timeframe
+                        and (signal is None or row.get("signal") == signal)
+                        for row in measured
+                    )
+                    for symbol, timeframe, signal in product(
+                        required_symbols, required_timeframes, required_signals
+                    )
+                )
+            ):
+                return True
+    if kind == "holdout_check":
+        return any(
+            _at_or_after(row.get("ts"), note_ts)
+            and row.get("verdict") in {"confirmed", "failed"}
+            and (
+                not requirement.get("symbol")
+                or row.get("symbol") == requirement.get("symbol")
+            )
+            and (
+                not requirement.get("signal")
+                or row.get("signal") == requirement.get("signal")
+            )
+            and (
+                not requirement.get("timeframe")
+                or row.get("timeframe") == requirement.get("timeframe")
+            )
+            and (
+                not requirement.get("horizon")
+                or int(row.get("horizon") or 0) == int(requirement.get("horizon") or 0)
+            )
+            for row in holdouts
+        )
+    if kind == "paper_probation":
+        return any(
+            row.get("type") in {"paper_probation_opened", "probation_leg_opened"}
+            and _at_or_after(row.get("ts"), note_ts)
+            and (
+                not requirement.get("symbol")
+                or row.get("symbol") == requirement.get("symbol")
+            )
+            and (
+                not requirement.get("signal")
+                or row.get("signal") == requirement.get("signal")
+            )
+            for row in journal
+        )
+    if kind == "rank_check":
+        required_horizons = {int(value) for value in requirement.get("horizons") or []}
+        return any(
+            row.get("type") == "rank_check_completed"
+            and _at_or_after(row.get("ts"), note_ts)
+            and (
+                not requirement.get("column")
+                or row.get("column") == requirement.get("column")
+            )
+            and required_horizons.issubset(
+                {int(value) for value in row.get("horizons") or []}
+            )
+            and row.get("artifact")
+            for row in journal
+        )
+    return False
+
+
+def _required_experiments(
+    journal: list[dict[str, Any]], scan_rows: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    holdouts = [row for row in scan_rows if row.get("kind") == "holdout_check"]
+    requirements: dict[str, dict[str, Any]] = {}
+    for note in journal:
+        if note.get("type") != "operator_note":
+            continue
+        note_ts = str(note.get("ts") or "")
+        for raw in note.get("required_experiments") or []:
+            if not isinstance(raw, Mapping):
+                continue
+            requirement = dict(raw)
+            requirement_id = str(requirement.get("id") or "").strip()
+            if not requirement_id:
+                continue
+            requirement["id"] = requirement_id
+            requirement["declared_at"] = note_ts
+            requirement["satisfied"] = _requirement_satisfied(
+                requirement,
+                note_ts=note_ts,
+                scan_rows=scan_rows,
+                holdouts=holdouts,
+                journal=journal,
+            )
+            if requirement["satisfied"]:
+                requirement["status"] = "completed"
+            else:
+                status = str(requirement.get("status") or "not_run")
+                requirement["status"] = (
+                    status if status in CRITICAL_CELL_STATUSES else "not_run"
+                )
+            requirements[requirement_id] = requirement
+    return list(requirements.values())
+
+
+def _candidate_followups(
+    cells: list[dict[str, Any]],
+    holdouts: list[dict[str, Any]],
+    journal: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    candidates = [
+        cell for cell in cells if str(cell.get("verdict") or "") in _CANDIDATE_VERDICTS
+    ]
+    candidate_symbols = [str(cell.get("symbol") or "") for cell in candidates]
+    followups: list[dict[str, Any]] = []
+    for cell in candidates:
+        matches = [
+            row
+            for row in holdouts
+            if row.get("symbol") == cell.get("symbol")
+            and row.get("signal") == cell.get("signal")
+            and row.get("timeframe") == cell.get("timeframe")
+            and int(row.get("horizon") or 0) == int(cell.get("horizon") or 0)
+            and _at_or_after(row.get("ts"), cell.get("ts"))
+        ]
+        latest = matches[-1] if matches else None
+        holdout_verdict = str((latest or {}).get("verdict") or "")
+        probation = None
+        symbol = str(cell.get("symbol") or "")
+        for event in journal:
+            if event.get("type") not in {
+                "paper_probation_opened",
+                "probation_leg_opened",
+            } or not _at_or_after(event.get("ts"), cell.get("ts")):
+                continue
+            exact = all(
+                not event.get(key) or event.get(key) == cell.get(key)
+                for key in ("symbol", "signal", "timeframe", "horizon")
+            )
+            # Legacy paper-probation events recorded only symbol + leg. A
+            # symbol-only event is unambiguous only when this scan has one
+            # candidate for that symbol.
+            symbol_only = (
+                event.get("symbol") == symbol
+                and not any(
+                    event.get(key) for key in ("signal", "timeframe", "horizon")
+                )
+                and candidate_symbols.count(symbol) == 1
+            )
+            if exact and (event.get("signal") or symbol_only):
+                probation = event
+        probation_outcome = None
+        if probation is not None:
+            outcomes = [
+                event
+                for event in journal
+                if event.get("type")
+                in {"probation_leg_graduated", "probation_leg_killed"}
+                and event.get("leg") == probation.get("leg")
+                and _at_or_after(event.get("ts"), probation.get("ts"))
+            ]
+            probation_outcome = outcomes[-1].get("type") if outcomes else None
+
+        if (
+            holdout_verdict == "confirmed"
+            or probation_outcome == "probation_leg_graduated"
+        ):
+            state = "confirmed_open"
+        elif holdout_verdict == "failed" or probation_outcome == "probation_leg_killed":
+            state = "refuted"
+        elif probation is not None:
+            state = "probation_active"
+        elif latest is None:
+            state = "parked"
+        else:
+            state = "holdout_underpowered"
+        followups.append(
+            {
+                **{
+                    key: cell.get(key)
+                    for key in ("symbol", "signal", "timeframe", "horizon", "regime")
+                },
+                "scan_verdict": cell.get("verdict"),
+                "state": state,
+                "holdout_verdict": holdout_verdict or None,
+                "probation_leg": (probation or {}).get("leg"),
+            }
+        )
+    return followups
+
+
+def build_coverage_certificate(
+    job_id: str,
+    lane: str,
+    *,
+    store: JobStore | None = None,
+    refs: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build a structured coverage certificate for one claimed lane."""
+    store = store or JobStore()
+    root = store.job_dir(job_id)
+    scan_rows = read_scan_ledger(root)
+    journal = store.read_jsonl(job_id, "journal.jsonl")
+    experiments = store.read_jsonl(job_id, _EXPERIMENTS_PATH)
+    meta, observed = _selected_scan(scan_rows, lane, refs or [])
+    declared = _declared_keys(meta, observed)
+
+    latest_cells: dict[tuple[str, str, str, int, str], dict[str, Any]] = {}
+    for row in observed:
+        latest_cells[_cell_key(row)] = row
+    for gap in _coverage_gap_rows(journal):
+        if all(gap.get(key) is not None for key in ("symbol", "signal", "timeframe")):
+            latest_cells[_cell_key(gap)] = gap
+
+    cells: list[dict[str, Any]] = []
+    for key in sorted(declared | set(latest_cells)):
+        cell_row = latest_cells.get(key)
+        if cell_row is None:
+            cells.append(
+                {
+                    **_coordinate(key),
+                    "status": "not_run",
+                    "reason": "declared_cell_not_recorded",
+                }
+            )
+            continue
+        status = _classify_cell(cell_row)
+        cells.append(
+            {
+                **_coordinate(key),
+                "status": status,
+                "reason": cell_row.get("reason"),
+                "ts": cell_row.get("ts"),
+                "family": cell_row.get("family"),
+                "library": cell_row.get("library"),
+                "verdict": cell_row.get("verdict"),
+                "n": cell_row.get("n"),
+                "t": cell_row.get("t") or cell_row.get("t_stat_vs_drift"),
+                "t_net": cell_row.get("t_net"),
+                "edge_net_bps": cell_row.get("edge_net_bps"),
+                "round_trip_cost_bps": cell_row.get("round_trip_cost_bps"),
+                "min_detectable_edge_bps": _minimum_detectable_edge(cell_row),
+            }
+        )
+    for control in (meta or {}).get("incumbent_controls") or []:
+        key = _cell_key({**control, "regime": "base"})
+        if any(_cell_key(cell) == key for cell in cells):
+            continue
+        cells.append(
+            {
+                **_coordinate(key),
+                "status": "not_run",
+                "reason": control.get("reason") or "incumbent_control_not_measured",
+                "incumbent_control": True,
+            }
+        )
+
+    counts = dict.fromkeys(CELL_COUNT_KEYS, 0)
+    for cell in cells:
+        status = str(cell["status"])
+        counts[status] += 1
+        if status in CELL_OUTCOMES:
+            counts["completed_valid"] += 1
+
+    selected_trials = {
+        _cell_key(cell)[:4]
+        for cell in cells
+        if cell.get("symbol") and cell.get("signal") and cell.get("timeframe")
+    }
+    holdouts = [
+        row
+        for row in scan_rows
+        if row.get("kind") == "holdout_check" and _cell_key(row)[:4] in selected_trials
+    ]
+    candidate_followups = _candidate_followups(cells, holdouts, journal)
+    parked = [row for row in candidate_followups if row["state"] == "parked"]
+    unresolved = [
+        row
+        for row in candidate_followups
+        if row["state"]
+        in {"parked", "confirmed_open", "holdout_underpowered", "probation_active"}
+    ]
+    negative_followups = sum(row["state"] == "refuted" for row in candidate_followups)
+
+    seen_experiments: set[str] = set()
+    duplicate_experiments = 0
+    invalid_experiments = 0
+    for experiment in experiments:
+        semantic_hash = experiment_semantic_hash(experiment)
+        if semantic_hash in seen_experiments:
+            duplicate_experiments += 1
+        else:
+            seen_experiments.add(semantic_hash)
+        if int(experiment.get("invalid_count") or 0) > 0:
+            invalid_experiments += 1
+
+    requirements = _required_experiments(journal, scan_rows)
+    incumbent_controls: list[dict[str, Any]] = []
+    for control in (meta or {}).get("incumbent_controls") or []:
+        key = _cell_key({**control, "regime": "base"})
+        incumbent_cell = next((item for item in cells if _cell_key(item) == key), None)
+        incumbent_controls.append(
+            {
+                **dict(control),
+                "status": (
+                    "not_run"
+                    if incumbent_cell is None
+                    or incumbent_cell.get("status") in CRITICAL_CELL_STATUSES
+                    else "pass"
+                    if incumbent_cell.get("verdict") == "promote"
+                    else "fail"
+                ),
+                "result": incumbent_cell,
+            }
+        )
+
+    detectable = [
+        float(cell["min_detectable_edge_bps"])
+        for cell in cells
+        if isinstance(cell.get("min_detectable_edge_bps"), (int, float))
+    ]
+    cost_values = [
+        float(cell["round_trip_cost_bps"])
+        for cell in cells
+        if isinstance(cell.get("round_trip_cost_bps"), (int, float))
+    ]
+    signal_families = dict((meta or {}).get("signal_families") or {})
+    if not signal_families:
+        signal_families = {
+            str(cell.get("signal")): str(cell.get("family") or cell.get("library"))
+            for cell in cells
+            if cell.get("signal")
+        }
+    completed_cells = [
+        {
+            key: cell.get(key)
+            for key in ("symbol", "signal", "timeframe", "horizon", "regime")
+        }
+        for cell in cells
+        if cell["status"] in CELL_OUTCOMES
+    ]
+    return {
+        "certificate_version": 1,
+        "job_id": job_id,
+        "lane": lane,
+        "generated_at": utc_now_iso(),
+        "lane_definition": {
+            "source": "latest_matching_scan" if meta else "no_scan_declaration",
+            "scan_id": (meta or {}).get("scan_id"),
+            "assets": list((meta or {}).get("symbols") or []),
+            "timeframes": list((meta or {}).get("timeframes") or []),
+            "signals": list((meta or {}).get("declared_signals") or signal_families),
+            "feature_families": sorted(set(signal_families.values())),
+            "data_revision": (meta or {}).get("data_revision")
+            or {"cutoff_ts": (meta or {}).get("cutoff_ts")},
+            "cost_revision": (meta or {}).get("cost_revision"),
+            "workspace_signals_sha": (meta or {}).get("workspace_signals_sha"),
+        },
+        "cell_counts": counts,
+        "cells": cells,
+        "completed_scope": completed_cells,
+        "negative_evidence_count": counts["negative"] + negative_followups,
+        "incumbent_controls": {
+            "declared": len(incumbent_controls),
+            "passing": sum(row["status"] == "pass" for row in incumbent_controls),
+            "cells": incumbent_controls,
+        },
+        "detectable_edge": {
+            "minimum_bps": min(detectable) if detectable else None,
+            "median_bps": median(detectable) if detectable else None,
+            "maximum_bps": max(detectable) if detectable else None,
+            "round_trip_cost_bps": sorted(set(cost_values)),
+            "cells_where_cost_exceeds_detectable_edge": sum(
+                isinstance(cell.get("round_trip_cost_bps"), (int, float))
+                and isinstance(cell.get("min_detectable_edge_bps"), (int, float))
+                and float(cell["round_trip_cost_bps"])
+                >= float(cell["min_detectable_edge_bps"])
+                for cell in cells
+            ),
+        },
+        "multiplicity": {
+            "family_size": (meta or {}).get("bh_family_size"),
+            "minimum_family_size": (meta or {}).get("bh_min_family_size"),
+            "method": (meta or {}).get("multiplicity_method"),
+            "family_mode": (meta or {}).get("bh_family_mode"),
+        },
+        "holdout_spends": {
+            "total": len(holdouts),
+            "unique": len({str(row.get("hash") or "") for row in holdouts}),
+            "repeats": len(holdouts)
+            - len({str(row.get("hash") or "") for row in holdouts}),
+            "rows": holdouts,
+        },
+        "candidate_followups": candidate_followups,
+        "parked_candidates": parked,
+        "unresolved_candidates": unresolved,
+        "required_experiments": requirements,
+        "experiments": {
+            "total": len(experiments),
+            "semantic_unique": len(seen_experiments),
+            "duplicates": duplicate_experiments,
+            "infra_invalid": invalid_experiments,
+        },
+        "sources": {
+            "scan_ledger": _SCAN_LEDGER_PATH,
+            "experiments": _EXPERIMENTS_PATH,
+            "journal": "journal.jsonl",
+        },
+    }
+
+
+def audit_exhaustion_claim(
+    store: JobStore, job_id: str, claim: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Return a deterministic pass/narrow/reject verdict for a claim."""
+    certificate = build_coverage_certificate(
+        job_id,
+        str(claim.get("lane") or ""),
+        store=store,
+        refs=[str(value) for value in claim.get("refs") or []],
+    )
+    cells = certificate["cells"]
+    critical_cells = [
+        cell for cell in cells if cell.get("status") in CRITICAL_CELL_STATUSES
+    ]
+    unmet_requirements = [
+        row for row in certificate["required_experiments"] if not row["satisfied"]
+    ]
+    unresolved_candidates = certificate["unresolved_candidates"]
+    mandated: list[dict[str, Any]] = []
+    for candidate in unresolved_candidates:
+        candidate_id = _cell_id(_cell_key(candidate))
+        mandated.append(
+            {
+                "id": f"candidate-followup:{candidate_id}",
+                "kind": "candidate_followup",
+                **candidate,
+            }
+        )
+    for cell in critical_cells:
+        cell_id = _cell_id(_cell_key(cell))
+        mandated.append(
+            {
+                "id": f"coverage-cell:{cell_id}",
+                "kind": "signal_scan_cell",
+                **{
+                    key: cell.get(key)
+                    for key in (
+                        "symbol",
+                        "signal",
+                        "timeframe",
+                        "horizon",
+                        "regime",
+                        "status",
+                        "reason",
+                    )
+                },
+            }
+        )
+    mandated.extend(dict(row) for row in unmet_requirements)
+
+    reasons: list[str] = []
+    if claim.get("provenance") == "agent-self-rejected":
+        reasons.append("agent_self_rejection_cannot_settle")
+    if unresolved_candidates:
+        reasons.append("probation_grade_candidates_unresolved")
+    if not certificate["cell_counts"]["completed_valid"]:
+        reasons.append("no_completed_valid_cells")
+    if not certificate["negative_evidence_count"]:
+        reasons.append("no_valid_negative_evidence")
+    if critical_cells or unmet_requirements:
+        reasons.append("critical_coverage_gaps")
+
+    if (
+        claim.get("provenance") == "agent-self-rejected"
+        or unresolved_candidates
+        or not certificate["cell_counts"]["completed_valid"]
+        or not certificate["negative_evidence_count"]
+    ):
+        verdict = "reject"
+    elif critical_cells or unmet_requirements:
+        verdict = "narrow"
+    else:
+        verdict = "pass"
+    return {
+        "verdict": verdict,
+        "reason_codes": reasons,
+        "audited_scope": {
+            "lane": claim.get("lane"),
+            "cells": certificate["completed_scope"],
+            "scope_reduced": verdict == "narrow",
+        },
+        "required_next_experiments": mandated,
+        "certificate": certificate,
+    }

--- a/wayfinder_paths/jobs/evolution_ledger.py
+++ b/wayfinder_paths/jobs/evolution_ledger.py
@@ -8,6 +8,8 @@ changes actually beat the incumbent forward (promotion reliability)."""
 from __future__ import annotations
 
 import json
+from bisect import bisect_left
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -15,6 +17,123 @@ from wayfinder_paths.jobs.models import utc_now_iso
 from wayfinder_paths.jobs.store import JobStore
 
 _VERDICTS_PATH = "state/promotion_verdicts.json"
+_LEARNING_EVENTS = {"probation_leg_graduated", "probation_leg_killed"}
+_ACTIVITY_EVENTS = {
+    "probation_leg_opened",
+    "paper_probation_opened",
+    "exhaustion_claim_filed",
+}
+_OWNER_ACTORS = {"owner", "user", "human"}
+_MANUAL_EVENT_TYPES = {
+    "operator_note",
+    "operator_leverage_set",
+}
+
+
+def _timestamp(value: Any) -> datetime | None:
+    try:
+        stamp = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+    if stamp.tzinfo is None:
+        stamp = stamp.replace(tzinfo=UTC)
+    return stamp.astimezone(UTC)
+
+
+def build_process_efficiency(store: JobStore, job_id: str) -> dict[str, Any]:
+    """Measure how many completed agent wakes produced valid new learning."""
+    root = store.job_dir(job_id)
+    journal = store.read_jsonl(job_id, "journal.jsonl")
+    experiments = store.read_jsonl(job_id, "results/backtest/experiments.jsonl")
+    wakes = sorted(
+        stamp
+        for row in journal
+        if row.get("type") == "agent_wakeup"
+        and (stamp := _timestamp(row.get("ts"))) is not None
+    )
+    learning_wakes: set[int] = set()
+    activity_wakes: set[int] = set()
+
+    def assign(stamp: datetime | None, target: set[int]) -> None:
+        if stamp is None:
+            return
+        index = bisect_left(wakes, stamp)
+        if index < len(wakes):
+            target.add(index)
+
+    manual_interventions = 0
+    false_closure_reversals = 0
+    for row in journal:
+        event_type = str(row.get("type") or "")
+        stamp = _timestamp(row.get("ts"))
+        if event_type in _LEARNING_EVENTS:
+            assign(stamp, learning_wakes)
+        if event_type in _ACTIVITY_EVENTS:
+            assign(stamp, activity_wakes)
+        actor = str(row.get("by") or row.get("set_by") or "").casefold()
+        source = str(row.get("source") or "").casefold()
+        if (
+            actor in _OWNER_ACTORS
+            or source in _OWNER_ACTORS
+            or event_type in _MANUAL_EVENT_TYPES
+            or event_type.startswith("owner_")
+            or (event_type == "halt_requested" and source == "manual")
+        ):
+            manual_interventions += 1
+        if event_type == "exhaustion_claim_reopened":
+            false_closure_reversals += 1
+
+    from wayfinder_paths.jobs.execution.experiments import experiment_semantic_hash
+
+    semantic_hashes: set[str] = set()
+    duplicate_experiments = 0
+    infra_invalid_experiments = 0
+    for row in experiments:
+        semantic_hash = experiment_semantic_hash(row)
+        if semantic_hash in semantic_hashes:
+            duplicate_experiments += 1
+            assign(_timestamp(row.get("ts")), activity_wakes)
+        else:
+            semantic_hashes.add(semantic_hash)
+            assign(_timestamp(row.get("ts")), learning_wakes)
+        if int(row.get("invalid_count") or 0) > 0:
+            infra_invalid_experiments += 1
+
+    for proposal in _load_proposals(root):
+        stamp = _timestamp(
+            (proposal.get("candidate_report") or {}).get("generated_at")
+            or proposal.get("created_at")
+            or proposal.get("updated_at")
+        )
+        assign(stamp, activity_wakes)
+
+    stalled_background_ops = 0
+    ops_dir = root / "state" / "background_ops"
+    if ops_dir.is_dir():
+        from wayfinder_paths.jobs.background import op_status_summary
+
+        for path in ops_dir.glob("*.json"):
+            if path.name.endswith(".result.json"):
+                continue
+            summary = op_status_summary(root, path.stem)
+            if summary and summary.get("status") == "failed":
+                stalled_background_ops += 1
+
+    wakes_with_learning = len(learning_wakes)
+    activity_only = len(activity_wakes - learning_wakes)
+    return {
+        "wakes_total": len(wakes),
+        "wakes_with_valid_learning": wakes_with_learning,
+        "activity_only_wakes": activity_only,
+        "duplicate_experiments": duplicate_experiments,
+        "infra_invalid_experiments": infra_invalid_experiments,
+        "manual_interventions": manual_interventions,
+        "false_closure_reversals": false_closure_reversals,
+        "stalled_background_ops": stalled_background_ops,
+        "wakes_per_valid_learning": (
+            round(len(wakes) / wakes_with_learning, 3) if wakes_with_learning else None
+        ),
+    }
 
 
 def build_evolution_report(store: JobStore, job_id: str) -> dict[str, Any]:
@@ -121,6 +240,7 @@ def build_evolution_report(store: JobStore, job_id: str) -> dict[str, Any]:
         },
         "opportunity_recall": _opportunity_recall(store, job_id),
         "research_staleness": _research_staleness(root, proposals),
+        "process_efficiency": build_process_efficiency(store, job_id),
         "replication": replication,
         "proposals": rows[-50:],
         "generated_at": utc_now_iso(),
@@ -295,6 +415,7 @@ def evolution_snapshot_block(store: JobStore, job_id: str) -> dict[str, Any]:
         "by_family": report["by_family"],
         "promotion_reliability": report["promotion_reliability"],
         "research_staleness": report["research_staleness"],
+        "process_efficiency": report["process_efficiency"],
         # A LIVE archived candidate outscoring the incumbent is a measured
         # missed opportunity — the branch-revival lane reads this.
         "opportunity_recall": report["opportunity_recall"],

--- a/wayfinder_paths/jobs/exhaustion.py
+++ b/wayfinder_paths/jobs/exhaustion.py
@@ -1,4 +1,4 @@
-"""Owner-adjudicated exhaustion claims: closing a research lane is a verdict.
+"""Evidence-adjudicated exhaustion claims: closing a lane is a verdict.
 
 The production stall this fixes: every research lane ended in an agent
 SELF-rejection, the agent's dead map recorded those lanes as FULLY SETTLED,
@@ -10,16 +10,17 @@ verdict for an authorized reviewer, not a self-grant: agents FILE claims
 ACCEPT one — the same owner-provenance pattern as proposal rejection, script
 mode stamps, and risk-latched halt clears.
 
-Only an owner-accepted claim settles its audited lane. Filing is activity — it
-puts an escalation in flight — but is not evidence that the lane is exhausted.
-A claim whose provenance is `agent-self-rejected` can never settle a lane,
-whatever its status: self-rejections are development evidence, not verdicts.
+Only an owner acceptance or a passing mechanical coverage audit settles its
+audited lane. Filing is activity — it puts an escalation in flight — but is
+not evidence that the lane is exhausted. A claim whose provenance is
+`agent-self-rejected` can never settle a lane, whatever its status.
 """
 
 from __future__ import annotations
 
 import re
 import uuid
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from wayfinder_paths.jobs.models import utc_now_iso
@@ -28,7 +29,11 @@ if TYPE_CHECKING:
     from wayfinder_paths.jobs.store import JobStore
 
 CLAIMS_DIR = "research/exhaustion_claims"
-CLAIM_STATUSES = {"pending", "accepted", "rejected"}
+AUDITS_DIR = "research/coverage"
+RESEARCH_LANE_PATH = "state/research_lane.json"
+RESEARCH_IMPASSE_PATH = "state/research_impasse.json"
+OWNER_OVERRIDE_WINDOW = timedelta(hours=48)
+CLAIM_STATUSES = {"pending", "accepted", "audit_passed", "rejected", "reopened"}
 CLAIM_PROVENANCES = {
     "holdout-refuted",
     "owner-rejected",
@@ -53,7 +58,7 @@ def file_exhaustion_claim(
     filed_by: str = "agent",
 ) -> dict[str, Any]:
     """File a claim that a research lane/region is exhausted. Anyone may
-    file; the claim starts `pending` and only the owner can accept it."""
+    file; it starts `pending` for a coverage audit or owner adjudication."""
     lane = str(lane or "").strip()
     if not lane:
         raise ValueError("exhaustion claim requires a lane/region name")
@@ -139,6 +144,294 @@ def adjudicate_exhaustion_claim(
     return claim
 
 
+def audit_and_adjudicate_exhaustion_claim(
+    store: JobStore, job_id: str, claim_id: str
+) -> dict[str, Any]:
+    """Run the distinct evidence-gated audit actor and apply its verdict.
+
+    Manual acceptance remains owner-only in ``adjudicate_exhaustion_claim``;
+    this path can settle only through a reproducible coverage certificate.
+    """
+    from wayfinder_paths.jobs.coverage import audit_exhaustion_claim
+
+    claim = store.read_json(job_id, _claim_path(store, job_id, claim_id))
+    if not isinstance(claim, dict):
+        raise FileNotFoundError(f"unknown exhaustion claim: {claim_id}")
+    if claim.get("status") != "pending":
+        raise ValueError(f"claim {claim_id} is already {claim.get('status')}")
+
+    audit = audit_exhaustion_claim(store, job_id, claim)
+    audited_at = datetime.now(UTC)
+    certificate_path = f"{AUDITS_DIR}/{claim_id}.json"
+    store.write_json(job_id, certificate_path, audit["certificate"])
+    audit_summary = {
+        "verdict": audit["verdict"],
+        "reason_codes": audit["reason_codes"],
+        "audited_scope": audit["audited_scope"],
+        "required_next_experiments": audit["required_next_experiments"],
+        "certificate": certificate_path,
+        "audited_at": audited_at.isoformat(),
+    }
+    claim["audit"] = audit_summary
+
+    if audit["verdict"] in {"pass", "narrow"}:
+        claim["status"] = "audit_passed"
+        claim["adjudication"] = {
+            "by": "coverage-audit",
+            "verdict": audit["verdict"],
+            "ts": audited_at.isoformat(),
+        }
+        claim["audited_scope"] = audit["audited_scope"]
+        claim["required_next_experiments"] = audit["required_next_experiments"]
+        claim["owner_override_until"] = (audited_at + OWNER_OVERRIDE_WINDOW).isoformat()
+        store.write_json(
+            job_id,
+            RESEARCH_LANE_PATH,
+            {
+                "active_lane": claim.get("next_region"),
+                "opened_at": audited_at.isoformat(),
+                "opened_from_claim": claim_id,
+                "settled_lane": claim.get("lane"),
+                "settled_scope": audit["audited_scope"],
+                "carryover_mandate": (
+                    audit["required_next_experiments"]
+                    if audit["verdict"] == "narrow"
+                    else []
+                ),
+            },
+        )
+        marker = store.read_json(job_id, RESEARCH_IMPASSE_PATH) or {}
+        if audit["verdict"] == "narrow":
+            mandate = {
+                "claim_id": claim_id,
+                "lane": claim.get("lane"),
+                "reason_codes": audit["reason_codes"],
+                "required_next_experiments": audit["required_next_experiments"],
+                "certificate": certificate_path,
+            }
+            store.write_json(
+                job_id,
+                RESEARCH_IMPASSE_PATH,
+                {
+                    **marker,
+                    "alerted_at": audited_at.isoformat(),
+                    "status": "mandated_work",
+                    "claim_ids": [claim_id],
+                    "mandate": mandate,
+                },
+            )
+        else:
+            store.write_json(job_id, RESEARCH_IMPASSE_PATH, {})
+        store.append_journal(
+            job_id,
+            {
+                "type": "exhaustion_claim_audit_passed",
+                "claim_id": claim_id,
+                "lane": claim.get("lane"),
+                "by": "coverage-audit",
+                "audit_verdict": audit["verdict"],
+                "certificate": certificate_path,
+                "owner_override_until": claim["owner_override_until"],
+            },
+        )
+        store.append_journal(
+            job_id,
+            {
+                "type": "research_lane_settled",
+                "claim_id": claim_id,
+                "lane": claim.get("lane"),
+                "scope": audit["audited_scope"],
+            },
+        )
+        store.append_journal(
+            job_id,
+            {
+                "type": "research_region_opened",
+                "claim_id": claim_id,
+                "region": claim.get("next_region"),
+            },
+        )
+        if audit["verdict"] == "narrow":
+            store.append_journal(
+                job_id,
+                {"type": "research_impasse_mandated", **mandate},
+            )
+        elif marker.get("alerted_at"):
+            store.append_journal(
+                job_id,
+                {
+                    "type": "research_impasse_resolved",
+                    "adjudication_signals": ["exhaustion_claim_audit_passed"],
+                },
+            )
+    else:
+        claim["status"] = "rejected"
+        claim["adjudication"] = {
+            "by": "coverage-audit",
+            "verdict": "reject",
+            "ts": audited_at.isoformat(),
+        }
+        claim["required_next_experiments"] = audit["required_next_experiments"]
+        current_marker = store.read_json(job_id, RESEARCH_IMPASSE_PATH) or {}
+        mandate = {
+            "claim_id": claim_id,
+            "lane": claim.get("lane"),
+            "reason_codes": audit["reason_codes"],
+            "required_next_experiments": audit["required_next_experiments"],
+            "certificate": certificate_path,
+        }
+        store.write_json(
+            job_id,
+            RESEARCH_IMPASSE_PATH,
+            {
+                **current_marker,
+                "alerted_at": current_marker.get("alerted_at")
+                or audited_at.isoformat(),
+                "status": "mandated_work",
+                "claim_ids": [claim_id],
+                "mandate": mandate,
+            },
+        )
+        store.append_journal(
+            job_id,
+            {
+                "type": "exhaustion_claim_rejected",
+                "claim_id": claim_id,
+                "lane": claim.get("lane"),
+                "by": "coverage-audit",
+                "reason_codes": audit["reason_codes"],
+                "required_next_experiments": audit["required_next_experiments"],
+                "certificate": certificate_path,
+            },
+        )
+        store.append_journal(
+            job_id,
+            {"type": "research_impasse_mandated", **mandate},
+        )
+
+    # Commit the terminal claim state after its lane/mandate side effects. If
+    # the process dies during those writes, the still-pending claim remains
+    # eligible for a watchdog retry instead of becoming permanently partial.
+    store.write_json(job_id, _claim_path(store, job_id, claim_id), claim)
+    store.refresh_scorecard(
+        job_id,
+        {
+            "coverage_audit": {
+                "claim_id": claim_id,
+                "lane": claim.get("lane"),
+                "verdict": audit["verdict"],
+                "certificate": certificate_path,
+                "audited_at": audited_at.isoformat(),
+                "required_next_experiments": audit["required_next_experiments"],
+                "owner_override_until": claim.get("owner_override_until"),
+            }
+        },
+    )
+    return claim
+
+
+def reopen_exhaustion_claim(
+    store: JobStore,
+    job_id: str,
+    claim_id: str,
+    *,
+    by: str,
+    reason: str,
+) -> dict[str, Any]:
+    """Owner override for an audit-settled lane during its 48-hour window."""
+    if by != "owner":
+        store.append_journal(
+            job_id,
+            {"type": "exhaustion_claim_reopen_refused", "claim_id": claim_id, "by": by},
+        )
+        raise PermissionError("only the owner may reopen an audit-settled lane")
+    if not str(reason or "").strip():
+        raise ValueError("reopening an exhaustion claim requires a reason")
+    claim = store.read_json(job_id, _claim_path(store, job_id, claim_id))
+    if not isinstance(claim, dict):
+        raise FileNotFoundError(f"unknown exhaustion claim: {claim_id}")
+    if claim.get("status") != "audit_passed":
+        raise ValueError(f"claim {claim_id} is not audit-passed")
+    try:
+        deadline = datetime.fromisoformat(str(claim["owner_override_until"]))
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError(f"claim {claim_id} has no valid override window") from exc
+    if deadline.tzinfo is None:
+        deadline = deadline.replace(tzinfo=UTC)
+    now = datetime.now(UTC)
+    if now > deadline:
+        raise ValueError(f"claim {claim_id} owner override window has expired")
+
+    claim["status"] = "reopened"
+    claim["reopened"] = {"by": by, "reason": reason, "ts": now.isoformat()}
+    required = [
+        {
+            "id": f"owner-reopen:{claim_id}",
+            "kind": "owner_reopen",
+            "lane": claim.get("lane"),
+            "reason": reason,
+            "status": "not_run",
+        }
+    ]
+    store.write_json(
+        job_id,
+        RESEARCH_LANE_PATH,
+        {
+            "active_lane": claim.get("lane"),
+            "reopened_at": now.isoformat(),
+            "reopened_claim": claim_id,
+        },
+    )
+    store.write_json(
+        job_id,
+        RESEARCH_IMPASSE_PATH,
+        {
+            "alerted_at": now.isoformat(),
+            "status": "mandated_work",
+            "claim_ids": [claim_id],
+            "mandate": {
+                "claim_id": claim_id,
+                "lane": claim.get("lane"),
+                "reason_codes": ["owner_override"],
+                "required_next_experiments": required,
+            },
+        },
+    )
+    store.append_journal(
+        job_id,
+        {
+            "type": "exhaustion_claim_reopened",
+            "claim_id": claim_id,
+            "lane": claim.get("lane"),
+            "by": by,
+            "reason": reason,
+        },
+    )
+    store.append_journal(
+        job_id,
+        {
+            "type": "research_lane_reopened",
+            "claim_id": claim_id,
+            "lane": claim.get("lane"),
+        },
+    )
+    # As above, commit the claim state last so a partial owner override can be
+    # retried while the audit-passed claim remains the durable source state.
+    store.write_json(job_id, _claim_path(store, job_id, claim_id), claim)
+    store.refresh_scorecard(
+        job_id,
+        {
+            "coverage_audit": {
+                "claim_id": claim_id,
+                "lane": claim.get("lane"),
+                "verdict": "reopened",
+                "reopened_at": now.isoformat(),
+            }
+        },
+    )
+    return claim
+
+
 def list_exhaustion_claims(
     store: JobStore, job_id: str, *, status: str | None = None
 ) -> list[dict[str, Any]]:
@@ -160,10 +453,16 @@ def list_exhaustion_claims(
 def claim_settles_lane(claim: dict[str, Any]) -> bool:
     """Whether this claim satisfies the progress constitution for its lane.
 
-    Filing is an escalation, not a verdict. Only owner acceptance settles;
-    `agent-self-rejected` provenance NEVER settles — nothing in the loop may
-    control the only evidence used for its own acceptance."""
+    Filing is an escalation, not a verdict. Owner acceptance and a passing
+    coverage audit settle; `agent-self-rejected` provenance NEVER settles."""
     if claim.get("provenance") == "agent-self-rejected":
         return False
     adjudication = claim.get("adjudication") or {}
-    return claim.get("status") == "accepted" and adjudication.get("by") == "owner"
+    return bool(
+        (claim.get("status") == "accepted" and adjudication.get("by") == "owner")
+        or (
+            claim.get("status") == "audit_passed"
+            and adjudication.get("by") == "coverage-audit"
+            and adjudication.get("verdict") in {"pass", "narrow"}
+        )
+    )

--- a/wayfinder_paths/jobs/research.py
+++ b/wayfinder_paths/jobs/research.py
@@ -962,8 +962,10 @@ def scan_signals(
     selected_canonical = (
         SIGNAL_LIBRARY if include_canonical else tuple(canonical_signals)
     )
+    signal_specs = (*selected_canonical, *extra_signals)
     round_trip_cost = 2 * (fee_bps + slippage_bps) / 1e4
     rows: list[dict[str, Any]] = []
+    unmeasured_rows: list[dict[str, Any]] = []
     tests_run = 0
     tests_skipped = 0
     horizons_used: dict[str, list[int]] = {}
@@ -971,14 +973,49 @@ def scan_signals(
     events_cache: dict[tuple[str, str, int], np.ndarray] = {}
     regime_arrays: dict[str, Any] = {}
     regime_now: str | None = None
+    regime_labels: tuple[str, ...] = ()
+    if condition_regime:
+        from wayfinder_paths.jobs.indicators import REGIME_LABELS
+
+        regime_labels = tuple(REGIME_LABELS)
+
+    def _record_unmeasured(
+        spec: SignalDef,
+        *,
+        timeframe: str,
+        horizon: int,
+        status: str,
+        reason: str,
+        regime: str | None = None,
+    ) -> None:
+        unmeasured_rows.append(
+            {
+                "signal": spec.name,
+                "family": spec.family,
+                "library": ("workspace" if spec.name in extra_names else "canonical"),
+                "timeframe": timeframe,
+                "horizon": horizon,
+                "regime": regime,
+                "status": status,
+                "reason": reason,
+            }
+        )
+
+    for skipped in timeframes_skipped:
+        for spec in signal_specs:
+            for horizon in horizons or [0]:
+                _record_unmeasured(
+                    spec,
+                    timeframe=skipped["timeframe"],
+                    horizon=int(horizon),
+                    status="invalid_harness",
+                    reason=skipped["reason"],
+                )
     for tf_name, tf_seconds in tf_specs:
         bars = resample_ohlcv(base, tf_seconds, bar_seconds=bar_seconds)
         frames_by_tf[tf_name] = bars
         if condition_regime:
-            from wayfinder_paths.jobs.indicators import (
-                REGIME_LABELS,
-                classify_regimes,
-            )
+            from wayfinder_paths.jobs.indicators import classify_regimes
 
             labels = classify_regimes(bars)
             regime_arrays[tf_name] = labels.to_numpy()
@@ -1006,10 +1043,44 @@ def scan_signals(
         for h in tf_horizons:
             if h <= 0 or h >= n:
                 tests_skipped += 1
+                for spec in signal_specs:
+                    _record_unmeasured(
+                        spec,
+                        timeframe=tf_name,
+                        horizon=h,
+                        status="underpowered",
+                        reason="horizon_out_of_range",
+                    )
+                    for label in regime_labels:
+                        _record_unmeasured(
+                            spec,
+                            timeframe=tf_name,
+                            horizon=h,
+                            status="underpowered",
+                            reason="horizon_out_of_range",
+                            regime=label,
+                        )
                 continue
             if n // h < min_events:
                 # Decimated-event ceiling can't reach the sample gate.
                 tests_skipped += 1
+                for spec in signal_specs:
+                    _record_unmeasured(
+                        spec,
+                        timeframe=tf_name,
+                        horizon=h,
+                        status="underpowered",
+                        reason="insufficient_bars_for_event_floor",
+                    )
+                    for label in regime_labels:
+                        _record_unmeasured(
+                            spec,
+                            timeframe=tf_name,
+                            horizon=h,
+                            status="underpowered",
+                            reason="insufficient_bars_for_event_floor",
+                            regime=label,
+                        )
                 continue
             fwd = np.log(close[h:] / close[:-h])
             drift = float(fwd.mean())
@@ -1097,6 +1168,7 @@ def scan_signals(
                     "drift_baseline": drift,
                     "t_stat_vs_drift": float(t),
                     "round_trip_cost_bps": round_trip_cost * 1e4,
+                    "min_detectable_edge_bps": 2.0 * sem * 1e4,
                     "edge_net_bps": float(edge_net_bps),
                     "t_net": float(t_net),
                     "p_value": _t_to_pvalue(float(t)),
@@ -1113,14 +1185,23 @@ def scan_signals(
             # Iterate the SAME def set the frame was built from: a campaign
             # frame has only workspace columns, so scoring the canonical
             # library against it would KeyError (hit live 2026-07-26).
-            for spec in (*selected_canonical, *extra_signals):
+            for spec in signal_specs:
                 sig = signals[spec.name].to_numpy()
                 events = _decimate_events(sig[: n - h], h)
                 n_raw = int(sig[: n - h].sum())
                 row = _stats_row(events, spec)
                 if row is None:
-                    if int(events.sum()) >= min_events:
-                        continue  # zero-variance cell
+                    _record_unmeasured(
+                        spec,
+                        timeframe=tf_name,
+                        horizon=h,
+                        status="underpowered",
+                        reason=(
+                            "zero_variance_returns"
+                            if int(events.sum()) >= min_events
+                            else "insufficient_events"
+                        ),
+                    )
                     continue
                 tests_run += 1
                 row["n_raw"] = n_raw
@@ -1128,7 +1209,7 @@ def scan_signals(
                 rows.append(row)
                 if condition_regime and regime_arrays.get(tf_name) is not None:
                     labels_arr = regime_arrays[tf_name]
-                    for label in REGIME_LABELS:
+                    for label in regime_labels:
                         mask = labels_arr[: n - h] == label
                         r_events = _decimate_events(sig[: n - h] & mask, h)
                         r_row = _stats_row(
@@ -1141,6 +1222,18 @@ def scan_signals(
                             },
                         )
                         if r_row is None:
+                            _record_unmeasured(
+                                spec,
+                                timeframe=tf_name,
+                                horizon=h,
+                                status="underpowered",
+                                reason=(
+                                    "zero_variance_returns"
+                                    if int(r_events.sum()) >= max(15, min_events // 2)
+                                    else "insufficient_events"
+                                ),
+                                regime=label,
+                            )
                             continue
                         tests_run += 1
                         rows.append(r_row)
@@ -1208,6 +1301,9 @@ def scan_signals(
         # q-values are only meaningful over the COMPLETE test family.
         # Stripped from the persisted artifact.
         "_all_rows": rows,
+        # Declared cells which could not produce a valid statistic. Coverage
+        # audits keep these distinct from negative evidence.
+        "_unmeasured_rows": unmeasured_rows,
         "read": (
             f"{len(promoted)} of {tests_run} tests PROMOTED "
             f"(q<={q_threshold} + >={min_folds_agree}/{folds} fold sign "
@@ -1783,7 +1879,8 @@ def _scan_dir(root: Any) -> Any:
     return root / "results" / "research" / "signal_scan"
 
 
-def _read_scan_ledger(root: Any) -> list[dict[str, Any]]:
+def read_scan_ledger(root: Any) -> list[dict[str, Any]]:
+    """Return every valid row in the append-only signal-scan ledger."""
     target = _scan_dir(root) / _SCAN_LEDGER
     if not target.exists():
         return []
@@ -1812,15 +1909,16 @@ def _append_scan_ledger(root: Any, rows: list[dict[str, Any]]) -> None:
                 json.dumps({"ts": utc_now_iso(), **row}, sort_keys=True, default=str)
                 + "\n"
             )
-    existing = _read_scan_ledger(root)
+    existing = read_scan_ledger(root)
     if len(existing) <= _SCAN_LEDGER_COMPACT_ROWS:
         return
-    # Compact: latest scan_test per hash; scan_meta and holdout_check rows
-    # are NEVER dropped — holdout spends are the honesty backbone.
+    # Compact: latest measured/unmeasured cell per hash; scan_meta and
+    # holdout_check rows are NEVER dropped — declarations and holdout spends
+    # are the honesty backbone.
     kept: list[dict[str, Any]] = []
     latest_by_hash: dict[str, dict[str, Any]] = {}
     for row in existing:
-        if row.get("kind") == "scan_test" and row.get("hash"):
+        if row.get("kind") in {"scan_test", "scan_cell"} and row.get("hash"):
             latest_by_hash[str(row["hash"])] = row
         else:
             kept.append(row)
@@ -2133,6 +2231,9 @@ def signal_scan_job(
     all_rows_by_symbol = {
         symbol: scan.pop("_all_rows") for symbol, scan in per_symbol.items()
     }
+    unmeasured_by_symbol = {
+        symbol: scan.pop("_unmeasured_rows") for symbol, scan in per_symbol.items()
+    }
     if window_days is not None:
         for rows_ in all_rows_by_symbol.values():
             for row in rows_:
@@ -2215,16 +2316,27 @@ def signal_scan_job(
         "passing": sum(cell["status"] == "pass" for cell in incumbent_cells),
         "declared": len(incumbent_cells),
     }
-    prior = _read_scan_ledger(root)
+    prior = read_scan_ledger(root)
     prior_scans = sum(1 for row in prior if row.get("kind") == "scan_meta")
     prior_tests = sum(1 for row in prior if row.get("kind") == "scan_test")
     prior_unique = len(
         {row.get("hash") for row in prior if row.get("kind") == "scan_test"}
     )
+    scan_id = utc_now_iso()
+    effective_canonical = SIGNAL_LIBRARY if include_canonical else selected_canonical
+    declared_defs = {
+        spec_.name: spec_ for spec_ in (*effective_canonical, *extra_signals)
+    }
+    if condition_regime:
+        from wayfinder_paths.jobs.indicators import REGIME_LABELS
+
+        declared_regimes = ["base", *REGIME_LABELS]
+    else:
+        declared_regimes = ["base"]
     ledger_rows: list[dict[str, Any]] = [
         {
             "kind": "scan_meta",
-            "scan_id": utc_now_iso(),
+            "scan_id": scan_id,
             "symbols": targets,
             "timeframes": scan_timeframes,
             "horizons": {
@@ -2236,6 +2348,10 @@ def signal_scan_job(
                 sym: scan["holdout"]["cutoff_ts"] for sym, scan in per_symbol.items()
             },
             "workspace_signals": [spec.name for spec in extra_signals],
+            "declared_signals": list(declared_defs),
+            "signal_families": {
+                name: spec_.family for name, spec_ in declared_defs.items()
+            },
             "workspace_signals_sha": (
                 workspace.sha if workspace is not None and extra_signals else None
             ),
@@ -2245,9 +2361,18 @@ def signal_scan_job(
             "bh_family_size": len(pooled_rows),
             "bh_min_family_size": MIN_BH_FAMILY_SIZE,
             "multiplicity_method": "benjamini_hochberg",
-            "incumbent_controls": incumbent_controls,
+            "incumbent_controls": incumbent_cells,
             "condition_regime": condition_regime,
+            "declared_regimes": declared_regimes,
             "window_days": window_days,
+            "data_revision": {
+                symbol: scan["fingerprint"] for symbol, scan in per_symbol.items()
+            },
+            "cost_revision": {
+                "fee_bps": fee_bps,
+                "slippage_bps": slippage_bps,
+                "round_trip_cost_bps": 2 * (fee_bps + slippage_bps),
+            },
         }
     ]
     # EVERY executed test is a recorded trial — not just the survivors.
@@ -2256,6 +2381,7 @@ def signal_scan_job(
             ledger_rows.append(
                 {
                     "kind": "scan_test",
+                    "scan_id": scan_id,
                     # Regime-conditional and windowed cells are DISTINCT
                     # trials — they must not collide with the base row's hash.
                     "hash": _trial_hash(
@@ -2268,6 +2394,7 @@ def signal_scan_job(
                     ),
                     "symbol": symbol,
                     "signal": row["signal"],
+                    "family": row.get("family"),
                     "timeframe": row["timeframe"],
                     "horizon": row["horizon"],
                     "direction": row["direction"],
@@ -2275,6 +2402,7 @@ def signal_scan_job(
                     "t": round(row["t_stat_vs_drift"], 3),
                     "t_net": round(row["t_net"], 3),
                     "edge_net_bps": round(row["edge_net_bps"], 3),
+                    "min_detectable_edge_bps": round(row["min_detectable_edge_bps"], 3),
                     "round_trip_cost_bps": round(row["round_trip_cost_bps"], 3),
                     "q": row.get("q_value"),
                     "bh_family_size": row.get("bh_family_size"),
@@ -2292,6 +2420,25 @@ def signal_scan_job(
                         )
                         for control in incumbent_controls
                     ),
+                }
+            )
+    for symbol, rows in unmeasured_by_symbol.items():
+        for row in rows:
+            signal_key = (
+                row["signal"]
+                + (f"|{row['regime']}" if row.get("regime") else "")
+                + (f"|w{window_days}" if window_days else "")
+            )
+            ledger_rows.append(
+                {
+                    "kind": "scan_cell",
+                    "scan_id": scan_id,
+                    "hash": _trial_hash(
+                        symbol, signal_key, row["timeframe"], row["horizon"]
+                    ),
+                    "symbol": symbol,
+                    **row,
+                    "campaign": campaign,
                 }
             )
     _append_scan_ledger(root, ledger_rows)
@@ -2397,7 +2544,7 @@ def holdout_check_job(
         extra_defs = {spec_.name: spec_ for spec_ in workspace.defs}
         scanned_shas = [
             row.get("workspace_signals_sha")
-            for row in _read_scan_ledger(root)
+            for row in read_scan_ledger(root)
             if row.get("kind") == "scan_meta" and row.get("workspace_signals_sha")
         ]
         if scanned_shas and scanned_shas[-1] != workspace.sha:
@@ -2413,7 +2560,7 @@ def holdout_check_job(
             )
         except ValueError:
             recorded_cutoffs = {}
-    ledger = _read_scan_ledger(root)
+    ledger = read_scan_ledger(root)
     per_symbol: dict[str, Any] = {}
     ledger_rows: list[dict[str, Any]] = []
     already_spent = False
@@ -2541,4 +2688,27 @@ def rank_check_job(
         )
     result = rank_ic(frames, column, horizons=horizons)
     result["symbols"] = symbols
+    from wayfinder_paths.jobs.models import utc_now_iso
+
+    generated_at = utc_now_iso()
+    result["column"] = column
+    result["horizons_requested"] = list(horizons or [])
+    result["generated_at"] = generated_at
+    relative_artifact = "results/research/rank_check.json"
+    artifact = root / relative_artifact
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_text(
+        json.dumps(result, indent=2, sort_keys=True, default=str) + "\n",
+        encoding="utf-8",
+    )
+    store.append_journal(
+        job_id,
+        {
+            "type": "rank_check_completed",
+            "column": column,
+            "horizons": list(horizons or []),
+            "artifact": relative_artifact,
+        },
+    )
+    result["artifact"] = str(artifact)
     return result

--- a/wayfinder_paths/jobs/store.py
+++ b/wayfinder_paths/jobs/store.py
@@ -273,6 +273,29 @@ class JobStore:
         )
         return path
 
+    def read_jsonl(
+        self, job_id: str, relative: str, *, limit: int | None = None
+    ) -> list[dict[str, Any]]:
+        """Read a job-owned JSONL artifact without letting one bad row hide
+        the rest of an append-only ledger."""
+        path = self.job_dir(job_id) / relative
+        if not path.exists():
+            return []
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+        if limit is not None:
+            lines = lines[-max(int(limit), 0) :]
+        rows: list[dict[str, Any]] = []
+        for line in lines:
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except ValueError:
+                continue
+            if isinstance(row, dict):
+                rows.append(row)
+        return rows
+
     def append_journal(self, job_id: str, event: dict[str, Any]) -> None:
         path = self.job_dir(job_id) / "journal.jsonl"
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -812,6 +835,10 @@ class JobStore:
         scorecard["pending_exhaustion_claims"] = len(
             list_exhaustion_claims(self, job_id, status="pending")
         )
+        # circular import: evolution reporting reads through JobStore
+        from wayfinder_paths.jobs.evolution_ledger import build_process_efficiency
+
+        scorecard["process_efficiency"] = build_process_efficiency(self, job_id)
         self.write_json(job_id, "scorecard.json", scorecard)
         return scorecard
 

--- a/wayfinder_paths/jobs/store.py
+++ b/wayfinder_paths/jobs/store.py
@@ -932,6 +932,7 @@ def _validate_applicable_proposal(
         # permanently unapprovable.
         return
     scenario_plan = proposal["scenario_plan"]
+    scenarios: Any
     match scenario_plan:
         case list():
             scenarios = scenario_plan

--- a/wayfinder_paths/jobs/sync.py
+++ b/wayfinder_paths/jobs/sync.py
@@ -190,6 +190,12 @@ def snapshot_job(job_id: str, *, store: JobStore | None = None) -> dict[str, Any
     store = store or JobStore()
     job = store.load(job_id)
     scorecard = store.read_json(job_id, "scorecard.json", default={}) or {}
+    from wayfinder_paths.jobs.evolution_ledger import build_process_efficiency
+
+    scorecard = {
+        **scorecard,
+        "process_efficiency": build_process_efficiency(store, job_id),
+    }
     # Reflect the live runner/engine state, not the declared job.yaml: mode
     # (paper/live), agent_mode, active_revision, paused, and scheduling/health
     # metrics all come from the runner where it is the source of truth. See

--- a/wayfinder_paths/jobs/watchdog.py
+++ b/wayfinder_paths/jobs/watchdog.py
@@ -356,8 +356,10 @@ def _check_successor_overdue(
     events: list[dict[str, Any]] = []
     changed = False
     for entry in expected:
-        if not isinstance(entry, dict) or entry.get("delivered") or entry.get(
-            "abandoned"
+        if (
+            not isinstance(entry, dict)
+            or entry.get("delivered")
+            or entry.get("abandoned")
         ):
             continue
         entry_ts = str(entry.get("ts") or "")
@@ -365,8 +367,7 @@ def _check_successor_overdue(
         successors = [
             p
             for p in proposals
-            if str(p.get("proposal_id")) != rejected_id
-            and _staged_after(p, entry_ts)
+            if str(p.get("proposal_id")) != rejected_id and _staged_after(p, entry_ts)
         ]
         alive = [p for p in successors if p.get("status") != "rejected"]
         owner_closed = [
@@ -376,9 +377,7 @@ def _check_successor_overdue(
             and str((p.get("rejection") or {}).get("by") or "")
             in {"owner", "user", "human"}
         ]
-        audit_progress = _research_progress_since(
-            store.job_dir(job_id), entry_ts
-        )
+        audit_progress = _research_progress_since(store.job_dir(job_id), entry_ts)
         if (
             alive
             or owner_closed
@@ -412,8 +411,8 @@ def _check_successor_overdue(
                             f"the successor invited by the process rejection of "
                             f"{rejected_id} was agent-self-rejected "
                             f"{rearms + 1} times — the agent cannot close this "
-                            "thread itself; owner must adjudicate (accept an "
-                            "exhaustion claim or reject the ask)"
+                            "thread itself; file a mechanically auditable "
+                            "exhaustion claim or ask the owner to reject the ask)"
                         ),
                     },
                 )
@@ -429,9 +428,7 @@ def _check_successor_overdue(
                 self_rejected,
                 key=lambda p: str((p.get("rejection") or {}).get("ts") or ""),
             )
-            rearm_ts = str(
-                (newest.get("rejection") or {}).get("ts") or now.isoformat()
-            )
+            rearm_ts = str((newest.get("rejection") or {}).get("ts") or now.isoformat())
             entry["ts"] = rearm_ts
             entry["notified"] = False
             entry["rearms"] = rearms + 1
@@ -862,8 +859,9 @@ def _check_disk_usage(
 # claims), journal `research_impasse`, write the marker the worker prompt
 # renders as a HATCH-STRIPPED mandate, and fire a trigger wake. Debounced by
 # a re-alert window (mirrors disk_pressure); the marker clears — and journals
-# `research_impasse_resolved` — only when valid learning or owner adjudication
-# appears. Activity remains visible without laundering it into learning.
+# `research_impasse_resolved` — only when valid learning or a trusted
+# owner/coverage adjudication appears. Activity remains visible without
+# laundering it into learning.
 _IMPASSE_PATH = "state/research_impasse.json"
 IMPASSE_WAKES_ENV = "WAYFINDER_IMPASSE_WAKES"
 DEFAULT_IMPASSE_WAKES = 3
@@ -882,6 +880,7 @@ _OWNER_ADJUDICATION_TYPES = {
     "exhaustion_claim_accepted",
     "exhaustion_claim_rejected",
 }
+_AUDIT_ADJUDICATION_TYPES = {"exhaustion_claim_audit_passed"}
 
 
 class ResearchProgressClassification(TypedDict):
@@ -934,9 +933,16 @@ def _research_progress_since(
             learning.add(event_type)
         elif event_type in _ACTIVITY_JOURNAL_TYPES:
             activity.add(event_type)
-        elif event_type in _OWNER_ADJUDICATION_TYPES and str(
-            row.get("by") or ""
-        ) in {"owner", "user", "human"}:
+        elif event_type in _OWNER_ADJUDICATION_TYPES and str(row.get("by") or "") in {
+            "owner",
+            "user",
+            "human",
+        }:
+            adjudications.add(event_type)
+        elif (
+            event_type in _AUDIT_ADJUDICATION_TYPES
+            and str(row.get("by") or "") == "coverage-audit"
+        ):
             adjudications.add(event_type)
 
     from wayfinder_paths.jobs.execution.experiments import experiment_semantic_hash
@@ -1008,10 +1014,12 @@ def _check_research_impasse(
     if len(wake_ts) < stale_wakes:
         return None  # startup — not enough wakes to judge
     basis_ts = sorted(wake_ts)[-stale_wakes]
-    progress = _research_progress_since(
-        root, basis_ts, rows=rows, proposals=proposals
-    )
-    if progress["valid_learning"] or progress["adjudicated"]:
+    progress = _research_progress_since(root, basis_ts, rows=rows, proposals=proposals)
+    mandated_work = marker.get("status") == "mandated_work"
+    # An adjudication created a carryover mandate; that same event cannot
+    # erase the named work on the next pass. Only learning may resolve it.
+    if progress["valid_learning"] or (progress["adjudicated"] and not mandated_work):
+        adjudication_signals = [] if mandated_work else progress["adjudication_signals"]
         if marker.get("alerted_at"):
             store.write_json(job.id, _IMPASSE_PATH, {})
             store.append_journal(
@@ -1019,15 +1027,40 @@ def _check_research_impasse(
                 {
                     "type": "research_impasse_resolved",
                     "learning_signals": progress["learning_signals"],
-                    "adjudication_signals": progress["adjudication_signals"],
+                    "adjudication_signals": adjudication_signals,
                 },
             )
             return {
                 "action": "research_impasse_resolved",
                 "learning_signals": progress["learning_signals"],
-                "adjudication_signals": progress["adjudication_signals"],
+                "adjudication_signals": adjudication_signals,
             }
         return None
+    if mandated_work:
+        if _age(now, marker.get("alerted_at")) < IMPASSE_REALERT_WINDOW:
+            return None
+        marker["alerted_at"] = now.isoformat()
+        store.write_json(job.id, _IMPASSE_PATH, marker)
+        mandate = marker.get("mandate") or {}
+        store.append_journal(
+            job.id,
+            {
+                "type": "research_impasse",
+                "status": "mandated_work",
+                "claim_id": mandate.get("claim_id"),
+                "required_next_experiments": mandate.get("required_next_experiments")
+                or [],
+            },
+        )
+        from wayfinder_paths.jobs.triggers import fire_triggers
+
+        fire_triggers(store, job, ["research_impasse"], source="watchdog")
+        return {
+            "action": "research_impasse",
+            "status": "mandated_work",
+            "claim_id": mandate.get("claim_id"),
+            "outcome": "agent_woken",
+        }
     if marker.get("status") == "awaiting_adjudication":
         if _age(now, marker.get("awaiting_since")) < IMPASSE_ADJUDICATION_WINDOW:
             return None
@@ -1046,11 +1079,7 @@ def _check_research_impasse(
             "status": "awaiting_adjudication",
             "awaiting_since": filed_at,
             "claim_ids": sorted(
-                {
-                    str(row.get("claim_id"))
-                    for row in filed
-                    if row.get("claim_id")
-                }
+                {str(row.get("claim_id")) for row in filed if row.get("claim_id")}
             ),
         }
         if not marker.get("alerted_at"):
@@ -1092,9 +1121,7 @@ def _check_research_impasse(
             "type": "research_impasse",
             "stale_wakes": stale_wakes,
             "basis_wake_ts": basis_ts,
-            "days_since_last_experiment": staleness.get(
-                "days_since_last_experiment"
-            ),
+            "days_since_last_experiment": staleness.get("days_since_last_experiment"),
             "wakes_since_last_proposal": staleness.get("wakes_since_last_proposal"),
         },
     )
@@ -1109,39 +1136,40 @@ def _check_research_impasse(
     }
 
 
-# Pending exhaustion claims are owner work: surface them on the watchdog
-# cadence (journal on change; the scorecard count refreshes with every
-# scorecard write) so a filed claim cannot silently rot un-adjudicated.
-_CLAIMS_SEEN_PATH = "state/exhaustion_claims_seen.json"
-
-
-def _surface_pending_claims(store: JobStore, job_id: str) -> dict[str, Any] | None:
-    from wayfinder_paths.jobs.exhaustion import list_exhaustion_claims
+# Pending claims are controller work: every watchdog pass runs the structured
+# coverage audit and applies pass/narrow/reject without waiting on an owner.
+def _audit_pending_claims(store: JobStore, job_id: str) -> dict[str, Any] | None:
+    from wayfinder_paths.jobs.exhaustion import (
+        audit_and_adjudicate_exhaustion_claim,
+        list_exhaustion_claims,
+    )
 
     pending = list_exhaustion_claims(store, job_id, status="pending")
-    ids = sorted(str(claim.get("claim_id")) for claim in pending)
-    seen = store.read_json(job_id, _CLAIMS_SEEN_PATH) or {}
-    if list(seen.get("pending") or []) == ids:
+    if not pending:
         return None
-    store.write_json(
-        job_id, _CLAIMS_SEEN_PATH, {"pending": ids, "checked_at": utc_now_iso()}
-    )
-    if not ids:
-        return None  # a cleared queue needs no alert
-    store.append_journal(
-        job_id,
-        {
-            "type": "exhaustion_claims_pending",
-            "count": len(ids),
-            "claim_ids": ids,
-            "owner_review_required": (
-                "pending exhaustion claims await owner adjudication — accept "
-                "or reject via `wayfinder job exhaustion adjudicate`"
-            ),
-        },
-    )
-    store.refresh_scorecard(job_id)
-    return {"action": "exhaustion_claims_pending", "count": len(ids)}
+    results: list[dict[str, Any]] = []
+    failures: list[dict[str, str]] = []
+    for claim in pending:
+        claim_id = str(claim["claim_id"])
+        try:
+            results.append(
+                audit_and_adjudicate_exhaustion_claim(store, job_id, claim_id)
+            )
+        except Exception as exc:  # noqa: BLE001 — other claims must still audit
+            failures.append({"claim_id": claim_id, "error": str(exc)})
+    return {
+        "action": "exhaustion_claims_audited",
+        "count": len(results),
+        "failures": failures,
+        "verdicts": [
+            {
+                "claim_id": claim["claim_id"],
+                "status": claim["status"],
+                "audit_verdict": (claim.get("audit") or {}).get("verdict"),
+            }
+            for claim in results
+        ],
+    }
 
 
 # Lifecycle evaluation is cheap (json reads + arithmetic) but its decisions
@@ -1360,7 +1388,7 @@ def recover_stalled_applications(
         if impasse_event is not None:
             recovered.append({"job_id": job.id, **impasse_event})
         try:
-            claims_event = _surface_pending_claims(store, job.id)
+            claims_event = _audit_pending_claims(store, job.id)
         except Exception as exc:
             errors.append({"job_id": job.id, "error": f"claims: {exc}"})
             claims_event = None

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -836,15 +836,15 @@ def _build_worker_prompt_sections(
         "tier accepts any candidate not clearly worse than baseline, no "
         "owner approval needed (wayfinder_paths.jobs.probation."
         "open_paper_probation_leg / `wayfinder job probation-open-paper`) "
-        "— or (c) an exhaustion claim FILED for owner adjudication "
+        "— or (c) an exhaustion claim FILED for mechanical coverage audit "
         "(`wayfinder job exhaustion file ...`). Stating that research is "
         "not warranted is NOT a legal outcome of a stale wake — prose "
         "never satisfies the constitution.\n"
         "- Self-rejections are development evidence, never verdicts: a "
         "proposal YOU rejected cannot mark a lane settled in the agenda/"
         "dead map, and reopening bars ('requires named new evidence') may "
-        "only be set by owner-accepted exhaustion claims or executed-"
-        "experiment results. Any lane marked settled on agent-self-"
+        "only be set by owner-accepted or coverage-audit-passed exhaustion "
+        "claims, or executed-experiment results. Any lane marked settled on agent-self-"
         "rejected provenance is OPEN.\n"
         "- Routine research wakes carry a `search_assignment` (dynamic "
         "context): one island among exploit / adjacent / divergent / "
@@ -1135,19 +1135,32 @@ def _build_worker_prompt_sections(
     impasse_directive = ""
     impasse_marker = store.read_json(job_id, "state/research_impasse.json") or {}
     if impasse_marker.get("alerted_at"):
-        impasse_directive = (
-            "RESEARCH IMPASSE — the watchdog flagged `research_impasse`: "
-            f"the last {impasse_marker.get('stale_wakes')} wakes staged zero "
-            "experiments, probation legs, staged proposals, or exhaustion "
-            "claims while research is stale.\n"
-            "This wake MUST end in exactly one of: (a) a staged+executed "
-            "experiment, (b) a new probation leg (paper entry tier "
-            "qualifies), (c) an exhaustion claim FILED for owner "
-            "adjudication. No other outcome closes an impasse wake.\n"
-            "It must also make a DIVERSITY move — resurrect an archived/"
-            "historical candidate or recombine signals across lanes. "
-            "Another audit of the incumbent does not count.\n\n"
-        )
+        if impasse_marker.get("status") == "mandated_work":
+            mandate = impasse_marker.get("mandate") or {}
+            required = mandate.get("required_next_experiments") or []
+            impasse_directive = (
+                "RESEARCH IMPASSE — a mechanical coverage audit REJECTED "
+                f"claim {mandate.get('claim_id')}. This wake MUST execute or "
+                "start one of the named required experiments below; filing "
+                "another exhaustion claim does not satisfy this mandate.\n"
+                f"REQUIRED_NEXT_EXPERIMENTS={json.dumps(required, default=str)}\n"
+                "Only a semantic-hash-unique experiment or a probation "
+                "graduate/kill outcome clears the impasse.\n\n"
+            )
+        else:
+            impasse_directive = (
+                "RESEARCH IMPASSE — the watchdog flagged `research_impasse`: "
+                f"the last {impasse_marker.get('stale_wakes')} wakes staged zero "
+                "experiments, probation legs, staged proposals, or exhaustion "
+                "claims while research is stale.\n"
+                "This wake MUST end in exactly one of: (a) a staged+executed "
+                "experiment, (b) a new probation leg (paper entry tier "
+                "qualifies), (c) an exhaustion claim FILED for mechanical "
+                "coverage audit. No other outcome closes an impasse wake.\n"
+                "It must also make a DIVERSITY move — resurrect an archived/"
+                "historical candidate or recombine signals across lanes. "
+                "Another audit of the incumbent does not count.\n\n"
+            )
     # Ideation is a FORCED session, not a prose suggestion: 130 consecutive
     # "nothing new, agenda stands" wakes proved the agent never consults an
     # external tool unless the wake's task IS the expedition. Stamp-gated on

--- a/wayfinder_paths/tests/test_jobs_coverage.py
+++ b/wayfinder_paths/tests/test_jobs_coverage.py
@@ -1,0 +1,582 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from wayfinder_paths.jobs.coverage import (
+    audit_exhaustion_claim,
+    build_coverage_certificate,
+)
+from wayfinder_paths.jobs.evolution_ledger import (
+    build_evolution_report,
+    build_process_efficiency,
+    evolution_snapshot_block,
+)
+from wayfinder_paths.jobs.exhaustion import (
+    audit_and_adjudicate_exhaustion_claim,
+    claim_settles_lane,
+    file_exhaustion_claim,
+    reopen_exhaustion_claim,
+)
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.jobs.sync import snapshot_job
+from wayfinder_paths.jobs.watchdog import recover_stalled_applications
+
+
+def _store(tmp_path: Path, job_id: str = "coverage-demo") -> tuple[JobStore, str]:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        job_id,
+        script="workspace/src/strategy.py",
+        agent_mode="intervene",
+        execution_contract="jobs_v1",
+    )
+    store.save(job)
+    return store, job.id
+
+
+def _append_rows(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row) + "\n")
+
+
+def _scan_meta(
+    *,
+    scan_id: str = "scan-1",
+    signals: list[str] | None = None,
+    horizons: list[int] | None = None,
+) -> dict:
+    signals = signals or ["sig_a"]
+    horizons = horizons or [1]
+    return {
+        "ts": "2026-08-20T00:00:00+00:00",
+        "kind": "scan_meta",
+        "scan_id": scan_id,
+        "symbols": ["BTC"],
+        "timeframes": ["1h"],
+        "horizons": {"BTC": {"1h": horizons}},
+        "declared_signals": signals,
+        "signal_families": dict.fromkeys(signals, "momentum"),
+        "declared_regimes": ["base"],
+        "bh_family_size": 50,
+        "bh_min_family_size": 50,
+        "multiplicity_method": "benjamini_hochberg",
+        "bh_family_mode": "canonical",
+        "cost_revision": {"round_trip_cost_bps": 17.0},
+        "incumbent_controls": [
+            {"symbol": "BTC", "signal": signals[0], "timeframe": "1h", "horizon": 1}
+        ],
+    }
+
+
+def _scan_test(
+    *,
+    signal: str = "sig_a",
+    horizon: int = 1,
+    verdict: str | None = None,
+    status: str | None = None,
+) -> dict:
+    row = {
+        "ts": "2026-08-20T00:01:00+00:00",
+        "kind": "scan_test" if status is None else "scan_cell",
+        "scan_id": "scan-1",
+        "symbol": "BTC",
+        "signal": signal,
+        "family": "momentum",
+        "library": "canonical",
+        "timeframe": "1h",
+        "horizon": horizon,
+        "regime": None,
+        "t": -0.5,
+        "t_net": -1.2,
+        "round_trip_cost_bps": 17.0,
+        "min_detectable_edge_bps": 12.0,
+        "verdict": verdict,
+    }
+    if status is not None:
+        row["status"] = status
+        row["reason"] = "synthetic gap"
+    return row
+
+
+def _write_scan(store: JobStore, job_id: str, rows: list[dict]) -> None:
+    _append_rows(
+        store.job_dir(job_id) / "results/research/signal_scan/ledger.jsonl", rows
+    )
+
+
+def test_certificate_counts_declared_gaps_without_laundering_negative(
+    tmp_path: Path,
+) -> None:
+    store, job_id = _store(tmp_path)
+    _write_scan(
+        store,
+        job_id,
+        [
+            _scan_meta(signals=["sig_a", "sig_b"], horizons=[1, 2]),
+            _scan_test(signal="sig_a", horizon=1),
+            _scan_test(signal="sig_b", horizon=1),
+            _scan_test(signal="sig_a", horizon=2, status="blocked_infrastructure"),
+        ],
+    )
+
+    certificate = build_coverage_certificate(job_id, "majors", store=store)
+    assert certificate["cell_counts"] == {
+        "completed_valid": 2,
+        "negative": 2,
+        "positive": 0,
+        "near_miss": 0,
+        "blocked_infrastructure": 1,
+        "invalid_harness": 0,
+        "underpowered": 0,
+        "not_run": 1,
+    }
+    assert certificate["negative_evidence_count"] == 2
+    assert certificate["detectable_edge"]["minimum_bps"] == 12.0
+    assert certificate["multiplicity"]["family_size"] == 50
+    assert certificate["incumbent_controls"]["declared"] == 1
+
+    claim = {
+        "lane": "majors",
+        "refs": [],
+        "provenance": "data-wall",
+    }
+    audit = audit_exhaustion_claim(store, job_id, claim)
+    assert audit["verdict"] == "narrow"
+    assert len(audit["audited_scope"]["cells"]) == 2
+    statuses = {row["status"] for row in audit["required_next_experiments"]}
+    assert statuses == {"blocked_infrastructure", "not_run"}
+
+    for minute in range(3):
+        store.append_journal(
+            job_id,
+            {
+                "ts": f"2026-08-19T00:0{minute}:00+00:00",
+                "type": "agent_wakeup",
+            },
+        )
+    filed = file_exhaustion_claim(
+        store,
+        job_id,
+        lane="majors",
+        evidence="two completed cells; two declared gaps",
+        provenance="data-wall",
+        next_region="cross-asset",
+    )
+    applied = audit_and_adjudicate_exhaustion_claim(store, job_id, filed["claim_id"])
+    assert applied["status"] == "audit_passed"
+    assert applied["audit"]["verdict"] == "narrow"
+    assert claim_settles_lane(applied)
+    assert (
+        store.read_json(job_id, "state/research_lane.json")["active_lane"]
+        == "cross-asset"
+    )
+    marker = store.read_json(job_id, "state/research_impasse.json")
+    assert marker["status"] == "mandated_work"
+    assert {
+        row["status"] for row in marker["mandate"]["required_next_experiments"]
+    } == {
+        "blocked_infrastructure",
+        "not_run",
+    }
+    recover_stalled_applications(store=store)
+    assert (
+        store.read_json(job_id, "state/research_impasse.json")["status"]
+        == "mandated_work"
+    )
+
+
+def test_legacy_scan_cells_require_contiguous_write_provenance(tmp_path: Path) -> None:
+    store, job_id = _store(tmp_path, "coverage-legacy-scan")
+    legacy_cell = _scan_test()
+    legacy_cell.pop("scan_id")
+    _write_scan(store, job_id, [_scan_meta(scan_id="legacy-scan"), legacy_cell])
+    legacy = build_coverage_certificate(job_id, "majors", store=store)
+    assert legacy["cell_counts"]["completed_valid"] == 1
+
+    store, job_id = _store(tmp_path, "coverage-compacted-scan")
+    unrelated = _scan_test()
+    unrelated["scan_id"] = "different-scan"
+    _write_scan(store, job_id, [_scan_meta(scan_id="old-scan"), unrelated])
+    compacted = build_coverage_certificate(job_id, "majors", store=store)
+    assert compacted["cell_counts"]["completed_valid"] == 0
+    assert compacted["cell_counts"]["not_run"] == 1
+
+
+def test_unmeasured_incumbent_control_is_a_critical_gap(tmp_path: Path) -> None:
+    store, job_id = _store(tmp_path, "coverage-incumbent-gap")
+    meta = _scan_meta()
+    meta["incumbent_controls"] = [
+        {
+            "symbol": "ETH",
+            "signal": "sig_a",
+            "timeframe": "1h",
+            "horizon": 1,
+        }
+    ]
+    _write_scan(store, job_id, [meta, _scan_test()])
+
+    certificate = build_coverage_certificate(job_id, "majors", store=store)
+    assert certificate["incumbent_controls"]["cells"][0]["status"] == "not_run"
+    assert certificate["cell_counts"]["not_run"] == 1
+    audit = audit_exhaustion_claim(
+        store,
+        job_id,
+        {"lane": "majors", "refs": [], "provenance": "data-wall"},
+    )
+    assert audit["verdict"] == "narrow"
+    assert any(
+        row["id"].startswith("coverage-cell:ETH:sig_a:1h:1")
+        for row in audit["required_next_experiments"]
+    )
+
+
+def test_pass_auto_settles_opens_next_region_and_owner_can_reopen(
+    tmp_path: Path,
+) -> None:
+    store, job_id = _store(tmp_path, "coverage-pass")
+    _write_scan(store, job_id, [_scan_meta(), _scan_test()])
+    claim = file_exhaustion_claim(
+        store,
+        job_id,
+        lane="majors",
+        evidence="structured scan is complete",
+        provenance="holdout-refuted",
+        next_region="cross-asset",
+    )
+
+    audited = audit_and_adjudicate_exhaustion_claim(store, job_id, claim["claim_id"])
+    assert audited["status"] == "audit_passed"
+    assert audited["adjudication"]["by"] == "coverage-audit"
+    assert claim_settles_lane(audited)
+    assert (
+        store.read_json(job_id, "state/research_lane.json")["active_lane"]
+        == "cross-asset"
+    )
+    journal_types = {row["type"] for row in store.read_jsonl(job_id, "journal.jsonl")}
+    assert "exhaustion_claim_audit_passed" in journal_types
+    assert "research_region_opened" in journal_types
+    assert (
+        store.read_json(job_id, "scorecard.json")["coverage_audit"]["verdict"] == "pass"
+    )
+
+    with pytest.raises(PermissionError):
+        reopen_exhaustion_claim(
+            store, job_id, claim["claim_id"], by="agent", reason="disagree"
+        )
+    reopened = reopen_exhaustion_claim(
+        store,
+        job_id,
+        claim["claim_id"],
+        by="owner",
+        reason="scope omitted a required market",
+    )
+    assert reopened["status"] == "reopened"
+    assert not claim_settles_lane(reopened)
+    assert (
+        store.read_json(job_id, "state/research_lane.json")["active_lane"] == "majors"
+    )
+    assert (
+        store.read_json(job_id, "state/research_impasse.json")["status"]
+        == "mandated_work"
+    )
+
+
+def test_parked_probation_candidate_rejects_and_names_mandate(
+    tmp_path: Path,
+) -> None:
+    store, job_id = _store(tmp_path, "coverage-reject")
+    _write_scan(store, job_id, [_scan_meta(), _scan_test(verdict="probation")])
+    claim = file_exhaustion_claim(
+        store,
+        job_id,
+        lane="majors",
+        evidence="agent says done",
+        provenance="data-wall",
+        next_region="other",
+    )
+    audited = audit_and_adjudicate_exhaustion_claim(store, job_id, claim["claim_id"])
+    assert audited["status"] == "rejected"
+    assert audited["audit"]["verdict"] == "reject"
+    required = audited["required_next_experiments"]
+    assert required[0]["id"].startswith("candidate-followup:BTC:sig_a:1h:1")
+    marker = store.read_json(job_id, "state/research_impasse.json")
+    assert marker["status"] == "mandated_work"
+    assert marker["mandate"]["required_next_experiments"] == required
+
+
+def test_probation_followup_is_not_parked_and_kill_is_negative_evidence(
+    tmp_path: Path,
+) -> None:
+    store, job_id = _store(tmp_path, "coverage-probation-followup")
+    _write_scan(store, job_id, [_scan_meta(), _scan_test(verdict="probation")])
+    store.append_journal(
+        job_id,
+        {"type": "paper_probation_opened", "leg": "sig-a-paper", "symbol": "BTC"},
+    )
+
+    active = build_coverage_certificate(job_id, "majors", store=store)
+    assert active["parked_candidates"] == []
+    assert active["unresolved_candidates"][0]["state"] == "probation_active"
+    active_audit = audit_exhaustion_claim(
+        store,
+        job_id,
+        {"lane": "majors", "refs": [], "provenance": "data-wall"},
+    )
+    assert active_audit["verdict"] == "reject"
+
+    store.append_journal(
+        job_id,
+        {"type": "probation_leg_killed", "leg": "sig-a-paper"},
+    )
+    killed = build_coverage_certificate(job_id, "majors", store=store)
+    assert killed["unresolved_candidates"] == []
+    assert killed["candidate_followups"][0]["state"] == "refuted"
+    killed_audit = audit_exhaustion_claim(
+        store,
+        job_id,
+        {"lane": "majors", "refs": [], "provenance": "data-wall"},
+    )
+    assert killed_audit["verdict"] == "pass"
+
+
+def test_structured_operator_requirement_is_a_named_gap(tmp_path: Path) -> None:
+    store, job_id = _store(tmp_path, "coverage-requirement")
+    _write_scan(store, job_id, [_scan_meta(), _scan_test()])
+    store.append_journal(
+        job_id,
+        {
+            "type": "operator_note",
+            "required_experiments": [
+                {
+                    "id": "hype-multi-timeframe",
+                    "kind": "signal_scan",
+                    "symbols": ["HYPE"],
+                    "timeframes": ["15m", "30m", "1h", "4h"],
+                }
+            ],
+        },
+    )
+    audit = audit_exhaustion_claim(
+        store,
+        job_id,
+        {"lane": "majors", "refs": [], "provenance": "data-wall"},
+    )
+    assert audit["verdict"] == "narrow"
+    assert any(
+        row["id"] == "hype-multi-timeframe"
+        for row in audit["required_next_experiments"]
+    )
+
+
+def test_declared_scan_or_insufficient_holdout_does_not_complete_requirement(
+    tmp_path: Path,
+) -> None:
+    store, job_id = _store(tmp_path, "coverage-requirement-evidence")
+    store.append_journal(
+        job_id,
+        {
+            "ts": "2026-08-20T00:00:00+00:00",
+            "type": "operator_note",
+            "required_experiments": [
+                {
+                    "id": "btc-scan",
+                    "kind": "signal_scan",
+                    "symbols": ["BTC"],
+                    "timeframes": ["1h"],
+                    "signals": ["sig_a"],
+                },
+                {
+                    "id": "btc-holdout",
+                    "kind": "holdout_check",
+                    "symbol": "BTC",
+                    "signal": "sig_a",
+                    "timeframe": "1h",
+                    "horizon": 1,
+                },
+            ],
+        },
+    )
+    meta = _scan_meta()
+    meta["ts"] = "2026-08-20T00:01:00+00:00"
+    insufficient = {
+        **_scan_test(),
+        "kind": "holdout_check",
+        "ts": "2026-08-20T00:02:00+00:00",
+        "hash": "holdout-1",
+        "verdict": "insufficient",
+    }
+    _write_scan(store, job_id, [meta, insufficient])
+
+    declared_only = build_coverage_certificate(job_id, "majors", store=store)
+    requirements = {row["id"]: row for row in declared_only["required_experiments"]}
+    assert not requirements["btc-scan"]["satisfied"]
+    assert not requirements["btc-holdout"]["satisfied"]
+
+    measured = _scan_test()
+    measured["ts"] = "2026-08-20T00:03:00+00:00"
+    failed_holdout = {
+        **insufficient,
+        "ts": "2026-08-20T00:04:00+00:00",
+        "verdict": "failed",
+    }
+    _write_scan(store, job_id, [measured, failed_holdout])
+    completed = build_coverage_certificate(job_id, "majors", store=store)
+    requirements = {row["id"]: row for row in completed["required_experiments"]}
+    assert requirements["btc-scan"]["satisfied"]
+    assert requirements["btc-holdout"]["satisfied"]
+
+
+def test_owner_reopen_window_expires(tmp_path: Path) -> None:
+    store, job_id = _store(tmp_path, "coverage-reopen-expired")
+    _write_scan(store, job_id, [_scan_meta(), _scan_test()])
+    claim = file_exhaustion_claim(
+        store,
+        job_id,
+        lane="majors",
+        evidence="complete negative scan",
+        provenance="data-wall",
+        next_region="cross-asset",
+    )
+    audited = audit_and_adjudicate_exhaustion_claim(store, job_id, claim["claim_id"])
+    audited["owner_override_until"] = (
+        datetime.now(UTC) - timedelta(seconds=1)
+    ).isoformat()
+    store.write_json(
+        job_id,
+        f"research/exhaustion_claims/{claim['claim_id']}.json",
+        audited,
+    )
+
+    with pytest.raises(ValueError, match="expired"):
+        reopen_exhaustion_claim(
+            store,
+            job_id,
+            claim["claim_id"],
+            by="owner",
+            reason="too late",
+        )
+
+
+def test_rank_requirement_needs_controller_completion_event(tmp_path: Path) -> None:
+    store, job_id = _store(tmp_path, "coverage-rank-requirement")
+    store.append_journal(
+        job_id,
+        {
+            "ts": "2026-08-20T00:00:00+00:00",
+            "type": "operator_note",
+            "required_experiments": [
+                {
+                    "id": "basket-rank",
+                    "kind": "rank_check",
+                    "column": "ratioz_basket96",
+                    "horizons": [1, 4],
+                }
+            ],
+        },
+    )
+    before = build_coverage_certificate(job_id, "majors", store=store)
+    assert not before["required_experiments"][0]["satisfied"]
+
+    store.append_journal(
+        job_id,
+        {
+            "ts": "2026-08-20T00:01:00+00:00",
+            "type": "rank_check_completed",
+            "column": "ratioz_basket96",
+            "horizons": [1, 4, 16],
+            "artifact": "results/research/rank_check.json",
+        },
+    )
+    after = build_coverage_certificate(job_id, "majors", store=store)
+    assert after["required_experiments"][0]["satisfied"]
+
+
+def test_process_efficiency_classifies_learning_activity_and_waste(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, job_id = _store(tmp_path, "efficiency")
+    base = datetime(2026, 8, 20, tzinfo=UTC)
+    experiments = [
+        {
+            "ts": (base + timedelta(minutes=1)).isoformat(),
+            "semantic_hash": "unique-a",
+            "invalid_count": 2,
+        },
+        {
+            "ts": (base + timedelta(minutes=11)).isoformat(),
+            "semantic_hash": "unique-a",
+            "invalid_count": 0,
+        },
+    ]
+    _append_rows(
+        store.job_dir(job_id) / "results/backtest/experiments.jsonl", experiments
+    )
+    journal = [
+        {"ts": (base + timedelta(minutes=5)).isoformat(), "type": "agent_wakeup"},
+        {
+            "ts": (base + timedelta(minutes=12)).isoformat(),
+            "type": "exhaustion_claim_filed",
+        },
+        {"ts": (base + timedelta(minutes=15)).isoformat(), "type": "agent_wakeup"},
+        {
+            "ts": (base + timedelta(minutes=21)).isoformat(),
+            "type": "probation_leg_killed",
+        },
+        {
+            "ts": (base + timedelta(minutes=22)).isoformat(),
+            "type": "operator_note",
+        },
+        {
+            "ts": (base + timedelta(minutes=23)).isoformat(),
+            "type": "exhaustion_claim_reopened",
+            "by": "owner",
+        },
+        {"ts": (base + timedelta(minutes=25)).isoformat(), "type": "agent_wakeup"},
+        {"ts": (base + timedelta(minutes=35)).isoformat(), "type": "agent_wakeup"},
+    ]
+    journal_path = store.job_dir(job_id) / "journal.jsonl"
+    journal_path.write_text("", encoding="utf-8")
+    _append_rows(journal_path, journal)
+    ops = store.job_dir(job_id) / "state/background_ops"
+    ops.mkdir(parents=True)
+    (ops / "rank_check.json").write_text(
+        json.dumps({"op": "rank_check", "state": "failed"}), encoding="utf-8"
+    )
+
+    efficiency = build_process_efficiency(store, job_id)
+    assert efficiency == {
+        "wakes_total": 4,
+        "wakes_with_valid_learning": 2,
+        "activity_only_wakes": 1,
+        "duplicate_experiments": 1,
+        "infra_invalid_experiments": 1,
+        "manual_interventions": 2,
+        "false_closure_reversals": 1,
+        "stalled_background_ops": 1,
+        "wakes_per_valid_learning": 2.0,
+    }
+    store.refresh_scorecard(job_id)
+    assert store.read_json(job_id, "scorecard.json")["process_efficiency"] == efficiency
+    assert (
+        snapshot_job(job_id, store=store)["scorecard"]["process_efficiency"]
+        == efficiency
+    )
+    assert build_evolution_report(store, job_id)["process_efficiency"] == efficiency
+    assert evolution_snapshot_block(store, job_id)["process_efficiency"] == efficiency
+
+    from click.testing import CliRunner
+
+    import wayfinder_paths.jobs.cli as cli_module
+
+    monkeypatch.setattr(cli_module, "JobStore", lambda: store)
+    report = CliRunner().invoke(cli_module.job_cli, ["report", job_id])
+    assert report.exit_code == 0, report.output
+    assert "2.0 wakes/valid-learning" in report.output

--- a/wayfinder_paths/tests/test_jobs_progress_constitution.py
+++ b/wayfinder_paths/tests/test_jobs_progress_constitution.py
@@ -1,5 +1,5 @@
 """Progress constitution: escalating staleness, successor re-arm,
-owner-adjudicated exhaustion, and the paper probation entry tier.
+evidence-adjudicated exhaustion, and the paper probation entry tier.
 
 Motivating incident: all three production research jobs' lanes ended in agent
 SELF-rejections, then froze. Staleness computed correctly every wake, but the
@@ -89,9 +89,7 @@ def _write_experiment_row(
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as handle:
         handle.write(
-            json.dumps(
-                {"ts": ts, "run_id": "exp-1", "semantic_hash": semantic_hash}
-            )
+            json.dumps({"ts": ts, "run_id": "exp-1", "semantic_hash": semantic_hash})
             + "\n"
         )
 
@@ -117,9 +115,7 @@ def test_research_impasse_fires_once_and_wakes_agent(
 
     # Second pass inside the re-alert window: debounced, no duplicate.
     result = recover_stalled_applications(store=store)
-    assert not [
-        e for e in result["recovered"] if e.get("action") == "research_impasse"
-    ]
+    assert not [e for e in result["recovered"] if e.get("action") == "research_impasse"]
     assert len(_journal_events(store, job_id, "research_impasse")) == 1
 
 
@@ -129,9 +125,7 @@ def test_research_impasse_needs_k_stale_wakes(
     store, job_id = _make_store(tmp_path, "impasse-few")
     _append_wakes(store, job_id, 2)  # below the K=3 default
     result = recover_stalled_applications(store=store)
-    assert not [
-        e for e in result["recovered"] if e.get("action") == "research_impasse"
-    ]
+    assert not [e for e in result["recovered"] if e.get("action") == "research_impasse"]
     assert not wakes
 
 
@@ -146,9 +140,7 @@ def test_research_impasse_respects_staleness_thresholds(
     )
     _append_wakes(store, job_id, 3)
     result = recover_stalled_applications(store=store)
-    assert not [
-        e for e in result["recovered"] if e.get("action") == "research_impasse"
-    ]
+    assert not [e for e in result["recovered"] if e.get("action") == "research_impasse"]
 
 
 def test_research_impasse_resolves_on_progress(
@@ -163,9 +155,7 @@ def test_research_impasse_resolves_on_progress(
     store.append_journal(job_id, {"type": "probation_leg_opened", "leg": "x"})
     result = recover_stalled_applications(store=store)
     assert not [
-        e
-        for e in result["recovered"]
-        if e.get("action") == "research_impasse_resolved"
+        e for e in result["recovered"] if e.get("action") == "research_impasse_resolved"
     ]
     assert store.read_json(job_id, "state/research_impasse.json")["alerted_at"]
 
@@ -173,9 +163,7 @@ def test_research_impasse_resolves_on_progress(
     store.append_journal(job_id, {"type": "probation_leg_killed", "leg": "x"})
     result = recover_stalled_applications(store=store)
     resolved = [
-        e
-        for e in result["recovered"]
-        if e.get("action") == "research_impasse_resolved"
+        e for e in result["recovered"] if e.get("action") == "research_impasse_resolved"
     ]
     assert len(resolved) == 1
     assert not store.read_json(job_id, "state/research_impasse.json")
@@ -215,9 +203,7 @@ def test_duplicate_experiment_is_activity_not_learning(
     _write_experiment_row(store, job_id, old, semantic_hash="same-question")
     _append_wakes(store, job_id, 3)
     recover_stalled_applications(store=store)
-    _write_experiment_row(
-        store, job_id, utc_now_iso(), semantic_hash="same-question"
-    )
+    _write_experiment_row(store, job_id, utc_now_iso(), semantic_hash="same-question")
 
     result = recover_stalled_applications(store=store)
     assert not [
@@ -312,9 +298,7 @@ def test_self_rejected_successor_rearms_then_overdue_fires_again(
     # Pass 2: the re-armed window (restarted at the 13h-old rejection) is
     # already overdue → the invitation wakes the agent again.
     result = recover_stalled_applications(store=store)
-    overdue = [
-        e for e in result["recovered"] if e.get("action") == "successor_overdue"
-    ]
+    overdue = [e for e in result["recovered"] if e.get("action") == "successor_overdue"]
     assert len(overdue) == 1
     assert wakes and wakes[-1]["job_id"] == job_id
 
@@ -372,7 +356,9 @@ def test_alive_successor_marks_delivered(
     )
     result = recover_stalled_applications(store=store)
     assert not [
-        e for e in result["recovered"] if str(e.get("action", "")).startswith("successor")
+        e
+        for e in result["recovered"]
+        if str(e.get("action", "")).startswith("successor")
     ]
     assert store.read_json(job_id, "state/successor_expected.json")[0]["delivered"]
     assert not wakes
@@ -386,14 +372,16 @@ def test_audit_progress_counts_as_successor_delivery(
     _write_experiment_row(store, job_id, datetime.now(UTC).isoformat())
     result = recover_stalled_applications(store=store)
     assert not [
-        e for e in result["recovered"] if str(e.get("action", "")).startswith("successor")
+        e
+        for e in result["recovered"]
+        if str(e.get("action", "")).startswith("successor")
     ]
     assert store.read_json(job_id, "state/successor_expected.json")[0]["delivered"]
     assert not wakes
 
 
 # ---------------------------------------------------------------------------
-# Piece 3: owner-adjudicated exhaustion claims
+# Piece 3: evidence-adjudicated exhaustion claims
 
 
 def test_exhaustion_claim_lifecycle_and_owner_only_accept(tmp_path: Path) -> None:
@@ -455,7 +443,12 @@ def test_exhaustion_claim_requires_full_shape(tmp_path: Path) -> None:
         )
     with pytest.raises(ValueError, match="evidence"):
         file_exhaustion_claim(
-            store, job_id, lane="x", evidence=" ", provenance="data-wall", next_region="y"
+            store,
+            job_id,
+            lane="x",
+            evidence=" ",
+            provenance="data-wall",
+            next_region="y",
         )
 
 
@@ -490,7 +483,7 @@ def test_agent_self_rejected_provenance_never_settles(tmp_path: Path) -> None:
     assert not claim_settles_lane(accepted)
 
 
-def test_filed_claim_awaits_without_resolving_then_owner_adjudication_resolves(
+def test_filed_claim_is_mechanically_rejected_without_resolving_impasse(
     tmp_path: Path, wakes: list[dict[str, Any]]
 ) -> None:
     store, job_id = _make_store(tmp_path, "claim-awaiting")
@@ -512,38 +505,31 @@ def test_filed_claim_awaits_without_resolving_then_owner_adjudication_resolves(
         if event.get("action") == "research_impasse_awaiting_adjudication"
     ]
     assert len(awaiting) == 1
+    audited = [
+        event
+        for event in result["recovered"]
+        if event.get("action") == "exhaustion_claims_audited"
+    ]
+    assert len(audited) == 1
+    assert audited[0]["verdicts"][0]["audit_verdict"] == "reject"
     marker = store.read_json(job_id, "state/research_impasse.json")
-    assert marker["status"] == "awaiting_adjudication"
+    assert marker["status"] == "mandated_work"
     assert marker["claim_ids"] == [claim["claim_id"]]
     assert not _journal_events(store, job_id, "research_impasse_resolved")
+    persisted = list_exhaustion_claims(store, job_id)[0]
+    assert persisted["status"] == "rejected"
+    assert persisted["adjudication"]["by"] == "coverage-audit"
 
-    # The in-flight escalation is quiet for the adjudication window.
+    # The rejected claim is terminal and cannot be re-consumed as progress.
     result = recover_stalled_applications(store=store)
     assert not [
         event
         for event in result["recovered"]
-        if event.get("action") in {
-            "research_impasse",
-            "research_impasse_awaiting_adjudication",
-            "research_impasse_resolved",
-        }
+        if event.get("action") == "exhaustion_claims_audited"
     ]
 
-    adjudicate_exhaustion_claim(
-        store, job_id, claim["claim_id"], status="rejected", by="owner"
-    )
-    result = recover_stalled_applications(store=store)
-    resolved = [
-        event
-        for event in result["recovered"]
-        if event.get("action") == "research_impasse_resolved"
-    ]
-    assert len(resolved) == 1
-    assert resolved[0]["adjudication_signals"] == ["exhaustion_claim_rejected"]
-    assert not store.read_json(job_id, "state/research_impasse.json")
 
-
-def test_awaiting_claim_refires_after_48_hours(
+def test_rejected_claim_mandate_refires_without_losing_named_work(
     tmp_path: Path, wakes: list[dict[str, Any]]
 ) -> None:
     store, job_id = _make_store(tmp_path, "claim-awaiting-expired")
@@ -559,8 +545,8 @@ def test_awaiting_claim_refires_after_48_hours(
     )
     recover_stalled_applications(store=store)
     marker = store.read_json(job_id, "state/research_impasse.json")
-    expired = (datetime.now(UTC) - timedelta(hours=49)).isoformat()
-    marker["awaiting_since"] = expired
+    required = marker["mandate"]["required_next_experiments"]
+    expired = (datetime.now(UTC) - timedelta(hours=25)).isoformat()
     marker["alerted_at"] = expired
     store.write_json(job_id, "state/research_impasse.json", marker)
 
@@ -572,10 +558,11 @@ def test_awaiting_claim_refires_after_48_hours(
     ]
     assert len(refired) == 1
     refreshed = store.read_json(job_id, "state/research_impasse.json")
-    assert refreshed.get("status") is None
+    assert refreshed["status"] == "mandated_work"
+    assert refreshed["mandate"]["required_next_experiments"] == required
 
 
-def test_watchdog_surfaces_pending_claims_once(
+def test_watchdog_audits_pending_claims_once(
     tmp_path: Path, wakes: list[dict[str, Any]]
 ) -> None:
     store, job_id = _make_store(tmp_path, "claims-surface")
@@ -588,15 +575,15 @@ def test_watchdog_surfaces_pending_claims_once(
         next_region="lane-b",
     )
     result = recover_stalled_applications(store=store)
-    surfaced = [
-        e for e in result["recovered"] if e.get("action") == "exhaustion_claims_pending"
+    audited = [
+        e for e in result["recovered"] if e.get("action") == "exhaustion_claims_audited"
     ]
-    assert len(surfaced) == 1 and surfaced[0]["count"] == 1
-    assert len(_journal_events(store, job_id, "exhaustion_claims_pending")) == 1
-    # Unchanged queue → silent next pass.
+    assert len(audited) == 1 and audited[0]["count"] == 1
+    assert len(_journal_events(store, job_id, "exhaustion_claim_rejected")) == 1
+    # Terminal queue → silent next pass.
     result = recover_stalled_applications(store=store)
     assert not [
-        e for e in result["recovered"] if e.get("action") == "exhaustion_claims_pending"
+        e for e in result["recovered"] if e.get("action") == "exhaustion_claims_audited"
     ]
 
 
@@ -761,7 +748,7 @@ def test_wake_mandate_hatch_stripped_and_pinned(tmp_path: Path) -> None:
     prompt = sections["stable_prefix"]
     assert "PROGRESS CONSTITUTION" in prompt
     assert "exactly ONE of" in prompt
-    assert "exhaustion claim FILED for owner adjudication" in prompt
+    assert "exhaustion claim FILED for mechanical coverage audit" in prompt
     assert "Self-rejections are development evidence" in prompt
     assert "agent-self-" in prompt
     assert "NOT a legal outcome" in prompt

--- a/wayfinder_paths/tests/test_jobs_rank_check_diagnosis.py
+++ b/wayfinder_paths/tests/test_jobs_rank_check_diagnosis.py
@@ -4,6 +4,10 @@ self-hole — instead of the silent n=0 that wedged the BTC-exog lane."""
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -25,8 +29,7 @@ def _frame(values: np.ndarray, *, seed: int = 0) -> pd.DataFrame:
 def test_panel_wide_column_fails_loud() -> None:
     shared = np.sin(np.arange(_N))  # varies in time, constant across symbols
     frames = {
-        s: _frame(shared.copy(), seed=i)
-        for i, s in enumerate(("A", "B", "C", "D"))
+        s: _frame(shared.copy(), seed=i) for i, s in enumerate(("A", "B", "C", "D"))
     }
     with pytest.raises(ValueError, match="cross-sectionally constant"):
         rank_ic(frames, "col")
@@ -51,6 +54,70 @@ def test_varying_column_still_ranks() -> None:
     }
     result = rank_ic(frames, "col")
     assert result["horizons"][0]["n"] > 0
+
+
+def test_rank_check_persists_controller_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import wayfinder_paths.jobs.execution.features as features_module
+    import wayfinder_paths.jobs.execution.job as job_module
+    import wayfinder_paths.jobs.execution.primitives as primitives_module
+    import wayfinder_paths.jobs.execution.simulator as simulator_module
+    import wayfinder_paths.jobs.execution.validation as validation_module
+    import wayfinder_paths.jobs.research as research_module
+    from wayfinder_paths.jobs.models import WayfinderJob
+    from wayfinder_paths.jobs.store import JobStore
+
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("rank-evidence", agent_mode="intervene")
+    store.save(job)
+    frame = pd.DataFrame(
+        {
+            "symbol": ["A", "B", "C", "D"],
+            "ratioz_basket96": [1.0, 2.0, 3.0, 4.0],
+        }
+    )
+    bars = SimpleNamespace(to_frame=lambda: frame)
+    monkeypatch.setattr(job_module, "_load_job_yaml", lambda _root: {})
+    monkeypatch.setattr(
+        validation_module, "resolve_execution_spec", lambda _root, _job: ({}, {})
+    )
+    monkeypatch.setattr(
+        primitives_module.ExecutionSpec,
+        "from_dict",
+        classmethod(lambda cls, _data: SimpleNamespace()),
+    )
+    monkeypatch.setattr(
+        job_module,
+        "_load_dataset",
+        lambda _root, _spec, _job, **_kwargs: SimpleNamespace(bars=bars),
+    )
+    monkeypatch.setattr(simulator_module, "_load_strategy", lambda *_args: object())
+    monkeypatch.setattr(features_module, "apply_precompute", lambda *_args: bars)
+    monkeypatch.setattr(store, "resolve_script_entrypoint", lambda *_args: tmp_path)
+    monkeypatch.setattr(
+        research_module,
+        "rank_ic",
+        lambda *_args, **_kwargs: {"has_edge": False, "horizons": []},
+    )
+
+    result = research_module.rank_check_job(
+        job.id,
+        column="ratioz_basket96",
+        horizons=[1, 4],
+        store=store,
+    )
+    artifact = store.job_dir(job.id) / "results/research/rank_check.json"
+    assert (
+        json.loads(artifact.read_text(encoding="utf-8"))["column"] == "ratioz_basket96"
+    )
+    assert result["artifact"] == str(artifact)
+    completed = [
+        row
+        for row in store.read_jsonl(job.id, "journal.jsonl")
+        if row.get("type") == "rank_check_completed"
+    ]
+    assert completed[0]["horizons"] == [1, 4]
 
 
 def test_basket_relative_column_derives_cross_sectionally(tmp_path) -> None:


### PR DESCRIPTION
## Summary

- build a durable coverage certificate from scan, experiment, journal, holdout, cost, and parked-candidate evidence
- classify audits as pass, narrow, or reject without treating blocked, invalid, underpowered, or not-run cells as negative evidence
- settle only audited scope, preserve unresolved mandates, and allow a 48-hour owner reopen
- persist rank-check evidence and surface process-efficiency counters in wake prompts, reports, and scorecards
- add focused coverage, provenance, retry-safety, probation, requirement, and efficiency tests

## Verification

- 1,040 passed, 9 skipped for pytest -k jobs or runner or mcp
- Ruff and formatting clean across all 19 changed Python files
- scoped mypy clean across all 12 changed production modules
- diff check clean

Stacked on scan-family-controls.