### PR TITLE
Retry transient Hyperliquid info failures

### DIFF
--- a/wayfinder_paths/core/clients/HyperliquidInfoClient.py
+++ b/wayfinder_paths/core/clients/HyperliquidInfoClient.py
@@ -10,13 +10,10 @@ from hyperliquid.utils.error import (  # type: ignore[import-untyped]
     ClientError,
     ServerError,
 )
-from loguru import logger
 from requests import ConnectionError as RequestsConnectionError
-from requests import Timeout as RequestsTimeout
 
 from wayfinder_paths.core.utils.retry import retry_async
 
-_MAX_ATTEMPTS = 3
 _RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
 
 
@@ -28,33 +25,14 @@ def _public_info() -> Info:
 def _is_retryable(exc: Exception) -> bool:
     if isinstance(exc, (ClientError, ServerError)):
         return getattr(exc, "status_code", None) in _RETRYABLE_STATUS_CODES
-    return isinstance(exc, (RequestsConnectionError, RequestsTimeout))
+    return isinstance(exc, RequestsConnectionError)
 
 
 class HyperliquidInfoClient:
     async def post(self, body: dict[str, Any]) -> Any:
-        async def _attempt() -> Any:
-            # Resolve the cached SDK client in the worker as its constructor performs
-            # synchronous metadata requests on first use.
-            return await asyncio.to_thread(lambda: _public_info().post("/info", body))
-
-        def _on_retry(attempt: int, exc: Exception, delay_s: float) -> None:
-            logger.warning(
-                "Hyperliquid info request '{}' failed with {}; retrying in {:.2f}s "
-                "(attempt {}/{})",
-                body.get("type", "unknown"),
-                type(exc).__name__,
-                delay_s,
-                attempt + 1,
-                _MAX_ATTEMPTS,
-            )
-
         return await retry_async(
-            _attempt,
-            max_retries=_MAX_ATTEMPTS,
-            base_delay_s=0.25,
+            lambda: asyncio.to_thread(_public_info().post, "/info", body),
             should_retry=_is_retryable,
-            on_retry=_on_retry,
         )
 
 

--- a/wayfinder_paths/core/clients/HyperliquidInfoClient.py
+++ b/wayfinder_paths/core/clients/HyperliquidInfoClient.py
@@ -6,6 +6,18 @@ from typing import Any
 
 from hyperliquid.info import Info
 from hyperliquid.utils import constants
+from hyperliquid.utils.error import (  # type: ignore[import-untyped]
+    ClientError,
+    ServerError,
+)
+from loguru import logger
+from requests import ConnectionError as RequestsConnectionError
+from requests import Timeout as RequestsTimeout
+
+from wayfinder_paths.core.utils.retry import retry_async
+
+_MAX_ATTEMPTS = 3
+_RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
 
 
 @cache
@@ -13,9 +25,37 @@ def _public_info() -> Info:
     return Info(constants.MAINNET_API_URL, skip_ws=True)
 
 
+def _is_retryable(exc: Exception) -> bool:
+    if isinstance(exc, (ClientError, ServerError)):
+        return getattr(exc, "status_code", None) in _RETRYABLE_STATUS_CODES
+    return isinstance(exc, (RequestsConnectionError, RequestsTimeout))
+
+
 class HyperliquidInfoClient:
     async def post(self, body: dict[str, Any]) -> Any:
-        return await asyncio.to_thread(_public_info().post, "/info", body)
+        async def _attempt() -> Any:
+            # Resolve the cached SDK client in the worker as its constructor performs
+            # synchronous metadata requests on first use.
+            return await asyncio.to_thread(lambda: _public_info().post("/info", body))
+
+        def _on_retry(attempt: int, exc: Exception, delay_s: float) -> None:
+            logger.warning(
+                "Hyperliquid info request '{}' failed with {}; retrying in {:.2f}s "
+                "(attempt {}/{})",
+                body.get("type", "unknown"),
+                type(exc).__name__,
+                delay_s,
+                attempt + 1,
+                _MAX_ATTEMPTS,
+            )
+
+        return await retry_async(
+            _attempt,
+            max_retries=_MAX_ATTEMPTS,
+            base_delay_s=0.25,
+            should_retry=_is_retryable,
+            on_retry=_on_retry,
+        )
 
 
 HYPERLIQUID_INFO_CLIENT = HyperliquidInfoClient()

--- a/wayfinder_paths/core/clients/test_hyperliquid_info_client.py
+++ b/wayfinder_paths/core/clients/test_hyperliquid_info_client.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import importlib
+from unittest.mock import Mock
+
+import pytest
+from hyperliquid.utils.error import (  # type: ignore[import-untyped]
+    ClientError,
+    ServerError,
+)
+from requests import ConnectionError as RequestsConnectionError
+from requests import Timeout as RequestsTimeout
+
+from wayfinder_paths.core.clients.HyperliquidInfoClient import (
+    HyperliquidInfoClient,
+)
+from wayfinder_paths.core.utils import retry as retry_utils
+
+client_module = importlib.import_module(
+    "wayfinder_paths.core.clients.HyperliquidInfoClient"
+)
+
+
+@pytest.fixture
+def no_retry_sleep(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(delay_s: float) -> None:
+        sleep_calls.append(delay_s)
+
+    monkeypatch.setattr(retry_utils.asyncio, "sleep", fake_sleep)
+    return sleep_calls
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "transient_error",
+    [
+        ServerError(500, "null"),
+        ClientError(429, None, "rate limited", {}),
+        RequestsConnectionError("connection reset"),
+        RequestsTimeout("request timed out"),
+    ],
+)
+async def test_post_retries_transient_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    no_retry_sleep: list[float],
+    transient_error: Exception,
+) -> None:
+    body = {"type": "candleSnapshot", "req": {"coin": "SOL"}}
+    expected = [{"t": 1, "c": "100"}]
+    info = Mock()
+    info.post.side_effect = [transient_error, expected]
+    monkeypatch.setattr(client_module, "_public_info", lambda: info)
+
+    result = await HyperliquidInfoClient().post(body)
+
+    assert result == expected
+    assert info.post.call_count == 2
+    info.post.assert_called_with("/info", body)
+    assert no_retry_sleep == [0.25]
+
+
+@pytest.mark.asyncio
+async def test_post_does_not_retry_non_transient_client_error(
+    monkeypatch: pytest.MonkeyPatch,
+    no_retry_sleep: list[float],
+) -> None:
+    error = ClientError(400, None, "bad request", {})
+    info = Mock()
+    info.post.side_effect = error
+    monkeypatch.setattr(client_module, "_public_info", lambda: info)
+
+    with pytest.raises(ClientError) as raised:
+        await HyperliquidInfoClient().post({"type": "invalid"})
+
+    assert raised.value is error
+    assert info.post.call_count == 1
+    assert no_retry_sleep == []
+
+
+@pytest.mark.asyncio
+async def test_post_reraises_after_bounded_attempts(
+    monkeypatch: pytest.MonkeyPatch,
+    no_retry_sleep: list[float],
+) -> None:
+    error = ServerError(503, "unavailable")
+    info = Mock()
+    info.post.side_effect = error
+    monkeypatch.setattr(client_module, "_public_info", lambda: info)
+
+    with pytest.raises(ServerError) as raised:
+        await HyperliquidInfoClient().post({"type": "allMids"})
+
+    assert raised.value is error
+    assert info.post.call_count == 3
+    assert no_retry_sleep == [0.25, 0.5]

--- a/wayfinder_paths/core/clients/test_hyperliquid_info_client.py
+++ b/wayfinder_paths/core/clients/test_hyperliquid_info_client.py
@@ -9,7 +9,6 @@ from hyperliquid.utils.error import (  # type: ignore[import-untyped]
     ServerError,
 )
 from requests import ConnectionError as RequestsConnectionError
-from requests import Timeout as RequestsTimeout
 
 from wayfinder_paths.core.clients.HyperliquidInfoClient import (
     HyperliquidInfoClient,
@@ -32,6 +31,13 @@ def no_retry_sleep(monkeypatch: pytest.MonkeyPatch) -> list[float]:
     return sleep_calls
 
 
+@pytest.fixture
+def mock_info(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    info = Mock()
+    monkeypatch.setattr(client_module, "_public_info", lambda: info)
+    return info
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "transient_error",
@@ -39,59 +45,52 @@ def no_retry_sleep(monkeypatch: pytest.MonkeyPatch) -> list[float]:
         ServerError(500, "null"),
         ClientError(429, None, "rate limited", {}),
         RequestsConnectionError("connection reset"),
-        RequestsTimeout("request timed out"),
     ],
 )
 async def test_post_retries_transient_failures(
-    monkeypatch: pytest.MonkeyPatch,
+    mock_info: Mock,
     no_retry_sleep: list[float],
     transient_error: Exception,
 ) -> None:
     body = {"type": "candleSnapshot", "req": {"coin": "SOL"}}
     expected = [{"t": 1, "c": "100"}]
-    info = Mock()
-    info.post.side_effect = [transient_error, expected]
-    monkeypatch.setattr(client_module, "_public_info", lambda: info)
+    mock_info.post.side_effect = [transient_error, expected]
 
     result = await HyperliquidInfoClient().post(body)
 
     assert result == expected
-    assert info.post.call_count == 2
-    info.post.assert_called_with("/info", body)
+    assert mock_info.post.call_count == 2
+    mock_info.post.assert_called_with("/info", body)
     assert no_retry_sleep == [0.25]
 
 
 @pytest.mark.asyncio
 async def test_post_does_not_retry_non_transient_client_error(
-    monkeypatch: pytest.MonkeyPatch,
+    mock_info: Mock,
     no_retry_sleep: list[float],
 ) -> None:
     error = ClientError(400, None, "bad request", {})
-    info = Mock()
-    info.post.side_effect = error
-    monkeypatch.setattr(client_module, "_public_info", lambda: info)
+    mock_info.post.side_effect = error
 
     with pytest.raises(ClientError) as raised:
         await HyperliquidInfoClient().post({"type": "invalid"})
 
     assert raised.value is error
-    assert info.post.call_count == 1
+    assert mock_info.post.call_count == 1
     assert no_retry_sleep == []
 
 
 @pytest.mark.asyncio
 async def test_post_reraises_after_bounded_attempts(
-    monkeypatch: pytest.MonkeyPatch,
+    mock_info: Mock,
     no_retry_sleep: list[float],
 ) -> None:
     error = ServerError(503, "unavailable")
-    info = Mock()
-    info.post.side_effect = error
-    monkeypatch.setattr(client_module, "_public_info", lambda: info)
+    mock_info.post.side_effect = error
 
     with pytest.raises(ServerError) as raised:
         await HyperliquidInfoClient().post({"type": "allMids"})
 
     assert raised.value is error
-    assert info.post.call_count == 3
+    assert mock_info.post.call_count == 3
     assert no_retry_sleep == [0.25, 0.5]


### PR DESCRIPTION
## Summary

- retry read-only Hyperliquid info calls on HTTP 429, common 5xx responses, and connection failures
- reuse the shared `retry_async` attempt and exponential-backoff policy while preserving immediate failure for non-transient 4xx responses
- add regression coverage for recovery, fail-fast behavior, and retry exhaustion

## Diagnosis

The reported `candleSnapshot` payload is valid. Matching SOL queries against the dev-backed candle endpoint succeeded for both 32-hour and 200-day windows, and the raw public endpoint also succeeded immediately after the observed `ServerError(500, "null")`. The direct SDK wrapper had no retry handling, so a transient upstream 500 aborted the entire research run.

## Verification

- `pytest -q wayfinder_paths/core/clients --no-cov` (25 passed, 2 skipped)
- `pytest -q wayfinder_paths/adapters/hyperliquid_adapter --no-cov` (45 passed, 2 skipped)
- `ruff check` and `ruff format --check` on changed files
- focused `mypy` on changed files
- exact live SOL `candleSnapshot` request for 1h candles over 32 hours (33 rows returned)