### PR TITLE
applications: survive RSS restarts, classify missing-data as infrastructure, never self-bury approved work

### DIFF
--- a/wayfinder_paths/jobs/failures.py
+++ b/wayfinder_paths/jobs/failures.py
@@ -57,6 +57,20 @@ INFRASTRUCTURE_PATTERNS = (
     "opencode-unavailable",
     "prompt_async",
     "resource temporarily unavailable",
+    # Missing-data box conditions: a data-feed incident that leaves the job
+    # without its backtest dataset (results/backtest/input_bars.json gone) is
+    # a BOX condition, not evidence against a change — every check that needs
+    # bars fails, which says nothing about the candidate. Emitters:
+    # execution/job.py _load_dataset ("No backtest bars found. Provide
+    # results/backtest/input_bars.json, ..."), validation.py ("no dataset for
+    # candidate backtest: ..."), derived_features.py (data_feed_degraded).
+    # Patterns stay tight: plain "backtest failed" is still evidence.
+    "no backtest bars",
+    "no bars found",
+    "input_bars",
+    "dataset not found",
+    "missing dataset",
+    "data_feed",
 )
 
 

--- a/wayfinder_paths/jobs/store.py
+++ b/wayfinder_paths/jobs/store.py
@@ -623,34 +623,59 @@ class JobStore:
         by = rejected_by or "owner"
         # Durable restage: an agent cannot bury owner-approved work over a
         # transient box failure. When the latest re-stage/validation failure
-        # is infrastructure-class (OOM, lock, timeout), the proposal stays
-        # approved with restage_requested and the watchdog retries — only the
-        # owner may abandon approved work. (Live incident: one OOM during a
-        # mechanical re-stage led the agent to self-reject an owner-approved
-        # proposal, freezing the change until a human noticed.)
+        # is infrastructure-class (OOM, lock, timeout, missing dataset) OR a
+        # fail-closed gate ESCALATE (the gate REFUSED TO EVALUATE — missing
+        # evidence, governance drift — as opposed to evaluating the change
+        # red), the proposal stays approved with restage_requested and the
+        # watchdog retries — only the owner may abandon approved work. (Live
+        # incidents: one OOM during a mechanical re-stage led the agent to
+        # self-reject an owner-approved proposal; later a missing backtest
+        # dataset made the governance gate ESCALATE during a mechanical
+        # re-stage and the restage flow's own auto-reject buried the
+        # owner-approved change again.)
         if proposal["status"] == "approved" and by != "owner":
             failure_text = _latest_failure_text(proposal, reason)
-            if classify_failure(failure_text) == "infrastructure":
+            is_infrastructure = classify_failure(failure_text) == "infrastructure"
+            is_escalate = _contains_fail_closed_escalate(failure_text)
+            if is_infrastructure or is_escalate:
                 proposal["application"]["restage_requested"] = True
                 proposal["updated_at"] = utc_now_iso()
                 self.write_proposal(job_id, proposal)
-                self.append_journal(
-                    job_id,
-                    {
-                        "type": "proposal_reject_refused",
-                        "proposal_id": proposal_id,
-                        "rejected_by": by,
-                        "failure_kind": "infrastructure",
-                    },
-                )
+                refusal_event: dict[str, Any] = {
+                    "type": "proposal_reject_refused",
+                    "proposal_id": proposal_id,
+                    "rejected_by": by,
+                    "failure_kind": (
+                        "infrastructure" if is_infrastructure else "escalate"
+                    ),
+                }
+                if is_escalate:
+                    refusal_event["owner_review_required"] = (
+                        f"a fail-closed gate ESCALATED instead of evaluating "
+                        f"approved proposal {proposal_id} — the agent may not "
+                        "translate that refusal-to-evaluate into a rejection. "
+                        "The proposal stays approved with restage_requested; "
+                        "the owner reviews or the box condition clears."
+                    )
+                self.append_journal(job_id, refusal_event)
+                if is_infrastructure:
+                    raise ValueError(
+                        f"refusing agent rejection of approved proposal "
+                        f"{proposal_id}: its latest re-stage/validation failure "
+                        "is infrastructure-class (OOM/lock/timeout) — a "
+                        "transient box condition, not evidence against the "
+                        "change. The proposal stays approved with "
+                        "restage_requested and the watchdog retries the "
+                        "re-stage; only the owner may abandon approved work."
+                    )
                 raise ValueError(
                     f"refusing agent rejection of approved proposal "
-                    f"{proposal_id}: its latest re-stage/validation failure "
-                    "is infrastructure-class (OOM/lock/timeout) — a "
-                    "transient box condition, not evidence against the "
-                    "change. The proposal stays approved with "
-                    "restage_requested and the watchdog retries the "
-                    "re-stage; only the owner may abandon approved work."
+                    f"{proposal_id}: its latest failure is a fail-closed gate "
+                    "ESCALATE — the gate refused to evaluate (missing "
+                    "evidence or governance drift), it did not evaluate the "
+                    "change red. The proposal stays approved with "
+                    "restage_requested and owner review required; only the "
+                    "owner may abandon approved work."
                 )
         if kind is not None and kind not in REJECTION_KINDS:
             raise ValueError(f"rejection kind must be one of {sorted(REJECTION_KINDS)}")
@@ -909,6 +934,20 @@ def _infer_rejection_kind(reason: str | None) -> str:
     if any(marker in text for marker in _PROCESS_REJECTION_MARKERS):
         return "process"
     return "substantive"
+
+
+def _contains_fail_closed_escalate(text: str) -> bool:
+    """Whether a failure text carries a fail-closed gate ESCALATE.
+
+    Fail-closed gates that REFUSE TO EVALUATE (governance chain tampered,
+    constitution drift, economic evidence unavailable) all prefix their
+    message with "ESCALATE:" — see _ensure_governance_gate and
+    application.claim_application. A refusal to evaluate is never evidence
+    against the change; a gate that evaluated and came back red ("candidate
+    is not economic-ready: ...") carries no ESCALATE prefix and still stops
+    the line.
+    """
+    return "escalate:" in (text or "").lower()
 
 
 def _latest_failure_text(proposal: Mapping[str, Any], reason: str | None) -> str:

--- a/wayfinder_paths/jobs/watchdog.py
+++ b/wayfinder_paths/jobs/watchdog.py
@@ -39,6 +39,12 @@ WATCHDOG_TIMEOUT_SECONDS = 2700
 # Deterministic applies (candidate_report staged): completer child normally
 # finishes in 1-3 minutes; a dead completer past this age is recovered.
 DETERMINISTIC_APPLYING_TIMEOUT = timedelta(minutes=15)
+# Orphaned deterministic applies (status "applying", stale started_at, no
+# live completer process — daemon RSS-exit or box reboot mid-apply): a dead
+# completer can never finish on its own, so waiting out the full applying
+# window just prolongs the loop pause. Short grace covers the claim→spawn
+# window where apply_worker.pid is not yet recorded.
+ORPHANED_APPLYING_TIMEOUT = timedelta(minutes=5)
 # Agent-owned applies (ungated, agent claims itself): sessions legitimately
 # take longer, but past this the session is presumed dead.
 AGENT_APPLYING_TIMEOUT = timedelta(minutes=60)
@@ -110,16 +116,27 @@ def _recover_applying(
 
     worker = application.get("apply_worker") or {}
     pid = int(worker.get("pid") or 0)
-    if _pid_alive(pid):
+    pid_alive = _pid_alive(pid)
+    if pid_alive:
         if age < HARD_KILL_TIMEOUT:
             return None
         _kill_process_group(pid)
 
     deterministic = bool(proposal.get("candidate_report"))
+    # Orphan signature: deterministic apply stuck "applying" with no live
+    # completer (recorded pid dead, or claim never reached spawn — e.g. the
+    # daemon RSS-exited mid-apply) past a short grace. Recovered NOW instead
+    # of waiting out the full applying window — a dead completer can never
+    # finish. Agent-owned applies record no pid, so the fast path never
+    # applies to them. Recovery re-enters the apply from the TOP of the
+    # completer pipeline: complete_application(status="applied") re-runs the
+    # baseline-drift guard and the FULL candidate validation before
+    # promoting — it never resumes a torn apply mid-stage.
+    orphaned = deterministic and not pid_alive and age >= ORPHANED_APPLYING_TIMEOUT
     timeout = (
         DETERMINISTIC_APPLYING_TIMEOUT if deterministic else AGENT_APPLYING_TIMEOUT
     )
-    if age < timeout:
+    if age < timeout and not orphaned:
         return None
 
     action = "complete_applied" if deterministic else "complete_failed"
@@ -153,6 +170,8 @@ def _recover_applying(
         "age_seconds": int(age.total_seconds()) if age != timedelta.max else None,
         "action": action,
         "outcome": outcome,
+        "orphaned": orphaned,
+        "worker_pid": pid or None,
     }
     store.append_journal(job_id, event)
     return event

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -44,6 +44,12 @@ from wayfinder_paths.runner.script_resolver import resolve_script_path
 JOB_RESULT_MARKER = "WAYFINDER_JOB_RESULT "
 DEFAULT_SYNC_DEBOUNCE_SECONDS = 90.0
 DEFAULT_MAX_RSS_MB = 900.0
+# While a proposal application is applying, the RSS restart exit is deferred
+# (an os._exit orphans the apply mid-flight AND leaves the job's loops
+# paused). Past cap × this multiplier the daemon exits anyway — an apply must
+# not hold a ballooning daemon hostage; the orphaned apply is journaled so
+# recovery knows why it died.
+RSS_HARD_EXIT_MULTIPLIER = 1.5
 JOB_LOCK_TIMEOUT_SECONDS = 3
 JOB_LOCK_BUSY_MSG = (
     "Runner Daemon lock is busy, no operations were completed, please try again later"
@@ -147,6 +153,69 @@ def _max_rss_mb_from_env() -> float:
             f"Invalid WAYFINDER_RUNNERD_MAX_RSS_MB={raw!r}; using {DEFAULT_MAX_RSS_MB}"
         )
         return DEFAULT_MAX_RSS_MB
+
+
+def _applying_applications(repo_root: Path) -> list[dict[str, str]]:
+    """Proposal applications currently in "applying", read straight off the
+    jobs store layout (.wayfinder/jobs/<job>/proposals/*.json) so runnerd
+    never imports the jobs package. `claim_application` pauses the job's
+    loops for the whole apply window — an RSS os._exit during that window
+    orphans the apply mid-flight and leaves the job dark (observed live
+    2026-08-24: runnerd RSS-exited 17s into an owner-approved apply). Never
+    raises; only consulted after the RSS cap is already breached."""
+    applying: list[dict[str, str]] = []
+    try:
+        paths = sorted((repo_root / ".wayfinder" / "jobs").glob("*/proposals/*.json"))
+    except OSError:
+        return applying
+    for path in paths:
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        application = data.get("application")
+        if isinstance(application, dict) and application.get("status") == "applying":
+            applying.append(
+                {
+                    "job_id": path.parent.parent.name,
+                    "proposal_id": str(data.get("proposal_id") or path.stem),
+                }
+            )
+    return applying
+
+
+def _journal_rss_exit_during_apply(
+    repo_root: Path,
+    applying: list[dict[str, str]],
+    *,
+    rss_mb: float,
+    max_rss_mb: float,
+) -> None:
+    """Best-effort breadcrumb in each affected job's journal: the apply about
+    to be orphaned died to a daemon hard-exit, not to anything about the
+    change itself. Mirrors JobStore.append_journal's row shape without
+    importing the jobs package. Never raises."""
+    for entry in applying:
+        path = repo_root / ".wayfinder" / "jobs" / entry["job_id"] / "journal.jsonl"
+        try:
+            with path.open("a", encoding="utf-8") as handle:
+                handle.write(
+                    json.dumps(
+                        {
+                            "ts": datetime.now(UTC).isoformat(),
+                            "type": "runnerd_rss_exit_during_apply",
+                            "proposal_id": entry["proposal_id"],
+                            "rss_mb": round(rss_mb, 1),
+                            "max_rss_mb": round(max_rss_mb, 1),
+                        },
+                        sort_keys=True,
+                    )
+                    + "\n"
+                )
+        except OSError:
+            continue
 
 
 def _rss_mb() -> float | None:
@@ -276,6 +345,9 @@ class RunnerDaemon:
         self._daemon_log_sink_id: int | None = None
         self._warm_spawner: Any | None = None
         self._max_rss_mb = _max_rss_mb_from_env()
+        # Last time the apply-in-flight RSS deferral was logged (monotonic);
+        # seeded so the FIRST deferral always logs.
+        self._rss_defer_logged_at = -3600.0
         self._sync_debouncer = _SyncDebouncer(
             action=lambda: self._start_backend_sync(),
             delay_seconds=_sync_debounce_seconds(),
@@ -398,12 +470,54 @@ class RunnerDaemon:
         rss_mb = _rss_mb()
         if rss_mb is None or rss_mb <= self._max_rss_mb:
             return
-        logger.critical(
-            f"runnerd RSS {rss_mb:.0f}MB exceeds WAYFINDER_RUNNERD_MAX_RSS_MB="
-            f"{self._max_rss_mb:.0f}MB; exiting now so the supervisor restarts "
-            "us cleanly between ticks instead of the kernel OOM-killing us "
-            "mid-write"
-        )
+        # A live apply owns the exit decision up to the hard override: exiting
+        # mid-apply orphaned an owner-approved apply in production (claim
+        # stood, completer died, loops stayed paused until the watchdog
+        # noticed). Defer and re-check next tick instead.
+        applying = _applying_applications(self._paths.repo_root)
+        hard_exit_mb = self._max_rss_mb * RSS_HARD_EXIT_MULTIPLIER
+        if applying and rss_mb <= hard_exit_mb:
+            # Ticks run every ~1s: debounce the deferral log so a minutes-long
+            # apply does not spam CRITICAL once per tick.
+            now = time.monotonic()
+            if now - self._rss_defer_logged_at >= 60.0:
+                self._rss_defer_logged_at = now
+                in_flight = ", ".join(
+                    f"{entry['job_id']}/{entry['proposal_id']}" for entry in applying
+                )
+                logger.critical(
+                    f"runnerd RSS {rss_mb:.0f}MB exceeds "
+                    f"WAYFINDER_RUNNERD_MAX_RSS_MB={self._max_rss_mb:.0f}MB but "
+                    f"{len(applying)} proposal application(s) are applying "
+                    f"({in_flight}); deferring the restart exit until no apply "
+                    f"is in flight (hard override at {hard_exit_mb:.0f}MB); "
+                    "re-checking next tick"
+                )
+            return
+        if applying:
+            # Hard override: an apply must not hold a ballooning daemon
+            # hostage. Journal the in-flight applies so recovery knows the
+            # orphaning cause was this exit, not the apply itself.
+            _journal_rss_exit_during_apply(
+                self._paths.repo_root,
+                applying,
+                rss_mb=rss_mb,
+                max_rss_mb=self._max_rss_mb,
+            )
+            logger.critical(
+                f"runnerd RSS {rss_mb:.0f}MB exceeds the hard override "
+                f"{hard_exit_mb:.0f}MB (cap {self._max_rss_mb:.0f}MB × "
+                f"{RSS_HARD_EXIT_MULTIPLIER}) with {len(applying)} apply(ies) "
+                "in flight; exiting anyway — orphaned applies journaled as "
+                "runnerd_rss_exit_during_apply for the watchdog"
+            )
+        else:
+            logger.critical(
+                f"runnerd RSS {rss_mb:.0f}MB exceeds "
+                f"WAYFINDER_RUNNERD_MAX_RSS_MB={self._max_rss_mb:.0f}MB; "
+                "exiting now so the supervisor restarts us cleanly between "
+                "ticks instead of the kernel OOM-killing us mid-write"
+            )
         os._exit(1)
 
     def _reap(self, *, now: int) -> None:

--- a/wayfinder_paths/tests/test_jobs_apply_watchdog.py
+++ b/wayfinder_paths/tests/test_jobs_apply_watchdog.py
@@ -263,6 +263,105 @@ def test_watchdog_fails_stalled_agent_owned_applying(
     assert completions == [("prop_agent_stale", "failed")]
 
 
+def test_watchdog_recovers_orphaned_apply_from_top(tmp_path: Path, monkeypatch) -> None:
+    """An apply orphaned by daemon death (status "applying", stale started_at,
+    dead completer pid) is recovered well before the full applying window and
+    re-entered from the TOP of the completer pipeline — complete_application
+    re-runs the drift guard + full candidate validation, never a mid-stage
+    resume. (2026-08-24: runnerd RSS-exited 17s into an owner-approved apply;
+    the old signature waited out the full window.)"""
+    _patch_runner(monkeypatch)
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "wd-orphan-demo")
+    _write_proposal(
+        store,
+        job.id,
+        "prop_orphan",
+        application={
+            "status": "applying",
+            "started_at": _iso_ago(6),
+            "apply_worker": {"pid": 424242, "spawned_at": utc_now_iso()},
+        },
+        candidate_report={"gate": "green"},
+    )
+    monkeypatch.setattr("wayfinder_paths.jobs.watchdog._pid_alive", lambda pid: False)
+
+    completions: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.watchdog.complete_application",
+        lambda store, job_id, proposal_id, *, status, **kw: completions.append(
+            (proposal_id, status)
+        )
+        or {},
+    )
+
+    report = recover_stalled_applications(store=store)
+
+    assert completions == [("prop_orphan", "applied")]
+    events = [e for e in report["recovered"] if e.get("stalled_status") == "applying"]
+    assert len(events) == 1
+    assert events[0]["orphaned"] is True
+    assert events[0]["worker_pid"] == 424242
+    assert "application_watchdog_recovered" in _journal_types(store, job.id)
+
+
+def test_watchdog_gives_dead_completer_a_short_grace(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Inside the orphan grace window (claim→spawn gap, slow pid record) a
+    dead/absent completer pid is not yet a stall."""
+    _patch_runner(monkeypatch)
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "wd-orphan-fresh")
+    _write_proposal(
+        store,
+        job.id,
+        "prop_fresh_orphan",
+        application={"status": "applying", "started_at": _iso_ago(2)},
+        candidate_report={"gate": "green"},
+    )
+    monkeypatch.setattr("wayfinder_paths.jobs.watchdog._pid_alive", lambda pid: False)
+
+    completions: list[str] = []
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.watchdog.complete_application",
+        lambda *a, **kw: completions.append("called") or {},
+    )
+
+    report = recover_stalled_applications(store=store)
+
+    assert completions == []
+    assert report["recovered"] == []
+
+
+def test_watchdog_orphan_fast_path_is_deterministic_only(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Agent-owned applies record no completer pid — a dead-pid signature must
+    not cut their 60-minute window short."""
+    _patch_runner(monkeypatch)
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "wd-orphan-agent")
+    _write_proposal(
+        store,
+        job.id,
+        "prop_agent_orphan",
+        application={"status": "applying", "started_at": _iso_ago(30)},
+    )
+    monkeypatch.setattr("wayfinder_paths.jobs.watchdog._pid_alive", lambda pid: False)
+
+    completions: list[str] = []
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.watchdog.complete_application",
+        lambda *a, **kw: completions.append("called") or {},
+    )
+
+    report = recover_stalled_applications(store=store)
+
+    assert completions == []
+    assert report["recovered"] == []
+
+
 def test_watchdog_skips_live_completer(tmp_path: Path, monkeypatch) -> None:
     _patch_runner(monkeypatch)
     store = JobStore(repo_root=tmp_path)

--- a/wayfinder_paths/tests/test_jobs_propose.py
+++ b/wayfinder_paths/tests/test_jobs_propose.py
@@ -467,6 +467,55 @@ def test_restage_gate_failure_auto_rejects(
     assert "re-stage gate failed" in str(rejected["rejection"]["reason"])
 
 
+def test_restage_gate_escalate_keeps_proposal_approved(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The 2026-08-24 burial class, end to end: a missing backtest dataset
+    makes the fail-closed governance gate ESCALATE during a mechanical
+    re-stage. The restage flow's own agent rejection routes through
+    store.reject_proposal, where the guard refuses it — the owner-approved
+    proposal stays approved with restage_requested instead of being buried."""
+    _patch_runner(monkeypatch)
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.worker.run_job_worker",
+        lambda job_id, *, mode, **k: {"status": "queued"},
+    )
+    store, job_id, root = _make_job(tmp_path)
+    proposal = _propose_params(store, job_id)
+    pid = proposal["proposal_id"]
+
+    script = root / "workspace" / "src" / "strategy.py"
+    script.write_text(
+        script.read_text(encoding="utf-8") + "\n# drift\n", encoding="utf-8"
+    )
+    store.approve_proposal(job_id, pid)
+    claim_application(store, job_id, pid)
+    complete_application(store, job_id, pid, status="applied")
+    assert store.load_proposal(job_id, pid)["application"]["restage_requested"]
+
+    escalate = ValueError(
+        "ESCALATE: blocking governance requires economic_ready=True for a "
+        "live-capable job; got None: economic evaluation failed: No backtest "
+        "bars found. Provide results/backtest/input_bars.json, "
+        "workspace/config/backtest_bars.json, execution_scenario_plan bars, "
+        "or execution_spec.validation.fixture_bars."
+    )
+
+    def raising_governance_gate(self, job_id, economic):  # noqa: ANN001
+        raise escalate
+
+    monkeypatch.setattr(JobStore, "_ensure_governance_gate", raising_governance_gate)
+
+    with pytest.raises(ValueError, match="refusing agent rejection"):
+        restage_proposal(store, job_id, pid)
+
+    kept = store.load_proposal(job_id, pid)
+    assert kept["status"] == "approved", "approval survives the gate ESCALATE"
+    assert kept["application"]["restage_requested"] is True
+    journal = (root / "journal.jsonl").read_text(encoding="utf-8")
+    assert "proposal_reject_refused" in journal
+
+
 # ── infra-vs-evidence at propose time + revalidation ─────────────────────────
 # Production bug (verified twice): a ComputeLockBusy during the propose-time
 # candidate backtest froze a FAILED validation_summary into the immutable

--- a/wayfinder_paths/tests/test_jobs_self_healing.py
+++ b/wayfinder_paths/tests/test_jobs_self_healing.py
@@ -89,6 +89,39 @@ def test_classify_failure_taxonomy() -> None:
         assert classify_failure(text) == "evidence", text
 
 
+def test_classify_missing_data_is_infrastructure() -> None:
+    """A data-feed incident that deletes the job's backtest dataset is a BOX
+    condition: every check that needs bars fails, which says nothing about the
+    candidate. (Live incident 2026-08-24: results/backtest/input_bars.json
+    gone → scenario replay + candidate backtest both failed → misclassified
+    as evidence → an owner-approved proposal was buried.)"""
+    infrastructure = [
+        # The _load_dataset raise from execution/job.py, verbatim.
+        "No backtest bars found. Provide results/backtest/input_bars.json, "
+        "workspace/config/backtest_bars.json, execution_scenario_plan bars, "
+        "or execution_spec.validation.fixture_bars.",
+        # How it rides through candidate validation (validation.py).
+        "no dataset for candidate backtest: No backtest bars found.",
+        # How it rides through the economic gate (proposals.py).
+        "economic evaluation failed: No backtest bars found",
+        "results/backtest/input_bars.json is missing after the data-feed reset",
+        "dataset not found for HYPE 5m",
+        "missing dataset: refetch via fetch-dataset",
+        "data_feed_degraded: newest feature bar is stale",
+        "no bars found in the requested window",
+    ]
+    for text in infrastructure:
+        assert classify_failure(text) == "infrastructure", text
+    # Tight patterns: a genuinely failing backtest is still evidence.
+    evidence = [
+        "backtest failed",
+        "candidate backtest failed: net_return regressed below baseline",
+        "dataset spans 30d but only 7d was requested",
+    ]
+    for text in evidence:
+        assert classify_failure(text) == "evidence", text
+
+
 def test_compute_status_block_in_wake_prompt(tmp_path: Path) -> None:
     from wayfinder_paths.jobs.worker import prepare_job_worker_prompt
 
@@ -137,6 +170,84 @@ def test_agent_cannot_bury_approved_work_on_infra_failure(tmp_path: Path) -> Non
     # The owner may still abandon approved work — the guard binds agents only.
     rejected = store.reject_proposal(
         job_id, "prop-heal", reason="no longer wanted", rejected_by="owner"
+    )
+    assert rejected["status"] == "rejected"
+
+
+def test_agent_cannot_bury_approved_work_on_missing_dataset(tmp_path: Path) -> None:
+    """Regression pin for the 2026-08-24 burial: a data-feed incident deleted
+    the job's backtest dataset, the mechanical re-stage hit the fail-closed
+    governance gate, and the restage flow's agent rejection buried the
+    owner-approved proposal. Missing-dataset text now classifies as
+    infrastructure and the guard refuses the rejection."""
+    store, job_id = _make_store(tmp_path)
+    store.write_proposal(job_id, _approved_proposal(None))
+    reason = (
+        "re-stage gate failed on current base abc123: ESCALATE: blocking "
+        "governance requires economic_ready=True for a live-capable job; got "
+        "None: economic evaluation failed: No backtest bars found. Provide "
+        "results/backtest/input_bars.json, workspace/config/backtest_bars.json, "
+        "execution_scenario_plan bars, or execution_spec.validation."
+        "fixture_bars.. The workspace changed materially since approval — "
+        "propose the change fresh so the owner can review it against the new "
+        "base."
+    )
+    with pytest.raises(ValueError, match="refusing agent rejection"):
+        store.reject_proposal(job_id, "prop-heal", reason=reason, rejected_by="agent")
+    kept = store.load_proposal(job_id, "prop-heal")
+    assert kept["status"] == "approved"
+    assert kept["application"]["restage_requested"] is True
+    assert _journal_events(store, job_id, "proposal_reject_refused")
+
+
+def test_agent_cannot_bury_approved_work_on_gate_escalate(tmp_path: Path) -> None:
+    """A fail-closed gate ESCALATE is a refusal to evaluate, never an
+    evaluation of the change — the agent may not translate it into a
+    rejection even when no infrastructure pattern matches. The owner still
+    can."""
+    store, job_id = _make_store(tmp_path)
+    store.write_proposal(job_id, _approved_proposal(None))
+    reason = (
+        "re-stage gate failed on current base abc123: ESCALATE: governance "
+        "changed since the candidate was evaluated (report aaa vs current "
+        "bbb) — re-run the economic report."
+    )
+    assert classify_failure(reason) == "evidence"  # no infra pattern involved
+    with pytest.raises(ValueError, match="fail-closed gate ESCALATE"):
+        store.reject_proposal(job_id, "prop-heal", reason=reason, rejected_by="agent")
+    kept = store.load_proposal(job_id, "prop-heal")
+    assert kept["status"] == "approved"
+    assert kept["application"]["restage_requested"] is True
+    refusals = _journal_events(store, job_id, "proposal_reject_refused")
+    assert refusals and refusals[-1]["failure_kind"] == "escalate"
+    assert "owner_review_required" in refusals[-1]
+
+    # Only the owner may abandon approved work — same text, owner passes.
+    rejected = store.reject_proposal(
+        job_id, "prop-heal", reason=reason, rejected_by="owner"
+    )
+    assert rejected["status"] == "rejected"
+
+
+def test_agent_reject_of_pending_evidence_red_gate_still_passes(
+    tmp_path: Path,
+) -> None:
+    """The guard binds APPROVED proposals only: an agent rejecting its own
+    pending proposal over a red evidence gate is the system working."""
+    store, job_id = _make_store(tmp_path)
+    store.write_proposal(
+        job_id,
+        {
+            "proposal_id": "prop-pending",
+            "status": "pending",
+            "application": {"status": "not_requested"},
+        },
+    )
+    rejected = store.reject_proposal(
+        job_id,
+        "prop-pending",
+        reason="candidate gate is not live-ready: net_return below baseline",
+        rejected_by="agent",
     )
     assert rejected["status"] == "rejected"
 

--- a/wayfinder_paths/tests/test_runner_view_server.py
+++ b/wayfinder_paths/tests/test_runner_view_server.py
@@ -588,3 +588,73 @@ def test_memory_watchdog_disabled_by_non_positive_env(
 
     daemon.tick()
     assert exits == []
+
+
+def _write_applying_proposal(
+    repo_root: Path, job_id: str, proposal_id: str, *, status: str = "applying"
+) -> None:
+    proposals = repo_root / ".wayfinder" / "jobs" / job_id / "proposals"
+    proposals.mkdir(parents=True, exist_ok=True)
+    (proposals / f"{proposal_id}.json").write_text(
+        json.dumps({"proposal_id": proposal_id, "application": {"status": status}}),
+        encoding="utf-8",
+    )
+
+
+def test_memory_watchdog_defers_exit_while_apply_in_flight(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """RSS over cap while a proposal application is applying → the restart
+    exit is deferred (an os._exit would orphan the apply mid-flight and leave
+    the job's loops paused; observed live 2026-08-24). Re-checked next tick:
+    once the apply is terminal, the deferred exit fires."""
+    import os as os_module
+
+    from wayfinder_paths.runner import daemon as daemon_module
+
+    monkeypatch.setenv("WAYFINDER_RUNNERD_MAX_RSS_MB", "900")
+    _write_applying_proposal(tmp_path, "majors-5m-lab", "prop-params-update")
+    daemon = daemon_module.RunnerDaemon(paths=_daemon_paths(tmp_path))
+    exits: list[int] = []
+    monkeypatch.setattr(daemon_module, "_rss_mb", lambda: 1200.0)
+    monkeypatch.setattr(os_module, "_exit", lambda code: exits.append(code))
+
+    daemon.tick()
+    assert exits == [], "exit deferred while the apply is in flight"
+
+    _write_applying_proposal(
+        tmp_path, "majors-5m-lab", "prop-params-update", status="applied"
+    )
+    daemon.tick()
+    assert exits == [1], "deferred exit fires once no apply is in flight"
+
+
+def test_memory_watchdog_hard_override_exits_and_journals_the_apply(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Past cap × 1.5 the daemon exits even mid-apply — an apply must not
+    hold a ballooning daemon hostage — and journals which apply was in
+    flight so recovery knows why it was orphaned."""
+    import os as os_module
+
+    from wayfinder_paths.runner import daemon as daemon_module
+
+    monkeypatch.setenv("WAYFINDER_RUNNERD_MAX_RSS_MB", "900")
+    _write_applying_proposal(tmp_path, "majors-5m-lab", "prop-params-update")
+    daemon = daemon_module.RunnerDaemon(paths=_daemon_paths(tmp_path))
+    exits: list[int] = []
+    monkeypatch.setattr(daemon_module, "_rss_mb", lambda: 1400.0)
+    monkeypatch.setattr(os_module, "_exit", lambda code: exits.append(code))
+
+    daemon.tick()
+
+    assert exits == [1]
+    journal = (
+        tmp_path / ".wayfinder" / "jobs" / "majors-5m-lab" / "journal.jsonl"
+    ).read_text(encoding="utf-8")
+    rows = [json.loads(line) for line in journal.splitlines() if line.strip()]
+    breadcrumbs = [r for r in rows if r["type"] == "runnerd_rss_exit_during_apply"]
+    assert len(breadcrumbs) == 1
+    assert breadcrumbs[0]["proposal_id"] == "prop-params-update"
+    assert breadcrumbs[0]["rss_mb"] == 1400.0
+    assert breadcrumbs[0]["max_rss_mb"] == 900.0


### PR DESCRIPTION
## Incident (2026-08-24, majors-5m-lab, owner-approved `prop-params-update-60fd5f0e` "disable HYPE short leg")

1. **Orphaned apply**: 15:01:11 apply queued+started → 17s later runnerd hit `_enforce_rss_limit` (900MB cap) and `os._exit`'d, orphaning the apply mid-flight. `recover-stalled-applications` scanned 49, recovered 0 — the stall did not match its signature.
2. **Misclassified failure**: a later recovery drove the apply to `proposal_apply_finished` FAILED with `{"failed_checks": ["scenario_baseline_replay", "candidate_backtest_valid"], "failure_kind": "evidence"}` — the TRUE cause was the job's backtest dataset missing (`results/backtest/input_bars.json` gone after a data-feed incident; both checks need bars). A box condition, recorded as evidence.
3. **Self-burial**: the mechanical restage re-ran the propose gates, hit the fail-closed governance gate (`ESCALATE: blocking governance requires economic_ready=True ... economic evaluation failed: No backtest bars found`) and the restage flow's own agent rejection (`rejection.by=agent, kind=process`) buried the owner-approved proposal. The PR #668 reject guard let it pass because `classify_failure` had no pattern for missing-dataset conditions.

## Fixes (4 pieces)

### A. `wayfinder_paths/jobs/failures.py` — missing-data patterns
New `INFRASTRUCTURE_PATTERNS`: `"no backtest bars"`, `"no bars found"`, `"input_bars"`, `"dataset not found"`, `"missing dataset"`, `"data_feed"`. Matched against the actual emitter texts (below). Tight: plain `"backtest failed"` still classifies as evidence. Side effect (fixes incident item 2): `validation_summary.failure_kind` now records `infrastructure` for missing-dataset validation failures.

Emitter sites of the incident message:
- `wayfinder_paths/jobs/execution/job.py` `_load_dataset` (~L451) — the sole raise: `"No backtest bars found. Provide results/backtest/input_bars.json, workspace/config/backtest_bars.json, execution_scenario_plan bars, or execution_spec.validation.fixture_bars."`
- rides into `wayfinder_paths/jobs/validation.py` (~L302): `"no dataset for candidate backtest: {exc}"`
- rides into `wayfinder_paths/jobs/proposals.py` (~L374): `"economic evaluation failed: {exc}"`
- rides into `wayfinder_paths/jobs/store.py` `_ensure_governance_gate` (~L499): `"ESCALATE: blocking governance requires economic_ready=True ..."`

### B. `wayfinder_paths/jobs/store.py` — reject guard covers fail-closed ESCALATE
For APPROVED proposals, an agent (non-owner) rejection is now ALSO refused when the latest failure text carries a fail-closed gate `ESCALATE:` — a gate that **refused to evaluate** (missing evidence, governance drift) is never evidence against the change; a gate that evaluated red carries no ESCALATE prefix and still stops the line. The proposal stays approved with `restage_requested`, and the `proposal_reject_refused` journal event surfaces `owner_review_required`. The restage flow's auto-reject (`proposals.py::restage_proposal`) already routes through `store.reject_proposal`, so the guard now covers today's exact burial path — regression-pinned end to end in `test_restage_gate_escalate_keeps_proposal_approved`.

### C. `wayfinder_paths/runner/daemon.py` — RSS exit defers to in-flight applies
`_enforce_rss_limit` never fires while a proposal application is applying: a cheap scan of `.wayfinder/jobs/*/proposals/*.json` `application.status` (no jobs-package import, only runs once the cap is already breached). Deferral logs CRITICAL (debounced to 1/min against the 1s tick) and re-checks next tick. **Hard override** at cap × 1.5 (900MB → 1350MB): exits anyway — an apply must not hold a ballooning daemon hostage — and journals `runnerd_rss_exit_during_apply` (proposal id, rss, cap) into each affected job's journal so recovery knows why the apply was orphaned.

### D. `wayfinder_paths/jobs/watchdog.py` — orphan signature + top-of-pipeline re-entry
`_recover_applying` now matches applies orphaned by daemon death: deterministic apply stuck `"applying"` with `started_at` past a 5-minute grace (`ORPHANED_APPLYING_TIMEOUT`) and no live completer pid — covering both a dead recorded pid and a claim that never reached spawn. Recovered immediately instead of waiting out the full 15-minute window, and re-entered from the TOP of the completer pipeline: `complete_application(status="applied")` re-runs the baseline-drift guard + FULL candidate validation before promoting — never a mid-stage resume. Agent-owned applies record no pid and keep their 60-minute window. Recovery events now carry `orphaned` + `worker_pid`.

## Tests

- `classify_failure`: each new pattern → infrastructure; `"backtest failed"` / `"candidate backtest failed: ..."` / `"dataset spans 30d..."` → evidence.
- Reject guard: agent rejection of approved proposal with the incident's exact "No backtest bars found" text → refused + `restage_requested`; ESCALATE-only text (no infra pattern) → refused with `owner_review_required`; owner rejection → allowed; agent evidence-red rejection of a PENDING proposal → allowed.
- Restage path: full-fidelity propose → approve → drift → restage with governance gate raising the incident ESCALATE → rejection refused, proposal remains approved with `restage_requested` (`test_restage_gate_escalate_keeps_proposal_approved`).
- RSS: applying application present → no exit; apply finishes → deferred exit fires next tick; RSS at 1400MB (>150% of 900MB cap) → exits anyway + `runnerd_rss_exit_during_apply` journaled with the in-flight proposal id.
- Recovery: orphaned apply (applying, `started_at` 6min, dead pid) → recovered via `complete_application(status="applied")` with `orphaned: true`; 2min-old dead-pid apply → grace, untouched; agent-owned dead-pid apply at 30min → untouched.

## Verification

- `pytest -k "jobs or runner or mcp"`: **baseline 1060 passed / 9 skipped → with changes 1070 passed / 9 skipped** (10 new tests, 0 regressions).
- `ruff check` + `ruff format --check`: clean on all touched files.
- Scoped mypy on the 4 changed source files: identical pre-existing legacy errors base vs. changed (yaml stubs + 5 legacy) — no new errors.
