### PR TITLE
starters: launch with agent_loop intervene by default

### DIFF
--- a/wayfinder_paths/jobs/application.py
+++ b/wayfinder_paths/jobs/application.py
@@ -607,6 +607,65 @@ def _candidate_dir_from_proposal(
     )
 
 
+# Operator-owned execution_params preserved across candidate promotion. Only
+# keys that compute_workspace_revision also excludes belong here — restoring
+# a hashed key would make the promoted revision diverge from the candidate
+# revision and orphan the candidate's gate stamps.
+_OPERATOR_OWNED_EXECUTION_PARAMS = ("wallet_label", "initial_capital")
+
+
+def _snapshot_operator_owned(job_yaml: Path) -> dict[str, Any]:
+    """Operator dials captured from the ACTIVE job.yaml before promotion.
+
+    The candidate's job.yaml is a snapshot from propose time; copying it
+    wholesale over the root reverted any watch-mode (agent set-mode — the FE
+    "Just run it"/"Watch & suggest" selector), paper/live, or wallet change
+    the operator made between propose and apply. Every preserved field is
+    excluded from the workspace revision hash, so restoring them keeps the
+    promoted revision equal to the candidate revision and the candidate's
+    gate stamps valid."""
+    try:
+        data = yaml.safe_load(job_yaml.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    snapshot: dict[str, Any] = {}
+    if isinstance(data.get("agent_loop"), dict):
+        snapshot["agent_loop"] = data["agent_loop"]
+    if data.get("job_kind"):
+        snapshot["job_kind"] = data["job_kind"]
+    script_loop = data.get("script_loop")
+    if isinstance(script_loop, dict) and "mode" in script_loop:
+        snapshot["script_mode"] = script_loop["mode"]
+    params = data.get("execution_params")
+    if isinstance(params, dict):
+        snapshot["execution_params"] = {
+            key: params[key]
+            for key in _OPERATOR_OWNED_EXECUTION_PARAMS
+            if key in params
+        }
+    return snapshot
+
+
+def _restore_operator_owned(job_yaml: Path, snapshot: dict[str, Any]) -> None:
+    if not snapshot:
+        return
+    data = yaml.safe_load(job_yaml.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        return
+    if "agent_loop" in snapshot:
+        data["agent_loop"] = snapshot["agent_loop"]
+    if "job_kind" in snapshot:
+        data["job_kind"] = snapshot["job_kind"]
+    if "script_mode" in snapshot and isinstance(data.get("script_loop"), dict):
+        data["script_loop"]["mode"] = snapshot["script_mode"]
+    preserved_params = snapshot.get("execution_params") or {}
+    if preserved_params and isinstance(data.get("execution_params"), dict):
+        data["execution_params"].update(preserved_params)
+    job_yaml.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+
 def _promote_candidate(store: JobStore, job_id: str, candidate_dir: Path) -> None:
     root = store.job_dir(job_id)
     candidate_workspace = candidate_dir / "workspace"
@@ -615,11 +674,13 @@ def _promote_candidate(store: JobStore, job_id: str, candidate_dir: Path) -> Non
         raise FileNotFoundError(f"candidate workspace missing: {candidate_workspace}")
     if not candidate_job_yaml.exists():
         raise FileNotFoundError(f"candidate job.yaml missing: {candidate_job_yaml}")
+    operator_owned = _snapshot_operator_owned(root / "job.yaml")
     active_workspace = root / "workspace"
     if active_workspace.exists():
         shutil.rmtree(active_workspace)
     shutil.copytree(candidate_workspace, active_workspace)
     shutil.copy2(candidate_job_yaml, root / "job.yaml")
+    _restore_operator_owned(root / "job.yaml", operator_owned)
     # Carry the candidate's revision-stamped gate artifacts (written during
     # candidate validation) into the job dirs: candidate revision equals the
     # post-promotion revision, so these keep evaluate_live_gate green after

--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -258,12 +258,20 @@ def starter_strategies_cmd() -> None:
     default=None,
     help="Initial paper leverage (1-5x; defaults to 1x).",
 )
+@click.option(
+    "--agent-mode",
+    "agent_mode",
+    type=click.Choice(["off", "monitor", "intervene", "auto", "improve", "decide"]),
+    default=None,
+    help="Override the catalog launch default (intervene).",
+)
 @click.option("--no-compile", is_flag=True, default=False)
 def create_starter_cmd(
     starter_id: str,
     job_id: str | None,
     initializer_session_id: str | None,
     leverage: int | None,
+    agent_mode: str | None,
     no_compile: bool,
 ) -> None:
     result = create_starter_job(
@@ -271,6 +279,7 @@ def create_starter_cmd(
         job_id=job_id,
         initializer_session_id=initializer_session_id,
         leverage=leverage,
+        agent_mode=agent_mode,
         compile_job=not no_compile,
     )
     _echo_json({"ok": True, "result": result})
@@ -1424,12 +1433,25 @@ def agent_set_mode_cmd(job_id: str, mode: AgentMode, wake_seconds: int | None) -
     store = JobStore()
     job = store.load(job_id)
     normalized_mode = normalize_agent_mode(mode)
+    previous_mode = job.agent_loop.mode
     job.agent_loop.mode = normalized_mode
     job.agent_loop.enabled = normalized_mode != "off"
     job.job_kind = infer_job_kind(job.script_loop.enabled, normalized_mode)
     if wake_seconds is not None:
         job.agent_loop.wake_interval_seconds = wake_seconds
     store.save(job)
+    # Journal the operator's selection so a later revert (e.g. a stale
+    # candidate promotion) is diagnosable from the job dir alone.
+    store.append_journal(
+        job_id,
+        {
+            "type": "operator_agent_mode_set",
+            "from": previous_mode,
+            "to": normalized_mode,
+            "wake_seconds": wake_seconds,
+            "via": "cli",
+        },
+    )
     result = JobCompiler(store=store).compile(job)
     sync_all_jobs(store=store)
     _echo_json({"ok": True, "result": result})

--- a/wayfinder_paths/jobs/gating.py
+++ b/wayfinder_paths/jobs/gating.py
@@ -95,6 +95,14 @@ def compute_workspace_revision(root: Path) -> str:
                 match data.get("script_loop"):
                     case dict() as script_loop:
                         script_loop.pop("mode", None)
+                # The agent watch level (FE "Just run it"/"Watch & suggest")
+                # is an operator dial, not strategy logic. Hashing it turned
+                # every mode flip into a phantom strategy change: stale gate
+                # stamps, baseline drift on staged candidates, and candidate
+                # promotion reverting the operator's selection. job_kind is
+                # derived from the same dial, so it leaves the hash with it.
+                data.pop("agent_loop", None)
+                data.pop("job_kind", None)
                 match data.get("execution_params"):
                     case dict() as execution_params:
                         execution_params.pop("wallet_label", None)

--- a/wayfinder_paths/jobs/starters.py
+++ b/wayfinder_paths/jobs/starters.py
@@ -15,7 +15,12 @@ from pathlib import Path
 from typing import Any
 
 from wayfinder_paths.jobs.background import spawn_detached_op
-from wayfinder_paths.jobs.models import WayfinderJob, safe_job_id
+from wayfinder_paths.jobs.models import (
+    AgentMode,
+    WayfinderJob,
+    normalize_agent_mode,
+    safe_job_id,
+)
 from wayfinder_paths.jobs.starter_leverage_evidence import STARTER_LEVERAGE_RESULTS
 from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.jobs.strategies._starter_utils import (
@@ -24,8 +29,17 @@ from wayfinder_paths.jobs.strategies._starter_utils import (
     RANKING_STOP_DEFAULTS,
 )
 
-STARTER_CATALOG_VERSION = "1.8.0"
+STARTER_CATALOG_VERSION = "1.9.0"
 STARTER_STRATEGY_INCEPTION_AT = "2026-08-24T00:00:00+00:00"
+# Catalog launch policy: every off-the-shelf starter launches with the agent
+# loop ON in intervene mode. Fleet evidence (two launches of the identical
+# starter): the intervene copy was the only productive research job (4
+# experiments/72h); the monitor twin burned ~49 wakes/48h unable to act — it
+# holdout-CONFIRMED a hypothesis and could not open its pre-registered paper
+# probation leg; agent-off copies did zero research. Callers may override
+# deliberately, but the default is intervene.
+STARTER_AGENT_MODE_DEFAULT: AgentMode = "intervene"
+STARTER_AGENT_WAKE_SECONDS = 3600
 STARTER_EVIDENCE_REVISION = "1.7.0"
 STARTER_LEVERAGE_DEFAULT = 1
 STARTER_LEVERAGE_MINIMUM = 1
@@ -1357,6 +1371,7 @@ def create_starter_job(
     compile_job: bool = True,
     initializer_session_id: str | None = None,
     leverage: int | float | None = None,
+    agent_mode: str | None = None,
 ) -> dict[str, Any]:
     """Materialize a selectable starter as an ordinary paper jobs_v1 job."""
     definition = get_starter(starter_id)
@@ -1391,6 +1406,13 @@ def create_starter_job(
     interval_seconds = int(bar_interval_seconds(definition.timeframe) or 0)
     if interval_seconds <= 0:
         raise ValueError(f"unsupported starter timeframe: {definition.timeframe}")
+    # None → catalog default (intervene). An explicit mode is honored so
+    # operator plumbing (CLI/MCP) can launch differently on purpose.
+    launch_agent_mode = (
+        normalize_agent_mode(agent_mode)
+        if agent_mode is not None
+        else STARTER_AGENT_MODE_DEFAULT
+    )
     job = WayfinderJob.new(
         resolved_id,
         name=definition.name,
@@ -1401,8 +1423,8 @@ def create_starter_job(
         script="workspace/src/strategy.py",
         interval_seconds=interval_seconds,
         timeout_seconds=180,
-        agent_mode="monitor",
-        agent_wake_seconds=3600,
+        agent_mode=launch_agent_mode,
+        agent_wake_seconds=STARTER_AGENT_WAKE_SECONDS,
         execution_contract="jobs_v1",
         initializer_session_id=initializer_session_id,
     )

--- a/wayfinder_paths/mcp/tools/jobs.py
+++ b/wayfinder_paths/mcp/tools/jobs.py
@@ -375,6 +375,8 @@ async def core_jobs(
       - `starter_strategies` lists the fixed, mixed crypto/equity paper
         starters. `create_starter` with `starter_id` materializes one as a
         normal jobs_v1 job; its own forward inception begins at selection.
+        Catalog launches default to `agent_mode="intervene"` (agent loop ON,
+        propose-only) — pass `agent_mode` explicitly only to deviate.
         It also spawns a detached 120-day `fetch_dataset` op — do not re-run
         `fetch_dataset` right after creating; poll `op_status` if a backtest
         reports the fetch still in progress.
@@ -453,6 +455,7 @@ async def core_jobs(
                 compile_job=compile,
                 initializer_session_id=initializer_session_id,
                 leverage=leverage,
+                agent_mode=agent_mode,
             )
         )
 
@@ -549,12 +552,25 @@ async def core_jobs(
     if action == "set_agent_mode":
         mode = normalize_agent_mode(agent_mode or "monitor")
         job = store.load(job_id)
+        previous_mode = job.agent_loop.mode
         job.agent_loop.mode = mode
         job.agent_loop.enabled = mode != "off"
         job.job_kind = infer_job_kind(job.script_loop.enabled, mode)
         if agent_wake_seconds is not None:
             job.agent_loop.wake_interval_seconds = agent_wake_seconds
         store.save(job)
+        # Journal the operator's selection so a later revert (e.g. a stale
+        # candidate promotion) is diagnosable from the job dir alone.
+        store.append_journal(
+            job_id,
+            {
+                "type": "operator_agent_mode_set",
+                "from": previous_mode,
+                "to": mode,
+                "wake_seconds": agent_wake_seconds,
+                "via": "mcp",
+            },
+        )
         result = JobCompiler(store=store).compile(job)
         sync_all_jobs(store=store)
         return ok(result)

--- a/wayfinder_paths/tests/test_jobs_application_gate.py
+++ b/wayfinder_paths/tests/test_jobs_application_gate.py
@@ -129,6 +129,43 @@ def test_apply_keeps_live_gate_green(
     assert job.execution_params["threshold"] == 10.7
 
 
+def test_apply_preserves_operator_agent_mode_set_after_propose(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """FE "Just run it"/"Watch & suggest" regression: an agent-mode change made
+    between propose and apply must survive candidate promotion. The candidate
+    job.yaml is a propose-time snapshot; promotion used to copy it wholesale,
+    silently reverting the operator's selection back to the propose-time mode."""
+    _patch_runner(monkeypatch)
+    store, job_id, _ = _make_job(tmp_path)
+    _write_bars_proposal(store, job_id, "prop_mode")
+    store.approve_proposal(job_id, "prop_mode", allow_ungated=True)
+    claim_application(store, job_id, "prop_mode")
+
+    # Operator flips the watch dial after the candidate was staged (the FE
+    # selector → `wayfinder job agent set-mode <job> off`).
+    job = store.load(job_id)
+    job.agent_loop.mode = "off"
+    job.agent_loop.enabled = False
+    job.job_kind = "script_only"
+    store.save(job)
+
+    validation = validate_application_candidate(store, job_id, "prop_mode")
+    assert validation["status"] == "passed", validation["checks"]
+    completed = complete_application(store, job_id, "prop_mode", status="applied")
+
+    job = store.load(job_id)
+    assert job.agent_loop.mode == "off"
+    assert job.agent_loop.enabled is False
+    assert job.job_kind == "script_only"
+    # The watch dial is excluded from the revision hash, so the promotion
+    # still lands on the candidate's stamped revision and the gate stays
+    # green despite the preserved operator fields.
+    gate = evaluate_live_gate(job_id, store=store)
+    assert gate["live_ready"] is True, gate["reasons"]
+    assert gate["revision"] == completed["promoted_revision"]
+
+
 def test_promote_params_via_proposal_is_approvable_without_scenario_plan(
     tmp_path: Path,
 ) -> None:

--- a/wayfinder_paths/tests/test_jobs_gating.py
+++ b/wayfinder_paths/tests/test_jobs_gating.py
@@ -110,6 +110,21 @@ def test_candidate_revision_matches_promoted_revision(tmp_path: Path) -> None:
     assert compute_workspace_revision(root) == candidate_revision
 
 
+def test_agent_mode_flip_does_not_move_the_revision(tmp_path: Path) -> None:
+    """The agent watch dial (set-mode) is operational, not strategy logic —
+    flipping it must not orphan gate stamps or drift staged candidates."""
+    store, job_id, root = _make_job(tmp_path)
+    baseline = compute_workspace_revision(root)
+
+    job = store.load(job_id)
+    job.agent_loop.mode = "intervene"
+    job.agent_loop.enabled = True
+    job.job_kind = "script_agent"
+    store.save(job)
+
+    assert compute_workspace_revision(root) == baseline
+
+
 def test_snapshot_carries_gate_and_keeps_existing_keys(tmp_path: Path) -> None:
     store, job_id, _ = _make_job(tmp_path)
     _run_full_gate_pipeline(store, job_id)

--- a/wayfinder_paths/tests/test_jobs_starters.py
+++ b/wayfinder_paths/tests/test_jobs_starters.py
@@ -25,6 +25,8 @@ from wayfinder_paths.jobs.execution.primitives import (
 )
 from wayfinder_paths.jobs.models import WayfinderJob
 from wayfinder_paths.jobs.starters import (
+    STARTER_AGENT_WAKE_SECONDS,
+    STARTER_CATALOG_VERSION,
     STARTER_DEFINITIONS,
     coerce_starter_leverage,
     create_starter_job,
@@ -787,6 +789,63 @@ def test_create_starter_materializes_job_and_forward_inception(tmp_path) -> None
     assert "mixed_volume_capitulation" in Path(
         balanced_result["script_entrypoint"]
     ).read_text(encoding="utf-8")
+
+
+# Catalog launch policy: every off-the-shelf starter launches with the agent
+# loop ON in intervene mode. Fleet evidence: the intervene copy of a starter
+# was the fleet's only productive research job; its monitor twin burned ~49
+# wakes/48h unable to act on a holdout-confirmed hypothesis; agent-off copies
+# did zero research. A starter must never launch monitor/off by default.
+def test_every_starter_launches_with_agent_loop_intervene(tmp_path) -> None:
+    store = JobStore(repo_root=tmp_path)
+    for definition in STARTER_DEFINITIONS:
+        create_starter_job(definition.id, store=store, compile_job=False)
+        job = store.load(definition.id)
+        assert job.agent_loop.enabled is True, definition.id
+        assert job.agent_loop.mode == "intervene", definition.id
+        assert job.agent_loop.wake_interval_seconds == STARTER_AGENT_WAKE_SECONDS, (
+            definition.id
+        )
+        assert job.job_kind == "script_agent", definition.id
+        assert (
+            job.controller["starter"]["catalog_version"] == STARTER_CATALOG_VERSION
+        ), definition.id
+
+
+def test_create_starter_honors_explicit_agent_mode_override(tmp_path) -> None:
+    store = JobStore(repo_root=tmp_path)
+    create_starter_job(
+        "mixed-rsi-snapback-1h",
+        job_id="monitor-override",
+        store=store,
+        compile_job=False,
+        agent_mode="monitor",
+    )
+    monitor_job = store.load("monitor-override")
+    assert monitor_job.agent_loop.mode == "monitor"
+    assert monitor_job.agent_loop.enabled is True
+
+    create_starter_job(
+        "mixed-rsi-snapback-1h",
+        job_id="off-override",
+        store=store,
+        compile_job=False,
+        agent_mode="off",
+    )
+    off_job = store.load("off-override")
+    assert off_job.agent_loop.mode == "off"
+    assert off_job.agent_loop.enabled is False
+    assert off_job.job_kind == "script_only"
+
+    # Aliases normalize the same way as the generic create path.
+    create_starter_job(
+        "mixed-rsi-snapback-1h",
+        job_id="improve-alias",
+        store=store,
+        compile_job=False,
+        agent_mode="improve",
+    )
+    assert store.load("improve-alias").agent_loop.mode == "intervene"
 
 
 def test_create_starter_reuses_its_canonical_job_id(tmp_path) -> None:


### PR DESCRIPTION
# starters: launch with agent_loop intervene by default

Off-the-shelf catalog starters now always launch with `agent_loop: {enabled: true, mode: intervene}`. Also fixes the SDK-side path that silently reverted a user's agent-mode selection (FE "Just run it" dropped back to monitor), and journals every operator set-mode so future reverts are diagnosable.

## Why

Two launches of the identical starter (`balanced-passive-capitulation-1h`) ended up in different modes. The intervene copy is the fleet's only productive research job (4 experiments/72h, island rotation). The monitor copy burned ~49 wakes/48h unable to act — it holdout-CONFIRMED a hypothesis and could not open its pre-registered paper-probation leg (agenda: "REQUIRES INTERVENE MODE (blocked by monitor)"). Two other starters launched with agent_loop off entirely and did zero research.

## What the launch path defaulted to before

- `create_starter_job` (wayfinder_paths/jobs/starters.py) hardcoded `agent_mode="monitor"` since the catalog was introduced (#669, a754759d). Every catalog launch — CLI `wayfinder job create-starter` and MCP `core_jobs(action="create_starter")` — came up **monitor**; neither surface carried a mode parameter.
- **vault-backend sends nothing at launch**: there is no starter-launch action anywhere in vault-backend (`grep create_starter src/` is empty). Starters are launched box-side by the Strategy Lab chat agent via MCP/CLI. The launch mode was therefore decided entirely SDK-side, and an SDK-side default change suffices — no backend change needed.
- The "agent_loop off entirely" starters are consistent with jobs built through the generic create path instead of the catalog: CLI `wayfinder job create` defaults `--agent-mode off` and MCP `core_jobs(action="create")` normalizes an omitted `agent_mode` to off. Those defaults are unchanged here; only catalog launches are forced to intervene.

## Where tester-2's "Just run it" selection was dropped (investigation)

The FE selector chain itself is sound:

1. **vault-frontend** `jobs/_components/strategies/JobOverview.tsx` maps off="Just run it", monitor="Watch & report", intervene="Watch & suggest", auto="Automatic", and fires `POST .../wayfinder-jobs/<job>/actions/ {action: "set_agent_mode", mode}`.
2. **vault-backend** `WayfinderJobsService._command_parts` translates that into a real box-side command `wayfinder job agent set-mode <job> <mode>` (machine exec, not a DB-only write; failures raise 502). The DB mirror is updated one-way by the SDK sync push, so there is no FE/backend split-brain on the toggle path.
3. **The broken link is SDK-side, at proposal apply.** A proposal's candidate bundle snapshots `job.yaml` at propose/claim time (`_ensure_candidate_dir`), and `_promote_candidate` copied that snapshot **wholesale** over the root `job.yaml` at apply. Any `agent set-mode` issued between propose and apply was silently reverted to the propose-time mode. Timeline that fits tester-2's box: starter launches monitor (old default) → a proposal is staged (candidate job.yaml carries monitor) → user clicks "Just run it" (job.yaml flips to off, mirror syncs, FE shows it took) → the proposal is approved/applied → promotion restores the stale snapshot → job.yaml is back to monitor. Aggravator: `agent_loop` was part of `compute_workspace_revision`, so the mode flip also bumped the active revision and flagged staged candidates as baseline drift — while the promote clobbered the flip anyway. And set-mode wrote no journal entry, so the revert left no trace.

**Follow-up FE/backend work: none required for this failure mode.** Optional hardening only: the FE could toast `set_agent_mode` 502s explicitly, and any future backend-side starter-launch surface should pass an explicit agent-mode.

## Changes

- **starters.py** — `STARTER_AGENT_MODE_DEFAULT = "intervene"`, `STARTER_AGENT_WAKE_SECONDS = 3600` (wake cadence unchanged); `create_starter_job` gains an `agent_mode` override param (None → intervene; explicit values honored and normalized, aliases included). `STARTER_CATALOG_VERSION` 1.8.0 → 1.9.0.
- **cli.py** — `wayfinder job create-starter --agent-mode ...` (default: catalog policy); `agent set-mode` now journals `operator_agent_mode_set` (from/to/wake/via).
- **mcp/tools/jobs.py** — `create_starter` passes the existing `agent_mode` arg through; `set_agent_mode` journals the same event; docstring notes the catalog launch default.
- **gating.py** — `compute_workspace_revision` now excludes `agent_loop` and `job_kind` (derived from it), same doctrine as the existing `script_loop.mode` / `wallet_label` / `initial_capital` exclusions: operator watch dials are not strategy logic, and flipping them must not orphan gate stamps or drift staged candidates.
- **application.py** — `_promote_candidate` preserves the ACTIVE job.yaml's operator-owned fields across promotion: `agent_loop`, `job_kind`, `script_loop.mode`, `execution_params.wallet_label`, `execution_params.initial_capital`. All preserved fields are revision-hash-excluded, so the promoted revision still equals the candidate's stamped revision and the candidate's gate artifacts stay valid. This also closes the sibling hazard of an apply silently flipping a live job back to paper (or dropping a wallet_label) from a stale snapshot.

## Deploy note

The revision-hash change means already-deployed jobs compute a different revision on first contact after upgrade, so existing validation/backtest/preflight stamps go stale until the next re-stamp (same one-time effect as the earlier `memory.md` hash exclusion). Paper research jobs are unaffected operationally; live-gate evaluations are red until the standard re-stamp runs.

## Tests

- Baseline on `origin/wayfinder-jobs-v1` (`pytest -k "jobs or runner or mcp"`): **1078 passed, 9 skipped**.
- After: **1082 passed, 9 skipped** (4 new tests, 0 regressions).
  - `test_every_starter_launches_with_agent_loop_intervene` — catalog-wide: all 12 starters launch enabled+intervene at wake 3600, `job_kind == "script_agent"`, catalog_version 1.9.0.
  - `test_create_starter_honors_explicit_agent_mode_override` — monitor/off/alias override paths.
  - `test_agent_mode_flip_does_not_move_the_revision` — set-mode no longer bumps the workspace revision.
  - `test_apply_preserves_operator_agent_mode_set_after_propose` — full claim→validate→apply pipeline: a set-mode issued after propose survives promotion AND the live gate stays green at the candidate's stamped revision.
- ruff check + format clean on touched files; scoped mypy introduces no new errors (6 pre-existing errors in touched files before and after).
