### PR TITLE
Jobs: make anti-spin resolution require valid learning

### DIFF
--- a/wayfinder_paths/jobs/execution/experiments.py
+++ b/wayfinder_paths/jobs/execution/experiments.py
@@ -50,9 +50,7 @@ def experiment_semantic_hash(row: Mapping[str, Any]) -> str:
 def _experiment_definition(grid_payload: Mapping[str, Any]) -> dict[str, Any]:
     result = grid_payload["result"]
     parameters = [run.get("params") for run in result.get("runs") or []]
-    parameters.sort(
-        key=lambda value: json.dumps(value, sort_keys=True, default=str)
-    )
+    parameters.sort(key=lambda value: json.dumps(value, sort_keys=True, default=str))
     return {
         "revision": grid_payload.get("revision"),
         "dataset": grid_payload.get("dataset"),

--- a/wayfinder_paths/jobs/execution/experiments.py
+++ b/wayfinder_paths/jobs/execution/experiments.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import tempfile
 from collections.abc import Mapping
@@ -15,6 +16,54 @@ from wayfinder_paths.jobs.store import JobStore
 
 EXPERIMENTS_FILE = "results/backtest/experiments.jsonl"
 TRIALS_FILE = "results/backtest/trials.jsonl"
+
+
+def experiment_semantic_hash(row: Mapping[str, Any]) -> str:
+    """Stable identity for the question an experiment asks, not its run id.
+
+    New experiment rows carry this hash directly. The fallback keeps legacy
+    ledgers classifiable using the definition fields they retained; timestamps,
+    generated ids and observed statistics deliberately do not participate.
+    """
+    recorded = str(row.get("semantic_hash") or "").strip()
+    if recorded:
+        return recorded
+    raw_best = row.get("best")
+    best: Mapping[str, Any] = raw_best if isinstance(raw_best, Mapping) else {}
+    definition = {
+        "revision": row.get("revision"),
+        "dataset": row.get("dataset"),
+        "rank_by": row.get("rank_by"),
+        "optimizer": row.get("optimizer") or "grid",
+        "search": row.get("search"),
+        "parameters": (
+            row.get("parameters")
+            if row.get("parameters") is not None
+            else ([best.get("params")] if best.get("params") is not None else [])
+        ),
+        "walk_forward": row.get("walk_forward_definition"),
+    }
+    encoded = json.dumps(definition, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _experiment_definition(grid_payload: Mapping[str, Any]) -> dict[str, Any]:
+    result = grid_payload["result"]
+    parameters = [run.get("params") for run in result.get("runs") or []]
+    parameters.sort(
+        key=lambda value: json.dumps(value, sort_keys=True, default=str)
+    )
+    return {
+        "revision": grid_payload.get("revision"),
+        "dataset": grid_payload.get("dataset"),
+        "rank_by": result.get("rank_by"),
+        "optimizer": result.get("optimizer") or "grid",
+        "search": result.get("search"),
+        # Grid ids and run ids are regenerated on every invocation. The tested
+        # coordinates are the semantic family and preserve duplicate identity.
+        "parameters": parameters,
+        "walk_forward_definition": grid_payload.get("walk_forward_definition"),
+    }
 
 
 def _behavior_descriptor(stats: Mapping[str, Any]) -> dict[str, Any]:
@@ -88,6 +137,7 @@ def record_experiment(
     result = grid_payload["result"]
     ranked = result["ranked"]
     best = ranked[0] if ranked else None
+    definition = _experiment_definition(grid_payload)
     row = {
         "ts": utc_now_iso(),
         **revision_stamp(store.job_dir(job_id)),
@@ -97,6 +147,7 @@ def record_experiment(
         "rank_by": result["rank_by"],
         "run_count": len(result["runs"]),
         "invalid_count": len(result["invalid"]),
+        "semantic_hash": experiment_semantic_hash(definition),
         "best": (
             {
                 "run_id": best["run_id"],

--- a/wayfinder_paths/jobs/execution/job.py
+++ b/wayfinder_paths/jobs/execution/job.py
@@ -215,6 +215,9 @@ def _backtest_execution_job_locked(
             **stamp,
         }
         if walk_forward is not None:
+            # Preserve the question asked separately from its observed folds;
+            # experiment identity must not change merely because results do.
+            payload["walk_forward_definition"] = dict(walk_forward)
             payload["walk_forward"] = run_walk_forward(
                 script,
                 dataset,

--- a/wayfinder_paths/jobs/exhaustion.py
+++ b/wayfinder_paths/jobs/exhaustion.py
@@ -10,10 +10,10 @@ verdict for an authorized reviewer, not a self-grant: agents FILE claims
 ACCEPT one — the same owner-provenance pattern as proposal rejection, script
 mode stamps, and risk-latched halt clears.
 
-A pending or accepted claim satisfies the progress constitution for its lane
-(the escalation is on the record and the decision is with the owner). A claim
-whose provenance is `agent-self-rejected` can never settle a lane, whatever
-its status: self-rejections are development evidence, not verdicts.
+Only an owner-accepted claim settles its audited lane. Filing is activity — it
+puts an escalation in flight — but is not evidence that the lane is exhausted.
+A claim whose provenance is `agent-self-rejected` can never settle a lane,
+whatever its status: self-rejections are development evidence, not verdicts.
 """
 
 from __future__ import annotations
@@ -160,9 +160,10 @@ def list_exhaustion_claims(
 def claim_settles_lane(claim: dict[str, Any]) -> bool:
     """Whether this claim satisfies the progress constitution for its lane.
 
-    Pending and accepted claims settle (the escalation is filed / decided);
+    Filing is an escalation, not a verdict. Only owner acceptance settles;
     `agent-self-rejected` provenance NEVER settles — nothing in the loop may
     control the only evidence used for its own acceptance."""
     if claim.get("provenance") == "agent-self-rejected":
         return False
-    return claim.get("status") in {"pending", "accepted"}
+    adjudication = claim.get("adjudication") or {}
+    return claim.get("status") == "accepted" and adjudication.get("by") == "owner"

--- a/wayfinder_paths/jobs/watchdog.py
+++ b/wayfinder_paths/jobs/watchdog.py
@@ -24,7 +24,7 @@ import signal
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from textwrap import dedent
-from typing import Any
+from typing import Any, TypedDict
 
 from wayfinder_paths.jobs.application import complete_application
 from wayfinder_paths.jobs.failures import cpu_steal_pct
@@ -379,7 +379,13 @@ def _check_successor_overdue(
         audit_progress = _research_progress_since(
             store.job_dir(job_id), entry_ts
         )
-        if alive or owner_closed or audit_progress["advanced"]:
+        if (
+            alive
+            or owner_closed
+            or audit_progress["valid_learning"]
+            or audit_progress["activity"]
+            or audit_progress["adjudicated"]
+        ):
             entry["delivered"] = True
             entry["notified"] = True
             changed = True
@@ -852,23 +858,40 @@ def _check_disk_usage(
 # verbatim across wakes) while staging nothing. Staleness was never a
 # watchdog trigger, so nothing escalated. This check is the escalation: when
 # a research job is stale AND the last K wakes produced zero progress
-# artifacts (experiments, probation legs, staged proposals, exhaustion
+# artifacts (experiments, probation outcomes, staged proposals, exhaustion
 # claims), journal `research_impasse`, write the marker the worker prompt
 # renders as a HATCH-STRIPPED mandate, and fire a trigger wake. Debounced by
 # a re-alert window (mirrors disk_pressure); the marker clears — and journals
-# `research_impasse_resolved` — only when a progress artifact appears.
+# `research_impasse_resolved` — only when valid learning or owner adjudication
+# appears. Activity remains visible without laundering it into learning.
 _IMPASSE_PATH = "state/research_impasse.json"
 IMPASSE_WAKES_ENV = "WAYFINDER_IMPASSE_WAKES"
 DEFAULT_IMPASSE_WAKES = 3
 IMPASSE_REALERT_WINDOW = timedelta(hours=24)
-# Journal event types that count as research progress: the three legal
-# outcomes of a stale wake plus a staged proposal (which carries its own
-# propose-time backtest audit; self-rejected stagings are filtered out).
-_PROGRESS_JOURNAL_TYPES = {
+IMPASSE_ADJUDICATION_WINDOW = timedelta(hours=48)
+_LEARNING_JOURNAL_TYPES = {
+    "probation_leg_graduated",
+    "probation_leg_killed",
+}
+_ACTIVITY_JOURNAL_TYPES = {
     "probation_leg_opened",
     "paper_probation_opened",
     "exhaustion_claim_filed",
 }
+_OWNER_ADJUDICATION_TYPES = {
+    "exhaustion_claim_accepted",
+    "exhaustion_claim_rejected",
+}
+
+
+class ResearchProgressClassification(TypedDict):
+    advanced: bool
+    valid_learning: bool
+    learning_signals: list[str]
+    activity: bool
+    activity_signals: list[str]
+    adjudicated: bool
+    adjudication_signals: list[str]
 
 
 def _journal_rows(root: Path, *, max_lines: int = 20_000) -> list[dict[str, Any]]:
@@ -892,23 +915,54 @@ def _research_progress_since(
     *,
     rows: list[dict[str, Any]] | None = None,
     proposals: list[dict[str, Any]] | None = None,
-) -> dict[str, Any]:
-    """Progress artifacts after `since_ts`: executed experiments, opened
-    probation legs, filed exhaustion claims and (when `proposals` is given)
-    staged proposals that were not agent-self-rejected. Prose does not count."""
-    signals: set[str] = set()
+) -> ResearchProgressClassification:
+    """Classify post-boundary research artifacts as learning or activity.
+
+    Valid learning is a previously unseen semantic experiment or a matured
+    probation outcome. Opening work, staging a proposal, filing a claim, and
+    repeating an experiment are activity only. Owner claim adjudication is a
+    separate resolution path. Prose never counts.
+    """
+    learning: set[str] = set()
+    activity: set[str] = set()
+    adjudications: set[str] = set()
     for row in rows if rows is not None else _journal_rows(root):
-        if row.get("type") in _PROGRESS_JOURNAL_TYPES and (
-            str(row.get("ts") or "") > since_ts
-        ):
-            signals.add(str(row["type"]))
-    line = _tail_line(root / "results" / "backtest" / "experiments.jsonl")
-    if line:
-        try:
-            if str(json.loads(line).get("ts") or "") > since_ts:
-                signals.add("experiment_run")
-        except ValueError:
-            pass
+        if str(row.get("ts") or "") <= since_ts:
+            continue
+        event_type = str(row.get("type") or "")
+        if event_type in _LEARNING_JOURNAL_TYPES:
+            learning.add(event_type)
+        elif event_type in _ACTIVITY_JOURNAL_TYPES:
+            activity.add(event_type)
+        elif event_type in _OWNER_ADJUDICATION_TYPES and str(
+            row.get("by") or ""
+        ) in {"owner", "user", "human"}:
+            adjudications.add(event_type)
+
+    from wayfinder_paths.jobs.execution.experiments import experiment_semantic_hash
+
+    seen_hashes: set[str] = set()
+    experiments_path = root / "results" / "backtest" / "experiments.jsonl"
+    if experiments_path.exists():
+        for line in experiments_path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                experiment = json.loads(line)
+            except ValueError:
+                continue
+            if not isinstance(experiment, dict):
+                continue
+            semantic_hash = experiment_semantic_hash(experiment)
+            if str(experiment.get("ts") or "") <= since_ts:
+                seen_hashes.add(semantic_hash)
+                continue
+            if semantic_hash in seen_hashes:
+                activity.add("duplicate_experiment")
+            else:
+                learning.add("experiment_run")
+                seen_hashes.add(semantic_hash)
+
     for proposal in proposals or []:
         if not _staged_after(proposal, since_ts):
             continue
@@ -917,8 +971,18 @@ def _research_progress_since(
             and str((proposal.get("rejection") or {}).get("by") or "") == "agent"
         ):
             continue  # a self-rejected staging delivered nothing
-        signals.add("staged_proposal")
-    return {"advanced": bool(signals), "signals": sorted(signals)}
+        activity.add("staged_proposal")
+    return {
+        # Compatibility for existing mechanical consumers: "advanced" now
+        # has the strict meaning the name promised.
+        "advanced": bool(learning),
+        "valid_learning": bool(learning),
+        "learning_signals": sorted(learning),
+        "activity": bool(activity),
+        "activity_signals": sorted(activity),
+        "adjudicated": bool(adjudications),
+        "adjudication_signals": sorted(adjudications),
+    }
 
 
 def _check_research_impasse(
@@ -947,21 +1011,63 @@ def _check_research_impasse(
     progress = _research_progress_since(
         root, basis_ts, rows=rows, proposals=proposals
     )
-    if progress["advanced"]:
+    if progress["valid_learning"] or progress["adjudicated"]:
         if marker.get("alerted_at"):
             store.write_json(job.id, _IMPASSE_PATH, {})
             store.append_journal(
                 job.id,
                 {
                     "type": "research_impasse_resolved",
-                    "signals": progress["signals"],
+                    "learning_signals": progress["learning_signals"],
+                    "adjudication_signals": progress["adjudication_signals"],
                 },
             )
             return {
                 "action": "research_impasse_resolved",
-                "signals": progress["signals"],
+                "learning_signals": progress["learning_signals"],
+                "adjudication_signals": progress["adjudication_signals"],
             }
         return None
+    if marker.get("status") == "awaiting_adjudication":
+        if _age(now, marker.get("awaiting_since")) < IMPASSE_ADJUDICATION_WINDOW:
+            return None
+        # The 48-hour adjudication window expired. Do not re-consume the old
+        # filing as fresh activity; fall through to the normal impasse re-fire.
+    elif "exhaustion_claim_filed" in progress["activity_signals"]:
+        filed = [
+            row
+            for row in rows
+            if row.get("type") == "exhaustion_claim_filed"
+            and str(row.get("ts") or "") > basis_ts
+        ]
+        filed_at = max(str(row.get("ts") or "") for row in filed)
+        awaiting = {
+            **marker,
+            "status": "awaiting_adjudication",
+            "awaiting_since": filed_at,
+            "claim_ids": sorted(
+                {
+                    str(row.get("claim_id"))
+                    for row in filed
+                    if row.get("claim_id")
+                }
+            ),
+        }
+        if not marker.get("alerted_at"):
+            awaiting["alerted_at"] = now.isoformat()
+        store.write_json(job.id, _IMPASSE_PATH, awaiting)
+        if marker.get("status") != "awaiting_adjudication":
+            store.append_journal(
+                job.id,
+                {
+                    "type": "research_impasse_awaiting_adjudication",
+                    "claim_ids": awaiting["claim_ids"],
+                },
+            )
+        return {
+            "action": "research_impasse_awaiting_adjudication",
+            "claim_ids": awaiting["claim_ids"],
+        }
     from wayfinder_paths.jobs.evolution_ledger import research_staleness_report
 
     staleness = research_staleness_report(store, job.id)

--- a/wayfinder_paths/tests/test_jobs_experiments.py
+++ b/wayfinder_paths/tests/test_jobs_experiments.py
@@ -29,9 +29,18 @@ def test_run_experiment_records_and_ranks(tmp_path: Path) -> None:
     assert experiment["rank_by"] == "sharpe"
     assert experiment["run_count"] == 2
     assert experiment["best"]["params"]
+    assert len(experiment["semantic_hash"]) == 64
     rows = list_experiments(job_id, store=store)
     assert len(rows) == 1
     assert (root / "results" / "backtest" / "experiments.jsonl").exists()
+
+    repeated = run_experiment(
+        job_id,
+        {"threshold": [100.0, 10.0]},  # coordinate order is not semantic
+        rank_by="sharpe",
+        store=store,
+    )["experiment"]
+    assert repeated["semantic_hash"] == experiment["semantic_hash"]
 
 
 def test_promote_params_direct_updates_job_and_revision(tmp_path: Path) -> None:

--- a/wayfinder_paths/tests/test_jobs_progress_constitution.py
+++ b/wayfinder_paths/tests/test_jobs_progress_constitution.py
@@ -22,6 +22,7 @@ from typing import Any
 
 import pytest
 
+from wayfinder_paths.jobs.execution.experiments import experiment_semantic_hash
 from wayfinder_paths.jobs.exhaustion import (
     adjudicate_exhaustion_claim,
     claim_settles_lane,
@@ -77,11 +78,22 @@ def _append_wakes(store: JobStore, job_id: str, count: int) -> None:
         store.append_journal(job_id, {"type": "agent_wakeup"})
 
 
-def _write_experiment_row(store: JobStore, job_id: str, ts: str) -> None:
+def _write_experiment_row(
+    store: JobStore,
+    job_id: str,
+    ts: str,
+    *,
+    semantic_hash: str = "experiment-a",
+) -> None:
     path = store.job_dir(job_id) / "results" / "backtest" / "experiments.jsonl"
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps({"ts": ts, "run_id": "exp-1"}) + "\n")
+        handle.write(
+            json.dumps(
+                {"ts": ts, "run_id": "exp-1", "semantic_hash": semantic_hash}
+            )
+            + "\n"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -147,8 +159,18 @@ def test_research_impasse_resolves_on_progress(
     recover_stalled_applications(store=store)
     assert store.read_json(job_id, "state/research_impasse.json")["alerted_at"]
 
-    # A real progress artifact appears (probation leg opened after the wakes).
+    # Opening a leg is activity, not learning; it must not clear the marker.
     store.append_journal(job_id, {"type": "probation_leg_opened", "leg": "x"})
+    result = recover_stalled_applications(store=store)
+    assert not [
+        e
+        for e in result["recovered"]
+        if e.get("action") == "research_impasse_resolved"
+    ]
+    assert store.read_json(job_id, "state/research_impasse.json")["alerted_at"]
+
+    # A matured probation outcome is valid learning and resolves the impasse.
+    store.append_journal(job_id, {"type": "probation_leg_killed", "leg": "x"})
     result = recover_stalled_applications(store=store)
     resolved = [
         e
@@ -158,6 +180,67 @@ def test_research_impasse_resolves_on_progress(
     assert len(resolved) == 1
     assert not store.read_json(job_id, "state/research_impasse.json")
     assert _journal_events(store, job_id, "research_impasse_resolved")
+
+
+def test_all_new_experiment_rows_checked_not_only_last(
+    tmp_path: Path, wakes: list[dict[str, Any]]
+) -> None:
+    store, job_id = _make_store(tmp_path, "impasse-all-experiments")
+    _append_wakes(store, job_id, 3)
+    recover_stalled_applications(store=store)
+
+    # The unique experiment is followed by a duplicate. Inspecting only the
+    # tail would miss the valid learning that occurred earlier in the batch.
+    _write_experiment_row(
+        store, job_id, utc_now_iso(), semantic_hash="new-semantic-question"
+    )
+    _write_experiment_row(
+        store, job_id, utc_now_iso(), semantic_hash="new-semantic-question"
+    )
+    result = recover_stalled_applications(store=store)
+    resolved = [
+        event
+        for event in result["recovered"]
+        if event.get("action") == "research_impasse_resolved"
+    ]
+    assert len(resolved) == 1
+    assert resolved[0]["learning_signals"] == ["experiment_run"]
+
+
+def test_duplicate_experiment_is_activity_not_learning(
+    tmp_path: Path, wakes: list[dict[str, Any]]
+) -> None:
+    store, job_id = _make_store(tmp_path, "impasse-duplicate")
+    old = (datetime.now(UTC) - timedelta(days=10)).isoformat()
+    _write_experiment_row(store, job_id, old, semantic_hash="same-question")
+    _append_wakes(store, job_id, 3)
+    recover_stalled_applications(store=store)
+    _write_experiment_row(
+        store, job_id, utc_now_iso(), semantic_hash="same-question"
+    )
+
+    result = recover_stalled_applications(store=store)
+    assert not [
+        event
+        for event in result["recovered"]
+        if event.get("action") == "research_impasse_resolved"
+    ]
+    assert store.read_json(job_id, "state/research_impasse.json")["alerted_at"]
+
+
+def test_experiment_semantic_hash_ignores_generated_ids() -> None:
+    definition = {
+        "revision": "rev-a",
+        "dataset": {"path": "candles.parquet"},
+        "rank_by": "sharpe",
+        "parameters": [{"lookback": 20}, {"lookback": 40}],
+    }
+    first = {**definition, "grid_id": "generated-a", "ts": "2026-08-20T00:00:00Z"}
+    second = {**definition, "grid_id": "generated-b", "ts": "2026-08-21T00:00:00Z"}
+    assert experiment_semantic_hash(first) == experiment_semantic_hash(second)
+    assert experiment_semantic_hash(first) != experiment_semantic_hash(
+        {**second, "parameters": [{"lookback": 80}]}
+    )
 
 
 def test_impasse_wake_carries_hatch_stripped_mandate(tmp_path: Path) -> None:
@@ -325,6 +408,7 @@ def test_exhaustion_claim_lifecycle_and_owner_only_accept(tmp_path: Path) -> Non
         refs=["results/backtest/experiments.jsonl"],
     )
     assert claim["status"] == "pending"
+    assert not claim_settles_lane(claim)
     assert _journal_events(store, job_id, "exhaustion_claim_filed")
     scorecard = store.read_json(job_id, "scorecard.json")
     assert scorecard["pending_exhaustion_claims"] == 1
@@ -385,7 +469,11 @@ def test_agent_self_rejected_provenance_never_settles(tmp_path: Path) -> None:
         provenance="holdout-refuted",
         next_region="lane-b",
     )
-    assert claim_settles_lane(settled)  # pending settles
+    assert not claim_settles_lane(settled)  # filing is activity, not a verdict
+    settled = adjudicate_exhaustion_claim(
+        store, job_id, settled["claim_id"], status="accepted", by="owner"
+    )
+    assert claim_settles_lane(settled)
     self_rej = file_exhaustion_claim(
         store,
         job_id,
@@ -400,6 +488,91 @@ def test_agent_self_rejected_provenance_never_settles(tmp_path: Path) -> None:
     )
     # Even owner-accepted, self-rejection provenance cannot settle a lane.
     assert not claim_settles_lane(accepted)
+
+
+def test_filed_claim_awaits_without_resolving_then_owner_adjudication_resolves(
+    tmp_path: Path, wakes: list[dict[str, Any]]
+) -> None:
+    store, job_id = _make_store(tmp_path, "claim-awaiting")
+    _append_wakes(store, job_id, 3)
+    recover_stalled_applications(store=store)
+    claim = file_exhaustion_claim(
+        store,
+        job_id,
+        lane="HYPE 5m",
+        evidence="completed 5m cells",
+        provenance="data-wall",
+        next_region="HYPE multi-timeframe",
+    )
+
+    result = recover_stalled_applications(store=store)
+    awaiting = [
+        event
+        for event in result["recovered"]
+        if event.get("action") == "research_impasse_awaiting_adjudication"
+    ]
+    assert len(awaiting) == 1
+    marker = store.read_json(job_id, "state/research_impasse.json")
+    assert marker["status"] == "awaiting_adjudication"
+    assert marker["claim_ids"] == [claim["claim_id"]]
+    assert not _journal_events(store, job_id, "research_impasse_resolved")
+
+    # The in-flight escalation is quiet for the adjudication window.
+    result = recover_stalled_applications(store=store)
+    assert not [
+        event
+        for event in result["recovered"]
+        if event.get("action") in {
+            "research_impasse",
+            "research_impasse_awaiting_adjudication",
+            "research_impasse_resolved",
+        }
+    ]
+
+    adjudicate_exhaustion_claim(
+        store, job_id, claim["claim_id"], status="rejected", by="owner"
+    )
+    result = recover_stalled_applications(store=store)
+    resolved = [
+        event
+        for event in result["recovered"]
+        if event.get("action") == "research_impasse_resolved"
+    ]
+    assert len(resolved) == 1
+    assert resolved[0]["adjudication_signals"] == ["exhaustion_claim_rejected"]
+    assert not store.read_json(job_id, "state/research_impasse.json")
+
+
+def test_awaiting_claim_refires_after_48_hours(
+    tmp_path: Path, wakes: list[dict[str, Any]]
+) -> None:
+    store, job_id = _make_store(tmp_path, "claim-awaiting-expired")
+    _append_wakes(store, job_id, 3)
+    recover_stalled_applications(store=store)
+    file_exhaustion_claim(
+        store,
+        job_id,
+        lane="rank lane",
+        evidence="caller timed out",
+        provenance="data-wall",
+        next_region="instrument caller timeout",
+    )
+    recover_stalled_applications(store=store)
+    marker = store.read_json(job_id, "state/research_impasse.json")
+    expired = (datetime.now(UTC) - timedelta(hours=49)).isoformat()
+    marker["awaiting_since"] = expired
+    marker["alerted_at"] = expired
+    store.write_json(job_id, "state/research_impasse.json", marker)
+
+    result = recover_stalled_applications(store=store)
+    refired = [
+        event
+        for event in result["recovered"]
+        if event.get("action") == "research_impasse"
+    ]
+    assert len(refired) == 1
+    refreshed = store.read_json(job_id, "state/research_impasse.json")
+    assert refreshed.get("status") is None
 
 
 def test_watchdog_surfaces_pending_claims_once(


### PR DESCRIPTION
## Summary

- separate durable learning from claim, proposal, and experiment activity
- fingerprint experiments semantically so replayed work cannot clear an impasse
- keep pending claims open until owner adjudication or qualifying learning, with a 48-hour awaiting state
- inspect the complete experiment ledger when classifying progress

## Verification

- included in 1,040 passing jobs, runner, and MCP tests
- Ruff and formatting clean
- scoped mypy clean
- diff check clean