### PR TITLE
Jobs: Treat paper-entry refusals as completed evidence

### DIFF
--- a/wayfinder_paths/jobs/coverage.py
+++ b/wayfinder_paths/jobs/coverage.py
@@ -36,6 +36,11 @@ CELL_COUNT_KEYS = (
     "not_run",
 )
 _CANDIDATE_VERDICTS = {"probation", "promote"}
+_PROBATION_ENTRY_EVENTS = {
+    "paper_probation_opened",
+    "probation_leg_opened",
+    "paper_probation_entry_refused",
+}
 _SCAN_LEDGER_PATH = "results/research/signal_scan/ledger.jsonl"
 _EXPERIMENTS_PATH = "results/backtest/experiments.jsonl"
 _LEGACY_SCAN_WRITE_WINDOW_SECONDS = 600
@@ -324,7 +329,7 @@ def _requirement_satisfied(
         )
     if kind == "paper_probation":
         return any(
-            row.get("type") in {"paper_probation_opened", "probation_leg_opened"}
+            row.get("type") in _PROBATION_ENTRY_EVENTS
             and _at_or_after(row.get("ts"), note_ts)
             and (
                 not requirement.get("symbol")
@@ -412,13 +417,12 @@ def _candidate_followups(
         ]
         latest = matches[-1] if matches else None
         holdout_verdict = str((latest or {}).get("verdict") or "")
-        probation = None
+        entry_event = None
         symbol = str(cell.get("symbol") or "")
         for event in journal:
-            if event.get("type") not in {
-                "paper_probation_opened",
-                "probation_leg_opened",
-            } or not _at_or_after(event.get("ts"), cell.get("ts")):
+            if event.get("type") not in _PROBATION_ENTRY_EVENTS or not _at_or_after(
+                event.get("ts"), cell.get("ts")
+            ):
                 continue
             exact = all(
                 not event.get(key) or event.get(key) == cell.get(key)
@@ -434,28 +438,47 @@ def _candidate_followups(
                 )
                 and candidate_symbols.count(symbol) == 1
             )
-            if exact and (event.get("signal") or symbol_only):
-                probation = event
-        probation_outcome = None
-        if probation is not None:
+            if event.get("type") == "paper_probation_entry_refused":
+                # A refusal may refute a scan candidate only when it names the
+                # exact coordinate and carries a durable evidence reference.
+                # The entry API also accepts explicit comparison numbers, so
+                # treating a legacy symbol-only refusal as candidate evidence
+                # would let one arbitrary call erase every lead for a symbol.
+                refusal_matches = all(
+                    event.get(key) == cell.get(key)
+                    for key in ("symbol", "signal", "timeframe", "horizon")
+                ) and bool(event.get("proposal_id") or event.get("artifact"))
+                if refusal_matches:
+                    entry_event = event
+            elif exact and (event.get("signal") or symbol_only):
+                entry_event = event
+        lifecycle_outcome = None
+        if entry_event is not None:
             outcomes = [
                 event
                 for event in journal
                 if event.get("type")
                 in {"probation_leg_graduated", "probation_leg_killed"}
-                and event.get("leg") == probation.get("leg")
-                and _at_or_after(event.get("ts"), probation.get("ts"))
+                and event.get("leg") == entry_event.get("leg")
+                and _at_or_after(event.get("ts"), entry_event.get("ts"))
             ]
-            probation_outcome = outcomes[-1].get("type") if outcomes else None
+            lifecycle_outcome = outcomes[-1].get("type") if outcomes else None
 
-        if (
-            holdout_verdict == "confirmed"
-            or probation_outcome == "probation_leg_graduated"
-        ):
+        refused = (entry_event or {}).get("type") == "paper_probation_entry_refused"
+        # A matured probation verdict is newer deployment evidence and
+        # outranks the holdout that admitted the candidate. Otherwise a
+        # holdout-confirmed leg that is later killed remains unresolved
+        # forever. A mechanical entry refusal is likewise completed negative
+        # evidence: no leg was deployed, but the candidate was not parked.
+        if lifecycle_outcome == "probation_leg_graduated":
             state = "confirmed_open"
-        elif holdout_verdict == "failed" or probation_outcome == "probation_leg_killed":
+        elif lifecycle_outcome == "probation_leg_killed" or refused:
             state = "refuted"
-        elif probation is not None:
+        elif holdout_verdict == "confirmed":
+            state = "confirmed_open"
+        elif holdout_verdict == "failed":
+            state = "refuted"
+        elif entry_event is not None:
             state = "probation_active"
         elif latest is None:
             state = "parked"
@@ -470,7 +493,7 @@ def _candidate_followups(
                 "scan_verdict": cell.get("verdict"),
                 "state": state,
                 "holdout_verdict": holdout_verdict or None,
-                "probation_leg": (probation or {}).get("leg"),
+                "probation_leg": (entry_event or {}).get("leg"),
             }
         )
     return followups

--- a/wayfinder_paths/jobs/probation.py
+++ b/wayfinder_paths/jobs/probation.py
@@ -188,6 +188,24 @@ def open_paper_probation_leg(
         spec=spec,
     )
     if not check["eligible"]:
+        # A mechanical refusal is a completed candidate evaluation, not an
+        # unattempted paper deployment. Keep it durable so coverage audits do
+        # not repeatedly mandate a candidate the entry gate already rejected.
+        store.append_journal(
+            job_id,
+            {
+                "type": "paper_probation_entry_refused",
+                "leg": name,
+                "symbol": symbol,
+                "proposal_id": proposal_id,
+                "entry": {
+                    "candidate_net_return": float(candidate_net),
+                    "baseline_net_return": float(baseline_net),
+                    "backtest_trades": int(backtest_trades or 0),
+                    **check,
+                },
+            },
+        )
         raise ValueError(
             "paper probation entry refused: " + "; ".join(check["reasons"])
         )

--- a/wayfinder_paths/tests/test_jobs_coverage.py
+++ b/wayfinder_paths/tests/test_jobs_coverage.py
@@ -346,6 +346,88 @@ def test_probation_followup_is_not_parked_and_kill_is_negative_evidence(
     assert killed_audit["verdict"] == "pass"
 
 
+def test_paper_entry_refusal_completes_requirement_and_refutes_candidate(
+    tmp_path: Path,
+) -> None:
+    store, job_id = _store(tmp_path, "coverage-paper-refusal")
+    _write_scan(store, job_id, [_scan_meta(), _scan_test(verdict="probation")])
+    store.append_journal(
+        job_id,
+        {
+            "ts": "2026-08-20T00:02:00+00:00",
+            "type": "operator_note",
+            "required_experiments": [
+                {
+                    "id": "btc-paper-probation",
+                    "kind": "paper_probation",
+                    "symbol": "BTC",
+                }
+            ],
+        },
+    )
+    before = build_coverage_certificate(job_id, "majors", store=store)
+    assert not before["required_experiments"][0]["satisfied"]
+    assert before["candidate_followups"][0]["state"] == "parked"
+
+    store.append_journal(
+        job_id,
+        {
+            "ts": "2026-08-20T00:03:00+00:00",
+            "type": "paper_probation_entry_refused",
+            "leg": "sig-a-paper",
+            "symbol": "BTC",
+            "signal": "sig_a",
+            "timeframe": "1h",
+            "horizon": 1,
+            "artifact": "results/research/sig-a-refusal.json",
+            "entry": {"eligible": False, "reasons": ["clearly worse"]},
+        },
+    )
+    after = build_coverage_certificate(job_id, "majors", store=store)
+    assert after["required_experiments"][0]["satisfied"]
+    assert after["required_experiments"][0]["status"] == "completed"
+    assert after["candidate_followups"][0]["state"] == "refuted"
+    assert after["unresolved_candidates"] == []
+
+
+def test_killed_probation_outweighs_its_admission_holdout(tmp_path: Path) -> None:
+    store, job_id = _store(tmp_path, "coverage-kill-after-holdout")
+    _write_scan(
+        store,
+        job_id,
+        [
+            _scan_meta(),
+            _scan_test(verdict="probation"),
+            {
+                **_scan_test(verdict="probation"),
+                "kind": "holdout_check",
+                "ts": "2026-08-20T00:02:00+00:00",
+                "verdict": "confirmed",
+            },
+        ],
+    )
+    store.append_journal(
+        job_id,
+        {
+            "ts": "2026-08-20T00:03:00+00:00",
+            "type": "paper_probation_opened",
+            "leg": "sig-a-paper",
+            "symbol": "BTC",
+        },
+    )
+    store.append_journal(
+        job_id,
+        {
+            "ts": "2026-08-20T00:04:00+00:00",
+            "type": "probation_leg_killed",
+            "leg": "sig-a-paper",
+        },
+    )
+    certificate = build_coverage_certificate(job_id, "majors", store=store)
+    assert certificate["candidate_followups"][0]["state"] == "refuted"
+    assert certificate["unresolved_candidates"] == []
+
+
 def test_structured_operator_requirement_is_a_named_gap(tmp_path: Path) -> None:
     store, job_id = _store(tmp_path, "coverage-requirement")
     _write_scan(store, job_id, [_scan_meta(), _scan_test()])

--- a/wayfinder_paths/tests/test_jobs_progress_constitution.py
+++ b/wayfinder_paths/tests/test_jobs_progress_constitution.py
@@ -637,6 +637,21 @@ def test_paper_leg_opens_within_budget_and_caps(tmp_path: Path) -> None:
         _open_paper(store, job_id, "leg-worse", candidate_net=0.05)
     with pytest.raises(ValueError, match="trade count"):
         _open_paper(store, job_id, "leg-thin", backtest_trades=2)
+    refusals = _journal_events(store, job_id, "paper_probation_entry_refused")
+    assert [row["leg"] for row in refusals] == ["leg-worse", "leg-thin"]
+    assert refusals[0]["entry"] == {
+        "candidate_net_return": 0.05,
+        "baseline_net_return": 0.10,
+        "backtest_trades": 25,
+        "eligible": False,
+        "budget": 0.025,
+        "floor": 0.075,
+        "reasons": [
+            "candidate net_return 0.05 clearly worse than baseline 0.1 "
+            "(allowed floor 0.075)"
+        ],
+    }
+    assert load_probation(store, job_id)["legs"] == [leg]
 
     _open_paper(store, job_id, "leg-b")
     _open_paper(store, job_id, "leg-c")


### PR DESCRIPTION
## Summary

- journal mechanical paper-probation entry refusals before raising
- let a refusal complete the corresponding structured operator requirement
- refute a scan candidate only when the refusal names its exact coordinate and cites a proposal or durable artifact
- make graduated/killed probation outcomes outrank their admission holdout

This closes an anti-spin edge case found on majors: PUMP was mechanically refused by the current-window paper gate but coverage continued to label the mandated action not_run.

## Validation

- 37 targeted progress/coverage tests passed
- full jobs/runner/MCP suite: 1042 passed, 9 skipped
- Ruff clean
- scoped mypy clean