### PR TITLE
jobs: detect portfolio regime deterioration

### DIFF
--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -65,6 +65,7 @@ from wayfinder_paths.jobs.proposals import (
     restage_proposal,
     revalidate_proposal,
 )
+from wayfinder_paths.jobs.regime_health import regime_health_job
 from wayfinder_paths.jobs.replication import replication_job
 from wayfinder_paths.jobs.research import (
     holdout_check_job,
@@ -1226,6 +1227,21 @@ def decision_log_cmd(job_id: str, limit: int) -> None:
 def replication_cmd(job_id: str, force: bool) -> None:
     _echo_json(
         {"ok": True, "result": replication_job(job_id, store=JobStore(), force=force)}
+    )
+
+
+@job_cli.command(
+    name="regime-health",
+    help="Portfolio-level 7/14/30d incumbent-health monitor: recent drawdown/"
+    "edge shape plus volatility, correlation, liquidity, regime-mix and "
+    "funding drift. Alerts refresh attribution before treatment design; "
+    "automatic responses are owner-governed and default to alert-only.",
+)
+@click.argument("job_id")
+@click.option("--force", is_flag=True, default=False)
+def regime_health_cmd(job_id: str, force: bool) -> None:
+    _echo_json(
+        {"ok": True, "result": regime_health_job(job_id, store=JobStore(), force=force)}
     )
 
 

--- a/wayfinder_paths/jobs/derived_features.py
+++ b/wayfinder_paths/jobs/derived_features.py
@@ -158,6 +158,9 @@ def derive_features_job(
     features_path = root / "state" / "features.jsonl"
     features_path.parent.mkdir(parents=True, exist_ok=True)
     newest_by_series: dict[tuple[str, str], str] = {}
+    funding_rows: list[dict[str, Any]] = []
+    market_first_ts = pd.Timestamp(frame["timestamp"].min())
+    market_last_ts = pd.Timestamp(frame["timestamp"].max())
     if features_path.exists():
         with features_path.open(encoding="utf-8") as handle:
             for line in handle:
@@ -171,6 +174,18 @@ def derive_features_job(
                 ts = str(row.get("timestamp"))
                 if ts > newest_by_series.get(series, ""):
                     newest_by_series[series] = ts
+                if series[0] == "funding":
+                    try:
+                        funding_ts = pd.Timestamp(ts)
+                    except (TypeError, ValueError):
+                        continue
+                    funding_ts = (
+                        funding_ts.tz_localize("UTC")
+                        if funding_ts.tzinfo is None
+                        else funding_ts.tz_convert("UTC")
+                    )
+                    if market_first_ts <= funding_ts <= market_last_ts:
+                        funding_rows.append(row)
     newest_existing = max(newest_by_series.values(), default="")
 
     if "exog" in sets or "venue" in sets:
@@ -241,6 +256,14 @@ def derive_features_job(
                     )
                     appended[name] = appended.get(name, 0) + 1
                     total += 1
+
+    # Reuse the dataset already resident in memory. Loading the 120-day bars
+    # a second time in the regime monitor doubled an hourly wake's peak memory
+    # on the small runner boxes. The monitor consumes this compact artifact.
+    from wayfinder_paths.jobs.regime_contract import MARKET_STATE_PATH
+    from wayfinder_paths.jobs.regime_market import write_market_state
+
+    market_state = write_market_state(root, frame, funding_rows=funding_rows)
     return {
         "sets": list(sets),
         "every_bars": every_bars,
@@ -250,6 +273,11 @@ def derive_features_job(
         # Newest stamp in the store after this run — rows_appended == 0 is
         # NORMAL between hourly stamps; THIS is the staleness signal.
         "newest_feature_ts": max(newest_by_series.values(), default=""),
+        "market_state": {
+            "available": market_state.get("available"),
+            "as_of": market_state.get("as_of"),
+            "path": str(root / MARKET_STATE_PATH),
+        },
         "generated_at": str(dt.datetime.now(dt.UTC)),
         "read": (
             "Research-side derived features appended to the feature store — "

--- a/wayfinder_paths/jobs/execution/driver.py
+++ b/wayfinder_paths/jobs/execution/driver.py
@@ -83,6 +83,24 @@ def run_scheduled_tick(job_dir: str | Path | None = None) -> dict[str, Any]:
         payload = asyncio.run(tick_job(job, root, mode, store=store))
     except Exception as exc:
         payload = {"ok": False, "error": str(exc)}
+    # Deterministic incumbent/regime health runs after recording this tick so
+    # a just-closed loss participates immediately. It is raise-free here: an
+    # observability failure must never turn a successful trading tick into a
+    # failed one. Owner-governed pause/flatten responses latch for next tick.
+    if store is not None and job is not None and payload.get("ok") is True:
+        try:
+            from wayfinder_paths.jobs.regime_health import (
+                compact_regime_health,
+                regime_health_job,
+            )
+
+            health = regime_health_job(job.id, store=store)
+            payload["regime_health"] = compact_regime_health(health)
+        except Exception as exc:  # noqa: BLE001
+            store.append_journal(
+                job.id,
+                {"type": "regime_health_failed", "error": str(exc)[:300]},
+            )
     if divergence is not None:
         payload.setdefault("guard_events", []).append(divergence)
     # Event-driven agent wakes fire ONLY from the scheduled entrypoint —
@@ -118,6 +136,9 @@ def _tick_trigger_events(payload: dict[str, Any]) -> list[str]:
         # Declared vs executed mode disagree — wake the advisor to reconcile
         # job.yaml (reuses the reconcile_mismatch trigger).
         events.append("reconcile_mismatch")
+    health_transition = (payload.get("regime_health") or {}).get("transition") or {}
+    if health_transition.get("alert"):
+        events.append("regime_shift")
     return events
 
 
@@ -169,8 +190,9 @@ async def tick_job(
     # the governed value. No governance ceiling -> params untouched.
     leverage_notes: list[dict[str, Any]] = []
     requested_leverage = params.get("leverage")
+    hard_constraints = governance_hard_constraints(root)
     effective_leverage, leverage_ceiling = clamp_leverage(
-        requested_leverage, governance_hard_constraints(root)
+        requested_leverage, hard_constraints
     )
     if leverage_ceiling is not None:
         params["leverage"] = effective_leverage
@@ -182,6 +204,38 @@ async def tick_job(
         leverage_notes.append({"kind": "leverage_clamped", **clamp_payload})
         store.append_journal(
             job.id, {"type": "leverage_clamped", "mode": mode, **clamp_payload}
+        )
+
+    # Optional owner-governed response to a warning/critical portfolio regime
+    # report. This is a runtime cap only: it does not edit the user's leverage
+    # dial or invalidate the strategy revision, and releases when health clears.
+    from wayfinder_paths.jobs.regime_health import (
+        active_regime_leverage_cap,
+        regime_health_job,
+    )
+
+    try:
+        # Recompute before consulting a mutating policy. regime_health.json is
+        # agent-visible state and therefore cannot itself authorize a clamp.
+        pre_tick_health = regime_health_job(job.id, store=store, force=True)
+        regime_cap = active_regime_leverage_cap(pre_tick_health)
+    except Exception as exc:  # noqa: BLE001 — monitor failures do not stop trading
+        regime_cap = None
+        store.append_journal(
+            job.id, {"type": "regime_health_failed", "error": str(exc)[:300]}
+        )
+    if regime_cap is not None and effective_leverage > regime_cap:
+        params["leverage"] = regime_cap
+        regime_payload = {
+            "requested": requested_leverage,
+            "max_leverage": regime_cap,
+            "effective": regime_cap,
+            "source": "regime_health",
+        }
+        leverage_notes.append({"kind": "regime_leverage_clamped", **regime_payload})
+        store.append_journal(
+            job.id,
+            {"type": "regime_leverage_clamped", "mode": mode, **regime_payload},
         )
 
     strategy = _load_strategy(entrypoint, params)

--- a/wayfinder_paths/jobs/execution/risk.py
+++ b/wayfinder_paths/jobs/execution/risk.py
@@ -74,6 +74,11 @@ def check_risk_halt(
         json.dumps(
             {
                 "peak_equity": snapshot["peak_equity"],
+                # Current marked state lets the portfolio-regime monitor use
+                # venue truth instead of approximating live drawdown from the
+                # configured paper capital and closed trades.
+                "equity": snapshot["equity"],
+                "drawdown": snapshot["drawdown"],
                 # The source the PEAK belongs to (not this tick's source):
                 # without it, the next tick's source check discards the peak
                 # and live drawdown resets to 0 every tick — a dead halt.

--- a/wayfinder_paths/jobs/halt.py
+++ b/wayfinder_paths/jobs/halt.py
@@ -26,7 +26,7 @@ HALTED_EXECUTION_STATUS = "halted"
 
 # Halts latched by the risk/protection layer: owner-clearable only. The loop
 # that tripped a circuit breaker must not be able to reset it.
-RISK_LATCH_SOURCES = frozenset({"risk_limits", "native_protection"})
+RISK_LATCH_SOURCES = frozenset({"risk_limits", "native_protection", "regime_health"})
 
 
 def read_halt(root: Path) -> dict[str, Any] | None:

--- a/wayfinder_paths/jobs/models.py
+++ b/wayfinder_paths/jobs/models.py
@@ -245,6 +245,7 @@ class WayfinderJob:
                 "proposal_created",
                 "reconcile_mismatch",
                 "risk_halt",
+                "regime_shift",
             ],
             auto_limits=auto_limits_payload if normalized_mode == "auto" else {},
         )
@@ -312,6 +313,7 @@ class WayfinderJob:
                     "proposal_created",
                     "health_red",
                     "script_failure",
+                    "regime_shift",
                 ],
                 "quiet_on": ["no_change", "normal_success"],
             },

--- a/wayfinder_paths/jobs/regime_contract.py
+++ b/wayfinder_paths/jobs/regime_contract.py
@@ -1,0 +1,6 @@
+"""Shared artifact contract for regime-market and regime-health stages."""
+
+REGIME_HEALTH_PATH = "results/research/regime_health.json"
+MARKET_STATE_PATH = "results/research/market_state.json"
+WINDOW_DAYS = (7, 14, 30)
+REGIME_HEALTH_SCHEMA_VERSION = "1.0"

--- a/wayfinder_paths/jobs/regime_health.py
+++ b/wayfinder_paths/jobs/regime_health.py
@@ -1,0 +1,974 @@
+"""Portfolio-level regime and incumbent-health monitor.
+
+The ordinary risk layer answers "has an account limit been breached?".  This
+monitor answers the earlier question: "is the deployed edge behaving like the
+one we validated, in market conditions that still resemble its training
+history?"  It combines three independent evidence families:
+
+* recent 7/14/30-day forward PnL shape (drawdown, drawdown velocity and loss
+  concentration),
+* forward trade edge versus the backtest population, and
+* market-state drift (volatility, cross-symbol correlation, liquidity,
+  regime mix and funding).
+
+The report is advisory by default.  An owner can select an automatic response
+in protected ``governance/<job_id>/hard_constraints.yaml``::
+
+    regime_response:
+      warning: alert_only       # alert_only | clamp_leverage | pause_entries
+      critical: pause_entries   # ... | flatten
+      max_leverage: 1.0         # required by clamp_leverage
+    regime_detector:            # optional protected threshold overrides
+      drawdown_warning: 0.04
+      drawdown_critical: 0.08
+
+Agent-writable job files cannot loosen or activate that policy. Automatic
+responses require a verified protected-governance epoch; legacy jobs remain
+alert-only. Pause/flatten responses use the durable risk halt, and therefore
+require the owner to clear.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+import math
+import statistics
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Literal
+
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.regime_contract import (
+    MARKET_STATE_PATH,
+    REGIME_HEALTH_PATH,
+    REGIME_HEALTH_SCHEMA_VERSION,
+    WINDOW_DAYS,
+)
+from wayfinder_paths.jobs.store import JobStore
+
+RegimeStatus = Literal["insufficient", "healthy", "watch", "warning", "critical"]
+
+_STATUS_RANK: dict[str, int] = {
+    "insufficient": 0,
+    "healthy": 1,
+    "watch": 2,
+    "warning": 3,
+    "critical": 4,
+}
+_ALERT_STATUSES = frozenset({"warning", "critical"})
+_RESPONSE_ACTIONS = frozenset(
+    {"alert_only", "clamp_leverage", "pause_entries", "flatten"}
+)
+
+
+def regime_health_job(
+    job_id: str,
+    *,
+    store: JobStore | None = None,
+    force: bool = False,
+    now: dt.datetime | None = None,
+    apply_response: bool = True,
+) -> dict[str, Any]:
+    """Compute and persist the current portfolio-regime health verdict.
+
+    The cache is content- and time-aware: a report is reused only within the
+    same UTC hour while forward trades, forensics, risk state, market state
+    and protected governance are unchanged. Monitoring failures never alter
+    execution.
+    """
+    store = store or JobStore()
+    job = store.load(job_id)
+    root = store.job_dir(job_id)
+    now = now or dt.datetime.now(dt.UTC)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=dt.UTC)
+    previous = _read_json(root / REGIME_HEALTH_PATH) or {}
+    fingerprint = _input_fingerprint(root)
+    fingerprint["evaluation_hour"] = now.replace(
+        minute=0, second=0, microsecond=0
+    ).isoformat()
+    hard_constraints, governance = _governance_context(root)
+    fingerprint["protected_governance"] = _governance_fingerprint(
+        hard_constraints, governance
+    )
+    if (
+        not force
+        and previous.get("input_fingerprint") == fingerprint
+        and previous.get("schema_version") == REGIME_HEALTH_SCHEMA_VERSION
+    ):
+        cached = dict(previous)
+        cached["cached"] = True
+        cached_policy = resolve_regime_response_policy(
+            hard_constraints,
+            str(cached.get("status") or "insufficient"),
+            governance=governance,
+        )
+        # The report lives in the agent-writable job tree. It is safe to reuse
+        # for alerting, but never let cached bytes authorize a mutating owner
+        # policy: recompute the deterministic verdict first.
+        if apply_response and cached_policy["action"] != "alert_only":
+            pass
+        elif apply_response:
+            cached["response"] = apply_regime_response(
+                store,
+                job,
+                cached,
+                hard_constraints=hard_constraints,
+                governance=governance,
+            )
+            return cached
+        else:
+            return cached
+
+    config = _detector_config(
+        hard_constraints, allow_overrides=bool(governance["trusted"])
+    )
+    baseline_rows = _load_backtest_forensics(root)
+    forward_forensics = store.read_jsonl(
+        job_id, "results/forward/trade_forensics.jsonl", limit=5_000
+    )
+    forward_trades = store.read_jsonl(
+        job_id, "results/forward/trades.jsonl", limit=10_000
+    )
+    market = _read_json(root / MARKET_STATE_PATH) or {
+        "available": False,
+        "reason": "market-state artifact not available yet",
+    }
+    windows = _performance_windows(
+        forward_trades,
+        forward_forensics,
+        baseline_rows,
+        now=now,
+        initial_capital=_initial_capital(job),
+    )
+    risk_state = _read_json(root / "state" / "risk_state.json") or {}
+    signals = _health_signals(
+        windows,
+        market,
+        risk_state=risk_state,
+        config=config,
+        now=now,
+    )
+    status, score = _verdict(signals, windows=windows, market=market)
+    prior_status = str(previous.get("status") or "insufficient")
+    transition = _transition(prior_status, status)
+    policy = resolve_regime_response_policy(
+        hard_constraints, status, governance=governance
+    )
+
+    attribution = _refresh_attribution_if_needed(
+        store,
+        job_id,
+        root,
+        status=status,
+        forward_count=len(forward_forensics),
+    )
+    report: dict[str, Any] = {
+        "schema_version": REGIME_HEALTH_SCHEMA_VERSION,
+        "job_id": job_id,
+        "computed_at": now.isoformat(),
+        "input_fingerprint": fingerprint,
+        "status": status,
+        "score": score,
+        "signals": signals,
+        "thresholds": config,
+        "windows": windows,
+        "market": market,
+        "risk_state": {
+            key: risk_state.get(key)
+            for key in (
+                "equity",
+                "peak_equity",
+                "drawdown",
+                "equity_source",
+                "updated_at",
+            )
+            if key in risk_state
+        },
+        "governance": governance,
+        "policy": policy,
+        "transition": transition,
+        "attribution": attribution,
+        "cached": False,
+        "_basis": (
+            "Portfolio-level incumbent health. warning/critical means recent "
+            "performance and/or market-state drift crossed deterministic "
+            "thresholds. Attribution is refreshed before treatment design. "
+            "The detector never changes strategy code; execution response is "
+            "owner-governed and defaults to alert_only."
+        ),
+    }
+    if apply_response:
+        report["response"] = apply_regime_response(
+            store,
+            job,
+            report,
+            hard_constraints=hard_constraints,
+            governance=governance,
+        )
+    else:
+        report["response"] = {"action": policy["action"], "applied": False}
+    store.write_json(job_id, REGIME_HEALTH_PATH, report)
+    _journal_transition(store, job_id, report)
+    return report
+
+
+def resolve_regime_response_policy(
+    hard_constraints: Mapping[str, Any],
+    status: str,
+    *,
+    governance: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Resolve the owner-owned response for a health status.
+
+    Invalid or absent policy is deliberately non-mutating (``alert_only``)
+    and carries a validation error in the artifact for the owner to fix.
+    """
+    raw = hard_constraints.get("regime_response")
+    if not isinstance(raw, Mapping):
+        return {"action": "alert_only", "source": "default"}
+    if not governance.get("trusted"):
+        return {
+            "action": "alert_only",
+            "source": str(governance.get("source") or "untrusted"),
+            "error": (
+                "automatic regime response requires a verified protected "
+                "governance epoch"
+            ),
+        }
+    requested = str(raw.get(status) or "alert_only")
+    if requested not in _RESPONSE_ACTIONS:
+        return {
+            "action": "alert_only",
+            "source": "governance",
+            "error": f"unsupported regime_response action {requested!r}",
+        }
+    policy: dict[str, Any] = {"action": requested, "source": "governance"}
+    if requested == "clamp_leverage":
+        try:
+            cap = float(raw["max_leverage"])
+        except (KeyError, TypeError, ValueError):
+            return {
+                "action": "alert_only",
+                "source": "governance",
+                "error": "clamp_leverage requires positive max_leverage",
+            }
+        if not math.isfinite(cap) or cap <= 0:
+            return {
+                "action": "alert_only",
+                "source": "governance",
+                "error": "clamp_leverage requires positive max_leverage",
+            }
+        policy["max_leverage"] = cap
+    return policy
+
+
+def active_regime_leverage_cap(report: Mapping[str, Any]) -> float | None:
+    """Cap from a freshly computed, owner-governed health report."""
+    if str(report.get("status")) not in _ALERT_STATUSES:
+        return None
+    governance = report.get("governance") or {}
+    policy = report.get("policy") or {}
+    if not isinstance(governance, Mapping) or not governance.get("trusted"):
+        return None
+    if not isinstance(policy, Mapping):
+        return None
+    if policy.get("action") != "clamp_leverage":
+        return None
+    cap = _finite_float(policy.get("max_leverage"))
+    return cap if cap is not None and cap > 0 else None
+
+
+def apply_regime_response(
+    store: JobStore,
+    job: WayfinderJob,
+    report: Mapping[str, Any],
+    *,
+    hard_constraints: Mapping[str, Any],
+    governance: Mapping[str, Any],
+) -> dict[str, Any]:
+    status = str(report.get("status") or "insufficient")
+    policy = resolve_regime_response_policy(
+        hard_constraints, status, governance=governance
+    )
+    action = str(policy["action"])
+    if status not in _ALERT_STATUSES or action == "alert_only":
+        return {**policy, "applied": False}
+    if action == "clamp_leverage":
+        # The driver reads this governed cap before constructing the strategy.
+        return {**policy, "applied": True, "effective_on": "next_tick"}
+
+    from wayfinder_paths.jobs.halt import request_halt
+
+    flatten = action == "flatten"
+    halt = request_halt(
+        store,
+        job.id,
+        reason=f"portfolio regime health {status}",
+        flatten=flatten,
+        source="regime_health",
+    )
+    return {
+        **policy,
+        "applied": True,
+        "effective_on": "next_tick",
+        "halt": {key: halt.get(key) for key in ("reason", "flatten", "source", "ts")},
+    }
+
+
+def compact_regime_health(report: Mapping[str, Any]) -> dict[str, Any]:
+    """Bounded trigger/prompt view; the full report remains on disk."""
+    signals = list(report.get("signals") or [])
+    return {
+        "status": report.get("status"),
+        "score": report.get("score"),
+        "computed_at": report.get("computed_at"),
+        "signals": signals[:8],
+        "policy": report.get("policy"),
+        "transition": report.get("transition"),
+        "attribution": report.get("attribution"),
+        "response": report.get("response"),
+    }
+
+
+def _performance_windows(
+    trades: Sequence[Mapping[str, Any]],
+    forensics: Sequence[Mapping[str, Any]],
+    baseline: Sequence[Mapping[str, Any]],
+    *,
+    now: dt.datetime,
+    initial_capital: float,
+) -> dict[str, Any]:
+    baseline_bps = [
+        value
+        for row in baseline
+        if (value := _finite_float(row.get("realized_bps"))) is not None
+    ]
+    baseline_mean = statistics.fmean(baseline_bps) if baseline_bps else None
+    result: dict[str, Any] = {}
+    for days in WINDOW_DAYS:
+        cutoff = now - dt.timedelta(days=days)
+        recent_trades = sorted(
+            (row for row in trades if _timestamp(row) >= cutoff),
+            key=_timestamp,
+        )
+        recent_forensics = [row for row in forensics if _timestamp(row) >= cutoff]
+        pnls = [
+            value for row in recent_trades if (value := _trade_pnl(row)) is not None
+        ]
+        bps = [
+            value
+            for row in recent_forensics
+            if (value := _finite_float(row.get("realized_bps"))) is not None
+        ]
+        drawdown = _max_drawdown(pnls)
+        negative = [abs(value) for value in pnls if value < 0]
+        loss_by_symbol: dict[str, float] = defaultdict(float)
+        for row in recent_trades:
+            pnl = _trade_pnl(row)
+            if pnl is not None and pnl < 0:
+                loss_by_symbol[str(row.get("symbol") or "unknown")] += abs(pnl)
+        loss_total = sum(negative)
+        edge_percentile = _rolling_mean_percentile(baseline_bps, bps)
+        observation_span_days = (
+            min(
+                float(days),
+                max(
+                    (
+                        now - min(_timestamp(row) for row in recent_trades)
+                    ).total_seconds()
+                    / 86_400.0,
+                    1.0,
+                ),
+            )
+            if recent_trades
+            else float(days)
+        )
+        result[str(days)] = {
+            "days": days,
+            "observation_span_days": round(observation_span_days, 4),
+            "closed_trades": len(recent_trades),
+            "forensics_trades": len(bps),
+            "net_pnl": round(sum(pnls), 6),
+            "max_drawdown_usd": round(drawdown, 6),
+            "max_drawdown_pct": round(drawdown / initial_capital, 6),
+            "drawdown_velocity_pct_per_day": round(
+                drawdown / initial_capital / observation_span_days, 8
+            ),
+            "largest_loss_share": round(max(negative) / loss_total, 4)
+            if negative
+            else None,
+            "largest_losing_symbol_share": round(
+                max(loss_by_symbol.values()) / loss_total, 4
+            )
+            if loss_by_symbol and loss_total
+            else None,
+            "largest_losing_symbol": max(
+                loss_by_symbol, key=lambda symbol: loss_by_symbol[symbol]
+            )
+            if loss_by_symbol
+            else None,
+            "forward_avg_realized_bps": round(statistics.fmean(bps), 4)
+            if bps
+            else None,
+            "baseline_avg_realized_bps": round(baseline_mean, 4)
+            if baseline_mean is not None
+            else None,
+            "edge_rolling_percentile": edge_percentile,
+        }
+    return {
+        "initial_capital_basis": initial_capital,
+        "baseline_forensics_trades": len(baseline_bps),
+        "windows": result,
+        "_basis": (
+            "Closed-trade PnL drawdown is normalized by configured initial_capital; "
+            "the venue-marked risk_state drawdown is evaluated separately. Edge "
+            "percentile compares the recent mean realized bps with all same-length "
+            "contiguous samples in the backtest forensics population."
+        ),
+    }
+
+
+def _health_signals(
+    performance: Mapping[str, Any],
+    market: Mapping[str, Any],
+    *,
+    risk_state: Mapping[str, Any],
+    config: Mapping[str, float],
+    now: dt.datetime,
+) -> list[dict[str, Any]]:
+    signals = _performance_signals(
+        performance, risk_state=risk_state, config=config
+    ) + _market_drift_signals(market, now=now)
+    return sorted(signals, key=lambda item: (-int(item["severity"]), item["kind"]))
+
+
+def _performance_signals(
+    performance: Mapping[str, Any],
+    *,
+    risk_state: Mapping[str, Any],
+    config: Mapping[str, float],
+) -> list[dict[str, Any]]:
+    signals: list[dict[str, Any]] = []
+    windows = performance.get("windows") or {}
+
+    exact_value = _finite_float(risk_state.get("drawdown"))
+    exact_drawdown = abs(exact_value) if exact_value is not None else 0.0
+    trade_drawdown = max(
+        (float(row.get("max_drawdown_pct") or 0.0) for row in windows.values()),
+        default=0.0,
+    )
+    drawdown = max(exact_drawdown, trade_drawdown)
+    if drawdown >= config["drawdown_critical"]:
+        signals.append(_signal("drawdown", 2, drawdown, config["drawdown_critical"]))
+    elif drawdown >= config["drawdown_warning"]:
+        signals.append(_signal("drawdown", 1, drawdown, config["drawdown_warning"]))
+
+    velocity = max(
+        (
+            float(row.get("drawdown_velocity_pct_per_day") or 0.0)
+            for row in windows.values()
+        ),
+        default=0.0,
+    )
+    if velocity >= config["velocity_critical"]:
+        signals.append(
+            _signal("drawdown_velocity", 2, velocity, config["velocity_critical"])
+        )
+    elif velocity >= config["velocity_warning"]:
+        signals.append(
+            _signal("drawdown_velocity", 1, velocity, config["velocity_warning"])
+        )
+
+    eligible_edges = [
+        row
+        for row in windows.values()
+        if int(row.get("forensics_trades") or 0) >= int(config["min_recent_trades"])
+        and row.get("edge_rolling_percentile") is not None
+        and float(row.get("forward_avg_realized_bps") or 0.0) < 0
+        and float(row.get("baseline_avg_realized_bps") or 0.0) > 0
+    ]
+    if eligible_edges:
+        weakest = min(eligible_edges, key=lambda row: row["edge_rolling_percentile"])
+        percentile = float(weakest["edge_rolling_percentile"])
+        if percentile <= config["edge_critical_percentile"]:
+            signals.append(
+                _signal(
+                    "edge_decay",
+                    2,
+                    percentile,
+                    config["edge_critical_percentile"],
+                    window_days=weakest["days"],
+                )
+            )
+        elif percentile <= config["edge_warning_percentile"]:
+            signals.append(
+                _signal(
+                    "edge_decay",
+                    1,
+                    percentile,
+                    config["edge_warning_percentile"],
+                    window_days=weakest["days"],
+                )
+            )
+
+    loss_rows = [
+        row
+        for row in windows.values()
+        if int(row.get("closed_trades") or 0) >= int(config["min_recent_trades"])
+        and float(row.get("net_pnl") or 0.0) < 0
+    ]
+    if loss_rows:
+        concentrated = max(
+            loss_rows,
+            key=lambda row: max(
+                float(row.get("largest_loss_share") or 0.0),
+                float(row.get("largest_losing_symbol_share") or 0.0),
+            ),
+        )
+        concentration = max(
+            float(concentrated.get("largest_loss_share") or 0.0),
+            float(concentrated.get("largest_losing_symbol_share") or 0.0),
+        )
+        if concentration >= config["loss_concentration_warning"]:
+            signals.append(
+                _signal(
+                    "loss_concentration",
+                    1,
+                    concentration,
+                    config["loss_concentration_warning"],
+                    window_days=concentrated["days"],
+                    symbol=concentrated.get("largest_losing_symbol"),
+                )
+            )
+    return signals
+
+
+def _market_drift_signals(
+    market: Mapping[str, Any], *, now: dt.datetime
+) -> list[dict[str, Any]]:
+    if market.get("available"):
+        as_of = _timestamp({"timestamp": market.get("as_of")})
+        age_hours = max((now - as_of).total_seconds() / 3_600.0, 0.0)
+        if age_hours > 6.0:
+            severity = 2 if age_hours > 24.0 else 1
+            return [
+                _signal(
+                    "market_data_stale",
+                    severity,
+                    age_hours,
+                    24.0 if severity == 2 else 6.0,
+                )
+            ]
+
+    signals: list[dict[str, Any]] = []
+    market_windows = market.get("windows") if isinstance(market, Mapping) else {}
+    for name, key, warning, critical, direction in (
+        ("volatility_shift", "volatility_ratio", 1.67, 2.5, "outside"),
+        ("correlation_shift", "correlation_delta", 0.20, 0.35, "absolute"),
+        ("liquidity_deterioration", "liquidity_ratio", 0.65, 0.40, "below"),
+        ("regime_mix_shift", "regime_js_divergence", 0.10, 0.20, "above"),
+    ):
+        candidates: list[tuple[int, float, int]] = []
+        for days, row in (market_windows or {}).items():
+            if not isinstance(row, Mapping) or not row.get("available"):
+                continue
+            raw = row.get(key)
+            value = _finite_float(raw)
+            if value is None:
+                continue
+            severity = _market_severity(value, warning, critical, direction)
+            if severity:
+                candidates.append((severity, value, int(days)))
+        if candidates:
+            severity, value, days = max(
+                candidates, key=lambda item: (item[0], abs(item[1]))
+            )
+            threshold = critical if severity == 2 else warning
+            signals.append(_signal(name, severity, value, threshold, window_days=days))
+
+    funding_candidates: list[tuple[int, float, int, str | None]] = []
+    for days, row in (market_windows or {}).items():
+        if not isinstance(row, Mapping):
+            continue
+        funding = row.get("funding_shift")
+        if not isinstance(funding, Mapping) or not _finite(funding.get("z_score")):
+            continue
+        value = abs(float(funding["z_score"]))
+        severity = 2 if value >= 3.0 else 1 if value >= 2.0 else 0
+        if severity:
+            funding_candidates.append(
+                (severity, value, int(days), funding.get("symbol"))
+            )
+    if funding_candidates:
+        severity, value, days, symbol = max(funding_candidates)
+        signals.append(
+            _signal(
+                "funding_shift",
+                severity,
+                value,
+                3.0 if severity == 2 else 2.0,
+                window_days=days,
+                symbol=symbol,
+            )
+        )
+    return signals
+
+
+def _verdict(
+    signals: Sequence[Mapping[str, Any]],
+    *,
+    windows: Mapping[str, Any],
+    market: Mapping[str, Any],
+) -> tuple[RegimeStatus, int]:
+    if not signals:
+        has_forward = any(
+            int(row.get("closed_trades") or 0) > 0
+            for row in (windows.get("windows") or {}).values()
+        )
+        return (
+            "healthy" if has_forward or market.get("available") else "insufficient"
+        ), 0
+    performance_kinds = {
+        "drawdown",
+        "drawdown_velocity",
+        "edge_decay",
+        "loss_concentration",
+    }
+    performance = [s for s in signals if s["kind"] in performance_kinds]
+    market_signals = [s for s in signals if s["kind"] not in performance_kinds]
+    performance_score = sum(int(s["severity"]) for s in performance)
+    market_score = sum(int(s["severity"]) for s in market_signals)
+    score = performance_score + market_score
+    critical_drawdown = any(
+        s["kind"] == "drawdown" and int(s["severity"]) == 2 for s in performance
+    )
+    critical_performance = any(int(s["severity"]) == 2 for s in performance)
+    if critical_drawdown or (critical_performance and market_score >= 1):
+        return "critical", score
+    if performance_score >= 2 or market_score >= 4:
+        return "warning", score
+    return "watch", score
+
+
+def _detector_config(
+    hard_constraints: Mapping[str, Any], *, allow_overrides: bool
+) -> dict[str, float]:
+    """Defaults plus optional OWNER overrides from protected governance.
+
+    Alarm thresholds must not live in agent-writable job/performance config:
+    the strategy being judged cannot move its own goalposts.
+    """
+    hard_drawdown = hard_constraints.get("max_drawdown")
+    if hard_drawdown is None:
+        hard_drawdown = hard_constraints.get("max_drawdown_pct")
+    hard_value = _finite_float(hard_drawdown)
+    hard = abs(hard_value) if hard_value is not None else 0.0
+    defaults = {
+        "min_recent_trades": 3.0,
+        "drawdown_warning": min(0.05, hard / 3.0) if hard else 0.05,
+        "drawdown_critical": min(0.10, hard * 2.0 / 3.0) if hard else 0.10,
+        "velocity_warning": 0.02,
+        "velocity_critical": 0.05,
+        "edge_warning_percentile": 0.10,
+        "edge_critical_percentile": 0.05,
+        "loss_concentration_warning": 0.60,
+    }
+    raw = hard_constraints.get("regime_detector") if allow_overrides else None
+    supplied = raw if isinstance(raw, Mapping) else {}
+    for key in defaults:
+        if key not in supplied:
+            continue
+        try:
+            value = float(supplied[key])
+        except (TypeError, ValueError):
+            continue
+        if math.isfinite(value) and value > 0:
+            defaults[key] = value
+    defaults["drawdown_critical"] = max(
+        defaults["drawdown_critical"], defaults["drawdown_warning"]
+    )
+    defaults["velocity_critical"] = max(
+        defaults["velocity_critical"], defaults["velocity_warning"]
+    )
+    defaults["edge_critical_percentile"] = min(
+        defaults["edge_critical_percentile"],
+        defaults["edge_warning_percentile"],
+    )
+    return defaults
+
+
+def _refresh_attribution_if_needed(
+    store: JobStore,
+    job_id: str,
+    root: Path,
+    *,
+    status: str,
+    forward_count: int,
+) -> dict[str, Any]:
+    if status not in _ALERT_STATUSES:
+        return {"required": False, "refreshed": False}
+    path = root / "results" / "research" / "attribution.json"
+    existing = _read_json(path) or {}
+    if int(existing.get("forward_trades") or -1) == forward_count:
+        return {
+            "required": True,
+            "refreshed": False,
+            "forward_trades": forward_count,
+            "path": "results/research/attribution.json",
+        }
+    try:
+        from wayfinder_paths.jobs.attribution import attribution_job
+
+        result = attribution_job(job_id, store=store)
+    except (ValueError, OSError) as exc:
+        return {"required": True, "refreshed": False, "error": str(exc)[:240]}
+    return {
+        "required": True,
+        "refreshed": True,
+        "forward_trades": result.get("forward_trades"),
+        "path": "results/research/attribution.json",
+    }
+
+
+def _journal_transition(
+    store: JobStore, job_id: str, report: Mapping[str, Any]
+) -> None:
+    transition = report.get("transition") or {}
+    if not transition.get("changed"):
+        return
+    status = str(report.get("status"))
+    event_type = (
+        "portfolio_regime_shift_detected"
+        if status in _ALERT_STATUSES
+        else "portfolio_regime_health_changed"
+    )
+    store.append_journal(
+        job_id,
+        {
+            "type": event_type,
+            "from_status": transition.get("from"),
+            "to_status": status,
+            "score": report.get("score"),
+            "signals": [
+                {key: signal.get(key) for key in ("kind", "severity", "value")}
+                for signal in list(report.get("signals") or [])[:8]
+            ],
+        },
+    )
+
+
+def _transition(previous: str, current: str) -> dict[str, Any]:
+    changed = previous != current
+    return {
+        "from": previous,
+        "to": current,
+        "changed": changed,
+        "worsened": _STATUS_RANK.get(current, 0) > _STATUS_RANK.get(previous, 0),
+        "alert": changed and current in _ALERT_STATUSES,
+    }
+
+
+def _input_fingerprint(root: Path) -> dict[str, Any]:
+    paths = (
+        root / "results" / "forward" / "trades.jsonl",
+        root / "results" / "forward" / "trade_forensics.jsonl",
+        root / "results" / "backtest" / "trade_forensics.json",
+        root / MARKET_STATE_PATH,
+        root / "state" / "risk_state.json",
+    )
+    return {
+        str(path.relative_to(root)): {
+            "size": path.stat().st_size,
+            "mtime_ns": path.stat().st_mtime_ns,
+        }
+        for path in paths
+        if path.exists()
+    }
+
+
+def _governance_context(root: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+    from wayfinder_paths.jobs.constitution import load_constitution
+
+    constitution = load_constitution(Path(root))
+    raw_hard = constitution.get("hard_constraints")
+    hard = dict(raw_hard) if isinstance(raw_hard, Mapping) else {}
+    metadata = constitution.get("governance")
+    chain_status = (
+        str(metadata.get("chain_status")) if isinstance(metadata, Mapping) else None
+    )
+    source = str(constitution.get("source") or "unknown")
+    return hard, {
+        "source": source,
+        "chain_status": chain_status,
+        "revision": constitution.get("revision"),
+        "trusted": source == "governance" and chain_status == "verified",
+    }
+
+
+def _governance_fingerprint(
+    hard_constraints: Mapping[str, Any], governance: Mapping[str, Any]
+) -> str:
+    relevant = {
+        key: hard_constraints.get(key)
+        for key in (
+            "max_drawdown",
+            "max_drawdown_pct",
+            "regime_detector",
+            "regime_response",
+        )
+        if key in hard_constraints
+    }
+    return hashlib.sha256(
+        json.dumps(
+            {"hard_constraints": relevant, "governance": dict(governance)},
+            sort_keys=True,
+            default=str,
+        ).encode("utf-8")
+    ).hexdigest()[:16]
+
+
+def _load_backtest_forensics(root: Path) -> list[dict[str, Any]]:
+    doc = _read_json(root / "results" / "backtest" / "trade_forensics.json") or {}
+    rows = doc.get("trades")
+    return (
+        [dict(row) for row in rows if isinstance(row, Mapping)]
+        if isinstance(rows, list)
+        else []
+    )
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+def _timestamp(row: Mapping[str, Any]) -> dt.datetime:
+    raw = (
+        row.get("exit_ts")
+        or row.get("closed_at")
+        or row.get("timestamp")
+        or row.get("ts")
+    )
+    try:
+        stamp = dt.datetime.fromisoformat(str(raw))
+    except (TypeError, ValueError):
+        return dt.datetime.min.replace(tzinfo=dt.UTC)
+    return (
+        stamp.replace(tzinfo=dt.UTC)
+        if stamp.tzinfo is None
+        else stamp.astimezone(dt.UTC)
+    )
+
+
+def _trade_pnl(row: Mapping[str, Any]) -> float | None:
+    raw = row.get("net_pnl")
+    if raw is None:
+        match row.get("pnl"):
+            case Mapping() as payload:
+                raw = (
+                    payload.get("net_usd")
+                    if payload.get("net_usd") is not None
+                    else payload.get("net")
+                )
+            case other:
+                raw = other
+    return _finite_float(raw)
+
+
+def _initial_capital(job: WayfinderJob) -> float:
+    from wayfinder_paths.jobs.execution.primitives import DEFAULT_INITIAL_CAPITAL
+
+    try:
+        value = float(
+            job.execution_params.get("initial_capital") or DEFAULT_INITIAL_CAPITAL
+        )
+    except (TypeError, ValueError):
+        value = DEFAULT_INITIAL_CAPITAL
+    return value if math.isfinite(value) and value > 0 else DEFAULT_INITIAL_CAPITAL
+
+
+def _max_drawdown(values: Sequence[float]) -> float:
+    peak = 0.0
+    running = 0.0
+    worst = 0.0
+    for value in values:
+        running += value
+        peak = max(peak, running)
+        worst = max(worst, peak - running)
+    return worst
+
+
+def _rolling_mean_percentile(
+    baseline: Sequence[float], recent: Sequence[float]
+) -> float | None:
+    width = len(recent)
+    if width < 2 or len(baseline) < width:
+        return None
+    observed = statistics.fmean(recent)
+    samples = [
+        statistics.fmean(baseline[index : index + width])
+        for index in range(len(baseline) - width + 1)
+    ]
+    rank = sum(value <= observed for value in samples)
+    return round((rank + 1) / (len(samples) + 1), 4)
+
+
+def _market_severity(
+    value: float, warning: float, critical: float, direction: str
+) -> int:
+    if direction == "absolute":
+        magnitude = abs(value)
+        return 2 if magnitude >= critical else 1 if magnitude >= warning else 0
+    if direction == "below":
+        return 2 if value <= critical else 1 if value <= warning else 0
+    if direction == "outside":
+        reciprocal_critical = 1.0 / critical
+        reciprocal_warning = 1.0 / warning
+        return (
+            2
+            if value >= critical or value <= reciprocal_critical
+            else 1
+            if value >= warning or value <= reciprocal_warning
+            else 0
+        )
+    return 2 if value >= critical else 1 if value >= warning else 0
+
+
+def _signal(
+    kind: str,
+    severity: int,
+    value: Any,
+    threshold: Any,
+    **context: Any,
+) -> dict[str, Any]:
+    return {
+        "kind": kind,
+        "severity": severity,
+        "value": round(float(value), 6) if _finite(value) else value,
+        "threshold": threshold,
+        **{key: item for key, item in context.items() if item is not None},
+    }
+
+
+def _finite(value: Any) -> bool:
+    try:
+        return math.isfinite(float(value))
+    except (TypeError, ValueError):
+        return False
+
+
+def _finite_float(value: Any) -> float | None:
+    try:
+        converted = float(value)
+    except (TypeError, ValueError):
+        return None
+    return converted if math.isfinite(converted) else None

--- a/wayfinder_paths/jobs/regime_market.py
+++ b/wayfinder_paths/jobs/regime_market.py
@@ -1,0 +1,264 @@
+"""Compact market-regime baselines built from the job's resident dataset.
+
+This module runs on the hourly derived-feature refresh, where the full bars
+frame is already in memory. The tick-time health monitor reads the resulting
+small JSON artifact instead of loading the 120-day dataset a second time.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import statistics
+from collections import Counter
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from wayfinder_paths.jobs.regime_contract import MARKET_STATE_PATH, WINDOW_DAYS
+
+
+def summarize_market_state(
+    bars: pd.DataFrame,
+    *,
+    funding_rows: Sequence[Mapping[str, Any]] = (),
+    windows: Sequence[int] = WINDOW_DAYS,
+) -> dict[str, Any]:
+    """Compare each recent market window with the preceding dataset.
+
+    Excluding the recent window from its baseline prevents a new regime from
+    diluting its own comparison population. Calculations are descriptive and
+    causal; no future bar participates in a recent-window metric.
+    """
+    if bars.empty:
+        return {"available": False, "reason": "empty bars dataset"}
+
+    frame = bars.copy()
+    frame["timestamp"] = pd.to_datetime(frame["timestamp"], utc=True)
+    frame = frame.sort_values(["timestamp", "symbol"]).reset_index(drop=True)
+    as_of = pd.Timestamp(frame["timestamp"].max())
+
+    from wayfinder_paths.jobs.indicators import classify_regimes
+
+    labels: list[pd.DataFrame] = []
+    for _symbol, symbol_frame in frame.groupby("symbol", sort=False):
+        ordered = symbol_frame.sort_values("timestamp").copy()
+        ordered["regime"] = classify_regimes(ordered.reset_index(drop=True)).to_numpy()
+        labels.append(ordered[["timestamp", "symbol", "regime"]])
+    regime_frame = (
+        pd.concat(labels, ignore_index=True)
+        if labels
+        else pd.DataFrame(columns=["timestamp", "symbol", "regime"])
+    )
+
+    dataset_first = pd.Timestamp(frame["timestamp"].min())
+    funding = _funding_frame(funding_rows)
+    if not funding.empty:
+        funding = funding[
+            (funding["timestamp"] >= dataset_first) & (funding["timestamp"] <= as_of)
+        ]
+    comparisons: dict[str, Any] = {}
+    for days in windows:
+        cutoff = as_of - pd.Timedelta(days=int(days))
+        recent = frame[frame["timestamp"] > cutoff]
+        baseline = frame[frame["timestamp"] <= cutoff]
+        recent_regimes = regime_frame[regime_frame["timestamp"] > cutoff]
+        baseline_regimes = regime_frame[regime_frame["timestamp"] <= cutoff]
+        if recent.empty or baseline.empty:
+            comparisons[str(days)] = {
+                "available": False,
+                "reason": "dataset does not contain both baseline and recent bars",
+            }
+            continue
+        recent_metrics = _market_metrics(recent, recent_regimes)
+        baseline_metrics = _market_metrics(baseline, baseline_regimes)
+        comparisons[str(days)] = {
+            "available": True,
+            "recent": recent_metrics,
+            "baseline": baseline_metrics,
+            "volatility_ratio": _ratio(
+                recent_metrics.get("realized_volatility"),
+                baseline_metrics.get("realized_volatility"),
+            ),
+            "correlation_delta": _difference(
+                recent_metrics.get("mean_pairwise_correlation"),
+                baseline_metrics.get("mean_pairwise_correlation"),
+            ),
+            "liquidity_ratio": _ratio(
+                recent_metrics.get("median_notional_volume"),
+                baseline_metrics.get("median_notional_volume"),
+            ),
+            "regime_js_divergence": _js_divergence(
+                baseline_metrics.get("regime_distribution") or {},
+                recent_metrics.get("regime_distribution") or {},
+            ),
+            "funding_shift": _funding_shift(funding, cutoff),
+        }
+    return {
+        "available": any(row.get("available") for row in comparisons.values()),
+        "as_of": as_of.isoformat(),
+        "dataset_first_ts": dataset_first.isoformat(),
+        "symbols": sorted(str(value) for value in frame["symbol"].unique()),
+        "windows": comparisons,
+        "_basis": (
+            "Each recent 7/14/30-day market window is compared with all earlier "
+            "bars in the same frozen dataset. volatility_ratio, correlation_delta, "
+            "liquidity_ratio, causal regime-mix JS divergence and funding shift are "
+            "descriptive drift inputs; they do not claim alpha by themselves."
+        ),
+    }
+
+
+def write_market_state(
+    root: Path,
+    bars: pd.DataFrame,
+    *,
+    funding_rows: Sequence[Mapping[str, Any]] = (),
+) -> dict[str, Any]:
+    report = summarize_market_state(bars, funding_rows=funding_rows)
+    path = Path(root) / MARKET_STATE_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, indent=2, default=str) + "\n", encoding="utf-8")
+    return report
+
+
+def _market_metrics(frame: pd.DataFrame, regime_frame: pd.DataFrame) -> dict[str, Any]:
+    closes = frame.pivot_table(
+        index="timestamp", columns="symbol", values="close", aggfunc="last"
+    ).sort_index()
+    returns = closes.pct_change(fill_method=None)
+    vol_values = [
+        float(returns[column].std())
+        for column in returns.columns
+        if pd.notna(returns[column].std())
+    ]
+    corr = returns.corr(min_periods=20)
+    corr_values = [
+        float(corr.iloc[i, j])
+        for i in range(len(corr.columns))
+        for j in range(i + 1, len(corr.columns))
+        if pd.notna(corr.iloc[i, j])
+    ]
+    volumes = pd.to_numeric(frame.get("volume"), errors="coerce")
+    notional = pd.to_numeric(frame["close"], errors="coerce") * volumes
+    distribution = _distribution(
+        str(value) for value in regime_frame["regime"].dropna().tolist()
+    )
+    return {
+        "bars": int(len(frame)),
+        "first_ts": pd.Timestamp(frame["timestamp"].min()).isoformat(),
+        "last_ts": pd.Timestamp(frame["timestamp"].max()).isoformat(),
+        "realized_volatility": _round_or_none(statistics.median(vol_values), 8)
+        if vol_values
+        else None,
+        "mean_pairwise_correlation": _round_or_none(statistics.fmean(corr_values), 6)
+        if corr_values
+        else None,
+        "median_notional_volume": _round_or_none(float(notional.median()), 4)
+        if notional.notna().any()
+        else None,
+        "regime_distribution": distribution,
+    }
+
+
+def _funding_frame(rows: Sequence[Mapping[str, Any]]) -> pd.DataFrame:
+    normalized: list[dict[str, Any]] = []
+    for row in rows:
+        try:
+            normalized.append(
+                {
+                    "timestamp": pd.Timestamp(str(row["timestamp"])),
+                    "symbol": str(row.get("symbol") or "portfolio"),
+                    "value": float(row["value"]),
+                }
+            )
+        except (KeyError, TypeError, ValueError):
+            continue
+    if not normalized:
+        return pd.DataFrame(columns=["timestamp", "symbol", "value"])
+    frame = pd.DataFrame(normalized)
+    frame["timestamp"] = pd.to_datetime(frame["timestamp"], utc=True)
+    return frame.sort_values("timestamp")
+
+
+def _funding_shift(frame: pd.DataFrame, cutoff: pd.Timestamp) -> dict[str, Any] | None:
+    if frame.empty:
+        return None
+    strongest: dict[str, Any] | None = None
+    for symbol, rows in frame.groupby("symbol"):
+        recent = rows.loc[rows["timestamp"] > cutoff, "value"].astype(float)
+        baseline = rows.loc[rows["timestamp"] <= cutoff, "value"].astype(float)
+        if len(recent) < 3 or len(baseline) < 10:
+            continue
+        sigma = float(baseline.std())
+        if not math.isfinite(sigma) or sigma <= 0:
+            continue
+        z = (float(recent.mean()) - float(baseline.mean())) / sigma
+        candidate = {
+            "symbol": str(symbol),
+            "z_score": round(z, 4),
+            "recent_mean": round(float(recent.mean()), 9),
+            "baseline_mean": round(float(baseline.mean()), 9),
+            "recent_n": int(len(recent)),
+            "baseline_n": int(len(baseline)),
+        }
+        if strongest is None or abs(z) > abs(float(strongest["z_score"])):
+            strongest = candidate
+    return strongest
+
+
+def _distribution(values: Iterable[str]) -> dict[str, float]:
+    counts = Counter(values)
+    total = sum(counts.values())
+    return (
+        {key: round(value / total, 6) for key, value in sorted(counts.items())}
+        if total
+        else {}
+    )
+
+
+def _js_divergence(left: Mapping[str, Any], right: Mapping[str, Any]) -> float | None:
+    keys = set(left) | set(right)
+    if not keys:
+        return None
+    p = [float(left.get(key) or 0.0) for key in keys]
+    q = [float(right.get(key) or 0.0) for key in keys]
+    if sum(p) <= 0 or sum(q) <= 0:
+        return None
+    p = [value / sum(p) for value in p]
+    q = [value / sum(q) for value in q]
+    middle = [(a + b) / 2.0 for a, b in zip(p, q, strict=True)]
+
+    def kl(values: Sequence[float], reference: Sequence[float]) -> float:
+        return sum(
+            value * math.log(value / ref)
+            for value, ref in zip(values, reference, strict=True)
+            if value > 0 and ref > 0
+        )
+
+    return round((kl(p, middle) + kl(q, middle)) / 2.0, 6)
+
+
+def _ratio(numerator: Any, denominator: Any) -> float | None:
+    if not _finite(numerator) or not _finite(denominator) or float(denominator) == 0:
+        return None
+    return round(float(numerator) / float(denominator), 6)
+
+
+def _difference(left: Any, right: Any) -> float | None:
+    if not _finite(left) or not _finite(right):
+        return None
+    return round(float(left) - float(right), 6)
+
+
+def _finite(value: Any) -> bool:
+    try:
+        return math.isfinite(float(value))
+    except (TypeError, ValueError):
+        return False
+
+
+def _round_or_none(value: float, digits: int) -> float | None:
+    return round(value, digits) if math.isfinite(value) else None

--- a/wayfinder_paths/jobs/store.py
+++ b/wayfinder_paths/jobs/store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import shutil
+from collections import deque
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -281,9 +282,16 @@ class JobStore:
         path = self.job_dir(job_id) / relative
         if not path.exists():
             return []
-        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
-        if limit is not None:
-            lines = lines[-max(int(limit), 0) :]
+        if limit is None:
+            lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+        else:
+            bounded = max(int(limit), 0)
+            if bounded == 0:
+                return []
+            # Stream append-only ledgers so a bounded consumer does not first
+            # materialize the entire (potentially multi-MB) file in memory.
+            with path.open(encoding="utf-8", errors="replace") as handle:
+                lines = list(deque(handle, maxlen=bounded))
         rows: list[dict[str, Any]] = []
         for line in lines:
             if not line.strip():

--- a/wayfinder_paths/jobs/sync.py
+++ b/wayfinder_paths/jobs/sync.py
@@ -212,6 +212,13 @@ def snapshot_job(job_id: str, *, store: JobStore | None = None) -> dict[str, Any
     latest_intervene = _report_with_session(store, job_id, "intervene", "improve")
     latest_auto = _report_with_session(store, job_id, "auto", "decide")
     latest_apply = _report_with_session(store, job_id, "apply")
+    from wayfinder_paths.jobs.regime_contract import REGIME_HEALTH_PATH
+
+    regime_health = store.read_json(job_id, REGIME_HEALTH_PATH, default=None)
+    if isinstance(regime_health, dict):
+        from wayfinder_paths.jobs.regime_health import compact_regime_health
+
+        regime_health = compact_regime_health(regime_health)
     validation = (
         store.read_json(job_id, "reports/validation/latest.json", default={}) or {}
     )
@@ -231,6 +238,7 @@ def snapshot_job(job_id: str, *, store: JobStore | None = None) -> dict[str, Any
         "proposals": store.proposals(job_id),
         "probation": store.read_json(job_id, "probation.json", default={"legs": []}),
         "post_apply_shadow": _shadow_topline(store, job_id),
+        "regime_health": regime_health,
         "decision_log": _decision_log(store, job_id),
         "proposal_queue": store.proposal_queue(job_id),
         "reports": {

--- a/wayfinder_paths/jobs/triggers.py
+++ b/wayfinder_paths/jobs/triggers.py
@@ -35,6 +35,8 @@ DEFAULT_DEBOUNCE_SECONDS = 600
 # research_impasse fires when a research-stale job's last K wakes produced
 # zero progress artifacts — the wake it triggers carries the hatch-stripped
 # progress mandate (worker renders it from state/research_impasse.json).
+# regime_shift is a deterministic incumbent-health warning/critical transition;
+# legacy jobs predate the configurable trigger name, so it always wakes.
 ALWAYS_WAKE_EVENTS = {
     "proposal_restage_requested",
     "verdict_matured",
@@ -42,6 +44,7 @@ ALWAYS_WAKE_EVENTS = {
     "runner_loop_gap",
     "disk_pressure",
     "research_impasse",
+    "regime_shift",
 }
 
 

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -491,6 +491,18 @@ def _standing_checks_block(root: Path) -> dict[str, Any]:
             }
     if replication:
         block["backtest_replication"] = replication
+    from wayfinder_paths.jobs.regime_contract import REGIME_HEALTH_PATH
+
+    regime_path = root / REGIME_HEALTH_PATH
+    if regime_path.exists():
+        try:
+            regime = json.loads(regime_path.read_text(encoding="utf-8"))
+        except ValueError:
+            regime = None
+        if isinstance(regime, dict):
+            from wayfinder_paths.jobs.regime_health import compact_regime_health
+
+            block["portfolio_regime_health"] = compact_regime_health(regime)
     if block:
         block["_basis"] = (
             "Routine numbers computed mechanically THIS wake — never re-fetch "
@@ -503,7 +515,10 @@ def _standing_checks_block(root: Path) -> dict[str, Any]:
             "backtest_replication.decayed=true means the ACTIVE revision's "
             "deploy-time in-sample edge is not reproducing on refreshed data "
             "— mechanical evidence of selection on window-local noise; treat "
-            "it as grounds for a revert/kill or re-validation proposal."
+            "it as grounds for a revert/kill or re-validation proposal. "
+            "portfolio_regime_health warning/critical is an incumbent-health "
+            "alarm, not a request to mine a replacement signal: cite the "
+            "fresh attribution artifact before designing treatment."
         )
     return block
 
@@ -1030,6 +1045,13 @@ def _build_worker_prompt_sections(
             "every wake via update_probation_leg; set status "
             "graduated/killed when a criterion trips. A leg missing from "
             "the registry is a protocol violation.\n"
+            "- Regime alarm triage: a standing_checks."
+            "portfolio_regime_health warning/critical "
+            "OVERRIDES the ordinary search assignment: stop signal mining, "
+            "read the detector's named signals, then cite the automatically "
+            "refreshed `attribution` block before choosing whether to revert, "
+            "de-risk, gate a regime, or re-validate. Never explain away a "
+            "critical drawdown because one entry signal still backtests.\n"
             "- Quant loop (diagnose -> design -> ablate -> propose): start "
             "from the `attribution` block — archetype counts name the "
             "dominant failure mode; expectation_deltas name where forward "
@@ -1315,6 +1337,18 @@ def prepare_job_worker_prompt(
     # merging cleanly into every scan frame). Stamp-gated hourly; never
     # raises.
     refresh_derived_features_if_stale(job.id, store=store)
+
+    # Portfolio regime/incumbent health consumes the fresh compact market
+    # artifact above plus forward PnL. On alert it refreshes attribution before
+    # this wake is prompted, and applies only an owner-governed response.
+    try:
+        from wayfinder_paths.jobs.regime_health import regime_health_job
+
+        regime_health_job(job.id, store=store)
+    except Exception as exc:  # noqa: BLE001 — monitor cannot kill a wake
+        store.append_journal(
+            job.id, {"type": "regime_health_failed", "error": str(exc)[:300]}
+        )
 
     # Ideation accountability: journal freshly produced expedition artifacts
     # (owner-visible bucket counts) and escalate once when the daily research

--- a/wayfinder_paths/mcp/tools/jobs.py
+++ b/wayfinder_paths/mcp/tools/jobs.py
@@ -26,6 +26,7 @@ from wayfinder_paths.jobs.models import (
     utc_now_iso,
 )
 from wayfinder_paths.jobs.proposals import propose_change
+from wayfinder_paths.jobs.regime_health import regime_health_job
 from wayfinder_paths.jobs.runner_bridge import RunnerBridge
 from wayfinder_paths.jobs.starters import create_starter_job, starter_catalog
 from wayfinder_paths.jobs.store import JobStore
@@ -41,6 +42,7 @@ JobAction = Literal[
     "create",
     "status",
     "report",
+    "regime_health",
     "set_agent_mode",
     "set_script_mode",
     "review_now",
@@ -317,6 +319,7 @@ async def core_jobs(
     parallel: Literal["serial", "thread", "process"] = "process",
     compile: bool = True,  # noqa: A002
     full: bool = False,
+    force: bool = False,
     quick_bars: int | None = None,
     background: bool | None = None,
     op: str | None = None,
@@ -383,6 +386,9 @@ async def core_jobs(
         gate (fresh validation/backtest/preflight) and declare a
         `wallet_label`, else the call returns an error naming the blocker.
       - `set_agent_mode` to change the agent watch level (monitor/intervene/…).
+      - `regime_health` returns the deterministic 7/14/30-day incumbent and
+        market-state drift report. warning/critical refreshes attribution first;
+        any automatic response comes only from protected owner governance.
       - `review_now` to queue an immediate worker wakeup.
       - `approve_proposal` / `reject_proposal` after the worker creates proposals.
       - `claim_application` / `validate_application` / `complete_application`
@@ -512,6 +518,9 @@ async def core_jobs(
 
     if action in {"status", "report"}:
         return ok(snapshot_job(job_id, store=store))
+
+    if action == "regime_health":
+        return ok(regime_health_job(job_id, store=store, force=force))
 
     if action == "set_agent_mode":
         mode = normalize_agent_mode(agent_mode or "monitor")

--- a/wayfinder_paths/tests/test_jobs_derived_features.py
+++ b/wayfinder_paths/tests/test_jobs_derived_features.py
@@ -75,6 +75,10 @@ def test_derive_features_appends_and_dedupes(tmp_path: Path) -> None:
     )
 
     assert result["rows_appended"] > 0
+    assert result["market_state"]["path"].endswith("market_state.json")
+    assert (
+        store.job_dir(job_id) / "results" / "research" / "market_state.json"
+    ).exists()
     names = set(result["per_feature"])
     assert {"breadth_sma50", "panelret_lag1", "btc_ret12", "btc_trend"} <= names
     assert any(n.startswith("corr_sol") for n in names)  # LIT gets corr to SOL

--- a/wayfinder_paths/tests/test_jobs_regime_health.py
+++ b/wayfinder_paths/tests/test_jobs_regime_health.py
@@ -1,0 +1,308 @@
+"""Portfolio regime/incumbent health and governed response policy."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import math
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from wayfinder_paths.jobs.governance import commit_epoch, governance_dir
+from wayfinder_paths.jobs.halt import clear_halt, read_halt
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.regime_health import (
+    active_regime_leverage_cap,
+    regime_health_job,
+)
+from wayfinder_paths.jobs.regime_market import summarize_market_state
+from wayfinder_paths.jobs.store import JobStore
+
+
+def _market_bars() -> pd.DataFrame:
+    """Sixty days of 6h bars, with a violent correlated final week."""
+    start = pd.Timestamp("2026-06-20T00:00:00Z")
+    prices = {"BTC": 100.0, "ETH": 80.0}
+    rows: list[dict[str, object]] = []
+    count = 60 * 4
+    for index in range(count):
+        timestamp = start + pd.Timedelta(hours=6 * index)
+        shifted = index >= count - 28
+        common = 0.018 if index % 2 == 0 else -0.016
+        for symbol in ("BTC", "ETH"):
+            if shifted:
+                change = common
+                volume = 5.0
+            else:
+                wave = 0.0015 * math.sin(index / 5)
+                change = wave if symbol == "BTC" else -wave
+                volume = 1_000.0
+            previous = prices[symbol]
+            close = max(previous * (1.0 + change), 1.0)
+            prices[symbol] = close
+            rows.append(
+                {
+                    "timestamp": timestamp.isoformat(),
+                    "symbol": symbol,
+                    "open": previous,
+                    "high": max(previous, close) * 1.001,
+                    "low": min(previous, close) * 0.999,
+                    "close": close,
+                    "volume": volume,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def _forensics_row(
+    timestamp: dt.datetime,
+    bps: float,
+    *,
+    symbol: str = "HYPE",
+) -> dict[str, object]:
+    return {
+        "symbol": symbol,
+        "entry_reason": "incumbent",
+        "exit_reason": "bracket_stop" if bps < 0 else "time_exit",
+        "realized_bps": bps,
+        "entry_ts": (timestamp - dt.timedelta(hours=1)).isoformat(),
+        "exit_ts": timestamp.isoformat(),
+        "regime_at_entry": {
+            "trend": "down",
+            "vol_pctile": 80.0,
+            "session": "us",
+        },
+        "archetype": "trend_fight" if bps < 0 else "clean_win",
+    }
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+
+
+def _loss_job(tmp_path: Path, *, response: str | None = None) -> tuple[JobStore, str]:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("regime-loss", agent_mode="intervene")
+    job.execution_params["initial_capital"] = 100.0
+    store.save(job)
+    root = store.job_dir(job.id)
+    now = dt.datetime(2026, 8, 21, tzinfo=dt.UTC)
+
+    baseline = [
+        _forensics_row(now - dt.timedelta(days=60 - index), 80.0 + index)
+        for index in range(30)
+    ]
+    backtest = root / "results" / "backtest"
+    backtest.mkdir(parents=True, exist_ok=True)
+    (backtest / "trade_forensics.json").write_text(
+        json.dumps({"trades": baseline}), encoding="utf-8"
+    )
+    forward_forensics = [
+        _forensics_row(now - dt.timedelta(days=2), -300.0),
+        _forensics_row(now - dt.timedelta(days=1), -50.0, symbol="SOL"),
+        _forensics_row(now - dt.timedelta(hours=2), -50.0, symbol="SOL"),
+    ]
+    _write_jsonl(
+        root / "results" / "forward" / "trade_forensics.jsonl",
+        forward_forensics,
+    )
+    trades = [
+        {
+            "symbol": "HYPE",
+            "closed_at": (now - dt.timedelta(days=2)).isoformat(),
+            "net_pnl": -12.0,
+        },
+        {
+            "symbol": "SOL",
+            "closed_at": (now - dt.timedelta(days=1)).isoformat(),
+            "net_pnl": -1.0,
+        },
+        {
+            "symbol": "SOL",
+            "closed_at": (now - dt.timedelta(hours=2)).isoformat(),
+            "net_pnl": -1.0,
+        },
+    ]
+    _write_jsonl(root / "results" / "forward" / "trades.jsonl", trades)
+    if response:
+        protected = governance_dir(tmp_path, job.id)
+        protected.mkdir(parents=True, exist_ok=True)
+        (protected / "hard_constraints.yaml").write_text(
+            "max_drawdown_pct: 0.15\n"
+            "regime_response:\n"
+            f"  warning: {response}\n"
+            f"  critical: {response}\n"
+            "  max_leverage: 1.0\n",
+            encoding="utf-8",
+        )
+        commit_epoch(protected, note="test owner policy")
+    return store, job.id
+
+
+def test_market_state_detects_joint_regime_break() -> None:
+    funding_start = pd.Timestamp("2026-06-20T00:00:00Z")
+    funding_rows = []
+    for index in range(60 * 6):
+        timestamp = funding_start + pd.Timedelta(hours=4 * index)
+        funding_rows.append(
+            {
+                "timestamp": timestamp.isoformat(),
+                "symbol": "ETH",
+                "value": (
+                    8e-5 if index >= (53 * 6) else (1e-5 if index % 2 else -1e-5)
+                ),
+            }
+        )
+    report = summarize_market_state(
+        _market_bars(), funding_rows=funding_rows, windows=(7,)
+    )
+    window = report["windows"]["7"]
+    assert report["available"] is True
+    assert window["volatility_ratio"] > 2.5
+    assert window["correlation_delta"] > 0.35
+    assert window["liquidity_ratio"] < 0.1
+    assert window["regime_js_divergence"] > 0.1
+    assert abs(window["funding_shift"]["z_score"]) > 3
+
+
+def test_large_concentrated_drawdown_is_critical_and_refreshes_attribution(
+    tmp_path: Path,
+) -> None:
+    store, job_id = _loss_job(tmp_path)
+    now = dt.datetime(2026, 8, 21, tzinfo=dt.UTC)
+    # Agent-writable job metadata cannot move the detector's goalposts.
+    job = store.load(job_id)
+    job.performance["regime_detector"] = {"drawdown_critical": 0.99}
+    store.save(job)
+    report = regime_health_job(job_id, store=store, force=True, now=now)
+
+    assert report["status"] == "critical"
+    assert {signal["kind"] for signal in report["signals"]} >= {
+        "drawdown",
+        "edge_decay",
+        "loss_concentration",
+    }
+    seven = report["windows"]["windows"]["7"]
+    assert seven["max_drawdown_pct"] == 0.14
+    assert seven["largest_loss_share"] == pytest.approx(12 / 14, abs=1e-4)
+    assert report["policy"]["action"] == "alert_only"
+    assert report["response"]["applied"] is False
+    assert report["attribution"]["required"] is True
+    assert (store.job_dir(job_id) / "results/research/attribution.json").exists()
+
+    # Recomputing unchanged evidence does not emit another transition event.
+    regime_health_job(job_id, store=store, force=True, now=now)
+    journal = (store.job_dir(job_id) / "journal.jsonl").read_text(encoding="utf-8")
+    assert journal.count("portfolio_regime_shift_detected") == 1
+
+
+def test_market_only_break_warns_before_forward_losses(tmp_path: Path) -> None:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("regime-market", agent_mode="intervene")
+    store.save(job)
+    market = summarize_market_state(_market_bars(), windows=(7,))
+    store.write_json(job.id, "results/research/market_state.json", market)
+
+    report = regime_health_job(
+        job.id,
+        store=store,
+        force=True,
+        now=pd.Timestamp(market["as_of"]).to_pydatetime(),
+    )
+
+    assert report["status"] == "warning"
+    assert report["transition"]["alert"] is True
+    assert report["windows"]["windows"]["7"]["closed_trades"] == 0
+    assert {signal["kind"] for signal in report["signals"]} >= {
+        "volatility_shift",
+        "correlation_shift",
+        "liquidity_deterioration",
+    }
+    assert report["response"]["applied"] is False
+
+
+def test_stale_market_artifact_is_not_treated_as_current_regime(
+    tmp_path: Path,
+) -> None:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("regime-stale-market", agent_mode="intervene")
+    store.save(job)
+    market = summarize_market_state(_market_bars(), windows=(7,))
+    store.write_json(job.id, "results/research/market_state.json", market)
+
+    report = regime_health_job(
+        job.id,
+        store=store,
+        force=True,
+        now=pd.Timestamp(market["as_of"]).to_pydatetime() + dt.timedelta(days=2),
+    )
+
+    assert [signal["kind"] for signal in report["signals"]] == ["market_data_stale"]
+    assert report["status"] == "watch"
+
+
+def test_legacy_constitution_cannot_authorize_automatic_response(
+    tmp_path: Path,
+) -> None:
+    store, job_id = _loss_job(tmp_path)
+    root = store.job_dir(job_id)
+    (root / "constitution.yaml").write_text(
+        "hard_constraints:\n"
+        "  regime_response:\n"
+        "    warning: flatten\n"
+        "    critical: flatten\n",
+        encoding="utf-8",
+    )
+
+    report = regime_health_job(
+        job_id,
+        store=store,
+        force=True,
+        now=dt.datetime(2026, 8, 21, tzinfo=dt.UTC),
+    )
+
+    assert report["status"] == "critical"
+    assert report["governance"]["trusted"] is False
+    assert report["policy"]["action"] == "alert_only"
+    assert "verified protected governance" in report["policy"]["error"]
+    assert read_halt(root) is None
+
+
+def test_owner_governed_pause_latches_and_requires_owner_clear(tmp_path: Path) -> None:
+    store, job_id = _loss_job(tmp_path, response="pause_entries")
+    report = regime_health_job(
+        job_id,
+        store=store,
+        force=True,
+        now=dt.datetime(2026, 8, 21, tzinfo=dt.UTC),
+    )
+    halt = read_halt(store.job_dir(job_id))
+    assert report["response"]["applied"] is True
+    assert halt and halt["source"] == "regime_health" and halt["flatten"] is False
+    with pytest.raises(PermissionError, match="requires by='owner'"):
+        clear_halt(store, job_id, by="agent")
+    assert clear_halt(store, job_id, by="owner")["cleared"] is True
+
+
+def test_governed_leverage_cap_is_runtime_only(tmp_path: Path) -> None:
+    store, job_id = _loss_job(tmp_path, response="clamp_leverage")
+    root = store.job_dir(job_id)
+    report = regime_health_job(
+        job_id,
+        store=store,
+        force=True,
+        now=dt.datetime(2026, 8, 21, tzinfo=dt.UTC),
+    )
+    assert report["response"]["effective_on"] == "next_tick"
+    assert active_regime_leverage_cap(report) == 1.0
+    assert store.load(job_id).execution_params.get("leverage") is None
+
+    # A healthy report releases the cap without rewriting the user's dial.
+    report_path = root / "results" / "research" / "regime_health.json"
+    doc = json.loads(report_path.read_text(encoding="utf-8"))
+    doc["status"] = "healthy"
+    report_path.write_text(json.dumps(doc), encoding="utf-8")
+    assert active_regime_leverage_cap(doc) is None

--- a/wayfinder_paths/tests/test_jobs_risk_limits.py
+++ b/wayfinder_paths/tests/test_jobs_risk_limits.py
@@ -192,6 +192,8 @@ def test_venue_peak_persists_across_ticks_and_drawdown_fires(tmp_path: Path) -> 
     saved = json.loads((root / "state" / "risk_state.json").read_text())
     assert saved["peak_equity"] == 10_000.0
     assert saved["equity_source"] == "venue"
+    assert saved["equity"] == 10_000.0
+    assert saved["drawdown"] == 0.0
 
     second_reason, second = check_risk_halt(
         root,
@@ -453,3 +455,40 @@ async def test_leverage_within_governance_ceiling_untouched(tmp_path: Path) -> N
 
     assert not any(e["kind"] == "leverage_clamped" for e in result["guard_events"])
     assert result["intents"][0]["size"] == 2.0
+
+
+async def test_regime_health_runtime_cap_clamps_without_rewriting_dial(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, job, root = _make_job(tmp_path, params={"leverage": 4.0})
+    _write_governance(
+        tmp_path,
+        job.id,
+        {
+            "regime_response": {
+                "warning": "clamp_leverage",
+                "critical": "clamp_leverage",
+                "max_leverage": 1.0,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.regime_health.regime_health_job",
+        lambda *args, **kwargs: {
+            "status": "critical",
+            "governance": {"trusted": True},
+            "policy": {"action": "clamp_leverage", "max_leverage": 1.0},
+        },
+    )
+
+    result = await _tick(job, root, store, view_count=1)
+
+    clamps = [
+        event
+        for event in result["guard_events"]
+        if event["kind"] == "regime_leverage_clamped"
+    ]
+    assert clamps[0]["effective"] == 1.0
+    assert result["intents"][0]["size"] == 1.0
+    assert store.load(job.id).execution_params["leverage"] == 4.0

--- a/wayfinder_paths/tests/test_jobs_store.py
+++ b/wayfinder_paths/tests/test_jobs_store.py
@@ -1,0 +1,25 @@
+"""JobStore resource-bound reads used by tick-time monitors."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from wayfinder_paths.jobs.store import JobStore
+
+
+def test_jsonl_limit_streams_only_requested_tail(tmp_path: Path) -> None:
+    store = JobStore(repo_root=tmp_path)
+    path = store.job_dir("bounded-tail") / "events.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(json.dumps({"index": index}) for index in range(5)) + "\n",
+        encoding="utf-8",
+    )
+
+    assert store.read_jsonl("bounded-tail", "events.jsonl", limit=2) == [
+        {"index": 3},
+        {"index": 4},
+    ]
+    assert store.read_jsonl("bounded-tail", "events.jsonl", limit=0) == []
+    assert store.read_jsonl("bounded-tail", "events.jsonl", limit=-1) == []

--- a/wayfinder_paths/tests/test_jobs_triggers.py
+++ b/wayfinder_paths/tests/test_jobs_triggers.py
@@ -136,6 +136,12 @@ def test_tick_trigger_event_derivation() -> None:
     assert _tick_trigger_events(
         {"ok": True, "guard_events": [{"kind": "native_protection_failed"}]}
     ) == ["risk_halt"]
+    assert _tick_trigger_events(
+        {
+            "ok": True,
+            "regime_health": {"transition": {"alert": True}},
+        }
+    ) == ["regime_shift"]
     assert _tick_trigger_events({"ok": True, "snapshot": {"status": "valid"}}) == []
 
 


### PR DESCRIPTION
## Summary

- add deterministic 7/14/30-day portfolio health windows for drawdown, drawdown velocity, loss concentration, and realized-edge decay versus the backtest population
- build compact market-state baselines during the existing derived-feature refresh for volatility, cross-symbol correlation, liquidity, causal regime mix, and funding drift
- surface warning/critical transitions through job snapshots, CLI/MCP, journals, and an always-wake regime_shift event; refresh attribution before the agent designs treatment
- default to alert-only; automatic leverage clamps, entry pauses, or flattening require a verified protected-governance epoch and are recomputed before execution rather than trusted from agent-writable state
- persist exact marked equity/drawdown and bound limited JSONL reads so the tick-time monitor stays memory-safe

## Safety behavior

Legacy jobs continue to receive detector output and alerts. Legacy job-root constitutions cannot authorize automatic responses or threshold overrides. A protected pause/flatten uses the durable owner-clear-only halt latch; a protected leverage clamp is runtime-only and never rewrites the owner leverage dial.

## Validation

- 704 passed: full jobs regression suite
- 85 passed: detector/live driver/governance/sync/MCP/attribution integration suite
- 67 passed: final affected suite after bounded-reader hardening
- Ruff format/check clean for all 19 changed files
- Mypy clean for the three new regime modules
- git diff --check clean