### PR TITLE
Add broad-rally upside overlay to crypto momentum

### DIFF
--- a/wayfinder_paths/jobs/starter_leverage_evidence.py
+++ b/wayfinder_paths/jobs/starter_leverage_evidence.py
@@ -68,11 +68,11 @@ STARTER_LEVERAGE_RESULTS: dict[str, tuple[dict[str, Any], ...]] = {
         _result(5, 1.4595, 1.7349, -0.4691, 267, 2481.69, OTHER_STARTER_HALT),
     ),
     "crypto-momentum-persistence-4h": (
-        _result(1, 0.8887, 1.4087, -0.1590, 408, 832.07, OTHER_STARTER_HALT),
-        _result(2, 1.7866, 1.2852, -0.2826, 411, 1932.90, OTHER_STARTER_HALT),
-        _result(3, 2.9024, 1.3000, -0.4385, 413, 3182.70, OTHER_STARTER_HALT),
-        _result(4, 4.4373, 1.3649, -0.5146, 419, 5279.70, OTHER_STARTER_HALT),
-        _result(5, 6.5530, 1.4534, -0.6563, 429, 7546.14, OTHER_STARTER_HALT),
+        _result(1, 1.0390, 1.5407, -0.1590, 436, 900.88, OTHER_STARTER_HALT),
+        _result(2, 2.5656, 1.5236, -0.2826, 439, 2404.53, OTHER_STARTER_HALT),
+        _result(3, 4.6651, 1.5437, -0.4385, 441, 4426.94, OTHER_STARTER_HALT),
+        _result(4, 6.9181, 1.5495, -0.5146, 448, 7417.53, OTHER_STARTER_HALT),
+        _result(5, 10.8986, 1.6338, -0.6563, 456, 11320.56, OTHER_STARTER_HALT),
     ),
     "mixed-sleeve-momentum-15m": (
         _result(1, 0.2587, 1.4915, -0.1146, 120, 141.12, OTHER_STARTER_HALT),

--- a/wayfinder_paths/jobs/starters.py
+++ b/wayfinder_paths/jobs/starters.py
@@ -308,7 +308,8 @@ _CRYPTO_MOMENTUM_RESEARCH_METHOD = {
     "funding": "not included; long and short carry can change live returns",
     "validation": (
         "training-only rank admission, four rolling 240-day train / 60-day "
-        "test folds, and all six daily 4h rebalance phases"
+        "test folds, neighboring broad-bull thresholds, and all six daily "
+        "4h rebalance phases"
     ),
 }
 
@@ -714,8 +715,8 @@ STARTER_DEFINITIONS: tuple[StarterDefinition, ...] = (
         name="Crypto Momentum Persistence · 4h",
         family="cross_sectional_momentum",
         summary=(
-            "A concentrated, market-neutral crypto basket that owns the "
-            "strongest risk-adjusted persistent trend and shorts the weakest."
+            "A concentrated crypto basket that owns the strongest risk-adjusted "
+            "persistent trend, shorts the weakest, and leans long in broad rallies."
         ),
         timeframe="4h",
         module="wayfinder_paths.jobs.strategies.crypto_momentum_persistence",
@@ -725,6 +726,7 @@ STARTER_DEFINITIONS: tuple[StarterDefinition, ...] = (
         rules=(
             "Blend trailing 7-day and 28-day returns equally, then divide by trailing 28-day volatility.",
             "Long the strongest and short the weakest at 35% each; gross 70%, net 0%.",
+            "When all four raw momentum blends reach 10%, shift 17.5% from the short leg to the long; gross stays 70% and net becomes +35%.",
             "Re-rank daily on the 12:00 UTC completed bar.",
         ),
         params={
@@ -735,14 +737,16 @@ STARTER_DEFINITIONS: tuple[StarterDefinition, ...] = (
             "rebalance_bars": 6,
             "rebalance_offset": 3,
             "weight_per_leg": 0.35,
+            "broad_bull_momentum_threshold": 0.10,
+            "broad_bull_weight_shift": 0.175,
             "stop_atr_period": 12,
         },
         research_evidence={
             **_CRYPTO_MOMENTUM_RESEARCH_METHOD,
-            "return_after_fees_and_slippage": 0.8887,
-            "return_after_costs_and_funding": 0.8887,
+            "return_after_fees_and_slippage": 1.0390,
+            "return_after_costs_and_funding": 1.0390,
             "funding_return_contribution": 0.0,
-            "sharpe": 1.4087,
+            "sharpe": 1.5407,
             "max_drawdown": -0.1590,
             "chronological_fold_returns": [0.1004, 0.0772, 0.1534, 0.0400],
             "rank_admission": {
@@ -754,6 +758,18 @@ STARTER_DEFINITIONS: tuple[StarterDefinition, ...] = (
                 "second_half_information_coefficient": 0.0396,
                 "passed": True,
             },
+            "broad_bull_overlay": {
+                "activation": "all four raw momentum blends >= 0.10",
+                "normal_weights": {"long": 0.35, "short": -0.35, "net": 0.0},
+                "active_weights": {"long": 0.525, "short": -0.175, "net": 0.35},
+                "gross_exposure": 0.70,
+                "threshold_sharpe_sensitivity": {
+                    "0.05": 1.3316,
+                    "0.10": 1.5407,
+                    "0.15": 1.4348,
+                },
+                "older_walk_forward_activation_count": 0,
+            },
             "walk_forward": {
                 "fold_count": 4,
                 "positive_folds": 4,
@@ -762,39 +778,39 @@ STARTER_DEFINITIONS: tuple[StarterDefinition, ...] = (
                 "worst_max_drawdown": -0.0939,
             },
             "rebalance_phase_returns": {
-                "00:00_utc": 0.6873,
-                "04:00_utc": 0.7447,
-                "08:00_utc": 0.7653,
-                "12:00_utc": 0.8887,
-                "16:00_utc": 0.5910,
-                "20:00_utc": 0.6285,
+                "00:00_utc": 0.6834,
+                "04:00_utc": 0.9323,
+                "08:00_utc": 0.9043,
+                "12:00_utc": 1.0390,
+                "16:00_utc": 0.6709,
+                "20:00_utc": 0.7512,
             },
             "rebalance_phase_sharpes": {
-                "00:00_utc": 1.1476,
-                "04:00_utc": 1.2071,
-                "08:00_utc": 1.2436,
-                "12:00_utc": 1.4087,
-                "16:00_utc": 1.0592,
-                "20:00_utc": 1.0816,
+                "00:00_utc": 1.1362,
+                "04:00_utc": 1.3922,
+                "08:00_utc": 1.3795,
+                "12:00_utc": 1.5407,
+                "16:00_utc": 1.1407,
+                "20:00_utc": 1.2191,
             },
             "recent_7_day_scenario": {
                 "window_start": "2026-08-17T20:00:00+00:00",
                 "window_end": "2026-08-24T16:00:00+00:00",
-                "return_after_fees_and_slippage": 0.0169,
-                "sharpe": 1.9805,
-                "max_drawdown": -0.0475,
+                "return_after_fees_and_slippage": 0.0447,
+                "sharpe": 5.5413,
+                "max_drawdown": -0.0235,
                 "trade_count": 8,
-                "total_fees_usd": 13.34,
+                "total_fees_usd": 15.01,
                 "initial_pair": {"long": "HYPE", "short": "BTC"},
                 "trace_valid": True,
                 "selection_role": "goal-directed development scenario, not holdout",
             },
             "jobs_v1_engine": {
-                "return_after_fees_and_slippage": 0.8887,
-                "sharpe": 1.4087,
+                "return_after_fees_and_slippage": 1.0390,
+                "sharpe": 1.5407,
                 "max_drawdown": -0.1590,
-                "trade_count": 408,
-                "total_fees_usd": 832.07,
+                "trade_count": 436,
+                "total_fees_usd": 900.88,
                 "stop_count": 0,
                 "full_period_vs_no_stop": "unchanged",
                 "chronological_folds_non_regressing": 4,
@@ -804,7 +820,8 @@ STARTER_DEFINITIONS: tuple[StarterDefinition, ...] = (
         },
         cautions=(
             "Funding is not included in the replay and can reduce live returns.",
-            "The recent seven-day scenario guided concentration and is not out-of-sample; the four older walk-forward folds are out-of-sample.",
+            "Broad-bull mode temporarily carries +35% net long exposure; the four older out-of-sample folds did not activate it.",
+            "The recent seven-day scenario guided the overlay and is not out-of-sample.",
             "Only 1x stayed within the -20% account-halt threshold in the leverage sweep.",
         ),
     ),

--- a/wayfinder_paths/jobs/strategies/crypto_momentum_persistence.py
+++ b/wayfinder_paths/jobs/strategies/crypto_momentum_persistence.py
@@ -1,4 +1,4 @@
-"""Risk-adjusted four-hour crypto momentum, rebalanced daily at 12:00 UTC."""
+"""Risk-adjusted four-hour crypto momentum with a broad-rally overlay."""
 
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ from wayfinder_paths.jobs.execution.primitives import ExecutionContext
 from wayfinder_paths.jobs.strategies._starter_utils import (
     RANKING_STOP_DEFAULTS,
     add_stop_atr,
-    current_feature_values,
+    current_rows,
     merge_params,
     ranked_weights,
     stop_brackets,
@@ -29,6 +29,8 @@ class CryptoMomentumPersistenceStrategy:
         "rebalance_bars": 6,
         "rebalance_offset": 3,
         "weight_per_leg": 0.35,
+        "broad_bull_momentum_threshold": 0.10,
+        "broad_bull_weight_shift": 0.175,
         "rebalance_threshold": 0.10,
         "min_trade_notional": 25.0,
         **RANKING_STOP_DEFAULTS,
@@ -54,7 +56,7 @@ class CryptoMomentumPersistenceStrategy:
         derived: dict[str, pd.DataFrame] = {}
         for symbol, frame in frames.items():
             close = pd.to_numeric(frame["close"], errors="coerce")
-            momentum = fast_weight * close.pct_change(fast) + (
+            raw_momentum = fast_weight * close.pct_change(fast) + (
                 1.0 - fast_weight
             ) * close.pct_change(slow)
             volatility = (
@@ -62,8 +64,13 @@ class CryptoMomentumPersistenceStrategy:
                 .rolling(volatility_bars, min_periods=volatility_bars)
                 .std()
             )
-            momentum = momentum / volatility.where(volatility.gt(0))
-            derived[symbol] = pd.DataFrame({"starter_momentum": momentum})
+            score = raw_momentum / volatility.where(volatility.gt(0))
+            derived[symbol] = pd.DataFrame(
+                {
+                    "starter_momentum": score,
+                    "starter_raw_momentum": raw_momentum,
+                }
+            )
         return add_stop_atr(derived, frames, period=int(self.params["stop_atr_period"]))
 
     def decide(self, ctx: ExecutionContext) -> list[dict[str, Any]]:
@@ -73,8 +80,18 @@ class CryptoMomentumPersistenceStrategy:
         ):
             return []
         symbols = list(self.params["symbols"])
-        scores = current_feature_values(ctx, symbols, "starter_momentum")
-        if scores is None:
+        rows = current_rows(
+            ctx,
+            symbols,
+            required_columns=("starter_momentum", "starter_raw_momentum"),
+        )
+        if rows is None:
+            return []
+        scores = {symbol: float(rows[symbol]["starter_momentum"]) for symbol in symbols}
+        raw_scores = {
+            symbol: float(rows[symbol]["starter_raw_momentum"]) for symbol in symbols
+        }
+        if any(pd.isna(value) for value in (*scores.values(), *raw_scores.values())):
             return []
         ranked = sorted(scores, key=lambda symbol: (scores[symbol], symbol))
         extremes = {symbol: scores[symbol] for symbol in (ranked[0], ranked[-1])}
@@ -84,6 +101,13 @@ class CryptoMomentumPersistenceStrategy:
                 extremes, weight_per_leg=float(self.params["weight_per_leg"])
             )
         )
+        if min(raw_scores.values()) >= float(
+            self.params["broad_bull_momentum_threshold"]
+        ):
+            # Transfer exposure from the short to the long without increasing gross.
+            shift = float(self.params["broad_bull_weight_shift"])
+            weights[ranked[0]] += shift
+            weights[ranked[-1]] += shift
         return target_weights_to_intents(
             ctx,
             weights,

--- a/wayfinder_paths/tests/test_jobs_starters.py
+++ b/wayfinder_paths/tests/test_jobs_starters.py
@@ -278,6 +278,8 @@ def test_starter_catalog_has_mixed_maker_and_pair_paper_strategies() -> None:
     by_id = {item["id"]: item for item in catalog}
     crypto_momentum = by_id["crypto-momentum-persistence-4h"]
     assert crypto_momentum["params"]["score_volatility_bars"] == 168
+    assert crypto_momentum["params"]["broad_bull_momentum_threshold"] == 0.10
+    assert crypto_momentum["params"]["broad_bull_weight_shift"] == 0.175
     assert crypto_momentum["research_evidence"]["sharpe"] > 1.0
     assert all(
         sharpe > 1.0
@@ -461,6 +463,35 @@ def test_crypto_momentum_concentrates_in_risk_adjusted_extremes() -> None:
     assert hype["starter_momentum"].iloc[-1] == pytest.approx(expected_score)
     assert _sides(intents) == {"BTC": "sell", "ETH": "buy"}
     assert {intent["notional"] for intent in intents} == {3500.0}
+
+
+def test_crypto_momentum_leans_long_without_raising_gross_in_broad_rally() -> None:
+    strategy = CryptoMomentumPersistenceStrategy(
+        {
+            "symbols": ["BTC", "ETH", "SOL", "HYPE"],
+            "fast_momentum_bars": 2,
+            "slow_momentum_bars": 4,
+            "score_volatility_bars": 4,
+            "rebalance_bars": 1,
+            "min_trade_notional": 0.0,
+        }
+    )
+    ctx = _context(
+        strategy,
+        {
+            "BTC": [1.00, 1.02, 1.04, 1.07, 1.10, 1.14, 1.18, 1.23],
+            "ETH": [1.00, 1.03, 1.06, 1.10, 1.15, 1.21, 1.28, 1.36],
+            "SOL": [1.00, 1.04, 1.08, 1.13, 1.19, 1.26, 1.34, 1.43],
+            "HYPE": [1.00, 1.05, 1.11, 1.18, 1.26, 1.35, 1.45, 1.56],
+        },
+        interval="4h",
+    )
+
+    intents = strategy.decide(ctx)
+
+    notionals = {intent["side"]: intent["notional"] for intent in intents}
+    assert notionals == pytest.approx({"sell": 1750.0, "buy": 5250.0})
+    assert sum(notionals.values()) == pytest.approx(7000.0)
 
 
 def test_sleeve_momentum_keeps_crypto_and_equity_sleeves_separate() -> None:


### PR DESCRIPTION
## Summary

- add a broad-rally overlay to the crypto momentum starter
- keep the existing volatility-adjusted winner/loser ranking and 70% gross cap
- when all four raw 7d/28d momentum blends are at least 10%, move 17.5 percentage points from the short leg to the long leg (52.5% long / 17.5% short, +35% net)
- publish the exact replay, phase, walk-forward, recent-scenario, and leverage evidence

## Results

Fully costed jobs_v1 replay over 712.7 days (4.5 bps fee + 3.5 bps slippage per side):

- return: 103.90% (previous starter: 88.87%)
- Sharpe: 1.5407 (previous: 1.4087)
- max drawdown: -15.90% (unchanged)
- trades: 436; fees: $900.88

Recent Aug 17–24 development scenario:

- return: 4.47% (previous: 1.69%)
- Sharpe: 5.5413
- max drawdown: -2.35%

Robustness checks:

- all four older 60-day OOS folds remained positive; mean OOS Sharpe 2.1025
- all six daily rebalance phases were positive; phase Sharpes ranged from 1.1362 to 1.5407
- neighboring 5% / 10% / 15% activation thresholds produced full-history Sharpes of 1.3316 / 1.5407 / 1.4348
- only 1x remained inside the starter's -20% account-halt threshold

## Validation

- `ruff format --check` and `ruff check` on all changed files
- `pytest -q wayfinder_paths/tests/test_jobs_starters.py --no-cov` (49 passed)
- strict jobs_v1 execution-contract validation
- exact full-history replay, 1x–5x leverage sweep, six-phase replay, four-fold walk-forward, and recent-scenario replay from the production strategy module

## Caveats

- funding is not included in these replays
- broad-rally mode temporarily carries +35% net long exposure
- the recent run-up guided this overlay and is not a holdout; the four older OOS folds did not activate the new regime gate, so they demonstrate non-regression rather than independent overlay edge
