### PR TITLE
fix: surface the latest starter first

### DIFF
--- a/wayfinder_paths/jobs/starters.py
+++ b/wayfinder_paths/jobs/starters.py
@@ -29,7 +29,8 @@ from wayfinder_paths.jobs.strategies._starter_utils import (
     RANKING_STOP_DEFAULTS,
 )
 
-STARTER_CATALOG_VERSION = "1.9.0"
+STARTER_CATALOG_VERSION = "1.10.0"
+_FEATURED_STARTER_ID = "crypto-momentum-persistence-4h"
 STARTER_STRATEGY_INCEPTION_AT = "2026-08-24T00:00:00+00:00"
 # Catalog launch policy: every off-the-shelf starter launches with the agent
 # loop ON in intervene mode. Fleet evidence (two launches of the identical
@@ -1300,7 +1301,11 @@ STARTER_DEFINITIONS: tuple[StarterDefinition, ...] = (
 
 
 def starter_catalog() -> list[dict[str, Any]]:
-    return [definition.to_dict() for definition in STARTER_DEFINITIONS]
+    definitions = sorted(
+        STARTER_DEFINITIONS,
+        key=lambda definition: definition.id != _FEATURED_STARTER_ID,
+    )
+    return [definition.to_dict() for definition in definitions]
 
 
 def get_starter(starter_id: str) -> StarterDefinition:

--- a/wayfinder_paths/jobs/sync.py
+++ b/wayfinder_paths/jobs/sync.py
@@ -46,14 +46,19 @@ class WayfinderJobsClient:
             headers["X-API-KEY"] = api_key
         return headers
 
-    def sync(self, jobs: list[dict[str, Any]]) -> None:
+    def sync(
+        self,
+        jobs: list[dict[str, Any]],
+        *,
+        starters: dict[str, Any],
+    ) -> None:
         base_url = self._base_url()
         if not base_url:
             return
         try:
             resp = self._client.post(
                 f"{base_url}/sync/",
-                json={"jobs": jobs},
+                json={"jobs": jobs, "starters": starters},
                 headers=self._headers(),
             )
             resp.raise_for_status()
@@ -293,9 +298,21 @@ def snapshot_job(job_id: str, *, store: JobStore | None = None) -> dict[str, Any
 
 
 def sync_all_jobs(*, store: JobStore | None = None) -> None:
+    from wayfinder_paths.jobs.starters import (
+        STARTER_CATALOG_VERSION,
+        starter_catalog,
+    )
+
     store = store or JobStore()
     snapshots = [snapshot_job(job.id, store=store) for job in store.list_jobs()]
-    WAYFINDER_JOBS_CLIENT.sync(snapshots)
+    WAYFINDER_JOBS_CLIENT.sync(
+        snapshots,
+        starters={
+            "items": starter_catalog(),
+            "catalog_version": STARTER_CATALOG_VERSION,
+            "cached_at": utc_now_iso(),
+        },
+    )
 
 
 OPERATOR_STATE_PATH = "state/operator.json"

--- a/wayfinder_paths/tests/test_jobs_starters.py
+++ b/wayfinder_paths/tests/test_jobs_starters.py
@@ -213,6 +213,12 @@ def dataset_fetch_spawns(monkeypatch) -> list[dict[str, Any]]:
 def test_starter_catalog_has_mixed_maker_and_pair_paper_strategies() -> None:
     catalog = starter_catalog()
     assert len(catalog) == 12
+    assert catalog[0]["id"] == "crypto-momentum-persistence-4h"
+    assert [item["id"] for item in catalog[1:]] == [
+        definition.id
+        for definition in STARTER_DEFINITIONS
+        if definition.id != "crypto-momentum-persistence-4h"
+    ]
     assert {item["timeframe"] for item in catalog} == {
         "5m",
         "15m",

--- a/wayfinder_paths/tests/test_runner_view_server.py
+++ b/wayfinder_paths/tests/test_runner_view_server.py
@@ -218,6 +218,7 @@ def test_starters_route_serves_the_bare_catalog_list(server: RunnerViewServer) -
     assert body["ok"] is True
     assert isinstance(body["result"], list)
     assert body["result"] == json.loads(json.dumps(starter_catalog(), default=str))
+    assert body["result"][0]["id"] == "crypto-momentum-persistence-4h"
 
 
 def test_backtest_view_parity_with_direct_loader(

--- a/wayfinder_paths/tests/test_wayfinder_jobs.py
+++ b/wayfinder_paths/tests/test_wayfinder_jobs.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import yaml
 
+from wayfinder_paths.jobs import sync as sync_module
 from wayfinder_paths.jobs.application import (
     claim_application,
     complete_application,
@@ -755,6 +757,28 @@ def test_sync_all_jobs_noops_outside_opencode(tmp_path: Path, monkeypatch) -> No
     store.save(WayfinderJob.new("local-script", script="workspace/src/loop.py"))
 
     sync_all_jobs(store=store)
+
+
+def test_sync_all_jobs_pushes_versioned_starter_catalog(
+    tmp_path: Path, monkeypatch
+) -> None:
+    client = sync_module.WAYFINDER_JOBS_CLIENT
+    response = MagicMock()
+    post = MagicMock(return_value=response)
+    monkeypatch.setattr(client, "_base_url", lambda: "https://api.example/jobs")
+    monkeypatch.setattr(client._client, "post", post)
+
+    sync_all_jobs(store=JobStore(repo_root=tmp_path))
+
+    assert post.call_args.args == ("https://api.example/jobs/sync/",)
+    payload = post.call_args.kwargs["json"]
+    assert payload["jobs"] == []
+    starters = payload["starters"]
+    assert starters["catalog_version"] == "1.10.0"
+    assert str(starters["cached_at"]).endswith("+00:00")
+    items = starters["items"]
+    assert items[0]["id"] == "crypto-momentum-persistence-4h"
+    response.raise_for_status.assert_called_once_with()
 
 
 def test_worker_prompt_ledgers_and_backtest_are_dynamic_only(


### PR DESCRIPTION
## Summary

- feature `crypto-momentum-persistence-4h` as the first item in the SDK starter catalog while preserving the relative order of every other starter
- bump the catalog version to `1.10.0`
- include the complete versioned starter catalog in every jobs sync, including zero-job syncs, so the backend DB-first cache is refreshed after runtime rollout
- keep ordering and strategy identity SDK-owned; the frontend already renders the backend list without filtering or sorting

## Root cause

The strategy existed in the SDK catalog but was sixth. More importantly, the SDK sent only `jobs` to the sync endpoint even though the backend already accepts a `starters` rider and serves that database copy first. A previously cached non-empty catalog could therefore remain stale indefinitely.

## Validation

- `51 passed` — starter catalog and creation suite
- `68 passed` — jobs, runner view, and daemon sync suites
- focused transport test verifies the outgoing `/sync/` JSON, catalog version, zero-job behavior, UTC cache timestamp, and featured first item
- Ruff format/check passed on all changed files
- isolated mypy passed for both changed source modules