### PR TITLE
Runner - Nice scheduled jobs so interactive work wins

### DIFF
--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -39,6 +39,11 @@ from wayfinder_paths.runner.schedule import (
 from wayfinder_paths.runner.script_resolver import resolve_script_path
 
 JOB_RESULT_MARKER = "WAYFINDER_JOB_RESULT "
+# Scheduled jobs are background work; run them at the lowest CPU priority so
+# foreground/interactive processes preempt them under contention. Jobs still run
+# full-speed on an idle machine — they only yield when something else needs the
+# CPU. Inherited by any subprocess the job spawns.
+JOB_NICE = 19
 JOB_LOCK_TIMEOUT_SECONDS = 3
 JOB_LOCK_BUSY_MSG = (
     "Runner Daemon lock is busy, no operations were completed, please try again later"
@@ -47,6 +52,15 @@ SESSION_ENV_KEYS = (
     "OPENCODE_SESSION_ID",
     "OPENCODE_SESSIONID",
 )
+
+
+def _deprioritize() -> None:
+    """preexec_fn: drop the child to the lowest CPU priority (see JOB_NICE).
+    Best-effort — a nice() failure must not stop the job from launching."""
+    try:
+        os.nice(JOB_NICE)
+    except OSError:
+        pass
 
 
 def _safe_job_dirname(name: str) -> str:
@@ -594,6 +608,7 @@ class RunnerDaemon:
                     stdout=log_f,
                     stderr=subprocess.STDOUT,
                     start_new_session=True,
+                    preexec_fn=_deprioritize,  # noqa: PLW1509
                 )
         except Exception as exc:  # noqa: BLE001
             err_text = f"spawn failed: {exc}"

--- a/wayfinder_paths/tests/test_runner_job_priority.py
+++ b/wayfinder_paths/tests/test_runner_job_priority.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+from wayfinder_paths.runner.daemon import JOB_NICE, _deprioritize
+
+
+def test_deprioritize_sets_lowest_nice() -> None:
+    """A subprocess launched with _deprioritize as preexec_fn runs at JOB_NICE;
+    a plain one stays at 0 — so scheduled jobs yield to interactive work."""
+    read_nice = "import os;print(os.getpriority(os.PRIO_PROCESS,0))"
+    niced = subprocess.check_output(
+        [sys.executable, "-c", read_nice], preexec_fn=_deprioritize
+    )
+    control = subprocess.check_output([sys.executable, "-c", read_nice])
+    assert int(niced.decode().strip()) == JOB_NICE
+    assert int(control.decode().strip()) == 0


### PR DESCRIPTION
### Summary

On a shared-CPU machine, the scheduled-job fleet (each job is a fresh Python subprocess, and jobs can spawn heavy backtests) competes for the same cores as the interactive agent and on-demand chart/forward-view processes — so heavy background work makes the foreground lag.

This launches every scheduled-job subprocess with a `preexec_fn` that drops it to **nice 19** (lowest priority). Under CPU contention the kernel preempts jobs in favor of foreground/interactive processes; on an idle machine jobs still run full-speed — they only yield when something else needs the CPU. The niceness is inherited by anything the job spawns (e.g. a backtest).

Notes:
- Best-effort: a `nice()` failure never blocks the job from launching.
- No throughput loss when idle; this only changes *who wins under contention*.
- A hard CPU cap (cgroup `cpu.max`) isn't available from inside the container (the cgroup tree is read-only), so priority is the right lever here.

Test: `test_runner_job_priority` asserts a `preexec_fn=_deprioritize` child runs at nice 19 while a plain child stays at 0.