### PR TITLE
propose: abort on infra-failed economic evaluation; revalidate refreshes the economic block

### DIFF
--- a/wayfinder_paths/jobs/gating.py
+++ b/wayfinder_paths/jobs/gating.py
@@ -261,7 +261,18 @@ def evaluate_economic_gate(
     )
     if baseline_script is None or candidate_script is None:
         return _economic_unavailable(constitution, "no script entrypoint", probation)
-    dataset = _load_dataset(candidate_root, spec, candidate_yaml)
+    try:
+        dataset = _load_dataset(candidate_root, spec, candidate_yaml)
+    except FileNotFoundError:
+        # Candidate bundles carry workspace/ + job.yaml only. Jobs that keep
+        # their dataset at the JOB root (results/backtest/input_bars.json —
+        # the standard fetch-dataset location) would otherwise never resolve
+        # bars here and every propose would die on "No backtest bars found".
+        # Same fallback candidate validation applies; if the job root ALSO
+        # has no bars the error propagates — with the propose-time
+        # infra-abort, a dataset that validated moments ago but vanished for
+        # the economic step is a box condition, not evidence.
+        dataset = _load_dataset(root, spec, candidate_yaml)
 
     evaluation = paired_fold_evaluation(
         baseline_script=baseline_script,

--- a/wayfinder_paths/jobs/proposals.py
+++ b/wayfinder_paths/jobs/proposals.py
@@ -355,17 +355,22 @@ def _generate_candidate_report(
         mode = "full"
         probation = bool((proposal.get("proposed_change") or {}).get("probation"))
         try:
-            economic = evaluate_economic_gate(
-                job_id,
-                candidate_dir=candidate_dir,
-                store=store,
-                probation=probation,
+            economic = _economic_gate_with_infra_retry(
+                store, job_id, candidate_dir, probation=probation
             )
-        except Exception as exc:  # noqa: BLE001 — a crashed economic eval must
-            # not break propose; the record carries the REAL enforcement so
-            # the approval gate can fail closed on live-capable jobs
-            # (previously the crash forced "advisory" — the review's central
-            # fail-open finding).
+        except TransientInfrastructureError:
+            # Box condition, not an economic verdict — propagate so the
+            # caller aborts instead of freezing ready=None + a bars/lock
+            # error into the immutable report that the fail-closed approve
+            # gate then ESCALATEs forever (2026-08-24 production incident:
+            # a transiently unlinked .wayfinder symlink made the bars file
+            # unreadable for exactly the economic step).
+            raise
+        except Exception as exc:  # noqa: BLE001 — an evidence-class crashed
+            # economic eval must not break propose; the record carries the
+            # REAL enforcement so the approval gate can fail closed on
+            # live-capable jobs (previously the crash forced "advisory" —
+            # the review's central fail-open finding).
             from wayfinder_paths.jobs.constitution import load_constitution
 
             constitution = load_constitution(store.job_dir(job_id))
@@ -461,17 +466,61 @@ def _compute_lock_freed(store: JobStore, job_id: str, wait_s: float) -> bool:
         return False
 
 
+def _economic_gate_with_infra_retry(
+    store: JobStore,
+    job_id: str,
+    candidate_dir: Path,
+    *,
+    probation: bool,
+) -> dict[str, Any]:
+    """Economic evaluation with the same infra-vs-evidence asymmetry as
+    candidate validation (`_retry_infrastructure_failure`): an
+    infrastructure-class crash (missing bars dataset, lock, OOM, timeout)
+    says nothing about the candidate's economics. Retry ONCE after a bounded
+    wait for the heavy-compute lock; if the box is still unhealthy, raise
+    TransientInfrastructureError so the propose aborts instead of staging an
+    un-approvable report. Evidence-class crashes propagate untouched — the
+    caller stages them with ready=None so the real enforcement rides in the
+    record."""
+    try:
+        return evaluate_economic_gate(
+            job_id, candidate_dir=candidate_dir, store=store, probation=probation
+        )
+    except Exception as exc:  # noqa: BLE001 — classify before deciding
+        if classify_failure(str(exc)) != "infrastructure":
+            raise
+        failure_text = str(exc)
+    wait_s = float(
+        os.environ.get(PROPOSE_LOCK_WAIT_ENV, "") or _PROPOSE_LOCK_WAIT_DEFAULT_S
+    )
+    if _compute_lock_freed(store, job_id, wait_s):
+        try:
+            return evaluate_economic_gate(
+                job_id, candidate_dir=candidate_dir, store=store, probation=probation
+            )
+        except Exception as exc:  # noqa: BLE001 — classify before deciding
+            if classify_failure(str(exc)) != "infrastructure":
+                raise
+            failure_text = str(exc)
+    raise TransientInfrastructureError(
+        "transient infrastructure failure — retry when the box is quiet: "
+        f"economic evaluation failed: {failure_text[:300] or 'unknown'}"
+    )
+
+
 def revalidate_proposal(
     store: JobStore, job_id: str, proposal_id: str
 ) -> dict[str, Any]:
-    """Re-run the full validation/comparison for a PENDING proposal against
-    the SAME staged candidate and base revision, replacing the embedded
-    candidate_report.
+    """Re-run the full validation/comparison/economic evaluation for a
+    PENDING proposal against the SAME staged candidate and base revision,
+    replacing the embedded candidate_report — including its `economic` block.
 
-    Recovery path for reports frozen by a transient infrastructure failure
-    (validation_summary.failure_kind == "infrastructure"): the propose-time
-    snapshot is immutable, so without this the only exit from an
-    infra-failed pending proposal is reject-and-repropose. The candidate and
+    Recovery path for reports frozen by a transient infrastructure failure —
+    either validation (validation_summary.failure_kind == "infrastructure")
+    or an economic evaluation that crashed on a box condition and froze
+    ready=None + the error into the snapshot: the propose-time snapshot is
+    immutable, so without this the only exit from an infra-poisoned pending
+    proposal is reject-and-repropose. The candidate and
     base revision are NOT rebuilt — the same evidence question, asked again
     on a quiet box. If the job's active revision moved past base_revision
     the comparison baseline would drift, so refuse: the owner should reject

--- a/wayfinder_paths/jobs/store.py
+++ b/wayfinder_paths/jobs/store.py
@@ -441,10 +441,14 @@ class JobStore:
             reasons = "; ".join(gate.get("reasons") or ["unknown"])
             raise ValueError(f"candidate gate is not live-ready: {reasons}")
         economic = report.get("economic") or {}
-        self._ensure_governance_gate(job_id, economic)
+        self._ensure_governance_gate(
+            job_id, economic, proposal_id=str(proposal.get("proposal_id") or "")
+        )
         self._ensure_candidate_matches_report(job_id, proposal, report)
 
-    def _ensure_governance_gate(self, job_id: str, economic: dict[str, Any]) -> None:
+    def _ensure_governance_gate(
+        self, job_id: str, economic: dict[str, Any], *, proposal_id: str = ""
+    ) -> None:
         """Fail-closed economic gating for live-capable jobs.
 
         The old semantics blocked only on an explicit ready=False under a
@@ -495,10 +499,25 @@ class JobStore:
                 economic.get("reasons")
                 or ["economic evidence unavailable (ready is not True)"]
             )
+            # Recovery affordance: a frozen economic block whose failure text
+            # is infrastructure-class (missing bars, lock, OOM) is a box
+            # condition frozen at propose time, not economic evidence — name
+            # the in-place fix instead of leaving an un-approvable pending
+            # proposal with no exit (2026-08-24 production incident). The
+            # reasons text already classifies as infrastructure, so the added
+            # wording cannot flip an evidence rejection's classification.
+            recovery = ""
+            if proposal_id and classify_failure(reasons) == "infrastructure":
+                recovery = (
+                    " — the economic evaluation failed on a transient box "
+                    "condition, not real evidence; run: wayfinder job "
+                    f"revalidate {safe_job_id(job_id)} {proposal_id} to "
+                    "re-run it against the same staged candidate"
+                )
             raise ValueError(
                 "ESCALATE: blocking governance requires economic_ready=True "
                 f"for a live-capable job; got {economic.get('ready')!r}: "
-                f"{reasons}"
+                f"{reasons}{recovery}"
             )
 
     def _job_is_live_capable(self, job_id: str) -> bool:

--- a/wayfinder_paths/tests/test_jobs_propose.py
+++ b/wayfinder_paths/tests/test_jobs_propose.py
@@ -22,8 +22,10 @@ from wayfinder_paths.jobs.application import (
     validate_application_candidate,
 )
 from wayfinder_paths.jobs.backtest_artifacts import load_backtest_view
+from wayfinder_paths.jobs.constitution import load_constitution
 from wayfinder_paths.jobs.failures import TransientInfrastructureError
 from wayfinder_paths.jobs.gating import evaluate_live_gate
+from wayfinder_paths.jobs.governance import migrate_from_constitution
 from wayfinder_paths.jobs.models import WayfinderJob
 from wayfinder_paths.jobs.proposals import (
     propose_change,
@@ -80,9 +82,24 @@ def test_propose_builds_full_candidate_report(tmp_path: Path) -> None:
 
 
 def test_proposal_is_automatically_linked_to_open_remediation_case(
-    tmp_path: Path,
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     store, job_id, _ = _make_job(tmp_path)
+    # This test pins the LINK, not economic readiness: the 8-bar fixture's
+    # real economic verdict is ready=False (insufficient history), which
+    # correctly marks the case "blocked" — neutralize it so the linked case
+    # lands in proposal_pending.
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.proposals.evaluate_economic_gate",
+        lambda *a, **k: {
+            "ready": None,
+            "reasons": ["economic evaluation unavailable: neutralized in test"],
+            "enforcement": "advisory",
+            "constitution_revision": None,
+            "status": "unavailable",
+            "escalate": True,
+        },
+    )
     sync_remediation_with_health(
         store,
         job_id,
@@ -501,7 +518,7 @@ def test_restage_gate_escalate_keeps_proposal_approved(
         "or execution_spec.validation.fixture_bars."
     )
 
-    def raising_governance_gate(self, job_id, economic):  # noqa: ANN001
+    def raising_governance_gate(self, job_id, economic, **_kwargs):  # noqa: ANN001
         raise escalate
 
     monkeypatch.setattr(JobStore, "_ensure_governance_gate", raising_governance_gate)
@@ -729,3 +746,195 @@ def test_revalidate_refuses_missing_candidate(tmp_path: Path) -> None:
 
     with pytest.raises(FileNotFoundError, match="no longer exists"):
         revalidate_proposal(store, job_id, pid)
+
+
+# ── economic evaluation: infra-vs-evidence at propose time ───────────────────
+# Production incident (2026-08-24, majors-5m-lab, prop-params-update-7bfa8f3f):
+# a ~35-minute candidate backtest PASSED, then the ECONOMIC evaluation crashed
+# on a transiently unreadable bars dataset (.wayfinder symlink briefly
+# unlinked by an image roll). The pre-fix propose staged the proposal anyway
+# with validation "passed" but economic.ready=None + the bars error frozen
+# into the immutable snapshot — the fail-closed approve gate then ESCALATEd
+# forever. Economic infra crashes must abort propose exactly like
+# infra-failed validation; evidence crashes still stage; revalidate replaces
+# the poisoned block in place; the gate names the recovery.
+
+_BARS_ERROR = (
+    "No backtest bars found. Provide results/backtest/input_bars.json, "
+    "workspace/config/backtest_bars.json, execution_scenario_plan bars, or "
+    "execution_spec.validation.fixture_bars."
+)
+
+
+def _make_live_blocking(
+    store: JobStore, job_id: str, root: Path, tmp_path: Path
+) -> str:
+    """Blocking constitution + recorded forward runs: the fail-closed
+    governance gate branch. Returns the committed constitution revision."""
+    (root / "constitution.yaml").write_text("enforcement: blocking\n")
+    migrate_from_constitution(tmp_path, job_id, root)
+    summary = root / "results" / "forward" / "summary.json"
+    summary.parent.mkdir(parents=True, exist_ok=True)
+    summary.write_text(json.dumps({"runs": {"count": 3}}), encoding="utf-8")
+    return str(load_constitution(root)["revision"])
+
+
+def test_economic_infra_crash_aborts_propose_after_bounded_retry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job_id, root = _make_job(tmp_path)
+    monkeypatch.setenv("WAYFINDER_PROPOSE_LOCK_WAIT_SECONDS", "0.1")
+    calls: list[int] = []
+
+    def missing_bars(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        calls.append(1)
+        raise RuntimeError(_BARS_ERROR)
+
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.proposals.evaluate_economic_gate", missing_bars
+    )
+
+    with pytest.raises(
+        TransientInfrastructureError, match="retry when the box is quiet"
+    ):
+        _propose_params(store, job_id)
+
+    assert len(calls) == 2, "exactly one bounded retry"
+    assert list((root / "proposals").glob("*.json")) == [], "no proposal staged"
+    assert not list((root / "applications").glob("*/candidate")), "candidate cleaned"
+    journal = (root / "journal.jsonl").read_text(encoding="utf-8")
+    assert "proposal_propose_aborted" in journal
+    assert "proposal_created" not in journal
+
+
+def test_economic_infra_crash_skips_retry_while_lock_still_held(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Box still busy after the bounded wait: the retry is pointless — abort
+    with one economic evaluation attempt, not two. The lock is grabbed
+    INSIDE the failing evaluation (after validation's own backtests released
+    it) so only the economic retry wait sees a busy box."""
+    store, job_id, root = _make_job(tmp_path)
+    monkeypatch.setenv("WAYFINDER_PROPOSE_LOCK_WAIT_SECONDS", "0.1")
+    calls: list[int] = []
+    holder = (tmp_path / ".wayfinder" / "compute.lock").open("a+")
+
+    def missing_bars_while_busy(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        calls.append(1)
+        fcntl.flock(holder.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        raise RuntimeError(_BARS_ERROR)
+
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.proposals.evaluate_economic_gate",
+        missing_bars_while_busy,
+    )
+    try:
+        with pytest.raises(TransientInfrastructureError):
+            _propose_params(store, job_id)
+    finally:
+        fcntl.flock(holder.fileno(), fcntl.LOCK_UN)
+        holder.close()
+
+    assert len(calls) == 1
+    assert list((root / "proposals").glob("*.json")) == []
+
+
+def test_economic_evidence_crash_still_stages_error_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An evidence-class economic crash keeps today's behavior: stage with
+    ready=None and the error in reasons — a real economic verdict (or its
+    absence) belongs in the report for the gate to fail closed on."""
+    store, job_id, root = _make_job(tmp_path)
+
+    def boom(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise RuntimeError("paired fold evaluation crashed: bad candidate params")
+
+    monkeypatch.setattr("wayfinder_paths.jobs.proposals.evaluate_economic_gate", boom)
+
+    proposal = _propose_params(store, job_id)
+
+    economic = proposal["candidate_report"]["economic"]
+    assert economic["ready"] is None
+    assert economic["status"] == "error"
+    assert economic["escalate"] is True
+    assert "economic evaluation failed" in economic["reasons"][0]
+    pid = proposal["proposal_id"]
+    assert (root / "proposals" / f"{pid}.json").exists()
+    journal = (root / "journal.jsonl").read_text(encoding="utf-8")
+    assert "proposal_created" in journal
+    assert "proposal_propose_aborted" not in journal
+
+
+def test_revalidate_refreshes_poisoned_economic_block(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The 2026-08-24 incident regression-pinned end to end at unit level:
+    validation passed but a pre-fix propose froze economic.ready=None + the
+    bars error into the snapshot of a live-capable blocking job. The approve
+    gate ESCALATEs naming the recovery; revalidate re-runs the economic
+    evaluation and replaces the block; approval then passes."""
+    store, job_id, root = _make_job(tmp_path)
+    proposal = _propose_params(store, job_id)
+    pid = proposal["proposal_id"]
+
+    revision = _make_live_blocking(store, job_id, root, tmp_path)
+    proposal["candidate_report"]["economic"] = {
+        "ready": None,
+        "reasons": [f"economic evaluation failed: {_BARS_ERROR}"[:300]],
+        "enforcement": "blocking",
+        "constitution_revision": revision,
+        "status": "error",
+        "escalate": True,
+    }
+    store.write_proposal(job_id, proposal)
+
+    with pytest.raises(ValueError, match="wayfinder job revalidate") as excinfo:
+        store.approve_proposal(job_id, pid)
+    assert "transient box condition" in str(excinfo.value)
+    assert pid in str(excinfo.value)
+
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.proposals.evaluate_economic_gate",
+        lambda *a, **k: {
+            "ready": True,
+            "reasons": [],
+            "enforcement": "blocking",
+            "constitution_revision": revision,
+            "status": "ok",
+        },
+    )
+
+    revalidated = revalidate_proposal(store, job_id, pid)
+
+    economic = revalidated["candidate_report"]["economic"]
+    assert economic["ready"] is True
+    assert economic["reasons"] == []
+    assert "No backtest bars" not in json.dumps(revalidated["candidate_report"])
+
+    approved = store.approve_proposal(job_id, pid)
+    assert approved["status"] == "approved"
+
+
+def test_gate_escalate_names_revalidate_only_for_infra_failures(
+    tmp_path: Path,
+) -> None:
+    """An evidence-class frozen economic verdict must NOT be advertised as
+    recoverable-by-revalidate — that message is reserved for box conditions."""
+    store, job_id, root = _make_job(tmp_path)
+    proposal = _propose_params(store, job_id)
+    pid = proposal["proposal_id"]
+
+    revision = _make_live_blocking(store, job_id, root, tmp_path)
+    proposal["candidate_report"]["economic"] = {
+        "ready": False,
+        "reasons": ["median paired delta below constitution floor"],
+        "enforcement": "blocking",
+        "constitution_revision": revision,
+        "status": "ok",
+    }
+    store.write_proposal(job_id, proposal)
+
+    with pytest.raises(ValueError, match="ESCALATE") as excinfo:
+        store.approve_proposal(job_id, pid)
+    assert "revalidate" not in str(excinfo.value)


### PR DESCRIPTION
## Production incident (2026-08-24, majors-5m-lab, prop-params-update-7bfa8f3f)

A `wayfinder job propose` ran a ~35-minute full-history candidate backtest successfully, but the ECONOMIC evaluation step crashed with "economic evaluation failed: No backtest bars found..." — the box's `/wf/sdk/.wayfinder` symlink was briefly unlinked by an image-roll entrypoint at exactly that moment (the 27MB bars file exists; a transient box condition). The propose STAGED the proposal anyway: `validation_summary.status: "passed"` but `candidate_report.economic.ready: None` with the bars error frozen into the immutable snapshot. Result: an un-approvable pending proposal — the approve-time `_ensure_governance_gate` fail-closed ESCALATEs forever. #687 aborts propose when CANDIDATE VALIDATION fails infra-class; the ECONOMIC evaluation step slipped past that net.

## Changes

**1. Propose aborts on infra-failed economic evaluation** (`proposals.py`)
- New `_economic_gate_with_infra_retry`: when `evaluate_economic_gate` raises and `classify_failure(str(exc)) == "infrastructure"` (#697 added "no backtest bars" etc. to the patterns), it retries ONCE after the same bounded heavy-compute-lock wait #687 uses (`_compute_lock_freed`, `WAYFINDER_PROPOSE_LOCK_WAIT_SECONDS`). If the box is still unhealthy, it raises `TransientInfrastructureError` — the existing #687 abort path then cleans the candidate, unlinks the memo, journals `proposal_propose_aborted`, and surfaces "transient infrastructure failure — retry when the box is quiet".
- Evidence-class economic crashes keep today's behavior exactly: stage with `ready=None` + the error in reasons, carrying the real enforcement for the fail-closed gate.

**2. Revalidate refreshes the economic block** (`proposals.py`)
- `revalidate_proposal` already regenerated the whole `candidate_report` via `_generate_candidate_report` — which recomputes `economic` — so the recovery path for already-staged poisoned reports existed structurally. This PR pins it with an end-to-end unit regression of the incident (poisoned block → gate ESCALATE → revalidate → approve passes) and updates the docstring to name the economic block explicitly.

**3. Approve-gate ergonomics** (`store.py`)
- `_ensure_governance_gate` now takes the `proposal_id`; when the frozen economic block's failure text is infrastructure-class, the ESCALATE message names the recovery: "…the economic evaluation failed on a transient box condition, not real evidence; run: `wayfinder job revalidate <job_id> <proposal_id>`…". Evidence-class frozen verdicts are NOT advertised as revalidate-recoverable.
- The recovery wording only appears when the reasons already classify as infrastructure, so it cannot flip an evidence rejection's classification (the store's reject-refusal guard reads these messages).

**4. Economic gate dataset fallback** (`gating.py`)
- `evaluate_economic_gate` resolved bars ONLY from the candidate bundle (workspace + job.yaml), while candidate validation falls back to the job root. Jobs keeping their dataset at the standard job-root `results/backtest/input_bars.json` location had their economic eval crash "No backtest bars found" on EVERY propose — previously frozen silently as `ready=None`, and with fix 1 it would have made every propose abort. The gate now applies the same job-root fallback validation uses; if bars are missing everywhere the error still propagates into the infra-abort (the incident case: everything unreadable).

## Tests (mirroring #687's in `test_jobs_propose.py`)

- `test_economic_infra_crash_aborts_propose_after_bounded_retry` — bars-error crash aborts after exactly one retry; no proposal file, candidate cleaned, `proposal_propose_aborted` journaled, no `proposal_created`.
- `test_economic_infra_crash_skips_retry_while_lock_still_held` — busy box after the bounded wait aborts with a single evaluation attempt.
- `test_economic_evidence_crash_still_stages_error_record` — evidence-class crash stages `ready=None`/`status=error` unchanged.
- `test_revalidate_refreshes_poisoned_economic_block` — the incident regression-pinned end to end: live-capable blocking job + poisoned frozen block → approve ESCALATEs naming `wayfinder job revalidate` → revalidate replaces the block → approve passes.
- `test_gate_escalate_names_revalidate_only_for_infra_failures` — evidence-class frozen `ready=False` does NOT get the revalidate hint.
- `test_proposal_is_automatically_linked_to_open_remediation_case` — neutralized economic eval: with the dataset fallback the 8-bar fixture now yields a real `ready=False` verdict, which correctly marks the remediation case "blocked"; the test pins the LINK, not readiness.

## Validation

- `pytest -k "jobs or runner or mcp"`: **1076 passed, 9 skipped** (baseline ~1070/9 post-#697; +6 new tests)
- ruff check + format clean on changed files; mypy introduces no new errors in changed files (remaining hits are pre-existing: missing yaml stubs, untouched `_build_comparison` unions).