### PR TITLE
sync: surface agent-mode drift between declared and actual state

### DIFF
--- a/wayfinder_paths/jobs/sync.py
+++ b/wayfinder_paths/jobs/sync.py
@@ -182,7 +182,14 @@ def _runtime_reconciliation(job: Any, store: JobStore) -> dict[str, Any]:
     if agent_state:
         aenv = (agent_state.get("payload") or {}).get("env") or {}
         if aenv.get("WAYFINDER_JOB_AGENT_MODE"):
-            out["agent_mode"] = str(aenv["WAYFINDER_JOB_AGENT_MODE"])
+            runtime_agent_mode = str(aenv["WAYFINDER_JOB_AGENT_MODE"])
+            out["agent_mode"] = runtime_agent_mode
+            # Box-internal split-brain tripwire, mirroring script mode_mismatch:
+            # the runner wakes under the env baked at last compile, so a failed
+            # or skipped recompile after a job.yaml edit leaves the two
+            # disagreeing. This does NOT compare against what the DB/UI think
+            # the mode is — the box never sees that (see snapshot_job).
+            out["agent_mode_mismatch"] = runtime_agent_mode != str(agent.mode)
     return out
 
 
@@ -204,6 +211,19 @@ def snapshot_job(job_id: str, *, store: JobStore | None = None) -> dict[str, Any
     runtime = _runtime_reconciliation(job, store)
     if runtime:
         scorecard = {**scorecard, **runtime}
+    # The box's authoritative agent mode, shipped unconditionally: job.yaml's
+    # agent_loop block is what the compiler bakes into the runner, so it is
+    # the runner truth regardless of daemon reachability. The sync channel is
+    # push-only — the box never learns what the DB/UI believe the mode is (a
+    # UI mode selection once got dropped before reaching job.yaml, and the DB
+    # showed autonomous while the box ran monitor, silently, for days) — so
+    # the backend-declared vs actual comparison must live backend-side, keyed
+    # on this field. agent_mode_source pins provenance for that comparison.
+    scorecard = {
+        **scorecard,
+        "agent_mode_actual": str(job.agent_loop.mode),
+        "agent_mode_source": "job_yaml",
+    }
     dataset_fetch = _dataset_fetch_state(store, job_id)
     if dataset_fetch is not None:
         scorecard = {**scorecard, "dataset_fetch": dataset_fetch}

--- a/wayfinder_paths/jobs/watchdog.py
+++ b/wayfinder_paths/jobs/watchdog.py
@@ -867,6 +867,70 @@ def _check_disk_usage(
     return None
 
 
+# Agent-mode drift alerting: `set_agent_mode` edits job.yaml and recompiles,
+# which re-bakes WAYFINDER_JOB_AGENT_MODE into the runner env. A failed or
+# skipped recompile leaves the runner waking under the OLD mode while
+# job.yaml — and everything that reads it, including the synced
+# agent_mode_actual — claims the new one: the agent-loop twin of the
+# paper/live split-brain that once had a live-trading job reading "paper".
+# The watchdog compares the baked env against job.yaml every pass and
+# journals once per drift episode (re-alert window mirrors disk_pressure).
+_AGENT_MODE_DRIFT_PATH = "state/agent_mode_drift_alert.json"
+AGENT_MODE_DRIFT_REALERT_WINDOW = timedelta(hours=6)
+
+
+def _check_agent_mode_drift(
+    store: JobStore, job: Any, now: datetime, runner_states: dict[str, Any]
+) -> dict[str, Any] | None:
+    loop = getattr(job, "agent_loop", None)
+    name = (
+        str(getattr(loop, "runner_job_name", "") or "")
+        if loop is not None and getattr(loop, "enabled", False)
+        else ""
+    )
+    state = runner_states.get(name) if name else None
+    env = ((state or {}).get("payload") or {}).get("env") or {}
+    compiled = str(env.get("WAYFINDER_JOB_AGENT_MODE") or "")
+    if not compiled:
+        # Daemon down or loop not compiled: nothing to compare — hold the
+        # marker so a transient outage neither re-alerts nor fake-"recovers".
+        return None
+    declared = str(getattr(loop, "mode", "") or "")
+    marker = store.read_json(job.id, _AGENT_MODE_DRIFT_PATH) or {}
+    if compiled != declared:
+        if (
+            marker.get("compiled") == compiled
+            and marker.get("declared") == declared
+            and _age(now, marker.get("alerted_at")) < AGENT_MODE_DRIFT_REALERT_WINDOW
+        ):
+            return None  # already alerted for this drift episode
+        store.write_json(
+            job.id,
+            _AGENT_MODE_DRIFT_PATH,
+            {
+                "declared": declared,
+                "compiled": compiled,
+                "alerted_at": now.isoformat(),
+            },
+        )
+        store.append_journal(
+            job.id,
+            {"type": "agent_mode_drift", "declared": declared, "compiled": compiled},
+        )
+        return {
+            "action": "agent_mode_drift",
+            "declared": declared,
+            "compiled": compiled,
+        }
+    if marker:
+        store.write_json(job.id, _AGENT_MODE_DRIFT_PATH, {})
+        store.append_journal(
+            job.id, {"type": "agent_mode_drift_recovered", "mode": declared}
+        )
+        return {"action": "agent_mode_drift_recovered", "mode": declared}
+    return None
+
+
 # Research-impasse alerting: all three production research jobs froze the
 # same way — staleness computed correctly and the wake mandate fired every
 # wake, but the mandate's "state why research is not warranted" hatch let the
@@ -1321,6 +1385,15 @@ def recover_stalled_applications(
     restaged_this_pass = False
     # A gate re-stamp runs a full backtest — same one-per-pass budget rule.
     restamped_this_pass = False
+    # One daemon RPC per pass, shared by the per-job agent-mode drift check.
+    # job_states() itself returns {} on an unreachable daemon; the guard is
+    # for everything else — a broken bridge must not stop recovery of the
+    # jobs, and the drift check degrades to a no-op exactly like a down
+    # daemon (no compare, marker held).
+    try:
+        runner_states = RunnerBridge(repo_root=store.repo_root).job_states()
+    except Exception:  # noqa: BLE001
+        runner_states = {}
     for job in store.list_jobs():
         try:
             proposals = store.proposals(job.id)
@@ -1399,6 +1472,13 @@ def recover_stalled_applications(
             disk_event = None
         if disk_event is not None:
             recovered.append({"job_id": job.id, **disk_event})
+        try:
+            drift_event = _check_agent_mode_drift(store, job, now, runner_states)
+        except Exception as exc:
+            errors.append({"job_id": job.id, "error": f"agent_mode: {exc}"})
+            drift_event = None
+        if drift_event is not None:
+            recovered.append({"job_id": job.id, **drift_event})
         try:
             impasse_event = _check_research_impasse(store, job, proposals, now)
         except Exception as exc:

--- a/wayfinder_paths/tests/test_jobs_fit_the_box.py
+++ b/wayfinder_paths/tests/test_jobs_fit_the_box.py
@@ -35,6 +35,7 @@ from wayfinder_paths.jobs.models import WayfinderJob
 from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.jobs.triggers import ALWAYS_WAKE_EVENTS
 from wayfinder_paths.jobs.watchdog import (
+    _check_agent_mode_drift,
     _check_disk_usage,
     _check_loop_gap,
     _recover_stale_gate,
@@ -404,3 +405,117 @@ def test_disk_used_pct_helper_and_compute_status_field(
 
     monkeypatch.setattr("shutil.disk_usage", _boom)
     assert disk_used_pct(tmp_path) is None  # never raises
+
+
+# ── watchdog: agent-mode drift alerting ──────────────────────────────────────
+# set_agent_mode edits job.yaml and recompiles, re-baking
+# WAYFINDER_JOB_AGENT_MODE into the runner env. A failed recompile leaves the
+# runner waking under the OLD mode while job.yaml claims the new one — the
+# agent-loop twin of the paper/live split-brain. The watchdog journals
+# `agent_mode_drift` once per episode (debounce mirrors disk_pressure).
+
+
+def _agent_states(job: WayfinderJob, compiled: str) -> dict[str, Any]:
+    return {
+        job.agent_loop.runner_job_name: {
+            "status": "ACTIVE",
+            "payload": {"env": {"WAYFINDER_JOB_AGENT_MODE": compiled}},
+        }
+    }
+
+
+def test_agent_mode_drift_journals_once_then_debounces(tmp_path: Path) -> None:
+    store, job = _make_store(tmp_path, "box-drift")  # declared intervene
+    now = datetime.now(UTC)
+    states = _agent_states(job, "monitor")  # baked env lags a failed recompile
+
+    event = _check_agent_mode_drift(store, job, now, states)
+    assert event == {
+        "action": "agent_mode_drift",
+        "declared": "intervene",
+        "compiled": "monitor",
+    }
+    journaled = _journal_events(store, job.id, "agent_mode_drift")
+    assert len(journaled) == 1
+    assert journaled[0]["declared"] == "intervene"
+    assert journaled[0]["compiled"] == "monitor"
+
+    # Same drift next pass, inside the window → debounced.
+    assert (
+        _check_agent_mode_drift(store, job, now + timedelta(minutes=5), states) is None
+    )
+    assert len(_journal_events(store, job.id, "agent_mode_drift")) == 1
+    # Past the re-alert window the still-standing episode re-alerts.
+    assert _check_agent_mode_drift(store, job, now + timedelta(hours=7), states)
+    assert len(_journal_events(store, job.id, "agent_mode_drift")) == 2
+
+
+def test_agent_mode_drift_new_pair_realerts_inside_window(tmp_path: Path) -> None:
+    store, job = _make_store(tmp_path, "box-drift-pair")
+    now = datetime.now(UTC)
+    assert _check_agent_mode_drift(store, job, now, _agent_states(job, "monitor"))
+    # A DIFFERENT drift (declared flipped to auto, env still stale) is a new
+    # episode — alerts immediately, no window wait.
+    job.agent_loop.mode = "auto"
+    event = _check_agent_mode_drift(
+        store, job, now + timedelta(minutes=5), _agent_states(job, "monitor")
+    )
+    assert event is not None and event["declared"] == "auto"
+    assert len(_journal_events(store, job.id, "agent_mode_drift")) == 2
+
+
+def test_agent_mode_drift_recovers_once_and_holds_on_outage(tmp_path: Path) -> None:
+    store, job = _make_store(tmp_path, "box-drift-rec")
+    now = datetime.now(UTC)
+    assert _check_agent_mode_drift(store, job, now, _agent_states(job, "monitor"))
+    # Daemon outage mid-episode: nothing to compare — no re-alert, and no
+    # fake "recovery" either; the marker holds.
+    assert _check_agent_mode_drift(store, job, now + timedelta(hours=7), {}) is None
+    assert not _journal_events(store, job.id, "agent_mode_drift_recovered")
+    # Recompile lands: env agrees with job.yaml → recovery journaled once.
+    healed = _agent_states(job, "intervene")
+    event = _check_agent_mode_drift(store, job, now + timedelta(hours=8), healed)
+    assert event == {"action": "agent_mode_drift_recovered", "mode": "intervene"}
+    assert _check_agent_mode_drift(store, job, now + timedelta(hours=8), healed) is None
+    assert len(_journal_events(store, job.id, "agent_mode_drift_recovered")) == 1
+
+
+def test_agent_mode_drift_quiet_when_matching_or_disabled(tmp_path: Path) -> None:
+    store, job = _make_store(tmp_path, "box-drift-quiet")
+    now = datetime.now(UTC)
+    # Matching env → quiet, no marker created.
+    assert (
+        _check_agent_mode_drift(store, job, now, _agent_states(job, "intervene"))
+        is None
+    )
+    assert not (
+        store.job_dir(job.id) / "state" / "agent_mode_drift_alert.json"
+    ).exists()
+    # Disabled loop → quiet even if a stale runner entry disagrees.
+    job.agent_loop.enabled = False
+    assert _check_agent_mode_drift(store, job, now, _agent_states(job, "monitor")) is (
+        None
+    )
+    assert not _journal_events(store, job.id, "agent_mode_drift")
+
+
+def test_agent_mode_drift_wired_into_watchdog_pass(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job = _make_store(tmp_path, "box-drift-pass")
+
+    class _FakeBridge:
+        def __init__(self, *, repo_root: Any = None) -> None:
+            pass
+
+        def job_states(self) -> dict[str, Any]:
+            return _agent_states(job, "monitor")
+
+    monkeypatch.setattr("wayfinder_paths.jobs.watchdog.RunnerBridge", _FakeBridge)
+    result = recover_stalled_applications(store=store, now=datetime.now(UTC))
+    drift_events = [
+        e for e in result["recovered"] if e.get("action") == "agent_mode_drift"
+    ]
+    assert len(drift_events) == 1
+    assert drift_events[0]["job_id"] == job.id
+    assert not [e for e in result["errors"] if "agent_mode" in str(e.get("error"))]

--- a/wayfinder_paths/tests/test_jobs_runtime_status.py
+++ b/wayfinder_paths/tests/test_jobs_runtime_status.py
@@ -111,6 +111,66 @@ def test_snapshot_reconciles_agent_mode_and_revision(tmp_path, monkeypatch):
     assert sc["active_revision"] == "rev123"
 
 
+def test_snapshot_ships_authoritative_agent_mode_even_runner_down(
+    tmp_path, monkeypatch
+):
+    # The sync channel is push-only: the box never sees the DB-declared agent
+    # mode (a UI selection once got dropped before reaching job.yaml, and the
+    # DB showed autonomous while the box ran monitor for days). The box-side
+    # contribution is to ALWAYS ship job.yaml's mode authoritative — even
+    # with the daemon down — so the backend can compare against its own
+    # stored declared value.
+    store, job = _job(tmp_path, mode="paper")
+    monkeypatch.setattr(sync_mod, "RunnerBridge", _FakeBridge({}))
+    sc = snapshot_job(job.id, store=store)["scorecard"]
+    assert sc["agent_mode_actual"] == "monitor"  # job.yaml agent_loop.mode
+    assert sc["agent_mode_source"] == "job_yaml"
+    assert "agent_mode_mismatch" not in sc  # no runner env -> no comparison
+
+
+def test_snapshot_flags_agent_mode_mismatch_against_baked_env(tmp_path, monkeypatch):
+    # job.yaml says monitor but the runner env was compiled as intervene —
+    # the internal split-brain a failed recompile after set_agent_mode leaves.
+    store, job = _job(tmp_path, mode="live")
+    monkeypatch.setattr(
+        sync_mod,
+        "RunnerBridge",
+        _FakeBridge(
+            {
+                "carry-script": _script_state(),
+                "carry-agent": {
+                    "status": "ACTIVE",
+                    "payload": {"env": {"WAYFINDER_JOB_AGENT_MODE": "intervene"}},
+                },
+            }
+        ),
+    )
+    sc = snapshot_job(job.id, store=store)["scorecard"]
+    assert sc["agent_mode"] == "intervene"  # runtime truth
+    assert sc["agent_mode_mismatch"] is True
+    assert sc["agent_mode_actual"] == "monitor"  # job.yaml stays authoritative
+
+
+def test_snapshot_agent_mode_agree_no_mismatch(tmp_path, monkeypatch):
+    store, job = _job(tmp_path, mode="live")
+    monkeypatch.setattr(
+        sync_mod,
+        "RunnerBridge",
+        _FakeBridge(
+            {
+                "carry-script": _script_state(),
+                "carry-agent": {
+                    "status": "ACTIVE",
+                    "payload": {"env": {"WAYFINDER_JOB_AGENT_MODE": "monitor"}},
+                },
+            }
+        ),
+    )
+    sc = snapshot_job(job.id, store=store)["scorecard"]
+    assert sc["agent_mode_mismatch"] is False
+    assert sc["agent_mode_actual"] == "monitor"
+
+
 def test_snapshot_falls_back_to_engine_mode(tmp_path, monkeypatch):
     # Runner env lacks WAYFINDER_JOB_MODE -> use engine_state.json (last ran as).
     store, job = _job(tmp_path, mode="paper")


### PR DESCRIPTION
## Incident

A user selected "Just run it" (autonomous agent mode) in the web UI, but the box's `job.yaml` stayed `agent_loop.mode: monitor` — the selection was dropped somewhere between FE → backend → box. Nothing surfaced the disagreement: the DB/UI showed one mode, the runner ran another, silently, for days. A prior incident had the same shape for script paper/live mode; the existing `mode_mismatch` scorecard flag came out of it. This PR gives the agent loop the same treatment, scoped to what the box can actually know.

## What the sync payload contained before (declared-vs-actual analysis)

- `job.agent_loop.mode` (inside `job.to_dict()`) — the box-declared mode from `job.yaml`. Already rides every sync.
- `scorecard.agent_mode` — the runner-baked env (`WAYFINDER_JOB_AGENT_MODE`), overlaid by `_runtime_reconciliation` **only when the daemon is reachable and the agent runner job exists**. Absent otherwise, and never compared against anything.
- **No backend echo**: `WayfinderJobsClient.sync` POSTs and discards the response body (`raise_for_status()` only). There is no inbound channel through which the box learns the DB/UI-declared mode. The box therefore **cannot** compute the DB-vs-box mismatch that bit us — it can only ship its own truth unambiguously and compare the two values it does hold (job.yaml vs runner env).

## Box-side changes (this PR)

1. **`scorecard.agent_mode_actual` + `agent_mode_source: "job_yaml"`** (`jobs/sync.py snapshot_job`) — shipped unconditionally on every sync, even with the runner daemon down. `job.yaml`'s `agent_loop.mode` is what the compiler bakes into the runner, so it is the box-authoritative value. `agent_mode_source` pins provenance so the backend comparison has a stable key to trust.
2. **`scorecard.agent_mode_mismatch`** (`jobs/sync.py _runtime_reconciliation`) — mirrors the script `mode_mismatch` pattern exactly: `true` when the runner-baked `WAYFINDER_JOB_AGENT_MODE` disagrees with `job.yaml agent_loop.mode`. This is the **box-internal** split-brain (a failed recompile after `set_agent_mode` diverges the two), not the DB-vs-box comparison — that one is impossible SDK-side (see above) and is not faked here.
3. **Watchdog standing check `agent_mode_drift`** (`jobs/watchdog.py`) — mirrors the disk-pressure debounce: every pass, compare the runner-links-compiled agent mode (live runner env via one shared `RunnerBridge.job_states()` RPC per pass) against `job.yaml agent_loop.mode`; journal `agent_mode_drift` once per drift episode (6h re-alert window, a new declared/compiled pair re-alerts immediately), `agent_mode_drift_recovered` once when the recompile lands. Daemon outage mid-episode neither re-alerts nor fake-recovers (marker held). Degrades to a no-op when the bridge is broken — the recovery pass never dies on it.

## Backend-side follow-up (documented, not in this PR)

The mismatch that actually caused the incident — DB-declared vs box-actual — must be stamped **backend-side**: the sync view compares the payload's `agent_mode_actual` (source-checked against `agent_mode_source == "job_yaml"`) with its stored declared mode and sets the drift flag on the model, so the UI can render the disagreement instead of silently preferring either value.

## Tests

- `test_jobs_runtime_status.py`: snapshot ships `agent_mode_actual`/`agent_mode_source` even with the runner down; `agent_mode_mismatch` true/false against the baked env; job.yaml stays authoritative under mismatch.
- `test_jobs_fit_the_box.py`: drift journals once then debounces inside the window; re-alerts past the window; a new declared/compiled pair re-alerts immediately; recovery journals once; daemon outage holds the marker; quiet when matching or loop disabled; wired into `recover_stalled_applications` end-to-end.
- Full `pytest -k "jobs or runner or mcp"`: 1086 passed, 3 skipped, 0 failed (baseline on `origin/wayfinder-jobs-v1`: 1078 passed, 3 skipped). ruff clean; scoped mypy introduces no new errors in the touched modules (2 pre-existing errors in `watchdog.py`, unchanged).
