### PR TITLE
jobs: operator CLIs for wallet binding and initial capital

### DIFF
--- a/.venv
+++ b/.venv
@@ -1,0 +1,1 @@
+/Users/felixchen/Desktop/wayfinder-paths-sdk/.venv

--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -80,7 +80,9 @@ from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.jobs.strategies import library_catalog
 from wayfinder_paths.jobs.sync import (
     apply_execution_leverage,
+    apply_initial_capital,
     apply_script_mode,
+    apply_wallet_label,
     snapshot_job,
     sync_all_jobs,
 )
@@ -1412,6 +1414,36 @@ def set_script_mode_cmd(job_id: str, mode: str, set_by: str, force: bool) -> Non
 def set_leverage_cmd(job_id: str, leverage: float) -> None:
     try:
         result = apply_execution_leverage(job_id, leverage)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+    _echo_json({"ok": True, "result": result})
+
+
+@job_cli.command(
+    name="set-wallet-label",
+    help="Bind the funded wallet a live job trades from "
+    "(execution_params.wallet_label). Takes effect next tick, no recompile.",
+)
+@click.argument("job_id")
+@click.argument("label")
+def set_wallet_label_cmd(job_id: str, label: str) -> None:
+    try:
+        result = apply_wallet_label(job_id, label)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+    _echo_json({"ok": True, "result": result})
+
+
+@job_cli.command(
+    name="set-initial-capital",
+    help="Operator accounting knob: set execution_params.initial_capital to "
+    "what the strategy wallet actually holds (USD). Takes effect next tick.",
+)
+@click.argument("job_id")
+@click.argument("amount", type=float)
+def set_initial_capital_cmd(job_id: str, amount: float) -> None:
+    try:
+        result = apply_initial_capital(job_id, amount)
     except ValueError as exc:
         raise click.ClickException(str(exc)) from exc
     _echo_json({"ok": True, "result": result})

--- a/wayfinder_paths/jobs/sync.py
+++ b/wayfinder_paths/jobs/sync.py
@@ -471,6 +471,58 @@ def apply_execution_leverage(
     }
 
 
+def apply_wallet_label(
+    job_id: str, label: str, *, store: JobStore | None = None
+) -> dict[str, Any]:
+    """Bind the funded wallet a live job trades from
+    (``execution_params.wallet_label``). Routing, not strategy logic — the
+    field is excluded from the workspace revision hash, so binding never
+    orphans the gate stamps. Params are re-read every tick; no recompile."""
+    cleaned = str(label).strip()
+    if not cleaned:
+        raise ValueError("wallet label cannot be empty")
+    store = store or JobStore()
+    job = store.load(job_id)
+    previous = job.execution_params.get("wallet_label")
+    job.execution_params["wallet_label"] = cleaned
+    job.touch()
+    store.save(job)
+    store.append_journal(
+        job_id,
+        {"type": "operator_wallet_label_set", "from": previous, "to": cleaned},
+    )
+    sync_all_jobs(store=store)
+    return {"job_id": job_id, "wallet_label": cleaned, "previous": previous}
+
+
+def apply_initial_capital(
+    job_id: str, amount: float, *, store: JobStore | None = None
+) -> dict[str, Any]:
+    """Operator accounting knob: ``execution_params.initial_capital`` — the
+    equity base live sizing compounds from. Set it to what the strategy
+    wallet actually holds; a mismatch makes the engine size against money
+    that isn't there. Excluded from the revision hash; applies next tick.
+
+    Zero is allowed deliberately: withdrawing the full bankroll should read
+    as "unfunded", which fails validation's initial_capital_declared check
+    and turns the live gate red — the honest state."""
+    value = float(amount)
+    if value < 0:
+        raise ValueError(f"initial capital cannot be negative, got {value:g}")
+    store = store or JobStore()
+    job = store.load(job_id)
+    previous = job.execution_params.get("initial_capital")
+    job.execution_params["initial_capital"] = value
+    job.touch()
+    store.save(job)
+    store.append_journal(
+        job_id,
+        {"type": "operator_initial_capital_set", "from": previous, "to": value},
+    )
+    sync_all_jobs(store=store)
+    return {"job_id": job_id, "initial_capital": value, "previous": previous}
+
+
 def _shadow_topline(store: JobStore, job_id: str) -> dict[str, Any]:
     """Read-only topline of the post-apply counterfactual for the UI — the
     artifact is computed on the wake path, never during sync."""

--- a/wayfinder_paths/tests/test_jobs_funding_knobs.py
+++ b/wayfinder_paths/tests/test_jobs_funding_knobs.py
@@ -1,0 +1,134 @@
+"""Operator funding knobs: wallet_label (which funded wallet a live job
+trades from) and initial_capital (the equity base live sizing compounds
+from) + their CLI surfaces. Both are revision-hash-excluded routing/
+accounting fields — pinned here so binding a wallet or recording a deposit
+never orphans the gate stamps."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from wayfinder_paths.jobs.gating import compute_workspace_revision
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.jobs.sync import apply_initial_capital, apply_wallet_label
+
+
+def _job(tmp_path) -> tuple[JobStore, str]:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("fund-demo", agent_mode="intervene")
+    job.execution_params["initial_capital"] = 10_000.0
+    store.save(job)
+    return store, job.id
+
+
+def test_apply_wallet_label_writes_journals_and_keeps_revision(
+    tmp_path, monkeypatch
+) -> None:
+    store, job_id = _job(tmp_path)
+    synced: list[bool] = []
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.sync.sync_all_jobs",
+        lambda **kwargs: synced.append(True),
+    )
+    before = compute_workspace_revision(store.job_dir(job_id))
+
+    result = apply_wallet_label(job_id, "fund-demo", store=store)
+    assert result == {
+        "job_id": job_id,
+        "wallet_label": "fund-demo",
+        "previous": None,
+    }
+    assert store.load(job_id).execution_params["wallet_label"] == "fund-demo"
+    assert synced == [True]
+    # Routing knob: the gate stamps must survive the bind.
+    assert compute_workspace_revision(store.job_dir(job_id)) == before
+    journal = (store.job_dir(job_id) / "journal.jsonl").read_text(encoding="utf-8")
+    row = json.loads(journal.strip().splitlines()[-1])
+    assert row["type"] == "operator_wallet_label_set"
+    assert row["to"] == "fund-demo"
+
+
+def test_apply_wallet_label_rejects_empty(tmp_path) -> None:
+    store, job_id = _job(tmp_path)
+    with pytest.raises(ValueError):
+        apply_wallet_label(job_id, "   ", store=store)
+
+
+def test_apply_initial_capital_writes_journals_and_keeps_revision(
+    tmp_path, monkeypatch
+) -> None:
+    store, job_id = _job(tmp_path)
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.sync.sync_all_jobs", lambda **kwargs: None
+    )
+    before = compute_workspace_revision(store.job_dir(job_id))
+
+    result = apply_initial_capital(job_id, 250.0, store=store)
+    assert result == {
+        "job_id": job_id,
+        "initial_capital": 250.0,
+        "previous": 10_000.0,
+    }
+    assert store.load(job_id).execution_params["initial_capital"] == 250.0
+    assert compute_workspace_revision(store.job_dir(job_id)) == before
+    journal = (store.job_dir(job_id) / "journal.jsonl").read_text(encoding="utf-8")
+    row = json.loads(journal.strip().splitlines()[-1])
+    assert row["type"] == "operator_initial_capital_set"
+    assert row["from"] == 10_000.0
+    assert row["to"] == 250.0
+
+
+def test_apply_initial_capital_zero_ok_negative_rejected(tmp_path, monkeypatch) -> None:
+    store, job_id = _job(tmp_path)
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.sync.sync_all_jobs", lambda **kwargs: None
+    )
+    # Full withdrawal: zero is the honest "unfunded" state, allowed.
+    assert apply_initial_capital(job_id, 0, store=store)["initial_capital"] == 0.0
+    with pytest.raises(ValueError):
+        apply_initial_capital(job_id, -1, store=store)
+
+
+def test_funding_knob_clis_round_trip(tmp_path, monkeypatch) -> None:
+    from wayfinder_paths.jobs import cli as cli_module
+
+    store, job_id = _job(tmp_path)
+    monkeypatch.setattr(
+        cli_module,
+        "apply_wallet_label",
+        lambda jid, label: {"job_id": jid, "wallet_label": label, "previous": None},
+    )
+    monkeypatch.setattr(
+        cli_module,
+        "apply_initial_capital",
+        lambda jid, amount: {
+            "job_id": jid,
+            "initial_capital": amount,
+            "previous": None,
+        },
+    )
+    runner = CliRunner()
+
+    outcome = runner.invoke(
+        cli_module.job_cli, ["set-wallet-label", job_id, "fund-demo"]
+    )
+    assert outcome.exit_code == 0, outcome.output
+    assert json.loads(outcome.output)["result"]["wallet_label"] == "fund-demo"
+
+    outcome = runner.invoke(cli_module.job_cli, ["set-initial-capital", job_id, "75.5"])
+    assert outcome.exit_code == 0, outcome.output
+    assert json.loads(outcome.output)["result"]["initial_capital"] == 75.5
+
+    # Errors surface as clean CLI errors, not tracebacks.
+    monkeypatch.setattr(
+        cli_module,
+        "apply_wallet_label",
+        lambda jid, label: (_ for _ in ()).throw(ValueError("wallet label")),
+    )
+    outcome = runner.invoke(cli_module.job_cli, ["set-wallet-label", job_id, " "])
+    assert outcome.exit_code != 0
+    assert "wallet label" in outcome.output


### PR DESCRIPTION
### Summary
Two operator knobs the backend's go-live/funding actions drive: `wayfinder job set-wallet-label <job> <label>` (binds `execution_params.wallet_label`) and `wayfinder job set-initial-capital <job> <amount>` (sets `execution_params.initial_capital`). Mirrors `set-leverage`: sync helper + journal entry + re-sync, ClickException on bad input. Both fields are revision-hash-excluded, so applying them keeps the live gate green — pinned by tests. Zero capital is deliberately allowed: a full withdrawal should read as unfunded and turn the gate red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)