### PR TITLE
apply: reuse propose-time validation when provably unchanged — stop re-running 30-minute backtests

### DIFF
--- a/wayfinder_paths/jobs/application.py
+++ b/wayfinder_paths/jobs/application.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import hashlib
 import json
+import os
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
@@ -20,9 +22,14 @@ from wayfinder_paths.jobs.runner_bridge import RunnerBridge
 from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.jobs.sync import sync_all_jobs
 from wayfinder_paths.jobs.validation import (
+    candidate_dataset_fingerprint,
     validate_candidate_application,
     validation_summary,
 )
+
+# Kill-switch: force the pre-reuse behavior (full re-validation backtest on
+# every apply) regardless of evidence-reuse eligibility.
+APPLY_ALWAYS_REVALIDATE_ENV = "WAYFINDER_APPLY_ALWAYS_REVALIDATE"
 
 
 @dataclass
@@ -262,6 +269,101 @@ def complete_application(
     }
 
 
+def assess_validation_reuse(
+    store: JobStore,
+    job_id: str,
+    proposal: dict[str, Any],
+    candidate_dir: Path,
+) -> dict[str, Any]:
+    """Mechanical eligibility check for reusing the propose-time validation
+    evidence at apply time, instead of re-running the ~30-minute candidate
+    backtest against a provably identical candidate + dataset.
+
+    Returns `{"eligible": bool, "reason": str, "proof": dict}` — `reason`
+    names the FIRST failed condition when ineligible; `proof` carries the
+    content-derived identity when eligible (revisions, dataset fingerprint,
+    frozen-report hash). Every condition is a hash comparison or a frozen
+    field read — never trust-based:
+
+    1. kill-switch off (`WAYFINDER_APPLY_ALWAYS_REVALIDATE=1` forces rerun)
+    2. frozen candidate_report present, mode "full", with a revision
+    3. active workspace revision is still base or candidate (no drift)
+    4. candidate dir still hashes to the report's revision (same content
+       equivalence as `store._ensure_candidate_matches_report`)
+    5. dataset fingerprint recorded at propose time matches the one
+       re-derived now (input bars + declared feature stores, by content)
+    6. the frozen evidence is green: validation_summary passed AND
+       economic.ready is True — failed/poisoned evidence is never reused
+    """
+    if os.environ.get(APPLY_ALWAYS_REVALIDATE_ENV) == "1":
+        return {"eligible": False, "reason": "kill_switch", "proof": {}}
+    report = proposal.get("candidate_report") or {}
+    report_revision = str(report.get("revision") or "")
+    if not report or report.get("mode") != "full" or not report_revision:
+        return {"eligible": False, "reason": "report_missing_or_not_full", "proof": {}}
+    base_revision = str(proposal.get("base_revision") or "")
+    active_revision = compute_workspace_revision(store.job_dir(job_id))
+    if base_revision and active_revision not in (base_revision, report_revision):
+        return {
+            "eligible": False,
+            "reason": "baseline_drift",
+            "proof": {
+                "base_revision": base_revision,
+                "active_revision": active_revision,
+            },
+        }
+    candidate_revision = compute_workspace_revision(candidate_dir)
+    if candidate_revision != report_revision:
+        return {
+            "eligible": False,
+            "reason": "candidate_mismatch",
+            "proof": {
+                "report_revision": report_revision,
+                "candidate_revision": candidate_revision,
+            },
+        }
+    recorded_fingerprint = report.get("dataset_fingerprint")
+    current_fingerprint = candidate_dataset_fingerprint(
+        candidate_dir, store.job_dir(job_id)
+    )
+    if not recorded_fingerprint or recorded_fingerprint != current_fingerprint:
+        return {
+            "eligible": False,
+            "reason": (
+                "dataset_changed" if recorded_fingerprint else "no_dataset_fingerprint"
+            ),
+            "proof": {
+                "recorded_fingerprint": recorded_fingerprint,
+                "current_fingerprint": current_fingerprint,
+            },
+        }
+    validation_status = (report.get("validation_summary") or {}).get("status")
+    economic_ready = (report.get("economic") or {}).get("ready")
+    if validation_status != "passed" or economic_ready is not True:
+        return {
+            "eligible": False,
+            "reason": "report_not_green",
+            "proof": {
+                "validation_status": validation_status,
+                "economic_ready": economic_ready,
+            },
+        }
+    report_hash = hashlib.sha256(
+        json.dumps(report, sort_keys=True, default=str).encode("utf-8")
+    ).hexdigest()
+    return {
+        "eligible": True,
+        "reason": "",
+        "proof": {
+            "base_revision": base_revision,
+            "candidate_revision": candidate_revision,
+            "active_revision": active_revision,
+            "dataset_fingerprint": current_fingerprint,
+            "report_hash": report_hash,
+        },
+    }
+
+
 def _complete_applied_application(
     store: JobStore,
     job_id: str,
@@ -321,26 +423,91 @@ def _complete_applied_application(
             },
             restage_requested=True,
         )
-    deterministic_validation = validate_candidate_application(
-        repo_root=store.repo_root,
-        job_dir=store.job_dir(job_id),
-        proposal=proposal,
-        candidate_dir=candidate_dir,
-        require_judge=bool(proposal.get("judge_required")),
-        allow_legacy=allow_legacy,
-    )
-    deterministic_validation = _with_execution_validation(
-        store,
-        job_id,
-        proposal,
-        deterministic_validation,
-    )
+    # Evidence reuse: the propose flow already ran the full validation
+    # (candidate backtest + preflight + execution validation) against this
+    # exact candidate content. When the candidate, dataset, and baseline are
+    # PROVABLY unchanged and the frozen evidence is green, re-running the
+    # ~30-minute backtest with trading loops paused adds nothing — keep only
+    # the cheap invariants (compile, scenario sims, config/report reads).
+    reuse = assess_validation_reuse(store, job_id, proposal, candidate_dir)
+    deterministic_validation: dict[str, Any] | None = None
+    if reuse["eligible"]:
+        cheap_validation = validate_candidate_application(
+            repo_root=store.repo_root,
+            job_dir=store.job_dir(job_id),
+            proposal=proposal,
+            candidate_dir=candidate_dir,
+            require_judge=bool(proposal.get("judge_required")),
+            allow_legacy=allow_legacy,
+            skip_behavior_checks=True,
+        )
+        cheap_validation = _with_execution_validation(
+            store,
+            job_id,
+            proposal,
+            cheap_validation,
+        )
+        if cheap_validation["status"] == "passed":
+            report = proposal.get("candidate_report") or {}
+            deterministic_validation = {
+                **cheap_validation,
+                "status": "reused",
+                "source": "propose-time report",
+                "reused_summary": dict(report.get("validation_summary") or {}),
+                "reuse_proof": reuse["proof"],
+            }
+            store.append_journal(
+                job_id,
+                {
+                    "type": "apply_validation_reused",
+                    "proposal_id": proposal_id,
+                    "source": "propose-time report",
+                    **reuse["proof"],
+                },
+            )
+        else:
+            # Defense in depth: a failed cheap invariant with green frozen
+            # evidence means something moved outside the fingerprinted
+            # surface — fall back to the authoritative full re-validation.
+            store.append_journal(
+                job_id,
+                {
+                    "type": "apply_validation_rerun",
+                    "proposal_id": proposal_id,
+                    "reason": "cheap_invariants_failed",
+                },
+            )
+    else:
+        store.append_journal(
+            job_id,
+            {
+                "type": "apply_validation_rerun",
+                "proposal_id": proposal_id,
+                "reason": reuse["reason"],
+                **({"details": reuse["proof"]} if reuse["proof"] else {}),
+            },
+        )
+    if deterministic_validation is None:
+        deterministic_validation = validate_candidate_application(
+            repo_root=store.repo_root,
+            job_dir=store.job_dir(job_id),
+            proposal=proposal,
+            candidate_dir=candidate_dir,
+            require_judge=bool(proposal.get("judge_required")),
+            allow_legacy=allow_legacy,
+        )
+        deterministic_validation = _with_execution_validation(
+            store,
+            job_id,
+            proposal,
+            deterministic_validation,
+        )
     store.record_proposal_application_validation(
         job_id,
         proposal_id,
         deterministic_validation,
     )
-    if deterministic_validation["status"] != "passed":
+    if deterministic_validation["status"] not in ("passed", "reused"):
         final_error = "Candidate validation failed: " + json.dumps(
             validation_summary(deterministic_validation), sort_keys=True, default=str
         )

--- a/wayfinder_paths/jobs/gating.py
+++ b/wayfinder_paths/jobs/gating.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -113,6 +113,65 @@ def compute_workspace_revision(root: Path) -> str:
             case _:
                 digest.update(job_yaml.read_bytes())
     return digest.hexdigest()[:12]
+
+
+def dataset_content_fingerprint(
+    candidate_dir: Path,
+    job_dir: Path,
+    *,
+    feature_paths: Sequence[str] = (),
+) -> dict[str, Any] | None:
+    """Content hash of the exact files a candidate backtest would consume.
+
+    The evidence-reuse identity companion to `compute_workspace_revision`:
+    revision hashes the CODE a backtest ran, this hashes the DATA it ran on.
+    Resolution mirrors the candidate behavior checks (candidate bundle first,
+    then the job root — `_resolve_dataset` order) plus the declared feature
+    stores (first-root-wins, mirroring `load_feature_rows`). Purely
+    mechanical file-byte hashing, no parsing. Returns None when no dataset
+    file exists (research-only jobs)."""
+    dataset_path = next(
+        (
+            path
+            for root in (candidate_dir, job_dir)
+            for path in (
+                root / "results" / "backtest" / "input_bars.json",
+                root / "workspace" / "config" / "backtest_bars.json",
+            )
+            if path.exists()
+        ),
+        None,
+    )
+    if dataset_path is None:
+        return None
+    fingerprint: dict[str, Any] = {
+        "path": str(dataset_path),
+        "sha256": _file_sha256(dataset_path),
+        "bytes": dataset_path.stat().st_size,
+    }
+    features: dict[str, str] = {}
+    for relative in dict.fromkeys(feature_paths):
+        chosen = next(
+            (
+                root / relative
+                for root in (candidate_dir, job_dir)
+                if (root / relative).exists()
+            ),
+            None,
+        )
+        if chosen is not None:
+            features[str(relative)] = _file_sha256(chosen)
+    if features:
+        fingerprint["features"] = features
+    return fingerprint
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def evaluate_live_gate(

--- a/wayfinder_paths/jobs/proposals.py
+++ b/wayfinder_paths/jobs/proposals.py
@@ -51,7 +51,11 @@ from wayfinder_paths.jobs.improver.spec import (
 from wayfinder_paths.jobs.models import utc_now_iso
 from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.jobs.sync import sync_all_jobs
-from wayfinder_paths.jobs.validation import validation_failure_text, validation_summary
+from wayfinder_paths.jobs.validation import (
+    candidate_dataset_fingerprint,
+    validation_failure_text,
+    validation_summary,
+)
 from wayfinder_paths.jobs.worker import JOB_RESULT_MARKER
 
 PROPOSAL_KINDS = {"code_change", "params_update", "model_update", "improver_change"}
@@ -398,6 +402,15 @@ def _generate_candidate_report(
         "mode": mode,
         "gate": gate_payload,
         "economic": economic,
+        # Content hash of the dataset (+ declared feature stores) this
+        # report's backtest consumed. The apply pipeline re-derives it and
+        # skips the expensive re-validation when it (and the candidate
+        # revision) provably match — see application.assess_validation_reuse.
+        "dataset_fingerprint": (
+            candidate_dataset_fingerprint(candidate_dir, store.job_dir(job_id))
+            if mode == "full"
+            else None
+        ),
         "validation_summary": validation_summary(validation),
         # Stats/deltas only — never point series (sync payload discipline).
         "comparison": (

--- a/wayfinder_paths/jobs/validation.py
+++ b/wayfinder_paths/jobs/validation.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import yaml
 
+from wayfinder_paths.jobs.execution.features import parse_feature_specs
 from wayfinder_paths.jobs.execution.job import _load_dataset
 from wayfinder_paths.jobs.execution.preflight import run_preflight
 from wayfinder_paths.jobs.execution.primitives import ExecutionSpec
@@ -22,9 +23,13 @@ from wayfinder_paths.jobs.execution.simulator import (
 from wayfinder_paths.jobs.execution.validation import (
     FORBIDDEN_ORDER_PATTERNS,
     entrypoint_inside_workspace_check,
+    resolve_execution_spec,
 )
 from wayfinder_paths.jobs.failures import classify_failure
-from wayfinder_paths.jobs.gating import compute_workspace_revision
+from wayfinder_paths.jobs.gating import (
+    compute_workspace_revision,
+    dataset_content_fingerprint,
+)
 from wayfinder_paths.jobs.models import utc_now_iso
 from wayfinder_paths.jobs.store import JobStore
 
@@ -47,13 +52,19 @@ def validate_candidate_application(
     candidate_dir: Path,
     require_judge: bool = False,
     allow_legacy: bool = False,
+    skip_behavior_checks: bool = False,
 ) -> dict[str, Any]:
     """Validate an approved job application candidate before promotion.
 
     The validator intentionally checks the candidate artifacts, not the active
     job workspace. It is deterministic: no market reads, no order tools, and no
     model calls. The optional judge result can be supplied by a separate worker.
-    """
+
+    `skip_behavior_checks=True` drops ONLY the expensive behavioral half
+    (full-dataset candidate backtest + preflight, `_candidate_behavior_checks`)
+    and keeps every cheap invariant. Callers may set it exclusively when the
+    propose-time evidence is provably reusable (see
+    `application.assess_validation_reuse`)."""
 
     checks: list[dict[str, Any]] = []
     candidate_job_yaml = candidate_dir / "job.yaml"
@@ -130,15 +141,16 @@ def validate_candidate_application(
         if contract == "jobs_v1":
             checks.extend(_jobs_v1_script_checks(script_path))
             checks.extend(_engine_scenario_checks(script_path, proposal, job_data))
-            checks.extend(
-                _candidate_behavior_checks(
-                    repo_root=repo_root,
-                    job_dir=job_dir,
-                    candidate_dir=candidate_dir,
-                    job_data=job_data,
-                    script_path=script_path,
+            if not skip_behavior_checks:
+                checks.extend(
+                    _candidate_behavior_checks(
+                        repo_root=repo_root,
+                        job_dir=job_dir,
+                        candidate_dir=candidate_dir,
+                        job_data=job_data,
+                        script_path=script_path,
+                    )
                 )
-            )
         else:
             checks.extend(_script_static_checks(script_path))
             checks.extend(_scenario_checks(script_path, proposal))
@@ -368,6 +380,40 @@ def _candidate_behavior_checks(
             {"name": "candidate_preflight_passed", "passed": False, "error": str(exc)}
         )
     return checks
+
+
+def candidate_dataset_fingerprint(
+    candidate_dir: Path, job_dir: Path
+) -> dict[str, Any] | None:
+    """Fingerprint of the dataset + declared feature stores the candidate
+    backtest consumes — the evidence-reuse identity recorded in the
+    candidate_report at propose time and re-derived at apply time (see
+    `application.assess_validation_reuse`). Resolves the execution spec from
+    the candidate bundle so the declared feature paths match what
+    `_candidate_behavior_checks` would actually merge."""
+    job_yaml = candidate_dir / "job.yaml"
+    job_data: dict[str, Any] = {}
+    if job_yaml.exists():
+        try:
+            loaded = yaml.safe_load(job_yaml.read_text(encoding="utf-8")) or {}
+            match loaded:
+                case dict():
+                    job_data = loaded
+        except yaml.YAMLError:
+            job_data = {}
+    spec_data, _ = resolve_execution_spec(candidate_dir, job_data)
+    feature_paths: tuple[str, ...] = ()
+    if spec_data:
+        try:
+            specs = parse_feature_specs(ExecutionSpec.from_dict(spec_data))
+            feature_paths = tuple(item.path for item in specs)
+        except ValueError:
+            # Malformed feature schema fails its own validation check; the
+            # fingerprint stays dataset-only rather than blocking here.
+            feature_paths = ()
+    return dataset_content_fingerprint(
+        candidate_dir, job_dir, feature_paths=feature_paths
+    )
 
 
 def _intent_contract_checks(proposal: Mapping[str, Any]) -> list[dict[str, Any]]:

--- a/wayfinder_paths/tests/test_jobs_apply_evidence_reuse.py
+++ b/wayfinder_paths/tests/test_jobs_apply_evidence_reuse.py
@@ -1,0 +1,358 @@
+"""Apply-time evidence reuse: a proposal validated in full at propose time
+(candidate backtest + preflight + execution validation + economic gate) must
+not re-run the expensive candidate backtest at apply time when the candidate,
+dataset, and baseline are PROVABLY unchanged and the frozen evidence is green.
+Covers the eligibility matrix (`assess_validation_reuse`), the journal
+contract (`apply_validation_reused` / `apply_validation_rerun`), the
+kill-switch, the propose-time dataset fingerprint, and the 2026-08 production
+incident shape (one-line params change re-backtested for 30+ minutes with
+trading lanes paused)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from wayfinder_paths.jobs import validation as validation_module
+from wayfinder_paths.jobs.application import (
+    assess_validation_reuse,
+    claim_application,
+    complete_application,
+)
+from wayfinder_paths.jobs.gating import (
+    dataset_content_fingerprint,
+    evaluate_live_gate,
+)
+from wayfinder_paths.jobs.proposals import propose_change
+from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.tests.test_jobs_application_gate import _patch_runner
+from wayfinder_paths.tests.test_jobs_gating import _make_job
+from wayfinder_paths.tests.test_wayfinder_jobs import _intent_contract
+
+
+def _count_behavior_checks(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Count invocations of the expensive behavioral half (full-dataset
+    candidate backtest + preflight) without changing its behavior."""
+    calls: list[str] = []
+    real = validation_module._candidate_behavior_checks
+
+    def counting(**kwargs: Any) -> list[dict[str, Any]]:
+        calls.append(str(kwargs.get("candidate_dir")))
+        return real(**kwargs)
+
+    monkeypatch.setattr(validation_module, "_candidate_behavior_checks", counting)
+    return calls
+
+
+def _ready_economic(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+    return {
+        "ready": True,
+        "reasons": [],
+        "enforcement": "advisory",
+        "constitution_revision": None,
+        "status": "evaluated",
+    }
+
+
+def _journal_entries(store: JobStore, job_id: str) -> list[dict[str, Any]]:
+    path = store.job_dir(job_id) / "journal.jsonl"
+    if not path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _entries_of(store: JobStore, job_id: str, kind: str) -> list[dict[str, Any]]:
+    return [item for item in _journal_entries(store, job_id) if item["type"] == kind]
+
+
+def _proposed_and_claimed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    params: dict[str, Any] | None = None,
+) -> tuple[JobStore, str, Path, str]:
+    _patch_runner(monkeypatch)
+    # The 8-bar fixture's real economic verdict is ready=False (insufficient
+    # history); reuse requires green frozen evidence, so neutralize it.
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.proposals.evaluate_economic_gate", _ready_economic
+    )
+    store, job_id, root = _make_job(tmp_path)
+    proposal = propose_change(
+        store,
+        job_id,
+        kind="params_update",
+        summary="Disable the short leg.",
+        intent_contract=_intent_contract(),
+        params=params or {"hype_short_enabled": False},
+    )
+    pid = proposal["proposal_id"]
+    store.approve_proposal(job_id, pid)
+    claim_application(store, job_id, pid)
+    return store, job_id, root, pid
+
+
+def _mutate_report(store: JobStore, job_id: str, pid: str, **updates: Any) -> None:
+    proposal = store.load_proposal(job_id, pid)
+    report = proposal["candidate_report"]
+    for key, value in updates.items():
+        if value is None:
+            report.pop(key, None)
+        else:
+            report[key] = value
+    store.write_proposal(job_id, proposal)
+
+
+def test_incident_shape_green_unchanged_apply_skips_revalidation_backtest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The production incident: a one-line params proposal validated in full
+    at propose time, approved minutes later, then re-backtested for 30+
+    minutes at apply with trading lanes paused — while the journal's own
+    `candidate_reused` proved the bundle was identical. With green frozen
+    evidence + unchanged candidate + unchanged dataset, apply must reuse."""
+    store, job_id, root, pid = _proposed_and_claimed(tmp_path, monkeypatch)
+    assert _entries_of(store, job_id, "candidate_reused"), "claim reused candidate"
+    behavior_calls = _count_behavior_checks(monkeypatch)
+
+    completed = complete_application(store, job_id, pid, status="applied")
+
+    assert completed["proposal"]["application"]["status"] == "applied"
+    assert behavior_calls == [], "candidate backtest must NOT re-run"
+    assert not _entries_of(store, job_id, "apply_validation_rerun")
+    reused = _entries_of(store, job_id, "apply_validation_reused")
+    assert len(reused) == 1
+    deterministic = completed["deterministic_validation"]
+    assert deterministic["status"] == "reused"
+    assert deterministic["source"] == "propose-time report"
+    assert deterministic["reused_summary"]["status"] == "passed"
+    proof = deterministic["reuse_proof"]
+    report = store.load_proposal(job_id, pid)["candidate_report"]
+    assert proof["candidate_revision"] == report["revision"]
+    assert proof["base_revision"] == report["base_revision"]
+    assert proof["dataset_fingerprint"] == report["dataset_fingerprint"]
+    assert proof["report_hash"]
+    for key in ("base_revision", "candidate_revision", "dataset_fingerprint"):
+        assert reused[0][key] == proof[key]
+    # Cheap invariants still ran and the promotion is fully wired.
+    assert deterministic["checks"]
+    assert store.load(job_id).execution_params["hype_short_enabled"] is False
+    assert evaluate_live_gate(job_id, store=store)["live_ready"] is True
+
+
+def test_pause_resume_window_unchanged_on_reuse(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reuse shortens the pause window; it must not change its shape — loops
+    pause at claim and resume at completion exactly as before."""
+    _patch_runner(monkeypatch)
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.proposals.evaluate_economic_gate", _ready_economic
+    )
+    store, job_id, root = _make_job(tmp_path)
+    job = store.load(job_id)
+    job.script_loop.runner_job_name = "job-gate-demo"
+    store.save(job)
+    proposal = propose_change(
+        store,
+        job_id,
+        kind="params_update",
+        summary="Disable the short leg.",
+        intent_contract=_intent_contract(),
+        params={"hype_short_enabled": False},
+    )
+    pid = proposal["proposal_id"]
+    store.approve_proposal(job_id, pid)
+    calls = _patch_runner(monkeypatch)
+    claim_application(store, job_id, pid)
+    completed = complete_application(store, job_id, pid, status="applied")
+
+    assert completed["deterministic_validation"]["status"] == "reused"
+    assert ("pause", "job-gate-demo") in calls
+    assert ("resume", "job-gate-demo") in calls
+
+
+def test_mutated_candidate_forces_full_revalidation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job_id, root, pid = _proposed_and_claimed(tmp_path, monkeypatch)
+    candidate_script = (
+        root / "applications" / pid / "candidate" / "workspace" / "src" / "strategy.py"
+    )
+    candidate_script.write_text(
+        candidate_script.read_text(encoding="utf-8") + "\n# mutated after report\n",
+        encoding="utf-8",
+    )
+    behavior_calls = _count_behavior_checks(monkeypatch)
+
+    completed = complete_application(store, job_id, pid, status="applied")
+
+    assert len(behavior_calls) == 1, "full re-validation must run"
+    rerun = _entries_of(store, job_id, "apply_validation_rerun")
+    assert rerun and rerun[0]["reason"] == "candidate_mismatch"
+    assert not _entries_of(store, job_id, "apply_validation_reused")
+    assert completed["deterministic_validation"]["status"] == "passed"
+
+
+def test_changed_dataset_fingerprint_forces_full_revalidation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job_id, root, pid = _proposed_and_claimed(tmp_path, monkeypatch)
+    bars_path = root / "results" / "backtest" / "input_bars.json"
+    # Byte-different, parse-identical: the fingerprint is content-derived,
+    # so ANY dataset rewrite invalidates the frozen evidence.
+    bars_path.write_text(
+        json.dumps(json.loads(bars_path.read_text(encoding="utf-8")), indent=2),
+        encoding="utf-8",
+    )
+    behavior_calls = _count_behavior_checks(monkeypatch)
+
+    completed = complete_application(store, job_id, pid, status="applied")
+
+    assert len(behavior_calls) == 1
+    rerun = _entries_of(store, job_id, "apply_validation_rerun")
+    assert rerun and rerun[0]["reason"] == "dataset_changed"
+    assert completed["proposal"]["application"]["status"] == "applied"
+
+
+@pytest.mark.parametrize(
+    ("updates", "reason"),
+    [
+        (
+            {"validation_summary": {"status": "failed", "failed_checks": []}},
+            "report_not_green",
+        ),
+        ({"economic": {"ready": False, "reasons": ["regression"]}}, "report_not_green"),
+        ({"economic": {"ready": None, "reasons": ["crashed"]}}, "report_not_green"),
+        ({"dataset_fingerprint": None}, "no_dataset_fingerprint"),
+        ({"mode": "validation_only"}, "report_missing_or_not_full"),
+    ],
+)
+def test_non_reusable_frozen_evidence_forces_full_revalidation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    updates: dict[str, Any],
+    reason: str,
+) -> None:
+    """Failed/poisoned/absent frozen evidence is never reused — the apply
+    falls back to today's authoritative full re-validation."""
+    store, job_id, root, pid = _proposed_and_claimed(tmp_path, monkeypatch)
+    _mutate_report(store, job_id, pid, **updates)
+    behavior_calls = _count_behavior_checks(monkeypatch)
+
+    completed = complete_application(store, job_id, pid, status="applied")
+
+    assert len(behavior_calls) == 1
+    rerun = _entries_of(store, job_id, "apply_validation_rerun")
+    assert rerun and rerun[0]["reason"] == reason
+    assert completed["proposal"]["application"]["status"] == "applied"
+
+
+def test_kill_switch_forces_full_revalidation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job_id, root, pid = _proposed_and_claimed(tmp_path, monkeypatch)
+    monkeypatch.setenv("WAYFINDER_APPLY_ALWAYS_REVALIDATE", "1")
+    behavior_calls = _count_behavior_checks(monkeypatch)
+
+    completed = complete_application(store, job_id, pid, status="applied")
+
+    assert len(behavior_calls) == 1
+    rerun = _entries_of(store, job_id, "apply_validation_rerun")
+    assert rerun and rerun[0]["reason"] == "kill_switch"
+    assert completed["proposal"]["application"]["status"] == "applied"
+
+
+def test_assess_reuse_reports_baseline_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An active workspace moved past the staged base is never reusable (the
+    drift guard refuses the promotion outright; the assessment is
+    self-contained and must agree)."""
+    store, job_id, root, pid = _proposed_and_claimed(tmp_path, monkeypatch)
+    active_script = root / "workspace" / "src" / "strategy.py"
+    active_script.write_text(
+        active_script.read_text(encoding="utf-8") + "\n# intervening apply\n",
+        encoding="utf-8",
+    )
+
+    proposal = store.load_proposal(job_id, pid)
+    result = assess_validation_reuse(
+        store, job_id, proposal, root / "applications" / pid / "candidate"
+    )
+
+    assert result["eligible"] is False
+    assert result["reason"] == "baseline_drift"
+
+
+def test_propose_records_dataset_fingerprint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_runner(monkeypatch)
+    store, job_id, root = _make_job(tmp_path)
+    proposal = propose_change(
+        store,
+        job_id,
+        kind="params_update",
+        summary="Loosen the entry threshold.",
+        intent_contract=_intent_contract(),
+        params={"threshold": 10.7},
+    )
+
+    fingerprint = proposal["candidate_report"]["dataset_fingerprint"]
+    bars_path = root / "results" / "backtest" / "input_bars.json"
+    assert fingerprint["path"] == str(bars_path)
+    assert fingerprint["sha256"] == hashlib.sha256(bars_path.read_bytes()).hexdigest()
+    assert fingerprint["bytes"] == bars_path.stat().st_size
+
+
+def test_dataset_content_fingerprint_resolution_and_features(
+    tmp_path: Path,
+) -> None:
+    candidate_dir = tmp_path / "candidate"
+    job_dir = tmp_path / "job"
+    for base in (candidate_dir, job_dir):
+        base.mkdir()
+
+    assert dataset_content_fingerprint(candidate_dir, job_dir) is None
+
+    job_bars = job_dir / "results" / "backtest" / "input_bars.json"
+    job_bars.parent.mkdir(parents=True)
+    job_bars.write_text("[1, 2, 3]", encoding="utf-8")
+    from_job = dataset_content_fingerprint(candidate_dir, job_dir)
+    assert from_job is not None
+    assert from_job["path"] == str(job_bars)
+    assert from_job["sha256"] == hashlib.sha256(b"[1, 2, 3]").hexdigest()
+
+    # Candidate-bundle bars win over the job root (mirrors _resolve_dataset).
+    candidate_bars = candidate_dir / "workspace" / "config" / "backtest_bars.json"
+    candidate_bars.parent.mkdir(parents=True)
+    candidate_bars.write_text("[4]", encoding="utf-8")
+    from_candidate = dataset_content_fingerprint(candidate_dir, job_dir)
+    assert from_candidate is not None
+    assert from_candidate["path"] == str(candidate_bars)
+
+    # Declared feature stores ride in the fingerprint, first-root-wins.
+    job_features = job_dir / "state" / "features.jsonl"
+    job_features.parent.mkdir(parents=True)
+    job_features.write_text('{"name": "funding"}\n', encoding="utf-8")
+    with_features = dataset_content_fingerprint(
+        candidate_dir, job_dir, feature_paths=("state/features.jsonl",)
+    )
+    assert with_features is not None
+    assert with_features["features"] == {
+        "state/features.jsonl": hashlib.sha256(job_features.read_bytes()).hexdigest()
+    }
+    job_features.write_text('{"name": "funding", "value": 1}\n', encoding="utf-8")
+    moved = dataset_content_fingerprint(
+        candidate_dir, job_dir, feature_paths=("state/features.jsonl",)
+    )
+    assert moved != with_features, "feature churn must invalidate the fingerprint"


### PR DESCRIPTION
## Problem (production incident)

A one-line params proposal (`hype_short_enabled=false`) was proposed with FULL validation (34,561-bar backtest + walk-forward + economic gate, ~35 min), approved minutes later through the FE (the approve gate read the frozen report), and then the APPLY re-ran a full validation backtest for another 30+ minutes — with trading lanes paused the whole window. The apply journal even logged `candidate_reused`: the pipeline already knew the bundle was byte-identical.

The expensive work lives in `validation.py::_candidate_behavior_checks` — the full-dataset `simulate_execution` under `heavy_compute_lock` plus `run_preflight` — invoked at apply time by `application.py::_complete_applied_application` even though the propose flow ran the exact same validation against the exact same candidate content.

## Change

**Evidence-reuse eligibility check** (`application.assess_validation_reuse(store, job_id, proposal, candidate_dir) -> {eligible, reason, proof}`) runs before the expensive re-validation. Every condition is mechanical (content hashes and frozen-field reads), never trust-based:

1. kill-switch off — `WAYFINDER_APPLY_ALWAYS_REVALIDATE=1` forces the old full re-validation path
2. frozen `candidate_report` present, `mode == "full"`, with a revision
3. active workspace revision still ∈ {base, candidate} (no baseline drift; restates the drift guard that runs just above)
4. candidate dir still hashes to the report's revision — same content equivalence as `store._ensure_candidate_matches_report`
5. dataset unchanged: the `dataset_fingerprint` recorded in the candidate_report at propose time (**new in this PR** — the report previously carried only dataset *metadata*: days/interval/fetched_at/source path, no content hash) matches the fingerprint re-derived at apply time. Fingerprint = sha256 of the resolved input-bars file (+ each declared feature store, first-root-wins), mirroring `_resolve_dataset` / `load_feature_rows` resolution order. Helpers: `gating.dataset_content_fingerprint(candidate_dir, job_dir, *, feature_paths=())` (pure, path-based) and `validation.candidate_dataset_fingerprint(candidate_dir, job_dir)` (spec-aware wrapper)
6. the frozen evidence is green: `validation_summary.status == "passed"` AND `economic.ready is True` — failed/poisoned evidence is never reused

**When ALL hold**: the candidate backtest + preflight are skipped. Every cheap invariant still runs (`validate_candidate_application(..., skip_behavior_checks=True)` + execution validation: compile, scenario sims, config-merge sanity, report reads — seconds). `deterministic_validation` records `status: "reused"`, `source: "propose-time report"`, the copied `reused_summary`, and a `reuse_proof` {base/candidate/active revisions, dataset_fingerprint, report_hash}. Journal: `apply_validation_reused` with the proof fields. Promotion/compile/rollback unchanged.

**When ANY fails**: today's full re-validation runs unchanged; journal `apply_validation_rerun` with the failed condition (`kill_switch` / `report_missing_or_not_full` / `baseline_drift` / `candidate_mismatch` / `dataset_changed` / `no_dataset_fingerprint` / `report_not_green` / `cheap_invariants_failed`). Proposals created before this PR carry no fingerprint → automatic safe fallback.

**Effect**: param-update applies drop from ~30 min to ~1-3 min, trading-lane pause windows shrink correspondingly, and the apply-time heavy-compute/RSS collision window mostly disappears.

## Tests

New `wayfinder_paths/tests/test_jobs_apply_evidence_reuse.py` (13 tests, real propose→approve→claim→complete flow on the 8-bar jobs_v1 fixture, counting `_candidate_behavior_checks` invocations):
- incident-shape regression: green fresh report + `candidate_reused` + same dataset → backtest NOT re-run, `apply_validation_reused` journaled with proof, promotion + live gate green
- pause/resume window shape unchanged on reuse
- each condition individually broken → full re-validation + `apply_validation_rerun` with reason: mutated candidate file, byte-changed dataset, failed validation_summary, economic ready False/None, missing fingerprint, non-full mode
- kill-switch forces rerun
- baseline-drift assessment unit test
- propose-time report records the dataset fingerprint (path + sha256 + bytes)
- `dataset_content_fingerprint` resolution order + feature-store churn invalidation

`pytest -k "jobs or runner or mcp"`: **1103 passed, 3 skipped** (baseline before change: 1090 passed, 3 skipped). ruff check + format clean; scoped mypy on the four touched modules introduces no new errors (remaining hits are pre-existing lines: yaml stubs, `_build_comparison`, claim-descriptor bool).