### PR TITLE
fix(jobs): close the regime remediation loop

### DIFF
--- a/wayfinder_paths/jobs/execution/driver.py
+++ b/wayfinder_paths/jobs/execution/driver.py
@@ -95,7 +95,21 @@ def run_scheduled_tick(job_dir: str | Path | None = None) -> dict[str, Any]:
             )
 
             health = regime_health_job(job.id, store=store)
-            payload["regime_health"] = compact_regime_health(health)
+            compact_health = compact_regime_health(health)
+            payload["regime_health"] = compact_health
+            try:
+                from wayfinder_paths.jobs.remediation import (
+                    sync_remediation_with_health,
+                )
+
+                remediation_event = sync_remediation_with_health(store, job.id, health)
+                if remediation_event:
+                    compact_health["remediation_event"] = remediation_event
+            except Exception as exc:  # noqa: BLE001
+                store.append_journal(
+                    job.id,
+                    {"type": "regime_remediation_failed", "error": str(exc)[:300]},
+                )
         except Exception as exc:  # noqa: BLE001
             store.append_journal(
                 job.id,
@@ -136,8 +150,12 @@ def _tick_trigger_events(payload: dict[str, Any]) -> list[str]:
         # Declared vs executed mode disagree — wake the advisor to reconcile
         # job.yaml (reuses the reconcile_mismatch trigger).
         events.append("reconcile_mismatch")
-    health_transition = (payload.get("regime_health") or {}).get("transition") or {}
-    if health_transition.get("alert"):
+    health = payload.get("regime_health") or {}
+    remediation_event = (health.get("remediation_event") or {}).get("event")
+    if remediation_event in {"regime_shift", "regime_remediation_due"}:
+        events.append(str(remediation_event))
+    elif (health.get("transition") or {}).get("alert"):
+        # Compatibility with reports produced before durable remediation cases.
         events.append("regime_shift")
     return events
 
@@ -849,14 +867,7 @@ def _record(
     # trade_rows are FillEvent.to_dict() + realized_pnl_delta: fixed shape.
     for row in tick.trade_rows:
         if row["reduce_only"]:
-            recorder.record_trade_close(
-                symbol=row["symbol"],
-                side=row["side"],
-                size=row["filled_size"],
-                price=row["avg_price"],
-                net_pnl=row["realized_pnl_delta"],
-                closed_at=row["timestamp"],
-            )
+            recorder.record_trade_close(_trade_close_payload(row, params=params))
     for row in funding_rows or []:
         recorder.record_funding(row)
     # Reconciliation runs AFTER the rows above so summary totals include
@@ -895,6 +906,63 @@ def _record(
         reason=tick.skip_reason,
         metrics={"fill_count": len(fills), "guard_event_count": len(tick.guard_events)},
     )
+
+
+def _trade_close_payload(
+    row: Mapping[str, Any], *, params: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Preserve the execution facts needed to diagnose a live stop-out."""
+    raw = dict(row.get("raw") or {})
+    metadata = dict(raw.get("intent_metadata") or {})
+    action = str(raw.get("intent_action") or "").upper()
+    bracket = dict(metadata.get("bracket") or {})
+    exit_reason = metadata.get("exit_reason")
+    if not exit_reason and action == "STOP_LOSS":
+        exit_reason = "bracket_stop"
+    elif not exit_reason and action == "TAKE_PROFIT":
+        exit_reason = "bracket_take_profit"
+    trigger_price = bracket.get("trigger_price")
+    fill_price = row.get("avg_price")
+    stop_slippage_bps = None
+    if action == "STOP_LOSS" and trigger_price and fill_price:
+        exit_side = str(row.get("side") or "").lower()
+        adverse_move = (
+            float(fill_price) - float(trigger_price)
+            if exit_side in {"buy", "long"}
+            else float(trigger_price) - float(fill_price)
+        )
+        stop_slippage_bps = round(adverse_move / float(trigger_price) * 10_000, 1)
+    venue = str(row.get("venue") or "")
+    payload = {
+        "symbol": row.get("symbol"),
+        "side": row.get("side"),
+        "size": row.get("filled_size"),
+        "price": fill_price,
+        "net_pnl": row.get("realized_pnl_delta"),
+        "closed_at": row.get("timestamp"),
+        "venue": venue,
+        "fee": row.get("fee"),
+        "order_id": row.get("order_id"),
+        "client_order_id": row.get("client_order_id"),
+        "exit_reason": exit_reason,
+        "effective_leverage": params.get("leverage") or 1.0,
+    }
+    if action == "STOP_LOSS":
+        payload.update(
+            {
+                "stop_trigger_price": trigger_price,
+                "stop_reference_price": bracket.get("price")
+                or raw.get("reference_price"),
+                "stop_gap_at_open": bracket.get("gap_at_open"),
+                "stop_slippage_bps": stop_slippage_bps,
+                "stop_slippage_bps_applied": raw.get("slippage_bps_applied"),
+                "protection_type": "trigger_market",
+                "venue_stop_slippage_tolerance_bps": (
+                    1_000 if venue == "hyperliquid" else None
+                ),
+            }
+        )
+    return payload
 
 
 def view_hash(view: CompletedBarsView) -> str:

--- a/wayfinder_paths/jobs/execution/primitives.py
+++ b/wayfinder_paths/jobs/execution/primitives.py
@@ -653,6 +653,8 @@ class BracketEngine:
         take_profit: float | None,
         policy: str = "conservative",
     ) -> dict[str, Any]:
+        normalized_side = _normalize_side(side)
+        open_price = _bar_value(bar, "open")
         stop_hit = stop_loss is not None and BracketEngine.ohlc_stop_hit(
             bar, side, stop_loss
         )
@@ -669,10 +671,26 @@ class BracketEngine:
             exit_type, price, hit, ambiguous = "TAKE_PROFIT", take_profit, True, False
         else:
             exit_type, price, hit, ambiguous = None, None, False, False
+        trigger_price = price
+        gap_at_open = False
+        if exit_type == "STOP_LOSS" and stop_loss is not None:
+            gap_at_open = (
+                open_price < stop_loss
+                if normalized_side == "long"
+                else open_price > stop_loss
+            )
+            if gap_at_open:
+                # A stop-market order cannot fill at a price the market gapped
+                # through. Use the first observable price, then let the broker's
+                # stop-specific slippage model apply on top.
+                price = open_price
         return {
             "hit": hit,
             "exit_type": exit_type,
             "price": price,
+            "trigger_price": trigger_price,
+            "open_price": open_price,
+            "gap_at_open": gap_at_open,
             "ambiguous": ambiguous,
             "policy": policy,
             "used_ohlc": True,

--- a/wayfinder_paths/jobs/execution/simulator.py
+++ b/wayfinder_paths/jobs/execution/simulator.py
@@ -116,10 +116,12 @@ class BacktestBroker:
         fee_bps: float = 0.0,
         maker_fee_bps: float = 0.0,
         slippage_bps: float = 0.0,
+        stop_market_slippage_bps: float = 0.0,
     ) -> None:
         self.fee_bps = fee_bps
         self.maker_fee_bps = maker_fee_bps
         self.slippage_bps = slippage_bps
+        self.stop_market_slippage_bps = stop_market_slippage_bps
 
     async def place(
         self,
@@ -188,10 +190,15 @@ class BacktestBroker:
             intent.limit_price is not None and intent.metadata.get("_resting_fill")
         )
         side_multiplier = 1 if str(intent.side).lower() in {"buy", "long"} else -1
+        applied_slippage_bps = (
+            self.stop_market_slippage_bps
+            if str(intent.action).upper() == "STOP_LOSS"
+            else self.slippage_bps
+        )
         fill_price = (
             price
             if maker_fill
-            else price * (1 + side_multiplier * self.slippage_bps / 10_000)
+            else price * (1 + side_multiplier * applied_slippage_bps / 10_000)
         )
         fee_bps = self.maker_fee_bps if maker_fill else self.fee_bps
         fee = abs(size * fill_price) * fee_bps / 10_000
@@ -210,6 +217,8 @@ class BacktestBroker:
                 "intent_metadata": intent.metadata,
                 "bracket": intent.bracket,
                 "liquidity": "maker" if maker_fill else "taker",
+                "reference_price": price,
+                "slippage_bps_applied": 0.0 if maker_fill else applied_slippage_bps,
             },
             timestamp=timestamp,
         )
@@ -413,6 +422,9 @@ def simulate_execution(
         fee_bps=_resolve_fee_bps(params_data, strategy),
         maker_fee_bps=_resolve_maker_fee_bps(params_data, strategy),
         slippage_bps=float(params_data.get("slippage_bps") or 0.0),
+        stop_market_slippage_bps=float(
+            params_data.get("stop_market_slippage_bps") or 0.0
+        ),
     )
     state = EngineState()
     trace = ExecutionTrace(execution_spec=spec.to_dict())

--- a/wayfinder_paths/jobs/proposals.py
+++ b/wayfinder_paths/jobs/proposals.py
@@ -156,6 +156,11 @@ def propose_change(
         "change_summary": memo or summary,
         "application": {"status": "not_requested", **candidate_descriptor},
     }
+    from wayfinder_paths.jobs.remediation import proposal_remediation_stamp
+
+    remediation = proposal_remediation_stamp(store, job_id)
+    if remediation:
+        proposal["remediation"] = remediation
     if memo:
         memo_path = store.job_dir(job_id) / "proposals" / f"{pid}.md"
         memo_path.parent.mkdir(parents=True, exist_ok=True)
@@ -186,6 +191,9 @@ def propose_change(
     proposal["candidate_report"] = candidate_report
 
     store.write_proposal(job_id, proposal)
+    from wayfinder_paths.jobs.remediation import link_remediation_proposal
+
+    link_remediation_proposal(store, job_id, proposal)
     store.append_journal(
         job_id,
         {
@@ -511,6 +519,9 @@ def revalidate_proposal(
     proposal["changed_files"] = _diff_workspaces(root, candidate_dir)
     proposal["updated_at"] = utc_now_iso()
     store.write_proposal(job_id, proposal)
+    from wayfinder_paths.jobs.remediation import link_remediation_proposal
+
+    link_remediation_proposal(store, job_id, proposal)
     store.append_journal(
         job_id,
         {
@@ -597,6 +608,9 @@ def restage_proposal(
     proposal["candidate_report"] = candidate_report
     proposal["updated_at"] = utc_now_iso()
     store.write_proposal(job_id, proposal)
+    from wayfinder_paths.jobs.remediation import link_remediation_proposal
+
+    link_remediation_proposal(store, job_id, proposal)
     store.append_journal(
         job_id,
         {

--- a/wayfinder_paths/jobs/regime_contract.py
+++ b/wayfinder_paths/jobs/regime_contract.py
@@ -3,4 +3,4 @@
 REGIME_HEALTH_PATH = "results/research/regime_health.json"
 MARKET_STATE_PATH = "results/research/market_state.json"
 WINDOW_DAYS = (7, 14, 30)
-REGIME_HEALTH_SCHEMA_VERSION = "1.0"
+REGIME_HEALTH_SCHEMA_VERSION = "1.1"

--- a/wayfinder_paths/jobs/regime_health.py
+++ b/wayfinder_paths/jobs/regime_health.py
@@ -40,6 +40,7 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any, Literal
 
+from wayfinder_paths.jobs.gating import compute_workspace_revision
 from wayfinder_paths.jobs.models import WayfinderJob
 from wayfinder_paths.jobs.regime_contract import (
     MARKET_STATE_PATH,
@@ -87,6 +88,8 @@ def regime_health_job(
         now = now.replace(tzinfo=dt.UTC)
     previous = _read_json(root / REGIME_HEALTH_PATH) or {}
     fingerprint = _input_fingerprint(root)
+    workspace_revision = compute_workspace_revision(root)
+    fingerprint["workspace_revision"] = workspace_revision
     fingerprint["evaluation_hour"] = now.replace(
         minute=0, second=0, microsecond=0
     ).isoformat()
@@ -166,6 +169,20 @@ def regime_health_job(
         status=status,
         forward_count=len(forward_forensics),
     )
+    declared_revision = job.versioning.get("active_revision")
+    incumbent = {
+        "declared_revision": declared_revision,
+        "workspace_revision": workspace_revision,
+        "revision_aligned": (
+            declared_revision == workspace_revision if declared_revision else None
+        ),
+    }
+    evidence_fingerprint = _evidence_fingerprint(
+        status=status,
+        score=score,
+        signals=signals,
+        incumbent_revision=workspace_revision,
+    )
     report: dict[str, Any] = {
         "schema_version": REGIME_HEALTH_SCHEMA_VERSION,
         "job_id": job_id,
@@ -174,6 +191,8 @@ def regime_health_job(
         "status": status,
         "score": score,
         "signals": signals,
+        "evidence_fingerprint": evidence_fingerprint,
+        "incumbent": incumbent,
         "thresholds": config,
         "windows": windows,
         "market": market,
@@ -327,6 +346,8 @@ def compact_regime_health(report: Mapping[str, Any]) -> dict[str, Any]:
         "score": report.get("score"),
         "computed_at": report.get("computed_at"),
         "signals": signals[:8],
+        "evidence_fingerprint": report.get("evidence_fingerprint"),
+        "incumbent": report.get("incumbent"),
         "policy": report.get("policy"),
         "transition": report.get("transition"),
         "attribution": report.get("attribution"),
@@ -788,6 +809,36 @@ def _input_fingerprint(root: Path) -> dict[str, Any]:
         for path in paths
         if path.exists()
     }
+
+
+def _evidence_fingerprint(
+    *,
+    status: str,
+    score: int,
+    signals: Sequence[Mapping[str, Any]],
+    incumbent_revision: str,
+) -> str:
+    """Stable identity for the evidence that requires owner remediation."""
+    bounded_signals = [
+        {
+            key: signal.get(key)
+            for key in ("kind", "severity", "value", "symbol", "window_days")
+            if signal.get(key) is not None
+        }
+        for signal in signals
+    ]
+    return hashlib.sha256(
+        json.dumps(
+            {
+                "status": status,
+                "score": score,
+                "signals": bounded_signals,
+                "incumbent_revision": incumbent_revision,
+            },
+            sort_keys=True,
+            default=str,
+        ).encode("utf-8")
+    ).hexdigest()[:16]
 
 
 def _governance_context(root: Path) -> tuple[dict[str, Any], dict[str, Any]]:

--- a/wayfinder_paths/jobs/remediation.py
+++ b/wayfinder_paths/jobs/remediation.py
@@ -1,0 +1,447 @@
+"""Durable closed-loop remediation for incumbent health alarms.
+
+The detector is deliberately descriptive and the trading response remains
+owner-governed.  This module owns the missing orchestration state between a
+warning/critical report and an agent-authored proposal: material evidence
+opens (or refreshes) one case, scheduled ticks keep an unhandled case awake,
+and proposals are stamped back to the evidence that caused them.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+from collections.abc import Mapping
+from pathlib import PurePosixPath
+from typing import Any
+
+from wayfinder_paths.jobs.models import utc_now_iso
+from wayfinder_paths.jobs.store import JobStore
+
+REMEDIATION_PATH = "state/regime_remediation.json"
+REMEDIATION_SCHEMA_VERSION = "1.0"
+REMEDIATION_RETRY_SECONDS = 30 * 60
+
+_ALERT_STATUSES = frozenset({"warning", "critical"})
+_STATUS_RANK = {
+    "insufficient": 0,
+    "healthy": 1,
+    "watch": 2,
+    "warning": 3,
+    "critical": 4,
+}
+_ACTIONABLE_STATES = frozenset({"open", "evaluating", "blocked"})
+
+
+def load_remediation(store: JobStore, job_id: str) -> dict[str, Any] | None:
+    doc = store.read_json(job_id, REMEDIATION_PATH)
+    return dict(doc) if isinstance(doc, Mapping) else None
+
+
+def sync_remediation_with_health(
+    store: JobStore,
+    job_id: str,
+    report: Mapping[str, Any],
+    *,
+    now: dt.datetime | None = None,
+) -> dict[str, Any] | None:
+    """Open/refresh a case and return the agent event that is due.
+
+    Called only by the scheduled driver.  Preflight/manual ticks may compute
+    health, but cannot consume or dispatch the durable alert.
+    """
+    status = str(report.get("status") or "insufficient")
+    now = now or dt.datetime.now(dt.UTC)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=dt.UTC)
+    now_iso = now.astimezone(dt.UTC).isoformat()
+    current = load_remediation(store, job_id)
+    if status not in _ALERT_STATUSES:
+        if (
+            current
+            and current.get("state") == "monitoring"
+            and status in {"healthy", "watch"}
+        ):
+            current.update(
+                {
+                    "state": "resolved",
+                    "updated_at": now_iso,
+                    "resolved_at": now_iso,
+                    "resolved_health_status": status,
+                }
+            )
+            store.write_json(job_id, REMEDIATION_PATH, current)
+            store.append_journal(
+                job_id,
+                {
+                    "type": "regime_remediation_resolved",
+                    "case_id": current.get("case_id"),
+                    "health_status": status,
+                },
+            )
+        return None
+
+    evidence = _health_evidence(report)
+    material_reasons = _material_reasons(current, evidence)
+
+    if current is None or material_reasons:
+        prior_state = str((current or {}).get("state") or "")
+        continuing_case = bool(
+            current and prior_state in _ACTIONABLE_STATES | {"proposal_pending"}
+        )
+        case_id = (
+            str((current or {}).get("case_id"))
+            if continuing_case
+            else _case_id(job_id, str(evidence["fingerprint"]))
+        )
+        state = prior_state if prior_state == "evaluating" else "open"
+        case = {
+            "schema_version": REMEDIATION_SCHEMA_VERSION,
+            "job_id": job_id,
+            "case_id": case_id,
+            "state": state,
+            "opened_at": (
+                (current or {}).get("opened_at") if continuing_case else now_iso
+            ),
+            "updated_at": now_iso,
+            "last_wake_requested_at": now_iso,
+            "attempts": (
+                int((current or {}).get("attempts") or 0) + 1 if continuing_case else 1
+            ),
+            "proposal_id": None,
+            "superseded_proposal_id": (current or {}).get("proposal_id"),
+            "health": evidence,
+            "material_reasons": material_reasons or ["entered_alert_state"],
+            "supersedes_fingerprint": (current or {})
+            .get("health", {})
+            .get("fingerprint")
+            if current
+            else None,
+        }
+        store.write_json(job_id, REMEDIATION_PATH, case)
+        store.append_journal(
+            job_id,
+            {
+                "type": "regime_remediation_opened"
+                if not continuing_case
+                else "regime_remediation_evidence_updated",
+                "case_id": case_id,
+                "state": state,
+                "health_status": status,
+                "evidence_fingerprint": evidence["fingerprint"],
+                "material_reasons": case["material_reasons"],
+            },
+        )
+        return {
+            "event": "regime_shift",
+            "case_id": case_id,
+            "evidence_fingerprint": evidence["fingerprint"],
+            "material_reasons": case["material_reasons"],
+        }
+
+    state = str(current.get("state") or "open")
+    if state not in _ACTIONABLE_STATES:
+        return None
+    last_wake = _parse_time(current.get("last_wake_requested_at"))
+    if last_wake and (now - last_wake).total_seconds() < REMEDIATION_RETRY_SECONDS:
+        return None
+
+    current["updated_at"] = now_iso
+    current["last_wake_requested_at"] = now_iso
+    current["attempts"] = int(current.get("attempts") or 0) + 1
+    current["health"] = evidence
+    store.write_json(job_id, REMEDIATION_PATH, current)
+    return {
+        "event": "regime_remediation_due",
+        "case_id": current.get("case_id"),
+        "evidence_fingerprint": evidence["fingerprint"],
+        "material_reasons": ["open_case_without_proposal"],
+    }
+
+
+def proposal_remediation_stamp(store: JobStore, job_id: str) -> dict[str, Any] | None:
+    """Trusted evidence stamp for a proposal authored during an open case."""
+    case = load_remediation(store, job_id)
+    if not case or str(case.get("state")) not in _ACTIONABLE_STATES:
+        return None
+    health = case.get("health") or {}
+    return {
+        "case_id": case.get("case_id"),
+        "evidence_fingerprint": health.get("fingerprint"),
+        "health_status": health.get("status"),
+        "health_score": health.get("score"),
+        "source_revision": health.get("incumbent_revision"),
+        "signals": list(health.get("signals") or []),
+    }
+
+
+def link_remediation_proposal(
+    store: JobStore,
+    job_id: str,
+    proposal: Mapping[str, Any],
+) -> None:
+    stamp = proposal.get("remediation")
+    if not isinstance(stamp, Mapping):
+        return
+    case = load_remediation(store, job_id)
+    if not case or case.get("case_id") != stamp.get("case_id"):
+        return
+    report = proposal.get("candidate_report") or {}
+    gate = report.get("gate") or {}
+    economic = report.get("economic") or {}
+    candidate_ready = (
+        gate.get("live_ready") is True and economic.get("ready") is not False
+    )
+    case.update(
+        {
+            "state": "proposal_pending" if candidate_ready else "blocked",
+            "proposal_id": proposal.get("proposal_id"),
+            "updated_at": utc_now_iso(),
+            "candidate_ready": candidate_ready,
+            "candidate_gate": {
+                "live_ready": gate.get("live_ready"),
+                "economic_ready": economic.get("ready"),
+                "economic_reasons": list(economic.get("reasons") or []),
+            },
+        }
+    )
+    store.write_json(job_id, REMEDIATION_PATH, case)
+    store.append_journal(
+        job_id,
+        {
+            "type": "regime_remediation_proposal_linked",
+            "case_id": case.get("case_id"),
+            "proposal_id": proposal.get("proposal_id"),
+            "candidate_ready": candidate_ready,
+        },
+    )
+
+
+def update_remediation_progress(
+    store: JobStore,
+    job_id: str,
+    *,
+    state: str,
+    note: str,
+    artifact_path: str | None = None,
+) -> dict[str, Any]:
+    """Record a bounded evaluation or blocker without closing the case."""
+    if state not in {"evaluating", "blocked"}:
+        raise ValueError("remediation state must be evaluating or blocked")
+    if not note.strip():
+        raise ValueError("remediation progress requires a structured note")
+    if artifact_path:
+        normalized_artifact = str(artifact_path).strip()
+        artifact = PurePosixPath(normalized_artifact)
+        if (
+            len(normalized_artifact) > 500
+            or artifact.is_absolute()
+            or ".." in artifact.parts
+        ):
+            raise ValueError("artifact_path must be a bounded job-relative path")
+        artifact_path = normalized_artifact
+    case = load_remediation(store, job_id)
+    if not case or str(case.get("state")) not in _ACTIONABLE_STATES:
+        raise ValueError(f"job {job_id} has no actionable remediation case")
+    case.update(
+        {
+            "state": state,
+            "updated_at": utc_now_iso(),
+            "progress": {
+                "note": note.strip()[:2_000],
+                "artifact_path": artifact_path,
+                "recorded_at": utc_now_iso(),
+            },
+        }
+    )
+    store.write_json(job_id, REMEDIATION_PATH, case)
+    store.append_journal(
+        job_id,
+        {
+            "type": "regime_remediation_progress",
+            "case_id": case.get("case_id"),
+            "state": state,
+            "artifact_path": artifact_path,
+            "note": note.strip()[:300],
+        },
+    )
+    return case
+
+
+def handle_remediation_rejection(
+    store: JobStore,
+    job_id: str,
+    proposal: Mapping[str, Any],
+) -> None:
+    stamp = proposal.get("remediation")
+    if not isinstance(stamp, Mapping):
+        return
+    case = load_remediation(store, job_id)
+    if not case or case.get("case_id") != stamp.get("case_id"):
+        return
+    rejection = proposal.get("rejection") or {}
+    owner_substantive = (
+        rejection.get("by") == "owner"
+        and str(rejection.get("kind") or "substantive") == "substantive"
+    )
+    case.update(
+        {
+            "state": "owner_accepted_risk" if owner_substantive else "open",
+            "proposal_id": None,
+            "updated_at": utc_now_iso(),
+            "rejection": dict(rejection),
+        }
+    )
+    store.write_json(job_id, REMEDIATION_PATH, case)
+
+
+def handle_remediation_application(
+    store: JobStore,
+    job_id: str,
+    proposal: Mapping[str, Any],
+    *,
+    status: str,
+) -> None:
+    stamp = proposal.get("remediation")
+    if not isinstance(stamp, Mapping):
+        return
+    case = load_remediation(store, job_id)
+    if not case or case.get("case_id") != stamp.get("case_id"):
+        return
+    case.update(
+        {
+            "state": "monitoring" if status == "applied" else "open",
+            "updated_at": utc_now_iso(),
+            "application_status": status,
+            "applied_at": utc_now_iso() if status == "applied" else None,
+        }
+    )
+    store.write_json(job_id, REMEDIATION_PATH, case)
+
+
+def compact_remediation(case: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    if not case:
+        return None
+    return {
+        key: case.get(key)
+        for key in (
+            "case_id",
+            "state",
+            "opened_at",
+            "updated_at",
+            "attempts",
+            "proposal_id",
+            "superseded_proposal_id",
+            "health",
+            "material_reasons",
+            "candidate_ready",
+            "candidate_gate",
+            "rejection",
+            "progress",
+            "application_status",
+            "applied_at",
+            "resolved_at",
+            "resolved_health_status",
+        )
+        if key in case
+    }
+
+
+def _health_evidence(report: Mapping[str, Any]) -> dict[str, Any]:
+    signals = [
+        {
+            key: signal.get(key)
+            for key in ("kind", "severity", "value", "symbol", "window_days")
+            if signal.get(key) is not None
+        }
+        for signal in report.get("signals") or []
+        if isinstance(signal, Mapping)
+    ]
+    incumbent = report.get("incumbent") or {}
+    return {
+        "fingerprint": report.get("evidence_fingerprint")
+        or _fingerprint(
+            {
+                "status": report.get("status"),
+                "score": report.get("score"),
+                "signals": signals,
+                "incumbent_revision": incumbent.get("workspace_revision"),
+            }
+        ),
+        "status": report.get("status"),
+        "score": int(report.get("score") or 0),
+        "signals": signals,
+        "drawdown": _drawdown_signal(signals),
+        "incumbent_revision": incumbent.get("workspace_revision"),
+        "computed_at": report.get("computed_at"),
+    }
+
+
+def _material_reasons(
+    current: Mapping[str, Any] | None, evidence: Mapping[str, Any]
+) -> list[str]:
+    if current is None:
+        return ["entered_alert_state"]
+    prior = current.get("health") or {}
+    reasons: list[str] = []
+    old_status = str(prior.get("status") or "insufficient")
+    new_status = str(evidence.get("status") or "insufficient")
+    if _STATUS_RANK.get(new_status, 0) > _STATUS_RANK.get(old_status, 0):
+        reasons.append("status_worsened")
+    if int(evidence.get("score") or 0) - int(prior.get("score") or 0) >= 2:
+        reasons.append("score_increased")
+    old_critical = _severity_two_keys(prior.get("signals") or [])
+    new_critical = _severity_two_keys(evidence.get("signals") or [])
+    if new_critical - old_critical:
+        reasons.append("new_severity_two_signal")
+    old_drawdown = float(prior.get("drawdown") or 0.0)
+    new_drawdown = float(evidence.get("drawdown") or 0.0)
+    if new_drawdown - old_drawdown >= 0.02:
+        reasons.append("drawdown_worsened_two_points")
+    if (
+        evidence.get("incumbent_revision")
+        and prior.get("incumbent_revision")
+        and evidence.get("incumbent_revision") != prior.get("incumbent_revision")
+    ):
+        reasons.append("incumbent_revision_changed")
+    return reasons
+
+
+def _severity_two_keys(signals: Any) -> set[tuple[str, str, str]]:
+    return {
+        (
+            str(signal.get("kind") or ""),
+            str(signal.get("symbol") or ""),
+            str(signal.get("window_days") or ""),
+        )
+        for signal in signals
+        if isinstance(signal, Mapping) and int(signal.get("severity") or 0) >= 2
+    }
+
+
+def _drawdown_signal(signals: list[dict[str, Any]]) -> float:
+    values = [
+        float(signal["value"])
+        for signal in signals
+        if signal.get("kind") == "drawdown" and signal.get("value") is not None
+    ]
+    return max(values, default=0.0)
+
+
+def _case_id(job_id: str, fingerprint: str) -> str:
+    return "rem-" + hashlib.sha256(f"{job_id}:{fingerprint}".encode()).hexdigest()[:12]
+
+
+def _fingerprint(payload: Mapping[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(dict(payload), sort_keys=True, default=str).encode()
+    ).hexdigest()[:16]
+
+
+def _parse_time(value: Any) -> dt.datetime | None:
+    try:
+        parsed = dt.datetime.fromisoformat(str(value))
+    except (TypeError, ValueError):
+        return None
+    return parsed.replace(tzinfo=dt.UTC) if parsed.tzinfo is None else parsed

--- a/wayfinder_paths/jobs/replication.py
+++ b/wayfinder_paths/jobs/replication.py
@@ -22,6 +22,7 @@ from wayfinder_paths.jobs.models import utc_now_iso
 from wayfinder_paths.jobs.store import JobStore
 
 REPLICATION_PATH = "results/backtest/replication.json"
+REPLICATION_SCHEMA_VERSION = "1.1"
 _RECOMPUTE_AFTER_S = 24 * 3600
 # Worker-safety: give up on the compute lock quickly (see _compute).
 _LOCK_TIMEOUT_S = 60.0
@@ -40,7 +41,12 @@ def replication_job(
 ) -> dict[str, Any]:
     store = store or JobStore()
     cached = load_replication(store, job_id)
-    if not force and cached and cached.get("available"):
+    if (
+        not force
+        and cached
+        and cached.get("available")
+        and cached.get("schema_version") == REPLICATION_SCHEMA_VERSION
+    ):
         age = _age_seconds(str(cached.get("computed_at")))
         if age < _RECOMPUTE_AFTER_S:
             return cached
@@ -77,6 +83,9 @@ def _compute(
     dataset_meta = (payload.get("dataset") or {}) if isinstance(payload, dict) else {}
     current = {
         "net_return": stats.get("net_return"),
+        "sharpe": stats.get("sharpe"),
+        "max_drawdown": stats.get("max_drawdown"),
+        "profit_factor": stats.get("profit_factor"),
         "avg_trade_pnl": stats.get("avg_trade_pnl"),
         "total_trades": stats.get("total_trades") or stats.get("trade_count"),
         "win_rate": stats.get("win_rate"),
@@ -103,10 +112,18 @@ def _compute(
         # own candidate report was its deploy evidence).
         baseline = dict(current)
 
-    decayed = _decayed(baseline, current)
+    declared_revision = store.load(job_id).versioning.get("active_revision")
+    status = _replication_status(
+        baseline,
+        current,
+        revision=revision,
+        declared_revision=str(declared_revision or ""),
+    )
     return {
+        "schema_version": REPLICATION_SCHEMA_VERSION,
         "available": True,
         "revision": revision,
+        "declared_revision": declared_revision,
         "baseline": baseline,
         "current": current,
         "dataset": {
@@ -114,14 +131,16 @@ def _compute(
             for key in ("days", "days_received", "source", "fetched_at")
             if isinstance(dataset_meta, dict)
         },
-        "decayed": decayed,
+        "status": status,
+        "decayed": status == "decayed",
         "_basis": (
             "Same ACTIVE strategy, re-backtested on the refreshed dataset and "
-            "compared to this revision's first replication run. decayed=true "
-            "means the in-sample edge that justified this revision is not "
-            "reproducing on newer data — mechanical evidence of selection on "
-            "window-local noise; treat it as grounds for a revert/kill or "
-            "re-validation proposal, not something to explain away."
+            "compared to this revision's first replication run. status=valid "
+            "means a positive edge still reproduces; decayed means a positive "
+            "edge lost more than half its return; invalid means either baseline "
+            "or current evidence is non-positive; stale means the computed and "
+            "declared active revisions disagree. decayed/invalid/stale require "
+            "revert, kill, or re-validation treatment — never explain them away."
         ),
         "computed_at": utc_now_iso(),
     }
@@ -149,6 +168,25 @@ def _decayed(baseline: dict[str, Any], current: dict[str, Any]) -> bool:
     if now <= 0:
         return True  # sign flip
     return (base - now) / base > _DECAY_RELATIVE
+
+
+def _replication_status(
+    baseline: dict[str, Any],
+    current: dict[str, Any],
+    *,
+    revision: str,
+    declared_revision: str,
+) -> str:
+    if declared_revision and revision != declared_revision:
+        return "stale"
+    try:
+        base = float(baseline.get("net_return") or 0.0)
+        now = float(current.get("net_return") or 0.0)
+    except (TypeError, ValueError):
+        return "invalid"
+    if base <= 0 or now <= 0:
+        return "invalid"
+    return "decayed" if _decayed(baseline, current) else "valid"
 
 
 def _age_seconds(computed_at: str) -> float:

--- a/wayfinder_paths/jobs/store.py
+++ b/wayfinder_paths/jobs/store.py
@@ -685,6 +685,9 @@ class JobStore:
             self._set_application_status(proposal, "canceled")
         proposal["updated_at"] = utc_now_iso()
         self.write_proposal(job_id, proposal)
+        from wayfinder_paths.jobs.remediation import handle_remediation_rejection
+
+        handle_remediation_rejection(self, job_id, proposal)
         try:
             from wayfinder_paths.jobs.archive import set_candidate_status
 
@@ -775,6 +778,9 @@ class JobStore:
         application["rollback"] = rollback
         proposal["updated_at"] = utc_now_iso()
         self.write_proposal(job_id, proposal)
+        from wayfinder_paths.jobs.remediation import handle_remediation_application
+
+        handle_remediation_application(self, job_id, proposal, status=status)
         self.append_journal(
             job_id,
             {

--- a/wayfinder_paths/jobs/trade_forensics.py
+++ b/wayfinder_paths/jobs/trade_forensics.py
@@ -248,6 +248,18 @@ def forensics_for_closed_trades(
         row["symbol"] = symbol
         row["entry_reason"] = entry_meta.get("entry_reason")
         row["net_pnl"] = trade.get("net_pnl") or trade.get("realized_pnl_delta")
+        for key in (
+            "effective_leverage",
+            "stop_trigger_price",
+            "stop_reference_price",
+            "stop_gap_at_open",
+            "stop_slippage_bps",
+            "stop_slippage_bps_applied",
+            "protection_type",
+            "venue_stop_slippage_tolerance_bps",
+        ):
+            if trade.get(key) is not None:
+                row[key] = trade.get(key)
         # Market-state tags at entry (trend vs SMA50, vol percentile, session)
         # so regime patterns across winners/losers are visible at a glance.
         from wayfinder_paths.jobs.indicators import regime_snapshot

--- a/wayfinder_paths/jobs/triggers.py
+++ b/wayfinder_paths/jobs/triggers.py
@@ -37,6 +37,8 @@ DEFAULT_DEBOUNCE_SECONDS = 600
 # progress mandate (worker renders it from state/research_impasse.json).
 # regime_shift is a deterministic incumbent-health warning/critical transition;
 # legacy jobs predate the configurable trigger name, so it always wakes.
+# regime_remediation_due retries an open remediation case until it produces a
+# proposal, bounded evaluation artifact, or structured blocker.
 ALWAYS_WAKE_EVENTS = {
     "proposal_restage_requested",
     "verdict_matured",
@@ -45,6 +47,7 @@ ALWAYS_WAKE_EVENTS = {
     "disk_pressure",
     "research_impasse",
     "regime_shift",
+    "regime_remediation_due",
 }
 
 
@@ -95,22 +98,45 @@ def _fire_triggers(
     wake_path = root / WAKE_STATE_PATH
     debounce = _debounce_seconds(loop)
     now = datetime.now(UTC)
+    wake_state: dict[str, Any] = {}
     if wake_path.exists():
         try:
-            last = json.loads(wake_path.read_text(encoding="utf-8"))
-            last_ts = datetime.fromisoformat(str(last.get("last_triggered_wake_ts")))
-            if (now - last_ts).total_seconds() < debounce:
-                return None
+            loaded = json.loads(wake_path.read_text(encoding="utf-8"))
+            wake_state = loaded if isinstance(loaded, dict) else {}
         except (ValueError, TypeError):
             pass  # unreadable state never blocks a wake
+
+    event_times = wake_state.get("events")
+    event_times = dict(event_times) if isinstance(event_times, dict) else {}
+    legacy_triggers = set(wake_state.get("triggers") or [])
+    due: list[str] = []
+    for event in matched:
+        timestamp = event_times.get(event)
+        if timestamp is None and event in legacy_triggers:
+            timestamp = wake_state.get("last_triggered_wake_ts")
+        try:
+            last_ts = datetime.fromisoformat(str(timestamp))
+            if last_ts.tzinfo is None:
+                last_ts = last_ts.replace(tzinfo=UTC)
+        except (ValueError, TypeError):
+            due.append(event)
+            continue
+        if (now - last_ts).total_seconds() >= debounce:
+            due.append(event)
+    if not due:
+        return None
+
+    for event in due:
+        event_times[event] = now.isoformat()
 
     wake_path.parent.mkdir(parents=True, exist_ok=True)
     wake_path.write_text(
         json.dumps(
             {
                 "last_triggered_wake_ts": now.isoformat(),
-                "triggers": matched,
+                "triggers": due,
                 "source": source,
+                "events": event_times,
             },
             indent=2,
         )
@@ -121,7 +147,7 @@ def _fire_triggers(
         job.id,
         {
             "type": "agent_triggered_wake",
-            "triggers": matched,
+            "triggers": due,
             "source": source,
             "mode": loop.mode,
         },
@@ -131,7 +157,7 @@ def _fire_triggers(
     from wayfinder_paths.jobs.worker import run_job_worker
 
     wakeup = run_job_worker(job.id, mode=loop.mode)
-    return {"triggers": matched, "source": source, "ts": utc_now_iso(), **wakeup}
+    return {"triggers": due, "source": source, "ts": utc_now_iso(), **wakeup}
 
 
 def _debounce_seconds(loop: Any) -> int:

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -391,7 +391,12 @@ def _evolution_block(store: JobStore, job_id: str) -> dict[str, Any]:
         return {}
 
 
-def _standing_checks_block(root: Path) -> dict[str, Any]:
+def _standing_checks_block(
+    root: Path,
+    *,
+    store: JobStore | None = None,
+    job_id: str | None = None,
+) -> dict[str, Any]:
     """Mechanical routine numbers, computed by the harness each wake.
 
     The audit found ~30 ledger entries re-deriving `funding_mean > 0` in LLM
@@ -483,9 +488,13 @@ def _standing_checks_block(root: Path) -> dict[str, Any]:
         if isinstance(rep, dict) and rep.get("available"):
             replication = {
                 "revision": rep.get("revision"),
+                "declared_revision": rep.get("declared_revision"),
+                "status": rep.get("status"),
                 "decayed": rep.get("decayed"),
                 "baseline_net_return": (rep.get("baseline") or {}).get("net_return"),
                 "current_net_return": (rep.get("current") or {}).get("net_return"),
+                "current_sharpe": (rep.get("current") or {}).get("sharpe"),
+                "current_max_drawdown": (rep.get("current") or {}).get("max_drawdown"),
                 "dataset_days": (rep.get("dataset") or {}).get("days_received")
                 or (rep.get("dataset") or {}).get("days"),
             }
@@ -503,6 +512,15 @@ def _standing_checks_block(root: Path) -> dict[str, Any]:
             from wayfinder_paths.jobs.regime_health import compact_regime_health
 
             block["portfolio_regime_health"] = compact_regime_health(regime)
+    from wayfinder_paths.jobs.remediation import compact_remediation, load_remediation
+
+    remediation = (
+        compact_remediation(load_remediation(store, job_id))
+        if store is not None and job_id is not None
+        else None
+    )
+    if remediation:
+        block["regime_remediation"] = remediation
     if block:
         block["_basis"] = (
             "Routine numbers computed mechanically THIS wake — never re-fetch "
@@ -512,10 +530,9 @@ def _standing_checks_block(root: Path) -> dict[str, Any]:
             "write it with family operations/monitoring/no_change and it "
             "lands in the ops ledger automatically. The candidates ledger "
             "is for research verdicts only. "
-            "backtest_replication.decayed=true means the ACTIVE revision's "
-            "deploy-time in-sample edge is not reproducing on refreshed data "
-            "— mechanical evidence of selection on window-local noise; treat "
-            "it as grounds for a revert/kill or re-validation proposal. "
+            "backtest_replication status decayed/invalid/stale means the ACTIVE "
+            "revision's deploy evidence is not currently trustworthy; treat it "
+            "as grounds for a revert/kill or re-validation proposal. "
             "portfolio_regime_health warning/critical is an incumbent-health "
             "alarm, not a request to mine a replacement signal: cite the "
             "fresh attribution artifact before designing treatment."
@@ -708,8 +725,20 @@ def _build_worker_prompt_sections(
     # Island rotation: routine research wakes get a deterministic search
     # assignment; apply/restage wakes and trigger wakes (bypass inside)
     # handle their event instead. Never blocks the wake.
+    standing_checks = _standing_checks_block(root, store=store, job_id=job_id)
+    remediation_case = standing_checks.get("regime_remediation") or {}
+    remediation_actionable = remediation_case.get("state") in {
+        "open",
+        "evaluating",
+        "blocked",
+    }
     search_assignment = None
-    if mode == "intervene" and apply_proposal_id is None and not restage_tasks:
+    if (
+        mode == "intervene"
+        and apply_proposal_id is None
+        and not restage_tasks
+        and not remediation_actionable
+    ):
         try:
             from wayfinder_paths.jobs.improver.scheduler import assign_island
 
@@ -737,7 +766,7 @@ def _build_worker_prompt_sections(
         "attribution": _attribution_block(root),
         "post_apply_shadow": _counterfactual_block(store, job_id),
         "research_substrate": _research_substrate_block(root),
-        "standing_checks": _standing_checks_block(root),
+        "standing_checks": standing_checks,
         "compute_status": _compute_status_block(root),
         "evolution": _evolution_block(store, job_id),
         "archive": _archive_block(store, job_id),
@@ -997,6 +1026,10 @@ def _build_worker_prompt_sections(
             "the improvement to hold in OOS folds and across neighbor cells "
             "(plateau), and only then propose. A handful of forward "
             "anecdotes NEVER justifies a retune directly — but a "
+            "stop-loss treatment must also include a stress cell with "
+            "execution_params.stop_market_slippage_bps=1000 (Hyperliquid's "
+            "native trigger-market tolerance envelope); the simulator applies "
+            "that haircut only to stop fills and already prices bar gaps at open. "
             "grid+WF-validated exit change motivated by them is a legitimate "
             "proposal even below the forward-sample floor, because its "
             "evidence is the backtest population, not the forward sample.\n"
@@ -1149,6 +1182,25 @@ def _build_worker_prompt_sections(
             "it as a strategy failure, but DO NOT report the gate as green. "
             "For any other reason, fixing the gate is a priority this wake.\n\n"
         )
+    remediation_directive = ""
+    if remediation_actionable and apply_proposal_id is None:
+        remediation_directive = (
+            "REGIME REMEDIATION REQUIRED — this durable case remains open:\n"
+            f"{_canonical_json(remediation_case, max_chars=3000)}\n"
+            "It OVERRIDES routine search and cannot end with no_change, "
+            "owner_terminal_decision, or an explanation that the technical "
+            "gate is green. The owner policy is continue-trading while review "
+            "is pending: do not pause, flatten, or silently clamp leverage. "
+            "Start with attribution and the cheapest causal treatment: ablate "
+            "or disable the largest losing symbol/leg before mining a replacement.\n"
+            "This wake must produce exactly one accountable outcome: (1) a "
+            "candidate-backed green proposal linked to this case; (2) a bounded "
+            "evaluation artifact plus core_jobs(action='remediation_progress', "
+            "remediation_state='evaluating', remediation_note=..., "
+            "artifact_path=...); or (3) a structured blocker recorded with "
+            "remediation_state='blocked'. Failed/red candidate attempts do not "
+            "close the case; record the blocker and the scheduler will retry.\n\n"
+        )
     # Impasse directive: written by the watchdog when a research-stale job's
     # last K wakes produced zero progress artifacts, cleared only when one
     # appears. Rendered as prompt text (never only snapshot JSON) with the
@@ -1270,6 +1322,7 @@ def _build_worker_prompt_sections(
     dynamic_context = (
         f"{DYNAMIC_CONTEXT_MARKER}\n"
         f"{gate_alert}"
+        f"{remediation_directive}"
         f"{restage_priority}"
         f"{impasse_directive}"
         f"{ideation_directive}"

--- a/wayfinder_paths/mcp/tools/jobs.py
+++ b/wayfinder_paths/mcp/tools/jobs.py
@@ -43,6 +43,7 @@ JobAction = Literal[
     "status",
     "report",
     "regime_health",
+    "remediation_progress",
     "set_agent_mode",
     "set_script_mode",
     "review_now",
@@ -303,6 +304,9 @@ async def core_jobs(
     validation: dict[str, Any] | None = None,
     error: str | None = None,
     reason: str | None = None,
+    remediation_state: Literal["evaluating", "blocked"] | None = None,
+    remediation_note: str | None = None,
+    artifact_path: str | None = None,
     flatten: bool = False,
     kind: str | None = None,
     summary: str | None = None,
@@ -389,6 +393,8 @@ async def core_jobs(
       - `regime_health` returns the deterministic 7/14/30-day incumbent and
         market-state drift report. warning/critical refreshes attribution first;
         any automatic response comes only from protected owner governance.
+      - `remediation_progress` records a bounded evaluation or blocker for an
+        open regime-health case; it never closes the case or changes trading.
       - `review_now` to queue an immediate worker wakeup.
       - `approve_proposal` / `reject_proposal` after the worker creates proposals.
       - `claim_application` / `validate_application` / `complete_application`
@@ -521,6 +527,24 @@ async def core_jobs(
 
     if action == "regime_health":
         return ok(regime_health_job(job_id, store=store, force=force))
+
+    if action == "remediation_progress":
+        if not remediation_state or not remediation_note:
+            return err(
+                "invalid_request",
+                "remediation_progress requires remediation_state and remediation_note",
+            )
+        from wayfinder_paths.jobs.remediation import update_remediation_progress
+
+        return ok(
+            update_remediation_progress(
+                store,
+                job_id,
+                state=remediation_state,
+                note=remediation_note,
+                artifact_path=artifact_path,
+            )
+        )
 
     if action == "set_agent_mode":
         mode = normalize_agent_mode(agent_mode or "monitor")

--- a/wayfinder_paths/tests/test_execution_contract.py
+++ b/wayfinder_paths/tests/test_execution_contract.py
@@ -117,6 +117,28 @@ def test_bracket_engine_uses_high_low_for_long_and_short() -> None:
     )
 
 
+def test_stop_market_uses_open_when_bar_gaps_through_trigger() -> None:
+    long_gap = BracketEngine.resolve_intrabar(
+        {"open": 85, "high": 90, "low": 80, "close": 88},
+        "long",
+        stop_loss=90,
+        take_profit=None,
+    )
+    assert long_gap["trigger_price"] == 90
+    assert long_gap["price"] == 85
+    assert long_gap["gap_at_open"] is True
+
+    short_gap = BracketEngine.resolve_intrabar(
+        {"open": 115, "high": 120, "low": 110, "close": 112},
+        "short",
+        stop_loss=110,
+        take_profit=None,
+    )
+    assert short_gap["trigger_price"] == 110
+    assert short_gap["price"] == 115
+    assert short_gap["gap_at_open"] is True
+
+
 def test_ledger_updates_only_from_fills_and_ticks_once() -> None:
     ledger = PositionLedger()
     ledger.on_bar_tick("t1")

--- a/wayfinder_paths/tests/test_execution_engine.py
+++ b/wayfinder_paths/tests/test_execution_engine.py
@@ -203,6 +203,37 @@ async def test_daily_notional_cap_accumulates_across_ticks() -> None:
     assert any("daily notional cap" in event["reason"] for event in second.guard_events)
 
 
+def test_backtest_broker_can_stress_stop_market_slippage_separately() -> None:
+    broker = BacktestBroker(slippage_bps=10, stop_market_slippage_bps=1_000)
+    ordinary = broker.execute(
+        OrderIntent(
+            action="OPEN",
+            venue="hyperliquid",
+            symbol="HYPE",
+            side="buy",
+            size=1,
+        ),
+        price=100,
+        timestamp="2026-08-21T00:00:00+00:00",
+    )
+    stopped = broker.execute(
+        OrderIntent(
+            action="STOP_LOSS",
+            venue="hyperliquid",
+            symbol="HYPE",
+            side="buy",
+            size=1,
+            reduce_only=True,
+        ),
+        price=100,
+        timestamp="2026-08-21T00:05:00+00:00",
+    )
+
+    assert ordinary.avg_price == pytest.approx(100.1)
+    assert stopped.avg_price == pytest.approx(110.0)
+    assert stopped.raw["slippage_bps_applied"] == 1_000
+
+
 async def test_passive_limit_rests_then_fills_on_next_bar_trade_through() -> None:
     state = EngineState()
     broker = BacktestBroker(fee_bps=4.5, maker_fee_bps=1.5, slippage_bps=3.5)

--- a/wayfinder_paths/tests/test_jobs_evidence_window.py
+++ b/wayfinder_paths/tests/test_jobs_evidence_window.py
@@ -177,15 +177,17 @@ def test_replication_pins_baseline_and_flags_decay(tmp_path, monkeypatch) -> Non
 
     first = replication_job(job.id, store=store)
     assert first["available"] and first["decayed"] is False
+    assert first["status"] == "valid"
     assert first["baseline"]["net_return"] == 0.21
 
     # Fresh cache -> no rerun without force.
     cached = replication_job(job.id, store=store)
     assert calls["n"] == 1 and cached["computed_at"] == first["computed_at"]
 
-    # Forced rerun on the refreshed window: edge collapsed -> decayed.
+    # Forced rerun on the refreshed window: non-positive evidence is invalid.
     second = replication_job(job.id, store=store, force=True)
-    assert second["decayed"] is True
+    assert second["status"] == "invalid"
+    assert second["decayed"] is False
     assert second["baseline"]["net_return"] == 0.21  # baseline pinned
     assert second["current"]["net_return"] == -0.004
 
@@ -194,6 +196,7 @@ def test_replication_pins_baseline_and_flags_decay(tmp_path, monkeypatch) -> Non
     assert third["revision"] == "rev-b"
     assert third["baseline"]["net_return"] == 0.05
     assert third["decayed"] is False
+    assert third["status"] == "valid"
 
 
 def test_replication_failure_degrades_and_journals(tmp_path, monkeypatch) -> None:
@@ -211,6 +214,29 @@ def test_replication_failure_degrades_and_journals(tmp_path, monkeypatch) -> Non
     assert doc["available"] is False
     journal = (store.job_dir(job.id) / "journal.jsonl").read_text(encoding="utf-8")
     assert "replication_failed" in journal
+
+
+def test_replication_distinguishes_decay_from_stale_revision() -> None:
+    from wayfinder_paths.jobs.replication import _replication_status
+
+    assert (
+        _replication_status(
+            {"net_return": 0.20},
+            {"net_return": 0.08},
+            revision="rev-a",
+            declared_revision="rev-a",
+        )
+        == "decayed"
+    )
+    assert (
+        _replication_status(
+            {"net_return": 0.20},
+            {"net_return": 0.18},
+            revision="rev-a",
+            declared_revision="rev-b",
+        )
+        == "stale"
+    )
 
 
 def _mk_dataset_job(tmp_path, symbols=("SNX",)):

--- a/wayfinder_paths/tests/test_jobs_propose.py
+++ b/wayfinder_paths/tests/test_jobs_propose.py
@@ -30,6 +30,10 @@ from wayfinder_paths.jobs.proposals import (
     restage_proposal,
     revalidate_proposal,
 )
+from wayfinder_paths.jobs.remediation import (
+    load_remediation,
+    sync_remediation_with_health,
+)
 from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.jobs.validation import validation_summary
 from wayfinder_paths.tests.test_jobs_application_gate import _patch_runner
@@ -73,6 +77,41 @@ def test_propose_builds_full_candidate_report(tmp_path: Path) -> None:
         (root / "applications" / pid / "candidate" / "job.yaml").read_text()
     )
     assert candidate_yaml["execution_params"]["threshold"] == 10.7
+
+
+def test_proposal_is_automatically_linked_to_open_remediation_case(
+    tmp_path: Path,
+) -> None:
+    store, job_id, _ = _make_job(tmp_path)
+    sync_remediation_with_health(
+        store,
+        job_id,
+        {
+            "status": "critical",
+            "score": 6,
+            "evidence_fingerprint": "evidence-a",
+            "incumbent": {"workspace_revision": "rev-a"},
+            "signals": [
+                {"kind": "drawdown", "severity": 2, "value": 0.12, "window_days": 7}
+            ],
+        },
+    )
+
+    proposal = _propose_params(store, job_id)
+
+    assert proposal["remediation"]["evidence_fingerprint"] == "evidence-a"
+    case = load_remediation(store, job_id)
+    assert case and case["state"] == "proposal_pending"
+    assert case["proposal_id"] == proposal["proposal_id"]
+
+    store.reject_proposal(
+        job_id,
+        proposal["proposal_id"],
+        reason="owner accepts current risk",
+        rejected_by="owner",
+        kind="substantive",
+    )
+    assert load_remediation(store, job_id)["state"] == "owner_accepted_risk"  # type: ignore[index]
 
 
 def test_claim_reuses_propose_time_candidate(

--- a/wayfinder_paths/tests/test_jobs_remediation.py
+++ b/wayfinder_paths/tests/test_jobs_remediation.py
@@ -1,0 +1,165 @@
+"""Durable regime remediation keeps incumbent alarms actionable."""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.remediation import (
+    handle_remediation_application,
+    handle_remediation_rejection,
+    link_remediation_proposal,
+    load_remediation,
+    proposal_remediation_stamp,
+    sync_remediation_with_health,
+    update_remediation_progress,
+)
+from wayfinder_paths.jobs.store import JobStore
+
+
+def _store(tmp_path: Path) -> tuple[JobStore, str]:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("remediation-demo", agent_mode="intervene")
+    store.save(job)
+    return store, job.id
+
+
+def _health(*, score: int = 4, fingerprint: str = "health-a") -> dict:
+    return {
+        "status": "critical",
+        "score": score,
+        "computed_at": "2026-08-21T12:00:00+00:00",
+        "evidence_fingerprint": fingerprint,
+        "incumbent": {"workspace_revision": "rev-active"},
+        "signals": [
+            {
+                "kind": "drawdown",
+                "severity": 2,
+                "value": 0.12,
+                "window_days": 7,
+            }
+        ],
+    }
+
+
+def test_case_opens_once_and_retries_until_accountable_outcome(
+    tmp_path: Path,
+) -> None:
+    store, job_id = _store(tmp_path)
+    now = dt.datetime(2026, 8, 21, 12, tzinfo=dt.UTC)
+
+    opened = sync_remediation_with_health(store, job_id, _health(), now=now)
+    assert opened and opened["event"] == "regime_shift"
+    assert (
+        sync_remediation_with_health(
+            store, job_id, _health(), now=now + dt.timedelta(minutes=10)
+        )
+        is None
+    )
+
+    retry = sync_remediation_with_health(
+        store, job_id, _health(), now=now + dt.timedelta(minutes=31)
+    )
+    assert retry and retry["event"] == "regime_remediation_due"
+    assert load_remediation(store, job_id)["attempts"] == 2  # type: ignore[index]
+
+
+def test_material_evidence_bypasses_retry_debounce(tmp_path: Path) -> None:
+    store, job_id = _store(tmp_path)
+    now = dt.datetime(2026, 8, 21, 12, tzinfo=dt.UTC)
+    sync_remediation_with_health(store, job_id, _health(), now=now)
+
+    refreshed = sync_remediation_with_health(
+        store,
+        job_id,
+        _health(score=6, fingerprint="health-b"),
+        now=now + dt.timedelta(minutes=1),
+    )
+
+    assert refreshed and refreshed["event"] == "regime_shift"
+    assert "score_increased" in refreshed["material_reasons"]
+
+
+def test_green_proposal_waits_for_owner_and_rejections_have_provenance(
+    tmp_path: Path,
+) -> None:
+    store, job_id = _store(tmp_path)
+    sync_remediation_with_health(store, job_id, _health())
+    stamp = proposal_remediation_stamp(store, job_id)
+    proposal = {
+        "proposal_id": "prop-disable-hype",
+        "remediation": stamp,
+        "candidate_report": {
+            "gate": {"live_ready": True},
+            "economic": {"ready": True},
+        },
+    }
+
+    link_remediation_proposal(store, job_id, proposal)
+    assert load_remediation(store, job_id)["state"] == "proposal_pending"  # type: ignore[index]
+
+    agent_rejection = {
+        **proposal,
+        "rejection": {"by": "agent", "kind": "process", "reason": "superseded"},
+    }
+    handle_remediation_rejection(store, job_id, agent_rejection)
+    assert load_remediation(store, job_id)["state"] == "open"  # type: ignore[index]
+
+    link_remediation_proposal(store, job_id, proposal)
+    owner_rejection = {
+        **proposal,
+        "rejection": {"by": "owner", "kind": "substantive", "reason": "accept risk"},
+    }
+    handle_remediation_rejection(store, job_id, owner_rejection)
+    assert load_remediation(store, job_id)["state"] == "owner_accepted_risk"  # type: ignore[index]
+
+
+def test_red_candidate_and_bounded_evaluation_keep_case_open(tmp_path: Path) -> None:
+    store, job_id = _store(tmp_path)
+    sync_remediation_with_health(store, job_id, _health())
+    proposal = {
+        "proposal_id": "prop-red",
+        "remediation": proposal_remediation_stamp(store, job_id),
+        "candidate_report": {
+            "gate": {"live_ready": False},
+            "economic": {"ready": False, "reasons": ["negative OOS"]},
+        },
+    }
+    link_remediation_proposal(store, job_id, proposal)
+    assert load_remediation(store, job_id)["state"] == "blocked"  # type: ignore[index]
+
+    update_remediation_progress(
+        store,
+        job_id,
+        state="evaluating",
+        note="Running HYPE ablation on all OOS folds",
+        artifact_path="results/backtest/hype_ablation.json",
+    )
+    case = load_remediation(store, job_id)
+    assert case and case["state"] == "evaluating"
+    assert case["progress"]["artifact_path"].endswith("hype_ablation.json")
+
+
+def test_applied_treatment_monitors_until_health_recovers(tmp_path: Path) -> None:
+    store, job_id = _store(tmp_path)
+    sync_remediation_with_health(store, job_id, _health())
+    proposal = {
+        "proposal_id": "prop-disable-hype",
+        "remediation": proposal_remediation_stamp(store, job_id),
+        "candidate_report": {
+            "gate": {"live_ready": True},
+            "economic": {"ready": True},
+        },
+    }
+    link_remediation_proposal(store, job_id, proposal)
+
+    handle_remediation_application(store, job_id, proposal, status="applied")
+    assert load_remediation(store, job_id)["state"] == "monitoring"  # type: ignore[index]
+
+    sync_remediation_with_health(
+        store,
+        job_id,
+        {**_health(), "status": "healthy", "score": 0, "signals": []},
+    )
+    assert load_remediation(store, job_id)["state"] == "resolved"  # type: ignore[index]

--- a/wayfinder_paths/tests/test_jobs_triggers.py
+++ b/wayfinder_paths/tests/test_jobs_triggers.py
@@ -53,10 +53,23 @@ def test_matching_trigger_fires_once_and_debounces(
     journal = (store.job_dir(job.id) / "journal.jsonl").read_text(encoding="utf-8")
     assert "agent_triggered_wake" in journal
 
-    # Second event inside the debounce window: suppressed.
-    second = fire_triggers(store, job, ["drift_warning"], source="test")
+    # The same event inside the debounce window is suppressed.
+    second = fire_triggers(store, job, ["risk_halt"], source="test")
     assert second is None
     assert len(wakes) == 1
+
+
+def test_unrelated_event_is_not_suppressed_by_global_debounce(
+    tmp_path: Path, wakes: list[dict[str, Any]]
+) -> None:
+    store, job = _make_job(tmp_path)
+    assert fire_triggers(store, job, ["risk_halt"], source="test") is not None
+
+    second = fire_triggers(store, job, ["regime_shift"], source="test")
+
+    assert second is not None
+    assert second["triggers"] == ["regime_shift"]
+    assert len(wakes) == 2
 
 
 def test_debounce_window_expiry_allows_next_wake(
@@ -142,6 +155,12 @@ def test_tick_trigger_event_derivation() -> None:
             "regime_health": {"transition": {"alert": True}},
         }
     ) == ["regime_shift"]
+    assert _tick_trigger_events(
+        {
+            "ok": True,
+            "regime_health": {"remediation_event": {"event": "regime_remediation_due"}},
+        }
+    ) == ["regime_remediation_due"]
     assert _tick_trigger_events({"ok": True, "snapshot": {"status": "valid"}}) == []
 
 

--- a/wayfinder_paths/tests/test_trade_forensics.py
+++ b/wayfinder_paths/tests/test_trade_forensics.py
@@ -8,7 +8,10 @@ from pathlib import Path
 
 import pandas as pd
 
-from wayfinder_paths.jobs.execution.driver import _record_pending_trade_forensics
+from wayfinder_paths.jobs.execution.driver import (
+    _record_pending_trade_forensics,
+    _trade_close_payload,
+)
 from wayfinder_paths.jobs.execution.primitives import CompletedBarsView
 from wayfinder_paths.jobs.trade_forensics import (
     aggregate_trade_forensics,
@@ -405,3 +408,36 @@ def test_worker_forensics_block_reads_both_sources(tmp_path: Path) -> None:
     assert "coverage" not in block["recent_forward_trades"][0]
     assert block["backtest_aggregate"] == {"trades": 332}
     assert "hypothesis fuel" in block["_basis"]
+
+
+def test_stop_close_payload_preserves_trigger_and_slippage_evidence() -> None:
+    payload = _trade_close_payload(
+        {
+            "venue": "hyperliquid",
+            "symbol": "HYPE",
+            "side": "buy",
+            "filled_size": 2.0,
+            "avg_price": 110.0,
+            "fee": 0.25,
+            "reduce_only": True,
+            "realized_pnl_delta": -10.0,
+            "timestamp": _ts(3).isoformat(),
+            "raw": {
+                "intent_action": "STOP_LOSS",
+                "intent_metadata": {
+                    "bracket": {
+                        "trigger_price": 100.0,
+                        "price": 105.0,
+                        "gap_at_open": True,
+                    }
+                },
+            },
+        },
+        params={"leverage": 3},
+    )
+
+    assert payload["exit_reason"] == "bracket_stop"
+    assert payload["stop_trigger_price"] == 100.0
+    assert payload["stop_slippage_bps"] == 1_000.0
+    assert payload["effective_leverage"] == 3
+    assert payload["venue_stop_slippage_tolerance_bps"] == 1_000

--- a/wayfinder_paths/tests/test_wayfinder_jobs.py
+++ b/wayfinder_paths/tests/test_wayfinder_jobs.py
@@ -963,6 +963,46 @@ def test_mcp_create_defaults_to_jobs_v1(tmp_path: Path, monkeypatch) -> None:
     assert "workspace/src/" in result["result"]["hint"]
 
 
+def test_mcp_records_bounded_remediation_progress(tmp_path: Path, monkeypatch) -> None:
+    import asyncio
+
+    from wayfinder_paths.jobs.remediation import (
+        load_remediation,
+        sync_remediation_with_health,
+    )
+    from wayfinder_paths.mcp.tools import jobs as jobs_tools
+
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("remediation-mcp", agent_mode="intervene")
+    store.save(job)
+    sync_remediation_with_health(
+        store,
+        job.id,
+        {
+            "status": "critical",
+            "score": 5,
+            "evidence_fingerprint": "health-a",
+            "signals": [{"kind": "drawdown", "severity": 2, "value": 0.1}],
+        },
+    )
+    monkeypatch.setattr(jobs_tools, "JobStore", lambda: store)
+
+    result = asyncio.run(
+        jobs_tools.core_jobs(
+            action="remediation_progress",
+            job_id=job.id,
+            remediation_state="evaluating",
+            remediation_note="Running the HYPE ablation across frozen folds",
+            artifact_path="results/backtest/hype_ablation.json",
+        )
+    )
+
+    assert result["ok"], result
+    case = load_remediation(store, job.id)
+    assert case and case["state"] == "evaluating"
+    assert case["progress"]["artifact_path"].endswith("hype_ablation.json")
+
+
 def test_mcp_sync_heals_stale_wrapper_after_contract_flip(
     tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary

- add durable regime-remediation cases so warning/critical incumbent evidence keeps waking the agent until there is a green proposal, bounded evaluation, blocker, or owner decision
- stamp proposals to immutable health evidence and carry rejection/application outcomes through monitoring and resolution without automatically pausing, flattening, or clamping trading
- debounce wakes per event, surface incumbent revision alignment, and classify replication as valid, decayed, invalid, or stale
- model stop-market bar gaps and stop-only stress slippage, and preserve normalized stop/leverage/slippage evidence in forward forensics
- direct the worker to ablate the largest losing leg first and support bounded remediation progress through core_jobs

## Validation

- ruff check on all touched Python files
- git diff --check
- 151 focused execution/jobs/proposal/application tests passed
- 80 post-cleanup remediation/proposal/forensics/MCP tests passed
- 7 final targeted remediation and stop-telemetry tests passed
- isolated mypy found no new errors in the added remediation path; the broader touched-file run still reports existing repository/stub errors