### PR TITLE
evidence reuse: revalidate + economic gate + scenarios + WF folds + experiment dedup + freshness bound

### DIFF
--- a/wayfinder_paths/jobs/application.py
+++ b/wayfinder_paths/jobs/application.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import hashlib
 import json
-import os
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
@@ -11,6 +9,15 @@ from typing import Any
 import yaml
 
 from wayfinder_paths.jobs.compiler import JobCompiler
+
+# Redundant alias: re-exported — #705 introduced the kill-switch here and
+# callers/tests import it from this module.
+from wayfinder_paths.jobs.evidence_reuse import (
+    APPLY_ALWAYS_REVALIDATE_ENV as APPLY_ALWAYS_REVALIDATE_ENV,
+)
+from wayfinder_paths.jobs.evidence_reuse import (
+    assess_evidence_reuse,
+)
 from wayfinder_paths.jobs.execution.validation import validate_execution_job
 from wayfinder_paths.jobs.gating import compute_workspace_revision, evaluate_live_gate
 from wayfinder_paths.jobs.improver.spec import (
@@ -22,14 +29,9 @@ from wayfinder_paths.jobs.runner_bridge import RunnerBridge
 from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.jobs.sync import sync_all_jobs
 from wayfinder_paths.jobs.validation import (
-    candidate_dataset_fingerprint,
     validate_candidate_application,
     validation_summary,
 )
-
-# Kill-switch: force the pre-reuse behavior (full re-validation backtest on
-# every apply) regardless of evidence-reuse eligibility.
-APPLY_ALWAYS_REVALIDATE_ENV = "WAYFINDER_APPLY_ALWAYS_REVALIDATE"
 
 
 @dataclass
@@ -292,76 +294,14 @@ def assess_validation_reuse(
        equivalence as `store._ensure_candidate_matches_report`)
     5. dataset fingerprint recorded at propose time matches the one
        re-derived now (input bars + declared feature stores, by content)
-    6. the frozen evidence is green: validation_summary passed AND
+    6. live-capable freshness bound (`evidence_reuse` module docstring)
+    7. the frozen evidence is green: validation_summary passed AND
        economic.ready is True — failed/poisoned evidence is never reused
+
+    Thin wrapper over the shared `evidence_reuse.assess_evidence_reuse`
+    (phase "apply") — revalidate uses the same helper with its own phase.
     """
-    if os.environ.get(APPLY_ALWAYS_REVALIDATE_ENV) == "1":
-        return {"eligible": False, "reason": "kill_switch", "proof": {}}
-    report = proposal.get("candidate_report") or {}
-    report_revision = str(report.get("revision") or "")
-    if not report or report.get("mode") != "full" or not report_revision:
-        return {"eligible": False, "reason": "report_missing_or_not_full", "proof": {}}
-    base_revision = str(proposal.get("base_revision") or "")
-    active_revision = compute_workspace_revision(store.job_dir(job_id))
-    if base_revision and active_revision not in (base_revision, report_revision):
-        return {
-            "eligible": False,
-            "reason": "baseline_drift",
-            "proof": {
-                "base_revision": base_revision,
-                "active_revision": active_revision,
-            },
-        }
-    candidate_revision = compute_workspace_revision(candidate_dir)
-    if candidate_revision != report_revision:
-        return {
-            "eligible": False,
-            "reason": "candidate_mismatch",
-            "proof": {
-                "report_revision": report_revision,
-                "candidate_revision": candidate_revision,
-            },
-        }
-    recorded_fingerprint = report.get("dataset_fingerprint")
-    current_fingerprint = candidate_dataset_fingerprint(
-        candidate_dir, store.job_dir(job_id)
-    )
-    if not recorded_fingerprint or recorded_fingerprint != current_fingerprint:
-        return {
-            "eligible": False,
-            "reason": (
-                "dataset_changed" if recorded_fingerprint else "no_dataset_fingerprint"
-            ),
-            "proof": {
-                "recorded_fingerprint": recorded_fingerprint,
-                "current_fingerprint": current_fingerprint,
-            },
-        }
-    validation_status = (report.get("validation_summary") or {}).get("status")
-    economic_ready = (report.get("economic") or {}).get("ready")
-    if validation_status != "passed" or economic_ready is not True:
-        return {
-            "eligible": False,
-            "reason": "report_not_green",
-            "proof": {
-                "validation_status": validation_status,
-                "economic_ready": economic_ready,
-            },
-        }
-    report_hash = hashlib.sha256(
-        json.dumps(report, sort_keys=True, default=str).encode("utf-8")
-    ).hexdigest()
-    return {
-        "eligible": True,
-        "reason": "",
-        "proof": {
-            "base_revision": base_revision,
-            "candidate_revision": candidate_revision,
-            "active_revision": active_revision,
-            "dataset_fingerprint": current_fingerprint,
-            "report_hash": report_hash,
-        },
-    }
+    return assess_evidence_reuse(store, job_id, proposal, candidate_dir, phase="apply")
 
 
 def _complete_applied_application(
@@ -430,6 +370,47 @@ def _complete_applied_application(
     # ~30-minute backtest with trading loops paused adds nothing — keep only
     # the cheap invariants (compile, scenario sims, config/report reads).
     reuse = assess_validation_reuse(store, job_id, proposal, candidate_dir)
+    if reuse["reason"] == "dataset_stale":
+        # Freshness bound (live-capable only): the frozen evidence and the
+        # on-disk dataset are provably identical, but the bars are older
+        # than the owner's evidence ceiling. Reusing would promote on stale
+        # evidence; blindly re-running the full validation would VALIDATE
+        # against the same stale bars — equally worthless for a job that
+        # trades live. Refuse both and route to refresh + revalidate.
+        proof = reuse["proof"]
+        final_error = (
+            "dataset stale — refresh and revalidate: the candidate's dataset "
+            f"was fetched {proof.get('age_hours')}h ago (max "
+            f"{proof.get('max_age_hours')}h for a live-capable job). Re-fetch "
+            "the dataset, revalidate the proposal, and re-apply."
+        )
+        store.append_journal(
+            job_id,
+            {
+                "type": "apply_refused_stale_dataset",
+                "proposal_id": proposal_id,
+                **proof,
+            },
+        )
+        _write_apply_report(
+            store,
+            job_id,
+            proposal_id,
+            status="red",
+            summary=f"Apply refused: {final_error}",
+            changed_files=changed_files or [],
+            validation={"status": "failed", "checks": [], "error": final_error},
+            error=final_error,
+        )
+        return _ApplicationOutcome(
+            final_status="failed",
+            final_error=final_error,
+            deterministic_validation={
+                "status": "failed",
+                "checks": [],
+                "error": final_error,
+            },
+        )
     deterministic_validation: dict[str, Any] | None = None
     if reuse["eligible"]:
         cheap_validation = validate_candidate_application(
@@ -961,10 +942,14 @@ def validate_candidate_bundle(
     *,
     require_judge: bool = False,
     allow_legacy: bool = False,
+    skip_behavior_checks: bool = False,
 ) -> dict[str, Any]:
     """The full candidate validation (deterministic checks + execution
     validation + revision-stamped artifact persistence), independent of
-    application status — shared by the apply flow and the propose flow."""
+    application status — shared by the apply flow and the propose flow.
+    `skip_behavior_checks` follows the `validate_candidate_application`
+    contract: cheap invariants only, set exclusively when the propose-time
+    behavioral evidence is provably reusable (`assess_evidence_reuse`)."""
     validation = validate_candidate_application(
         repo_root=store.repo_root,
         job_dir=store.job_dir(job_id),
@@ -972,6 +957,7 @@ def validate_candidate_bundle(
         candidate_dir=candidate_dir,
         require_judge=require_judge,
         allow_legacy=allow_legacy,
+        skip_behavior_checks=skip_behavior_checks,
     )
     return _with_execution_validation(
         store, job_id, proposal, validation, candidate_dir=candidate_dir

--- a/wayfinder_paths/jobs/evidence_reuse.py
+++ b/wayfinder_paths/jobs/evidence_reuse.py
@@ -1,0 +1,208 @@
+"""Shared evidence-reuse eligibility across the proposal lifecycle.
+
+One mechanical question, asked at more than one phase: is the frozen
+propose-time evidence PROVABLY about the exact candidate + dataset in front
+of us right now, and is it green? Apply (see `application.
+assess_validation_reuse`) and revalidate (`proposals.revalidate_proposal`)
+both call `assess_evidence_reuse` — the conditions are content-derived hash
+comparisons and frozen field reads, never trust-based.
+
+Phase differences, deliberately small:
+- "apply" requires the WHOLE report green (validation passed AND
+  economic.ready True) — apply consumes the report as-is.
+- "revalidate" requires only the validation half green: revalidate exists to
+  CURE poisoned reports, and it re-runs the economic evaluation
+  unconditionally (the #700 incident cure) — reusing the expensive
+  validation backtest must never short-circuit that.
+
+Freshness bound (owner policy): for LIVE-CAPABLE jobs, evidence whose
+underlying dataset was fetched more than `WAYFINDER_EVIDENCE_MAX_AGE_HOURS`
+(default 24) ago is refused for reuse — and the apply path additionally
+refuses to blindly recompute against the same stale bars (routing to
+refresh + revalidate instead). Paper jobs reuse regardless of age
+(containment). A dataset with no recorded `fetched_at` has unknown age and
+is not treated as stale — the live gate's 30-day backtest-age ceiling still
+bounds it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from wayfinder_paths.jobs.gating import compute_workspace_revision
+from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.jobs.validation import candidate_dataset_fingerprint
+
+# Kill-switches — one per reuse surface, all following #705's env pattern
+# ("=1" forces the pre-reuse behavior for that surface only).
+APPLY_ALWAYS_REVALIDATE_ENV = "WAYFINDER_APPLY_ALWAYS_REVALIDATE"
+REVALIDATE_ALWAYS_RERUN_ENV = "WAYFINDER_REVALIDATE_ALWAYS_RERUN"
+
+EVIDENCE_MAX_AGE_ENV = "WAYFINDER_EVIDENCE_MAX_AGE_HOURS"
+DEFAULT_EVIDENCE_MAX_AGE_HOURS = 24.0
+
+_PHASE_KILL_SWITCH = {
+    "apply": APPLY_ALWAYS_REVALIDATE_ENV,
+    "revalidate": REVALIDATE_ALWAYS_RERUN_ENV,
+}
+
+
+def evidence_max_age_hours() -> float:
+    raw = os.environ.get(EVIDENCE_MAX_AGE_ENV, "")
+    try:
+        return float(raw) if raw else DEFAULT_EVIDENCE_MAX_AGE_HOURS
+    except ValueError:
+        return DEFAULT_EVIDENCE_MAX_AGE_HOURS
+
+
+def dataset_fetched_at(fingerprint: dict[str, Any] | None) -> str | None:
+    """The `metadata.fetched_at` stamp of the fingerprinted dataset file
+    (written by fetch-dataset). None for bare row-list files or torn reads."""
+    if not fingerprint or not fingerprint.get("path"):
+        return None
+    try:
+        loaded = json.loads(Path(str(fingerprint["path"])).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    match loaded:
+        case {"metadata": dict() as meta}:
+            value = meta.get("fetched_at")
+            return str(value) if value else None
+    return None
+
+
+def _dataset_age_hours(fetched_at: str | None) -> float | None:
+    if not fetched_at:
+        return None
+    try:
+        stamp = datetime.fromisoformat(str(fetched_at).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if stamp.tzinfo is None:
+        stamp = stamp.replace(tzinfo=UTC)
+    return (datetime.now(UTC) - stamp).total_seconds() / 3600.0
+
+
+def assess_evidence_reuse(
+    store: JobStore,
+    job_id: str,
+    proposal: dict[str, Any],
+    candidate_dir: Path,
+    *,
+    phase: str = "apply",
+) -> dict[str, Any]:
+    """Mechanical eligibility check for reusing the frozen propose-time
+    validation evidence instead of re-running the expensive candidate
+    backtest. Returns `{"eligible": bool, "reason": str, "proof": dict}` —
+    `reason` names the FIRST failed condition when ineligible; `proof`
+    carries the content-derived identity when eligible.
+
+    Conditions, in order:
+    1. phase kill-switch off
+    2. frozen candidate_report present, mode "full", with a revision
+    3. active workspace revision has not drifted past the staged base
+       (apply also accepts active == candidate: crash-resume after promotion)
+    4. candidate dir still hashes to the report's revision
+    5. dataset fingerprint recorded at propose matches the one re-derived now
+    6. freshness bound: live-capable jobs refuse evidence whose dataset
+       `fetched_at` age exceeds the configured maximum (reason
+       "dataset_stale" — the apply path escalates this to a hard refusal)
+    7. the frozen evidence is green — validation passed always; economic
+       ready additionally required for phase "apply"
+    """
+    if phase not in _PHASE_KILL_SWITCH:
+        raise ValueError(f"unknown evidence-reuse phase: {phase}")
+    if os.environ.get(_PHASE_KILL_SWITCH[phase]) == "1":
+        return {"eligible": False, "reason": "kill_switch", "proof": {}}
+    report = proposal.get("candidate_report") or {}
+    report_revision = str(report.get("revision") or "")
+    if not report or report.get("mode") != "full" or not report_revision:
+        return {"eligible": False, "reason": "report_missing_or_not_full", "proof": {}}
+    base_revision = str(proposal.get("base_revision") or "")
+    active_revision = compute_workspace_revision(store.job_dir(job_id))
+    allowed_active = (
+        (base_revision, report_revision) if phase == "apply" else (base_revision,)
+    )
+    if base_revision and active_revision not in allowed_active:
+        return {
+            "eligible": False,
+            "reason": "baseline_drift",
+            "proof": {
+                "base_revision": base_revision,
+                "active_revision": active_revision,
+            },
+        }
+    candidate_revision = compute_workspace_revision(candidate_dir)
+    if candidate_revision != report_revision:
+        return {
+            "eligible": False,
+            "reason": "candidate_mismatch",
+            "proof": {
+                "report_revision": report_revision,
+                "candidate_revision": candidate_revision,
+            },
+        }
+    recorded_fingerprint = report.get("dataset_fingerprint")
+    current_fingerprint = candidate_dataset_fingerprint(
+        candidate_dir, store.job_dir(job_id)
+    )
+    if not recorded_fingerprint or recorded_fingerprint != current_fingerprint:
+        return {
+            "eligible": False,
+            "reason": (
+                "dataset_changed" if recorded_fingerprint else "no_dataset_fingerprint"
+            ),
+            "proof": {
+                "recorded_fingerprint": recorded_fingerprint,
+                "current_fingerprint": current_fingerprint,
+            },
+        }
+    if store._job_is_live_capable(job_id):
+        fetched_at = dataset_fetched_at(current_fingerprint)
+        age_hours = _dataset_age_hours(fetched_at)
+        max_age = evidence_max_age_hours()
+        if age_hours is not None and age_hours > max_age:
+            return {
+                "eligible": False,
+                "reason": "dataset_stale",
+                "proof": {
+                    "fetched_at": fetched_at,
+                    "age_hours": round(age_hours, 3),
+                    "max_age_hours": max_age,
+                    "live_capable": True,
+                },
+            }
+    validation_status = (report.get("validation_summary") or {}).get("status")
+    economic_ready = (report.get("economic") or {}).get("ready")
+    green = validation_status == "passed" and (
+        phase != "apply" or economic_ready is True
+    )
+    if not green:
+        return {
+            "eligible": False,
+            "reason": "report_not_green",
+            "proof": {
+                "validation_status": validation_status,
+                "economic_ready": economic_ready,
+            },
+        }
+    report_hash = hashlib.sha256(
+        json.dumps(report, sort_keys=True, default=str).encode("utf-8")
+    ).hexdigest()
+    return {
+        "eligible": True,
+        "reason": "",
+        "proof": {
+            "phase": phase,
+            "base_revision": base_revision,
+            "candidate_revision": candidate_revision,
+            "active_revision": active_revision,
+            "dataset_fingerprint": current_fingerprint,
+            "report_hash": report_hash,
+        },
+    }

--- a/wayfinder_paths/jobs/execution/experiments.py
+++ b/wayfinder_paths/jobs/execution/experiments.py
@@ -2,20 +2,29 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import tempfile
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
 from wayfinder_paths.jobs.execution.job import backtest_execution_job
+from wayfinder_paths.jobs.execution.optimize import is_search_space
 from wayfinder_paths.jobs.execution.preflight import run_preflight
 from wayfinder_paths.jobs.gating import compute_workspace_revision
 from wayfinder_paths.jobs.improver.spec import revision_stamp
 from wayfinder_paths.jobs.models import utc_now_iso
 from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.jobs.validation import candidate_dataset_fingerprint
 
 EXPERIMENTS_FILE = "results/backtest/experiments.jsonl"
 TRIALS_FILE = "results/backtest/trials.jsonl"
+
+# Kill-switch: run every submitted experiment regardless of a green identical
+# prior in the ledger (evidence-reuse surface, #705 env pattern).
+EXPERIMENT_ALWAYS_RUN_ENV = "WAYFINDER_EXPERIMENT_ALWAYS_RUN"
+# Bounded ledger scan when looking for a green identical prior.
+_DEDUP_LOOKBACK_ROWS = 200
 
 
 def experiment_semantic_hash(row: Mapping[str, Any]) -> str:
@@ -45,6 +54,117 @@ def experiment_semantic_hash(row: Mapping[str, Any]) -> str:
     }
     encoded = json.dumps(definition, sort_keys=True, separators=(",", ":"), default=str)
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _normalized_search_definition(grid: Any) -> dict[str, Any]:
+    """Order-insensitive identity of the search question. Coordinate order is
+    not semantic (#692): dict-of-lists value order and explicit-combo order
+    are normalized; optuna search spaces hash as-is (typed dimensions)."""
+    match grid:
+        case Mapping() if is_search_space(grid):
+            return {"kind": "search_space", "space": dict(grid)}
+        case Mapping():
+            return {
+                "kind": "grid",
+                "grid": {
+                    str(name): sorted(
+                        (
+                            json.dumps(value, sort_keys=True, default=str)
+                            for value in values
+                        )
+                        if isinstance(values, list)
+                        else [json.dumps(values, sort_keys=True, default=str)]
+                    )
+                    for name, values in grid.items()
+                },
+            }
+        case list():
+            return {
+                "kind": "combos",
+                "combos": sorted(
+                    json.dumps(combo, sort_keys=True, default=str) for combo in grid
+                ),
+            }
+    return {"kind": "unknown", "raw": str(grid)}
+
+
+def experiment_submission_hash(
+    job_id: str,
+    grid: Any,
+    *,
+    rank_by: str,
+    optimizer: str,
+    optuna_options: Mapping[str, Any] | None,
+    walk_forward: Mapping[str, Any] | None,
+    quick_bars: int | None,
+    store: JobStore,
+) -> str:
+    """Pre-run identity of a submitted experiment: workspace revision +
+    dataset content fingerprint + the normalized search definition. Two
+    submissions with equal hashes would compute byte-identical evidence —
+    the dedup key recorded on every experiment row."""
+    root = store.job_dir(job_id)
+    definition = {
+        "revision": compute_workspace_revision(root),
+        "dataset_fingerprint": candidate_dataset_fingerprint(root, root),
+        "grid": _normalized_search_definition(grid),
+        "rank_by": rank_by,
+        "optimizer": optimizer,
+        "optuna_options": dict(optuna_options or {}),
+        "walk_forward": dict(walk_forward) if walk_forward else None,
+        "quick_bars": quick_bars,
+    }
+    encoded = json.dumps(definition, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _experiment_row_green(row: Mapping[str, Any]) -> bool:
+    """A prior row is reusable evidence only when it computed cleanly: runs
+    present, zero invalid cells, a ranked best, and (when walk-forward rode
+    along) every fold ok. Anything less re-runs — non-green evidence is
+    never reused."""
+    try:
+        if int(row.get("run_count") or 0) <= 0:
+            return False
+        if int(row.get("invalid_count") or 0) != 0:
+            return False
+    except (TypeError, ValueError):
+        return False
+    if not row.get("best"):
+        return False
+    walk_forward = row.get("walk_forward")
+    if walk_forward is not None:
+        folds = (walk_forward or {}).get("folds") or []
+        if not folds or any(fold.get("status") != "ok" for fold in folds):
+            return False
+    return True
+
+
+def _reusable_prior_experiment(
+    job_id: str, submission_hash: str, *, store: JobStore
+) -> dict[str, Any] | None:
+    """Most recent ledger row with the same submission hash decides: green →
+    reuse it; non-green → None (rerun). Requires the prior grid's summary
+    artifact to still exist so the result can be surfaced."""
+    for row in reversed(
+        list_experiments(job_id, store=store, limit=_DEDUP_LOOKBACK_ROWS)
+    ):
+        if row.get("submission_hash") != submission_hash:
+            continue
+        if not _experiment_row_green(row):
+            return None
+        summary_path = (
+            store.job_dir(job_id)
+            / "results"
+            / "backtest"
+            / "grids"
+            / str(row.get("grid_id") or "")
+            / "summary.json"
+        )
+        if not summary_path.exists():
+            return None
+        return row
+    return None
 
 
 def _experiment_definition(grid_payload: Mapping[str, Any]) -> dict[str, Any]:
@@ -128,9 +248,13 @@ def record_experiment(
     grid_payload: Mapping[str, Any],
     *,
     store: JobStore | None = None,
+    submission_hash: str | None = None,
 ) -> dict[str, Any]:
     """Append one experiment row per grid run so parameter searches leave a
-    durable, comparable trail instead of evaporating into a grids/ folder."""
+    durable, comparable trail instead of evaporating into a grids/ folder.
+    `submission_hash` (when the caller staged one) is the pre-run dedup key
+    future identical submissions match against; the post-run
+    `semantic_hash` (#692 replication tagging) is unchanged."""
     store = store or JobStore()
     result = grid_payload["result"]
     ranked = result["ranked"]
@@ -146,6 +270,7 @@ def record_experiment(
         "run_count": len(result["runs"]),
         "invalid_count": len(result["invalid"]),
         "semantic_hash": experiment_semantic_hash(definition),
+        **({"submission_hash": submission_hash} if submission_hash else {}),
         "best": (
             {
                 "run_id": best["run_id"],
@@ -389,6 +514,7 @@ def run_experiment(
     match grid:
         case str() | Path():
             grid_path = Path(grid)
+            grid_content = json.loads(grid_path.read_text(encoding="utf-8"))
         case _:
             handle = tempfile.NamedTemporaryFile(
                 "w", suffix=".json", delete=False, encoding="utf-8"
@@ -396,6 +522,52 @@ def run_experiment(
             json.dump(grid, handle)
             handle.close()
             grid_path = Path(handle.name)
+            grid_content = json.loads(json.dumps(grid, default=str))
+    # Evidence reuse (submission dedup): an identical submission — same
+    # workspace revision, same dataset content, same normalized search
+    # definition — against a GREEN prior ledger row computes nothing new.
+    # Surface the prior result instead of burning the box on a re-run (the
+    # dominant redundancy class: 71/107 grid runs in one audited burst).
+    submission_hash = experiment_submission_hash(
+        job_id,
+        grid_content,
+        rank_by=rank_by,
+        optimizer=optimizer,
+        optuna_options=optuna_options,
+        walk_forward=walk_forward,
+        quick_bars=quick_bars,
+        store=store,
+    )
+    if os.environ.get(EXPERIMENT_ALWAYS_RUN_ENV) != "1":
+        prior = _reusable_prior_experiment(job_id, submission_hash, store=store)
+        if prior is not None:
+            grid_id = str(prior["grid_id"])
+            grids_dir = store.job_dir(job_id) / "results" / "backtest" / "grids"
+            summary_path = grids_dir / grid_id / "summary.json"
+            store.append_journal(
+                job_id,
+                {
+                    "type": "experiment_reused",
+                    "grid_id": grid_id,
+                    "submission_hash": submission_hash,
+                    "prior_ts": prior.get("ts"),
+                    "revision": prior.get("revision"),
+                },
+            )
+            backtest: dict[str, Any] = {
+                "type": "grid",
+                "reused_from_grid_id": grid_id,
+                "revision": prior.get("revision"),
+                "dataset": prior.get("dataset"),
+                "result": json.loads(summary_path.read_text(encoding="utf-8")),
+                "artifacts": {"summary": str(summary_path)},
+            }
+            if prior.get("walk_forward") is not None:
+                backtest["walk_forward"] = prior["walk_forward"]
+            return {
+                "experiment": {**prior, "reused": True},
+                "backtest": backtest,
+            }
     payload = backtest_execution_job(
         job_id,
         grid_path=grid_path,
@@ -408,5 +580,7 @@ def run_experiment(
         quick_bars=quick_bars,
         store=store,
     )
-    row = record_experiment(job_id, payload, store=store)
+    row = record_experiment(
+        job_id, payload, store=store, submission_hash=submission_hash
+    )
     return {"experiment": row, "backtest": payload}

--- a/wayfinder_paths/jobs/execution/job.py
+++ b/wayfinder_paths/jobs/execution/job.py
@@ -25,8 +25,15 @@ from wayfinder_paths.jobs.execution.validation import (
     resolve_execution_spec,
     validate_execution_job,
 )
-from wayfinder_paths.jobs.execution.walk_forward import run_walk_forward
-from wayfinder_paths.jobs.gating import compute_workspace_revision
+from wayfinder_paths.jobs.execution.walk_forward import (
+    load_walk_forward_folds,
+    persist_walk_forward_folds,
+    run_walk_forward,
+)
+from wayfinder_paths.jobs.gating import (
+    compute_workspace_revision,
+    dataset_content_fingerprint,
+)
 from wayfinder_paths.jobs.models import utc_now_iso
 from wayfinder_paths.jobs.store import JobStore
 
@@ -45,7 +52,14 @@ def summarize_backtest_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
     """
     summary: dict[str, Any] = {
         k: payload[k]
-        for k in ("type", "artifacts", "stamp", "walk_forward", "validation")
+        for k in (
+            "type",
+            "artifacts",
+            "stamp",
+            "walk_forward",
+            "validation",
+            "reused_from_grid_id",
+        )
         if k in payload
     }
     coverage = ((payload.get("dataset") or {}).get("feature_coverage")) or {}
@@ -218,18 +232,59 @@ def _backtest_execution_job_locked(
             # Preserve the question asked separately from its observed folds;
             # experiment identity must not change merely because results do.
             payload["walk_forward_definition"] = dict(walk_forward)
-            payload["walk_forward"] = run_walk_forward(
-                script,
-                dataset,
-                spec,
-                param_grid,
-                rank_by=rank_by,
-                workers=workers,
-                parallel=parallel,
-                optimizer=optimizer,
-                optuna_options=optuna_options,
-                **dict(walk_forward),
-            )
+            # Evidence reuse: each fold is deterministic in {grid + WF layout
+            # + ranking, dataset content/window, workspace revision}. A prior
+            # grid dir carrying a complete green fold set under the exact
+            # same key answers the same question — skip the re-simulation.
+            timestamps = dataset.bars.timestamps
+            wf_key = {
+                "fold_spec": {
+                    "walk_forward": dict(walk_forward),
+                    "param_grid": param_grid,
+                    "rank_by": rank_by,
+                    "optimizer": optimizer,
+                    "optuna_options": dict(optuna_options or {}),
+                },
+                "dataset_window": {
+                    "start": str(timestamps[0]) if timestamps else None,
+                    "end": str(timestamps[-1]) if timestamps else None,
+                    "bars": len(timestamps),
+                    "fingerprint": dataset_content_fingerprint(
+                        root,
+                        root,
+                        feature_paths=tuple(
+                            item.path for item in parse_feature_specs(spec)
+                        ),
+                    ),
+                    "quick_bars": quick_bars,
+                },
+                "revision": stamp["revision"],
+            }
+            wf_report = load_walk_forward_folds(output_dir / "grids", wf_key)
+            if wf_report is not None:
+                store.append_journal(
+                    job_id,
+                    {
+                        "type": "walk_forward_folds_reused",
+                        "grid_id": result.grid_id,
+                        **wf_report["reused"],
+                    },
+                )
+            else:
+                wf_report = run_walk_forward(
+                    script,
+                    dataset,
+                    spec,
+                    param_grid,
+                    rank_by=rank_by,
+                    workers=workers,
+                    parallel=parallel,
+                    optimizer=optimizer,
+                    optuna_options=optuna_options,
+                    **dict(walk_forward),
+                )
+            payload["walk_forward"] = wf_report
+            persist_walk_forward_folds(grid_dir, wf_key, wf_report)
     else:
         params = job_data.get("execution_params") or {}
         result = simulate_execution(script, dataset, spec, params)

--- a/wayfinder_paths/jobs/execution/walk_forward.py
+++ b/wayfinder_paths/jobs/execution/walk_forward.py
@@ -7,6 +7,9 @@ acts on it."""
 
 from __future__ import annotations
 
+import hashlib
+import json
+import os
 from collections.abc import Callable, Mapping
 from pathlib import Path
 from statistics import fmean
@@ -32,6 +35,106 @@ from wayfinder_paths.jobs.execution.simulator import (
 # interactive validation. Anchored/expanding windows (opt-in) re-replay all prior
 # history every fold — ~4x slower on a full dataset.
 DEFAULT_WF_TRAIN_MULTIPLE = 4
+
+# Kill-switch: recompute walk-forward folds on every run, ignoring persisted
+# fold artifacts (evidence-reuse surface, #705 env pattern).
+WF_FOLDS_ALWAYS_RUN_ENV = "WAYFINDER_WF_FOLDS_ALWAYS_RUN"
+# Bounded lookback when scanning prior grid dirs for matching fold artifacts.
+_WF_FOLD_LOOKUP_GRIDS = 20
+
+
+def walk_forward_fold_key_hash(key: Mapping[str, Any]) -> str:
+    """Content hash of the walk-forward question: fold spec (grid + WF
+    layout + ranking), dataset window/content, and workspace revision."""
+    encoded = json.dumps(key, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def persist_walk_forward_folds(
+    grid_dir: Path, key: Mapping[str, Any], report: Mapping[str, Any]
+) -> None:
+    """One `fold_{i}.json` per fold under the grid dir, each carrying the
+    full key — the durable per-fold evidence a later identical walk-forward
+    can reuse instead of re-simulating every fold. Best-effort: persistence
+    is an optimization, never a walk-forward failure."""
+    key_hash = walk_forward_fold_key_hash(key)
+    folds = list(report["folds"])
+    try:
+        grid_dir.mkdir(parents=True, exist_ok=True)
+        for index, row in enumerate(folds):
+            (grid_dir / f"fold_{index}.json").write_text(
+                json.dumps(
+                    {
+                        "key": key,
+                        "key_hash": key_hash,
+                        "fold": index,
+                        "fold_count": len(folds),
+                        "spec": report["spec"],
+                        "row": row,
+                    },
+                    indent=2,
+                    sort_keys=True,
+                    default=str,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+    except OSError:
+        pass
+
+
+def load_walk_forward_folds(
+    grids_root: Path, key: Mapping[str, Any]
+) -> dict[str, Any] | None:
+    """Reconstruct a walk-forward report from persisted fold artifacts when a
+    recent grid carries a COMPLETE set of folds under the exact same key and
+    every fold is green (status "ok"). Partial sets, key mismatches, or any
+    non-ok fold → None (recompute — non-green evidence is never reused)."""
+    if os.environ.get(WF_FOLDS_ALWAYS_RUN_ENV) == "1" or not grids_root.exists():
+        return None
+    key_hash = walk_forward_fold_key_hash(key)
+    grid_dirs = sorted(
+        (path for path in grids_root.iterdir() if path.is_dir()),
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )[:_WF_FOLD_LOOKUP_GRIDS]
+    for grid_dir in grid_dirs:
+        report = _report_from_fold_files(grid_dir, key_hash)
+        if report is not None:
+            report["reused"] = {
+                "source_grid_id": grid_dir.name,
+                "key_hash": key_hash,
+            }
+            return report
+    return None
+
+
+def _report_from_fold_files(grid_dir: Path, key_hash: str) -> dict[str, Any] | None:
+    payloads = []
+    for path in sorted(grid_dir.glob("fold_*.json")):
+        try:
+            payloads.append(json.loads(path.read_text(encoding="utf-8")))
+        except (OSError, ValueError):
+            return None
+    if not payloads:
+        return None
+    expected = payloads[0].get("fold_count")
+    if (
+        not isinstance(expected, int)
+        or len(payloads) != expected
+        or any(item.get("key_hash") != key_hash for item in payloads)
+        or sorted(item.get("fold") for item in payloads) != list(range(expected))
+    ):
+        return None
+    rows = [item["row"] for item in sorted(payloads, key=lambda entry: entry["fold"])]
+    if any(row.get("status") != "ok" for row in rows):
+        return None
+    spec = payloads[0].get("spec") or {}
+    return {
+        "spec": spec,
+        "folds": rows,
+        "summary": _summary(rows, str(spec.get("rank_by") or "net_return")),
+    }
 
 
 def run_walk_forward(

--- a/wayfinder_paths/jobs/gating.py
+++ b/wayfinder_paths/jobs/gating.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
@@ -13,6 +14,14 @@ from wayfinder_paths.jobs.models import utc_now_iso
 from wayfinder_paths.jobs.store import JobStore
 
 DEFAULT_MAX_BACKTEST_AGE_DAYS = 30
+
+# Kill-switch: force the paired fold evaluation to recompute on every call,
+# ignoring persisted fold results (evidence-reuse surface, #705 env pattern).
+ECONOMIC_ALWAYS_RECOMPUTE_ENV = "WAYFINDER_ECONOMIC_ALWAYS_RECOMPUTE"
+# Persisted inside the candidate bundle (outside workspace/, so the candidate
+# revision is unchanged): the expensive 2xK-fold paired replay, keyed by the
+# full content identity it was computed under.
+PAIRED_FOLDS_RELATIVE = Path("reports") / "economic" / "paired_folds.json"
 
 
 def governance_hard_constraints(root: Path) -> dict[str, Any]:
@@ -328,28 +337,78 @@ def evaluate_economic_gate(
     )
     if baseline_script is None or candidate_script is None:
         return _economic_unavailable(constitution, "no script entrypoint", probation)
-    try:
-        dataset = _load_dataset(candidate_root, spec, candidate_yaml)
-    except FileNotFoundError:
-        # Candidate bundles carry workspace/ + job.yaml only. Jobs that keep
-        # their dataset at the JOB root (results/backtest/input_bars.json —
-        # the standard fetch-dataset location) would otherwise never resolve
-        # bars here and every propose would die on "No backtest bars found".
-        # Same fallback candidate validation applies; if the job root ALSO
-        # has no bars the error propagates — with the propose-time
-        # infra-abort, a dataset that validated moments ago but vanished for
-        # the economic step is a box condition, not evidence.
-        dataset = _load_dataset(root, spec, candidate_yaml)
 
-    evaluation = paired_fold_evaluation(
-        baseline_script=baseline_script,
-        candidate_script=candidate_script,
-        dataset=dataset,
-        spec=spec,
-        baseline_params=baseline_yaml.get("execution_params") or {},
-        candidate_params=candidate_yaml.get("execution_params") or {},
-        constitution=constitution,
+    # Evidence reuse: the paired replay is deterministic in {candidate code,
+    # baseline code, constitution, dataset content, fold layout}. When a
+    # persisted evaluation carries the exact same key AND is green, replaying
+    # 2xK fold sims answers a question already answered — reuse it. The
+    # readiness verdict is always recomputed (pure policy, no simulation).
+    fold_key = {
+        "candidate_revision": compute_workspace_revision(candidate_root),
+        "baseline_revision": compute_workspace_revision(root),
+        "constitution_revision": constitution.get("revision"),
+        "dataset_fingerprint": _candidate_dataset_fingerprint(candidate_root, root),
+        "fold_spec": {**constitution["evaluation"], "warmup_bars": 60},
+    }
+    persist_path = candidate_root / PAIRED_FOLDS_RELATIVE
+    evaluation = _reusable_paired_evaluation(
+        persist_path, fold_key, constitution, probation=probation
     )
+    if evaluation is not None:
+        store.append_journal(
+            job_id,
+            {
+                "type": "economic_evaluation_reused",
+                "candidate_revision": fold_key["candidate_revision"],
+                "baseline_revision": fold_key["baseline_revision"],
+                "constitution_revision": fold_key["constitution_revision"],
+                "paired_folds_path": str(persist_path),
+            },
+        )
+        reused = True
+    else:
+        try:
+            dataset = _load_dataset(candidate_root, spec, candidate_yaml)
+        except FileNotFoundError:
+            # Candidate bundles carry workspace/ + job.yaml only. Jobs that
+            # keep their dataset at the JOB root
+            # (results/backtest/input_bars.json — the standard fetch-dataset
+            # location) would otherwise never resolve bars here and every
+            # propose would die on "No backtest bars found". Same fallback
+            # candidate validation applies; if the job root ALSO has no bars
+            # the error propagates — with the propose-time infra-abort, a
+            # dataset that validated moments ago but vanished for the
+            # economic step is a box condition, not evidence.
+            dataset = _load_dataset(root, spec, candidate_yaml)
+
+        evaluation = paired_fold_evaluation(
+            baseline_script=baseline_script,
+            candidate_script=candidate_script,
+            dataset=dataset,
+            spec=spec,
+            baseline_params=baseline_yaml.get("execution_params") or {},
+            candidate_params=candidate_yaml.get("execution_params") or {},
+            constitution=constitution,
+        )
+        reused = False
+        try:
+            persist_path.parent.mkdir(parents=True, exist_ok=True)
+            persist_path.write_text(
+                json.dumps(
+                    {
+                        "key": fold_key,
+                        "evaluation": evaluation,
+                        "generated_at": utc_now_iso(),
+                    },
+                    indent=2,
+                    sort_keys=True,
+                    default=str,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+        except OSError:
+            pass  # persistence is an optimization, never a gate failure
     readiness = evaluate_economic_readiness(
         evaluation, constitution, probation=probation
     )
@@ -367,8 +426,53 @@ def evaluate_economic_gate(
         "fold_count": evaluation.get("fold_count"),
         "audit_slice": _audit_summary(evaluation.get("audit_slice")),
         "status": evaluation.get("status"),
+        **({"reused": True} if reused else {}),
         "checked_at": utc_now_iso(),
     }
+
+
+def _candidate_dataset_fingerprint(
+    candidate_root: Path, root: Path
+) -> dict[str, Any] | None:
+    # Lazy import: validation imports gating at module level.
+    from wayfinder_paths.jobs.validation import candidate_dataset_fingerprint
+
+    return candidate_dataset_fingerprint(candidate_root, root)
+
+
+def _reusable_paired_evaluation(
+    persist_path: Path,
+    fold_key: dict[str, Any],
+    constitution: Mapping[str, Any],
+    *,
+    probation: bool,
+) -> dict[str, Any] | None:
+    """Persisted paired-fold evaluation, ONLY when the full content key
+    matches and the persisted evidence is green (status ok + the readiness
+    it implies under the current constitution is ready=True). Non-green
+    evidence is never reused — it recomputes fresh, every time."""
+    # Lazy: economics pulls pandas; gating is imported on every cheap path.
+    from wayfinder_paths.jobs.economics import evaluate_economic_readiness
+
+    if os.environ.get(ECONOMIC_ALWAYS_RECOMPUTE_ENV) == "1":
+        return None
+    persisted = _read_json(persist_path)
+    if not persisted:
+        return None
+    # JSON round-trip normalization: the key was persisted via default=str,
+    # so compare against the same normalization of the freshly-derived key.
+    normalized_key = json.loads(json.dumps(fold_key, sort_keys=True, default=str))
+    if persisted.get("key") != normalized_key:
+        return None
+    evaluation = persisted.get("evaluation")
+    if not isinstance(evaluation, dict) or evaluation.get("status") != "ok":
+        return None
+    readiness = evaluate_economic_readiness(
+        evaluation, constitution, probation=probation
+    )
+    if readiness.get("ready") is not True:
+        return None
+    return evaluation
 
 
 def _audit_summary(audit: dict[str, Any] | None) -> dict[str, Any] | None:

--- a/wayfinder_paths/jobs/proposals.py
+++ b/wayfinder_paths/jobs/proposals.py
@@ -31,6 +31,7 @@ from wayfinder_paths.jobs.application import (
     validate_candidate_bundle,
 )
 from wayfinder_paths.jobs.compute_lock import ComputeLockBusy, heavy_compute_lock
+from wayfinder_paths.jobs.evidence_reuse import assess_evidence_reuse
 from wayfinder_paths.jobs.execution.job import (
     backtest_execution_job,
     synthesize_scenario_plan,
@@ -341,8 +342,19 @@ def _generate_candidate_report(
     *,
     base_revision: str,
     pid: str,
+    skip_behavior_checks: bool = False,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
-    validation = validate_candidate_bundle(store, job_id, proposal, candidate_dir)
+    """`skip_behavior_checks=True` keeps only the cheap validation invariants
+    — set exclusively when the prior behavioral evidence is provably
+    reusable (`assess_evidence_reuse`); the candidate backtest artifact from
+    that prior run still feeds the comparison below."""
+    validation = validate_candidate_bundle(
+        store,
+        job_id,
+        proposal,
+        candidate_dir,
+        skip_behavior_checks=skip_behavior_checks,
+    )
     validation = _retry_infrastructure_failure(
         store, job_id, proposal, candidate_dir, validation
     )
@@ -538,6 +550,12 @@ def revalidate_proposal(
     on a quiet box. If the job's active revision moved past base_revision
     the comparison baseline would drift, so refuse: the owner should reject
     and re-propose against the current workspace instead.
+
+    Evidence reuse: only GREEN, provably-unchanged pieces skip re-running
+    (`assess_evidence_reuse`, phase "revalidate") — a green validation half
+    keeps its candidate backtest; the economic block always re-evaluates
+    (with its own persisted-fold reuse inside `evaluate_economic_gate`).
+    Failed/poisoned pieces re-run in full: that is what revalidate is for.
     """
     proposal = store.load_proposal(job_id, proposal_id)
     if proposal["status"] != "pending":
@@ -566,14 +584,71 @@ def revalidate_proposal(
     old_summary = (proposal.get("candidate_report") or {}).get(
         "validation_summary"
     ) or {}
-    validation, candidate_report = _generate_candidate_report(
-        store,
-        job_id,
-        proposal,
-        candidate_dir,
-        base_revision=base_revision,
-        pid=proposal_id,
+    # Evidence reuse (validation half only): when the candidate, dataset and
+    # baseline are PROVABLY unchanged and the frozen VALIDATION evidence is
+    # green, re-running the expensive candidate backtest asks an answered
+    # question. The economic block is regenerated regardless — revalidate
+    # exists to CURE poisoned reports (the #700 incident shape), and reuse
+    # must never short-circuit the cure: a failed validation half re-runs
+    # (that is the point), and the economic evaluation below re-runs with
+    # its own persisted-fold reuse deciding whether ITS green half replays.
+    reuse = assess_evidence_reuse(
+        store, job_id, proposal, candidate_dir, phase="revalidate"
     )
+    validation: dict[str, Any] | None = None
+    candidate_report: dict[str, Any] | None = None
+    if reuse["eligible"]:
+        validation, candidate_report = _generate_candidate_report(
+            store,
+            job_id,
+            proposal,
+            candidate_dir,
+            base_revision=base_revision,
+            pid=proposal_id,
+            skip_behavior_checks=True,
+        )
+        if validation["status"] == "passed":
+            candidate_report["evidence_reuse"] = dict(reuse["proof"])
+            store.append_journal(
+                job_id,
+                {
+                    "type": "revalidate_evidence_reused",
+                    "proposal_id": proposal_id,
+                    **reuse["proof"],
+                },
+            )
+        else:
+            # Defense in depth: a failed cheap invariant with green frozen
+            # evidence means something moved outside the fingerprinted
+            # surface — fall back to the authoritative full re-validation.
+            store.append_journal(
+                job_id,
+                {
+                    "type": "revalidate_evidence_rerun",
+                    "proposal_id": proposal_id,
+                    "reason": "cheap_invariants_failed",
+                },
+            )
+            validation = candidate_report = None
+    else:
+        store.append_journal(
+            job_id,
+            {
+                "type": "revalidate_evidence_rerun",
+                "proposal_id": proposal_id,
+                "reason": reuse["reason"],
+                **({"details": reuse["proof"]} if reuse["proof"] else {}),
+            },
+        )
+    if candidate_report is None or validation is None:
+        validation, candidate_report = _generate_candidate_report(
+            store,
+            job_id,
+            proposal,
+            candidate_dir,
+            base_revision=base_revision,
+            pid=proposal_id,
+        )
     proposal["candidate_report"] = candidate_report
     # Recomputed against the same base: unchanged for an intact candidate,
     # honest for one that was edited since propose (the regenerated report's

--- a/wayfinder_paths/jobs/validation.py
+++ b/wayfinder_paths/jobs/validation.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import importlib.util
 import inspect
+import json
+import os
 import py_compile
 import sys
 from collections.abc import Mapping
@@ -42,6 +45,10 @@ REQUIRED_INTENT_FIELDS = (
     "exit_conditions",
     "known_non_goals",
 )
+
+# Kill-switch: force scenario replays to run fresh on every validation,
+# ignoring the persisted per-candidate scenario cache.
+SCENARIOS_ALWAYS_RUN_ENV = "WAYFINDER_SCENARIOS_ALWAYS_RUN"
 
 
 def validate_candidate_application(
@@ -140,7 +147,11 @@ def validate_candidate_application(
     if script_path and script_path.exists():
         if contract == "jobs_v1":
             checks.extend(_jobs_v1_script_checks(script_path))
-            checks.extend(_engine_scenario_checks(script_path, proposal, job_data))
+            checks.extend(
+                _engine_scenario_checks(
+                    script_path, proposal, job_data, candidate_dir=candidate_dir
+                )
+            )
             if not skip_behavior_checks:
                 checks.extend(
                     _candidate_behavior_checks(
@@ -196,11 +207,60 @@ def _jobs_v1_script_checks(script_path: Path) -> list[dict[str, Any]]:
     return checks
 
 
+def _scenario_set_hash(scenarios: list[Any], spec_data: Mapping[str, Any]) -> str:
+    """Content identity of the scenario replay question: the scenario set
+    (bars + params + expect) plus the execution spec the engine replays them
+    under. Changing ANY scenario definition changes the hash."""
+    encoded = json.dumps(
+        {"scenarios": scenarios, "execution_spec": dict(spec_data)},
+        sort_keys=True,
+        default=str,
+    )
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _cached_scenario_checks(
+    cache_path: Path, scenario_hash: str, candidate_revision: str
+) -> list[dict[str, Any]] | None:
+    """Green-only scenario reuse: persisted rows come back when the cache key
+    {scenario_hash, candidate_revision} matches AND every row passed — a
+    failed scenario is a verdict and always re-runs fresh."""
+    if os.environ.get(SCENARIOS_ALWAYS_RUN_ENV) == "1" or not cache_path.exists():
+        return None
+    try:
+        cached = json.loads(cache_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    match cached:
+        case {
+            "scenario_hash": str() as cached_hash,
+            "candidate_revision": str() as cached_revision,
+            "checks": list() as rows,
+        } if (
+            cached_hash == scenario_hash
+            and cached_revision == candidate_revision
+            and rows
+            and all(isinstance(row, dict) and row.get("passed") for row in rows)
+        ):
+            return [{**row, "reused": True} for row in rows]
+    return None
+
+
 def _engine_scenario_checks(
-    script_path: Path, proposal: Mapping[str, Any], job_data: Mapping[str, Any]
+    script_path: Path,
+    proposal: Mapping[str, Any],
+    job_data: Mapping[str, Any],
+    *,
+    candidate_dir: Path | None = None,
 ) -> list[dict[str, Any]]:
     """Run proposal scenarios through the real engine (simulate_execution)
-    instead of the legacy decide_from_snapshot fixture convention."""
+    instead of the legacy decide_from_snapshot fixture convention.
+
+    Scenario replays are deterministic in {scenario set, execution spec,
+    candidate content}: results are persisted inside the candidate bundle
+    (outside workspace/, so the candidate revision is unchanged) and reused
+    across phases (propose → revalidate → apply) when that key matches and
+    every persisted row passed."""
     scenario_plan = proposal.get("scenario_plan")
     match scenario_plan:
         case list():
@@ -218,7 +278,21 @@ def _engine_scenario_checks(
     ]
     if not scenarios:
         return checks
-    spec = ExecutionSpec.from_dict(dict(job_data.get("execution_spec") or {}))
+    spec_data = dict(job_data.get("execution_spec") or {})
+    cache_path: Path | None = None
+    scenario_hash = ""
+    candidate_revision = ""
+    if candidate_dir is not None:
+        scenario_hash = _scenario_set_hash(list(scenarios), spec_data)
+        candidate_revision = compute_workspace_revision(candidate_dir)
+        cache_path = candidate_dir / "reports" / "validation" / "scenario_cache.json"
+        cached_rows = _cached_scenario_checks(
+            cache_path, scenario_hash, candidate_revision
+        )
+        if cached_rows is not None and len(cached_rows) == len(scenarios):
+            return checks + cached_rows
+    spec = ExecutionSpec.from_dict(spec_data)
+    scenario_rows: list[dict[str, Any]] = []
     for index, scenario in enumerate(scenarios):
         match scenario:
             case Mapping():
@@ -228,7 +302,7 @@ def _engine_scenario_checks(
         name = str(scenario_data.get("name") or f"scenario_{index + 1}")
         bars = scenario_data.get("bars")
         if not bars:
-            checks.append(
+            scenario_rows.append(
                 {
                     "name": f"scenario_{name}",
                     "passed": False,
@@ -263,7 +337,7 @@ def _engine_scenario_checks(
                 failures.append(
                     f"execution_valid expected {expected['execution_valid']}"
                 )
-            checks.append(
+            scenario_rows.append(
                 {
                     "name": f"scenario_{name}",
                     "passed": not failures,
@@ -273,10 +347,30 @@ def _engine_scenario_checks(
                 }
             )
         except Exception as exc:
-            checks.append(
+            scenario_rows.append(
                 {"name": f"scenario_{name}", "passed": False, "error": str(exc)}
             )
-    return checks
+    if (
+        cache_path is not None
+        and scenario_rows
+        and all(row["passed"] for row in scenario_rows)
+    ):
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(
+            json.dumps(
+                {
+                    "scenario_hash": scenario_hash,
+                    "candidate_revision": candidate_revision,
+                    "checks": scenario_rows,
+                },
+                indent=2,
+                sort_keys=True,
+                default=str,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+    return checks + scenario_rows
 
 
 def _candidate_behavior_checks(

--- a/wayfinder_paths/tests/test_backtest_profile_and_summary.py
+++ b/wayfinder_paths/tests/test_backtest_profile_and_summary.py
@@ -777,7 +777,9 @@ def test_run_experiment_threads_quick_bars_and_parallel(monkeypatch) -> None:
 
     monkeypatch.setattr(experiments_mod, "backtest_execution_job", fake_backtest)
     monkeypatch.setattr(
-        experiments_mod, "record_experiment", lambda job_id, payload, store: {}
+        experiments_mod,
+        "record_experiment",
+        lambda job_id, payload, store, submission_hash=None: {},
     )
     experiments_mod.run_experiment("j", {"a": [1, 2]}, quick_bars=2000)
     assert captured["quick_bars"] == 2000

--- a/wayfinder_paths/tests/test_jobs_apply_evidence_reuse.py
+++ b/wayfinder_paths/tests/test_jobs_apply_evidence_reuse.py
@@ -1,17 +1,22 @@
-"""Apply-time evidence reuse: a proposal validated in full at propose time
-(candidate backtest + preflight + execution validation + economic gate) must
-not re-run the expensive candidate backtest at apply time when the candidate,
+"""Evidence reuse across the proposal lifecycle: a proposal validated in
+full at propose time (candidate backtest + preflight + execution validation +
+economic gate) must not re-run the expensive pieces when the candidate,
 dataset, and baseline are PROVABLY unchanged and the frozen evidence is green.
-Covers the eligibility matrix (`assess_validation_reuse`), the journal
-contract (`apply_validation_reused` / `apply_validation_rerun`), the
-kill-switch, the propose-time dataset fingerprint, and the 2026-08 production
-incident shape (one-line params change re-backtested for 30+ minutes with
-trading lanes paused)."""
+Covers the eligibility matrix (`assess_validation_reuse` /
+`assess_evidence_reuse`), the journal contract (`*_reused` with proof inline
+/ `*_rerun` with reason), the per-piece kill-switches, the propose-time
+dataset fingerprint, revalidate-time reuse (which must never short-circuit
+the cure of a poisoned report — the #700 incident shape), economic paired-
+fold persistence, the live-capable dataset freshness bound, and the 2026-08
+production incident shape (one-line params change re-backtested for 30+
+minutes with trading lanes paused)."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import shutil
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -23,14 +28,19 @@ from wayfinder_paths.jobs.application import (
     claim_application,
     complete_application,
 )
+from wayfinder_paths.jobs.constitution import load_constitution
+from wayfinder_paths.jobs.evidence_reuse import assess_evidence_reuse
 from wayfinder_paths.jobs.gating import (
+    PAIRED_FOLDS_RELATIVE,
     dataset_content_fingerprint,
+    evaluate_economic_gate,
     evaluate_live_gate,
 )
-from wayfinder_paths.jobs.proposals import propose_change
+from wayfinder_paths.jobs.proposals import propose_change, revalidate_proposal
 from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.tests.test_jobs_application_gate import _patch_runner
 from wayfinder_paths.tests.test_jobs_gating import _make_job
+from wayfinder_paths.tests.test_jobs_preflight import _bars
 from wayfinder_paths.tests.test_wayfinder_jobs import _intent_contract
 
 
@@ -356,3 +366,652 @@ def test_dataset_content_fingerprint_resolution_and_features(
         candidate_dir, job_dir, feature_paths=("state/features.jsonl",)
     )
     assert moved != with_features, "feature churn must invalidate the fingerprint"
+
+
+# ── revalidate-time evidence reuse ───────────────────────────────────────────
+
+
+def _proposed_pending(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[JobStore, str, Path, str]:
+    """Propose only (proposal stays PENDING — the revalidate precondition),
+    with green frozen economic evidence like `_proposed_and_claimed`."""
+    _patch_runner(monkeypatch)
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.proposals.evaluate_economic_gate", _ready_economic
+    )
+    store, job_id, root = _make_job(tmp_path)
+    proposal = propose_change(
+        store,
+        job_id,
+        kind="params_update",
+        summary="Disable the short leg.",
+        intent_contract=_intent_contract(),
+        params={"hype_short_enabled": False},
+    )
+    return store, job_id, root, proposal["proposal_id"]
+
+
+def test_revalidate_reuses_green_validation_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unchanged candidate + dataset + baseline with green frozen validation:
+    revalidate must not re-run the expensive candidate backtest — it keeps
+    the cheap invariants and regenerates the report around the prior run."""
+    store, job_id, root, pid = _proposed_pending(tmp_path, monkeypatch)
+    behavior_calls = _count_behavior_checks(monkeypatch)
+
+    revalidated = revalidate_proposal(store, job_id, pid)
+
+    assert behavior_calls == [], "candidate backtest must NOT re-run"
+    reused = _entries_of(store, job_id, "revalidate_evidence_reused")
+    assert len(reused) == 1
+    assert not _entries_of(store, job_id, "revalidate_evidence_rerun")
+    report = revalidated["candidate_report"]
+    assert report["mode"] == "full"
+    assert report["validation_summary"]["status"] == "passed"
+    assert report["gate"]["live_ready"] is True, report["gate"]["reasons"]
+    assert report["comparison"]["candidate"]["stats"]
+    proof = report["evidence_reuse"]
+    assert proof["phase"] == "revalidate"
+    assert proof["candidate_revision"] == report["revision"]
+    for key in ("base_revision", "candidate_revision", "dataset_fingerprint"):
+        assert reused[0][key] == proof[key]
+
+
+def test_revalidate_reruns_on_mutated_candidate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job_id, root, pid = _proposed_pending(tmp_path, monkeypatch)
+    candidate_script = (
+        root / "applications" / pid / "candidate" / "workspace" / "src" / "strategy.py"
+    )
+    candidate_script.write_text(
+        candidate_script.read_text(encoding="utf-8") + "\n# edited after report\n",
+        encoding="utf-8",
+    )
+    behavior_calls = _count_behavior_checks(monkeypatch)
+
+    revalidated = revalidate_proposal(store, job_id, pid)
+
+    assert len(behavior_calls) == 1, "full re-validation must run"
+    rerun = _entries_of(store, job_id, "revalidate_evidence_rerun")
+    assert rerun and rerun[0]["reason"] == "candidate_mismatch"
+    assert not _entries_of(store, job_id, "revalidate_evidence_reused")
+    assert revalidated["candidate_report"]["validation_summary"]["status"] == "passed"
+
+
+def test_revalidate_reruns_on_changed_dataset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job_id, root, pid = _proposed_pending(tmp_path, monkeypatch)
+    bars_path = root / "results" / "backtest" / "input_bars.json"
+    bars_path.write_text(
+        json.dumps(json.loads(bars_path.read_text(encoding="utf-8")), indent=2),
+        encoding="utf-8",
+    )
+    behavior_calls = _count_behavior_checks(monkeypatch)
+
+    revalidate_proposal(store, job_id, pid)
+
+    assert len(behavior_calls) == 1
+    rerun = _entries_of(store, job_id, "revalidate_evidence_rerun")
+    assert rerun and rerun[0]["reason"] == "dataset_changed"
+
+
+def test_revalidate_reruns_failed_validation_and_cures_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reuse must never short-circuit the cure: a frozen FAILED validation
+    half is exactly what revalidate exists to re-run (#700 recovery shape)."""
+    store, job_id, root, pid = _proposed_pending(tmp_path, monkeypatch)
+    _mutate_report(
+        store,
+        job_id,
+        pid,
+        validation_summary={
+            "status": "failed",
+            "failed_checks": ["candidate_backtest_valid"],
+            "failure_kind": "infrastructure",
+        },
+    )
+    behavior_calls = _count_behavior_checks(monkeypatch)
+
+    revalidated = revalidate_proposal(store, job_id, pid)
+
+    assert len(behavior_calls) == 1, "the poisoned half must re-run"
+    rerun = _entries_of(store, job_id, "revalidate_evidence_rerun")
+    assert rerun and rerun[0]["reason"] == "report_not_green"
+    assert revalidated["candidate_report"]["validation_summary"]["status"] == "passed"
+
+
+def test_revalidate_kill_switch_forces_full_rerun(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job_id, root, pid = _proposed_pending(tmp_path, monkeypatch)
+    monkeypatch.setenv("WAYFINDER_REVALIDATE_ALWAYS_RERUN", "1")
+    behavior_calls = _count_behavior_checks(monkeypatch)
+
+    revalidate_proposal(store, job_id, pid)
+
+    assert len(behavior_calls) == 1
+    rerun = _entries_of(store, job_id, "revalidate_evidence_rerun")
+    assert rerun and rerun[0]["reason"] == "kill_switch"
+
+
+def test_revalidate_reuse_still_cures_poisoned_economic_block(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The #700 incident shape WITH reuse active: validation green and
+    provably unchanged (reused — zero backtests), economic block poisoned by
+    a box condition (ready=None + error). Revalidate must reuse the
+    validation half AND refresh the economic half — the cure is the point."""
+    store, job_id, root, pid = _proposed_pending(tmp_path, monkeypatch)
+    _mutate_report(
+        store,
+        job_id,
+        pid,
+        economic={
+            "ready": None,
+            "reasons": ["economic evaluation failed: No backtest bars found."],
+            "enforcement": "advisory",
+            "constitution_revision": None,
+            "status": "error",
+            "escalate": True,
+        },
+    )
+    behavior_calls = _count_behavior_checks(monkeypatch)
+
+    revalidated = revalidate_proposal(store, job_id, pid)
+
+    assert behavior_calls == [], "green validation half must be reused"
+    assert _entries_of(store, job_id, "revalidate_evidence_reused")
+    economic = revalidated["candidate_report"]["economic"]
+    assert economic["ready"] is True, "the poisoned economic block must refresh"
+    assert economic["reasons"] == []
+
+    store.approve_proposal(job_id, pid)
+    assert store.load_proposal(job_id, pid)["status"] == "approved"
+
+
+# ── full lifecycle: the expensive backtest runs EXACTLY once ─────────────────
+
+
+def test_lifecycle_unchanged_candidate_backtests_exactly_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """propose → revalidate → approve → claim → apply for an unchanged
+    candidate: the expensive behavioral half (full-dataset candidate backtest
+    + preflight) runs exactly ONCE — at propose."""
+    _patch_runner(monkeypatch)
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.proposals.evaluate_economic_gate", _ready_economic
+    )
+    store, job_id, root = _make_job(tmp_path)
+    behavior_calls = _count_behavior_checks(monkeypatch)
+
+    proposal = propose_change(
+        store,
+        job_id,
+        kind="params_update",
+        summary="Disable the short leg.",
+        intent_contract=_intent_contract(),
+        params={"hype_short_enabled": False},
+    )
+    pid = proposal["proposal_id"]
+    assert len(behavior_calls) == 1, "propose runs the backtest once"
+
+    revalidate_proposal(store, job_id, pid)
+    assert len(behavior_calls) == 1, "revalidate reuses"
+
+    store.approve_proposal(job_id, pid)
+    claim_application(store, job_id, pid)
+    completed = complete_application(store, job_id, pid, status="applied")
+
+    assert len(behavior_calls) == 1, "apply reuses"
+    assert completed["proposal"]["application"]["status"] == "applied"
+    assert completed["deterministic_validation"]["status"] == "reused"
+    assert store.load(job_id).execution_params["hype_short_enabled"] is False
+    assert evaluate_live_gate(job_id, store=store)["live_ready"] is True
+
+
+# ── freshness bound: live-capable jobs refuse stale-dataset evidence ─────────
+
+
+def _stamp_dataset_fetched_at(root: Path, fetched_at: str) -> None:
+    bars_path = root / "results" / "backtest" / "input_bars.json"
+    bars_path.write_text(
+        json.dumps({"bars": _bars(), "metadata": {"fetched_at": fetched_at}}),
+        encoding="utf-8",
+    )
+
+
+def _make_live_capable(root: Path) -> None:
+    summary = root / "results" / "forward" / "summary.json"
+    summary.parent.mkdir(parents=True, exist_ok=True)
+    summary.write_text(json.dumps({"runs": {"count": 3}}), encoding="utf-8")
+
+
+def _proposed_and_claimed_with_stale_dataset(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    age_hours: float,
+) -> tuple[JobStore, str, Path, str]:
+    _patch_runner(monkeypatch)
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.proposals.evaluate_economic_gate", _ready_economic
+    )
+    store, job_id, root = _make_job(tmp_path)
+    fetched_at = (datetime.now(UTC) - timedelta(hours=age_hours)).isoformat()
+    _stamp_dataset_fetched_at(root, fetched_at)
+    proposal = propose_change(
+        store,
+        job_id,
+        kind="params_update",
+        summary="Disable the short leg.",
+        intent_contract=_intent_contract(),
+        params={"hype_short_enabled": False},
+    )
+    pid = proposal["proposal_id"]
+    store.approve_proposal(job_id, pid)
+    claim_application(store, job_id, pid)
+    return store, job_id, root, pid
+
+
+def test_stale_dataset_refuses_reuse_and_recompute_for_live_capable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """LIVE-CAPABLE + dataset older than the evidence ceiling: reusing would
+    promote on stale evidence, blindly re-validating would validate against
+    the same stale bars — the apply must refuse BOTH and route to
+    refresh + revalidate."""
+    store, job_id, root, pid = _proposed_and_claimed_with_stale_dataset(
+        tmp_path, monkeypatch, age_hours=48.0
+    )
+    _make_live_capable(root)
+    behavior_calls = _count_behavior_checks(monkeypatch)
+
+    completed = complete_application(store, job_id, pid, status="applied")
+
+    assert behavior_calls == [], "no blind recompute against stale bars"
+    assert completed["proposal"]["application"]["status"] == "failed"
+    error = completed["proposal"]["application"]["error"]
+    assert "dataset stale — refresh and revalidate" in error
+    refused = _entries_of(store, job_id, "apply_refused_stale_dataset")
+    assert len(refused) == 1
+    assert refused[0]["max_age_hours"] == 24.0
+    assert refused[0]["age_hours"] > 24.0
+    assert not _entries_of(store, job_id, "apply_validation_reused")
+
+
+def test_stale_dataset_still_reuses_for_paper_jobs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Containment: a job that never entered paper/live keeps reusing old
+    evidence — the freshness bound protects live capital only."""
+    store, job_id, root, pid = _proposed_and_claimed_with_stale_dataset(
+        tmp_path, monkeypatch, age_hours=48.0
+    )
+    behavior_calls = _count_behavior_checks(monkeypatch)
+
+    completed = complete_application(store, job_id, pid, status="applied")
+
+    assert behavior_calls == []
+    assert completed["proposal"]["application"]["status"] == "applied"
+    assert completed["deterministic_validation"]["status"] == "reused"
+
+
+def test_evidence_max_age_env_raises_the_ceiling(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job_id, root, pid = _proposed_and_claimed_with_stale_dataset(
+        tmp_path, monkeypatch, age_hours=48.0
+    )
+    _make_live_capable(root)
+    monkeypatch.setenv("WAYFINDER_EVIDENCE_MAX_AGE_HOURS", "1000")
+    behavior_calls = _count_behavior_checks(monkeypatch)
+
+    completed = complete_application(store, job_id, pid, status="applied")
+
+    assert behavior_calls == []
+    assert completed["proposal"]["application"]["status"] == "applied"
+    assert completed["deterministic_validation"]["status"] == "reused"
+
+
+def test_fresh_dataset_reuses_for_live_capable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job_id, root, pid = _proposed_and_claimed_with_stale_dataset(
+        tmp_path, monkeypatch, age_hours=1.0
+    )
+    _make_live_capable(root)
+    behavior_calls = _count_behavior_checks(monkeypatch)
+
+    completed = complete_application(store, job_id, pid, status="applied")
+
+    assert behavior_calls == []
+    assert completed["deterministic_validation"]["status"] == "reused"
+
+
+def test_stale_dataset_forces_revalidate_rerun_for_live_capable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """At revalidate the stale bound refuses REUSE only — the rerun proceeds
+    (revalidate is the named cure; the refreshed report's fingerprint then
+    covers whatever bars are on disk)."""
+    _patch_runner(monkeypatch)
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.proposals.evaluate_economic_gate", _ready_economic
+    )
+    store, job_id, root = _make_job(tmp_path)
+    fetched_at = (datetime.now(UTC) - timedelta(hours=48.0)).isoformat()
+    _stamp_dataset_fetched_at(root, fetched_at)
+    proposal = propose_change(
+        store,
+        job_id,
+        kind="params_update",
+        summary="Disable the short leg.",
+        intent_contract=_intent_contract(),
+        params={"hype_short_enabled": False},
+    )
+    pid = proposal["proposal_id"]
+    _make_live_capable(root)
+    candidate_dir = root / "applications" / pid / "candidate"
+
+    result = assess_evidence_reuse(
+        store,
+        job_id,
+        store.load_proposal(job_id, pid),
+        candidate_dir,
+        phase="revalidate",
+    )
+    assert result["eligible"] is False
+    assert result["reason"] == "dataset_stale"
+
+    behavior_calls = _count_behavior_checks(monkeypatch)
+    revalidate_proposal(store, job_id, pid)
+    assert len(behavior_calls) == 1
+    rerun = _entries_of(store, job_id, "revalidate_evidence_rerun")
+    assert rerun and rerun[0]["reason"] == "dataset_stale"
+
+
+# ── economic paired-fold persistence ─────────────────────────────────────────
+
+_GREEN_VECTOR = {
+    "net_log_growth": 0.05,
+    "downside_deviation": 0.01,
+    "tail_loss": 0.0,
+    "fee_load": 0.001,
+    "max_drawdown_pct": 0.05,
+    "trade_count": 20,
+    "day_count": 30,
+}
+_BASE_VECTOR = {**_GREEN_VECTOR, "net_log_growth": 0.01, "trade_count": 18}
+
+
+def _fake_evaluation(*, positive_folds: int = 4) -> dict[str, Any]:
+    return {
+        "status": "ok",
+        "folds": [
+            {"fold": index, "delta_utility": 0.01 if index < positive_folds else -0.01}
+            for index in range(4)
+        ],
+        "fold_count": 4,
+        "positive_folds": positive_folds,
+        "objective": {"baseline": _BASE_VECTOR, "candidate": _GREEN_VECTOR},
+        "paired_incumbent_delta": {
+            "estimate": 0.02,
+            "lcb": 0.01,
+            "confidence": 0.9,
+            "paired_days": 30,
+        },
+        "audit_slice": {
+            "start": "2026-01-01T00:00:00Z",
+            "end": "2026-01-07T00:00:00Z",
+            "bars": 10,
+            "baseline": _BASE_VECTOR,
+            "candidate": _GREEN_VECTOR,
+            "delta_utility": 0.01,
+        },
+    }
+
+
+def _economic_fixture(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, **evaluation_kwargs: Any
+) -> tuple[JobStore, str, Path, Path, list[int]]:
+    store, job_id, root = _make_job(tmp_path)
+    candidate_dir = tmp_path / "candidate"
+    candidate_dir.mkdir()
+    shutil.copytree(root / "workspace", candidate_dir / "workspace")
+    shutil.copy2(root / "job.yaml", candidate_dir / "job.yaml")
+    calls: list[int] = []
+
+    def fake_paired(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        calls.append(1)
+        return _fake_evaluation(**evaluation_kwargs)
+
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.economics.paired_fold_evaluation", fake_paired
+    )
+    return store, job_id, root, candidate_dir, calls
+
+
+def test_economic_folds_persisted_and_reused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job_id, root, candidate_dir, calls = _economic_fixture(tmp_path, monkeypatch)
+
+    first = evaluate_economic_gate(job_id, candidate_dir=candidate_dir, store=store)
+    assert first["ready"] is True
+    assert "reused" not in first
+    assert len(calls) == 1
+    assert (candidate_dir / PAIRED_FOLDS_RELATIVE).exists()
+
+    second = evaluate_economic_gate(job_id, candidate_dir=candidate_dir, store=store)
+    assert second["ready"] is True
+    assert second["reused"] is True
+    assert len(calls) == 1, "green matching folds must not recompute"
+    assert second["objective"] == first["objective"]
+    reused = _entries_of(store, job_id, "economic_evaluation_reused")
+    assert len(reused) == 1
+    assert reused[0]["candidate_revision"]
+
+
+def test_economic_folds_recompute_on_constitution_revision_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job_id, root, candidate_dir, calls = _economic_fixture(tmp_path, monkeypatch)
+    evaluate_economic_gate(job_id, candidate_dir=candidate_dir, store=store)
+    assert len(calls) == 1
+
+    (root / "constitution.yaml").write_text("enforcement: advisory\n")
+    assert load_constitution(root)["revision"], "constitution now has a revision"
+
+    result = evaluate_economic_gate(job_id, candidate_dir=candidate_dir, store=store)
+    assert len(calls) == 2, "constitution revision change must invalidate"
+    assert "reused" not in result
+
+
+def test_economic_folds_recompute_on_candidate_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job_id, root, candidate_dir, calls = _economic_fixture(tmp_path, monkeypatch)
+    evaluate_economic_gate(job_id, candidate_dir=candidate_dir, store=store)
+
+    script = candidate_dir / "workspace" / "src" / "strategy.py"
+    script.write_text(
+        script.read_text(encoding="utf-8") + "\n# tweak\n", encoding="utf-8"
+    )
+
+    evaluate_economic_gate(job_id, candidate_dir=candidate_dir, store=store)
+    assert len(calls) == 2
+
+
+def test_economic_folds_recompute_on_dataset_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job_id, root, candidate_dir, calls = _economic_fixture(tmp_path, monkeypatch)
+    evaluate_economic_gate(job_id, candidate_dir=candidate_dir, store=store)
+
+    bars_path = root / "results" / "backtest" / "input_bars.json"
+    bars_path.write_text(
+        json.dumps(json.loads(bars_path.read_text(encoding="utf-8")), indent=2),
+        encoding="utf-8",
+    )
+
+    evaluate_economic_gate(job_id, candidate_dir=candidate_dir, store=store)
+    assert len(calls) == 2
+
+
+def test_non_green_economic_folds_never_reused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job_id, root, candidate_dir, calls = _economic_fixture(
+        tmp_path, monkeypatch, positive_folds=0
+    )
+    first = evaluate_economic_gate(job_id, candidate_dir=candidate_dir, store=store)
+    assert first["ready"] is False
+
+    second = evaluate_economic_gate(job_id, candidate_dir=candidate_dir, store=store)
+    assert second["ready"] is False
+    assert "reused" not in second
+    assert len(calls) == 2, "non-green evidence recomputes every time"
+
+
+def test_economic_kill_switch_forces_recompute(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job_id, root, candidate_dir, calls = _economic_fixture(tmp_path, monkeypatch)
+    evaluate_economic_gate(job_id, candidate_dir=candidate_dir, store=store)
+    monkeypatch.setenv("WAYFINDER_ECONOMIC_ALWAYS_RECOMPUTE", "1")
+
+    result = evaluate_economic_gate(job_id, candidate_dir=candidate_dir, store=store)
+    assert len(calls) == 2
+    assert "reused" not in result
+
+
+# ── scenario replay cache ────────────────────────────────────────────────────
+
+
+def _scenario_fixture(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, expect: dict[str, Any]
+) -> tuple[JobStore, str, Path, Path, dict[str, Any], list[int]]:
+    store, job_id, root = _make_job(tmp_path)
+    candidate_dir = tmp_path / "candidate"
+    candidate_dir.mkdir()
+    shutil.copytree(root / "workspace", candidate_dir / "workspace")
+    shutil.copy2(root / "job.yaml", candidate_dir / "job.yaml")
+    proposal = {
+        "job_id": job_id,
+        "intent_contract": _intent_contract(),
+        "scenario_plan": {
+            "scenarios": [{"name": "replay", "bars": _bars(), "expect": expect}]
+        },
+    }
+    calls: list[int] = []
+    real = validation_module.simulate_execution
+
+    def counting(*args: Any, **kwargs: Any) -> Any:
+        calls.append(1)
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(validation_module, "simulate_execution", counting)
+    return store, job_id, root, candidate_dir, proposal, calls
+
+
+def _run_cheap_validation(
+    store: JobStore, root: Path, candidate_dir: Path, proposal: dict[str, Any]
+) -> dict[str, Any]:
+    return validation_module.validate_candidate_application(
+        repo_root=store.repo_root,
+        job_dir=root,
+        proposal=proposal,
+        candidate_dir=candidate_dir,
+        skip_behavior_checks=True,
+    )
+
+
+def test_scenario_results_reused_across_validations(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job_id, root, candidate_dir, proposal, calls = _scenario_fixture(
+        tmp_path, monkeypatch, expect={"execution_valid": True}
+    )
+
+    first = _run_cheap_validation(store, root, candidate_dir, proposal)
+    assert first["status"] == "passed"
+    assert len(calls) == 1
+    cache = candidate_dir / "reports" / "validation" / "scenario_cache.json"
+    assert cache.exists()
+
+    second = _run_cheap_validation(store, root, candidate_dir, proposal)
+    assert second["status"] == "passed"
+    assert len(calls) == 1, "cached scenario replay must not re-simulate"
+    reused_rows = [check for check in second["checks"] if check.get("reused") is True]
+    assert len(reused_rows) == 1
+    assert reused_rows[0]["name"] == "scenario_replay"
+
+
+def test_scenario_hash_invalidates_on_definition_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job_id, root, candidate_dir, proposal, calls = _scenario_fixture(
+        tmp_path, monkeypatch, expect={"execution_valid": True}
+    )
+    _run_cheap_validation(store, root, candidate_dir, proposal)
+    assert len(calls) == 1
+
+    proposal["scenario_plan"]["scenarios"][0]["expect"] = {
+        "execution_valid": True,
+        "max_trades": 5,
+    }
+    second = _run_cheap_validation(store, root, candidate_dir, proposal)
+    assert len(calls) == 2, "changed scenario definition must re-simulate"
+    assert not any(check.get("reused") for check in second["checks"])
+
+
+def test_scenario_cache_invalidates_on_candidate_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job_id, root, candidate_dir, proposal, calls = _scenario_fixture(
+        tmp_path, monkeypatch, expect={"execution_valid": True}
+    )
+    _run_cheap_validation(store, root, candidate_dir, proposal)
+
+    script = candidate_dir / "workspace" / "src" / "strategy.py"
+    script.write_text(
+        script.read_text(encoding="utf-8") + "\n# tweak\n", encoding="utf-8"
+    )
+    _run_cheap_validation(store, root, candidate_dir, proposal)
+    assert len(calls) == 2
+
+
+def test_failed_scenarios_never_cached(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job_id, root, candidate_dir, proposal, calls = _scenario_fixture(
+        tmp_path, monkeypatch, expect={"min_trades": 99}
+    )
+
+    first = _run_cheap_validation(store, root, candidate_dir, proposal)
+    assert first["status"] == "failed"
+    cache = candidate_dir / "reports" / "validation" / "scenario_cache.json"
+    assert not cache.exists(), "a failed scenario is a verdict, never cached"
+
+    _run_cheap_validation(store, root, candidate_dir, proposal)
+    assert len(calls) == 2
+
+
+def test_scenario_kill_switch_forces_rerun(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job_id, root, candidate_dir, proposal, calls = _scenario_fixture(
+        tmp_path, monkeypatch, expect={"execution_valid": True}
+    )
+    _run_cheap_validation(store, root, candidate_dir, proposal)
+    monkeypatch.setenv("WAYFINDER_SCENARIOS_ALWAYS_RUN", "1")
+
+    _run_cheap_validation(store, root, candidate_dir, proposal)
+    assert len(calls) == 2

--- a/wayfinder_paths/tests/test_jobs_experiments.py
+++ b/wayfinder_paths/tests/test_jobs_experiments.py
@@ -2,16 +2,46 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
+from wayfinder_paths.jobs.execution import experiments as experiments_module
 from wayfinder_paths.jobs.execution.experiments import (
     list_experiments,
     promote_params,
     run_experiment,
 )
 from wayfinder_paths.jobs.gating import compute_workspace_revision
+from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.tests.test_jobs_preflight import _make_job
+
+
+def _count_backtests(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    calls: list[int] = []
+    real = experiments_module.backtest_execution_job
+
+    def counting(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        calls.append(1)
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(experiments_module, "backtest_execution_job", counting)
+    return calls
+
+
+def _journal_entries(store: JobStore, job_id: str, kind: str) -> list[dict[str, Any]]:
+    path = store.job_dir(job_id) / "journal.jsonl"
+    if not path.exists():
+        return []
+    return [
+        row
+        for row in (
+            json.loads(line)
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        )
+        if row["type"] == kind
+    ]
 
 
 def test_run_experiment_records_and_ranks(tmp_path: Path) -> None:
@@ -96,3 +126,82 @@ def test_promote_params_requires_grid_or_params(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="grid_id"):
         promote_params(job_id, store=store)
+
+
+# ── submission dedup (evidence reuse) ────────────────────────────────────────
+
+
+def test_identical_submission_dedups_to_prior_green_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The audit's dominant redundancy class (71/107 identical grid runs in
+    one burst): an identical submission against a green prior must skip
+    compute entirely, journal the linkage, and surface the prior result."""
+    store, job_id, root = _make_job(tmp_path)
+    calls = _count_backtests(monkeypatch)
+
+    first = run_experiment(job_id, {"threshold": [10.0, 100.0]}, store=store)
+    assert len(calls) == 1
+    assert first["experiment"]["submission_hash"]
+
+    second = run_experiment(job_id, {"threshold": [10.0, 100.0]}, store=store)
+    assert len(calls) == 1, "identical submission must skip compute"
+    assert second["experiment"]["reused"] is True
+    assert second["experiment"]["grid_id"] == first["experiment"]["grid_id"]
+    backtest = second["backtest"]
+    assert backtest["reused_from_grid_id"] == first["experiment"]["grid_id"]
+    assert backtest["result"]["ranked"], "prior grid summary surfaced"
+    reused = _journal_entries(store, job_id, "experiment_reused")
+    assert len(reused) == 1
+    assert reused[0]["grid_id"] == first["experiment"]["grid_id"]
+    assert reused[0]["submission_hash"] == first["experiment"]["submission_hash"]
+    assert len(list_experiments(job_id, store=store)) == 1, "no duplicate row"
+
+    # Coordinate order is not semantic (#692) — reordering still dedups.
+    reordered = run_experiment(job_id, {"threshold": [100.0, 10.0]}, store=store)
+    assert len(calls) == 1
+    assert reordered["experiment"]["reused"] is True
+
+
+def test_changed_submission_runs_fresh(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job_id, root = _make_job(tmp_path)
+    calls = _count_backtests(monkeypatch)
+    run_experiment(job_id, {"threshold": [10.0, 100.0]}, store=store)
+
+    # Different search coordinates → different question → runs.
+    run_experiment(job_id, {"threshold": [10.0, 50.0]}, store=store)
+    assert len(calls) == 2
+
+    # Same coordinates but the workspace revision moved → runs.
+    script = root / "workspace" / "src" / "strategy.py"
+    script.write_text(
+        script.read_text(encoding="utf-8") + "\n# tweak\n", encoding="utf-8"
+    )
+    run_experiment(job_id, {"threshold": [10.0, 100.0]}, store=store)
+    assert len(calls) == 3
+
+    # Dataset content moved → runs.
+    bars_path = root / "results" / "backtest" / "input_bars.json"
+    bars_path.write_text(
+        json.dumps(json.loads(bars_path.read_text(encoding="utf-8")), indent=2),
+        encoding="utf-8",
+    )
+    run_experiment(job_id, {"threshold": [10.0, 100.0]}, store=store)
+    assert len(calls) == 4
+    assert len(list_experiments(job_id, store=store)) == 4
+
+
+def test_experiment_kill_switch_forces_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job_id, root = _make_job(tmp_path)
+    calls = _count_backtests(monkeypatch)
+    run_experiment(job_id, {"threshold": [10.0, 100.0]}, store=store)
+    monkeypatch.setenv("WAYFINDER_EXPERIMENT_ALWAYS_RUN", "1")
+
+    repeated = run_experiment(job_id, {"threshold": [10.0, 100.0]}, store=store)
+    assert len(calls) == 2, "kill-switch must force the run"
+    assert "reused" not in repeated["experiment"]
+    assert len(list_experiments(job_id, store=store)) == 2

--- a/wayfinder_paths/tests/test_jobs_walk_forward.py
+++ b/wayfinder_paths/tests/test_jobs_walk_forward.py
@@ -7,11 +7,13 @@ from typing import Any
 import pytest
 
 from wayfinder_paths.jobs.execution import ExecutionSpec
+from wayfinder_paths.jobs.execution import job as job_module
 from wayfinder_paths.jobs.execution.experiments import (
     list_experiments,
     promote_params,
     run_experiment,
 )
+from wayfinder_paths.jobs.execution.job import backtest_execution_job
 from wayfinder_paths.jobs.execution.simulator import PreparedExecutionDataset
 from wayfinder_paths.jobs.execution.walk_forward import run_walk_forward
 from wayfinder_paths.jobs.models import WayfinderJob
@@ -243,3 +245,114 @@ def test_insufficient_bars_error_names_feasible_sizing(tmp_path: Path) -> None:
             test_bars=100,
             train_bars=80,
         )
+
+
+# ── fold artifact persistence + reuse (evidence reuse) ───────────────────────
+
+
+def _count_walk_forward_runs(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    calls: list[int] = []
+    real = job_module.run_walk_forward
+
+    def counting(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        calls.append(1)
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(job_module, "run_walk_forward", counting)
+    return calls
+
+
+def _grid_backtest(store: JobStore, job_id: str, tmp_path: Path, **overrides: Any):
+    grid_file = tmp_path / "grid.json"
+    grid_file.write_text(
+        json.dumps(overrides.pop("grid", {"direction": ["long"]})), encoding="utf-8"
+    )
+    return backtest_execution_job(
+        job_id,
+        grid_path=grid_file,
+        walk_forward=overrides.pop(
+            "walk_forward", {"folds": 2, "test_bars": 50, "anchored": True}
+        ),
+        store=store,
+        **overrides,
+    )
+
+
+def _journal_types(store: JobStore, job_id: str) -> list[str]:
+    path = store.job_dir(job_id) / "journal.jsonl"
+    if not path.exists():
+        return []
+    return [
+        json.loads(line)["type"]
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def test_walk_forward_folds_reused_on_identical_rerun(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Identical fold spec + dataset + revision: the second run must
+    reconstruct the report from persisted fold artifacts instead of
+    re-simulating every fold."""
+    store, job_id = _make_bundle(tmp_path)
+    calls = _count_walk_forward_runs(monkeypatch)
+
+    first = _grid_backtest(store, job_id, tmp_path)
+    assert len(calls) == 1
+    first_grid = first["result"]["grid_id"]
+    grids_root = store.job_dir(job_id) / "results" / "backtest" / "grids"
+    fold_files = sorted((grids_root / first_grid).glob("fold_*.json"))
+    assert len(fold_files) == 2, "per-fold artifacts persisted"
+    assert json.loads(fold_files[0].read_text())["key"]["revision"]
+
+    second = _grid_backtest(store, job_id, tmp_path)
+    assert len(calls) == 1, "folds must NOT re-simulate"
+    reused = second["walk_forward"]["reused"]
+    assert reused["source_grid_id"] == first_grid
+    assert second["walk_forward"]["summary"] == first["walk_forward"]["summary"]
+    assert [row["test"] for row in second["walk_forward"]["folds"]] == [
+        row["test"] for row in first["walk_forward"]["folds"]
+    ]
+    assert "walk_forward_folds_reused" in _journal_types(store, job_id)
+
+
+def test_walk_forward_folds_recompute_on_key_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job_id = _make_bundle(tmp_path)
+    calls = _count_walk_forward_runs(monkeypatch)
+    _grid_backtest(store, job_id, tmp_path)
+
+    # Different fold layout → different key → recompute.
+    changed_layout = _grid_backtest(
+        store,
+        job_id,
+        tmp_path,
+        walk_forward={"folds": 2, "test_bars": 40, "anchored": True},
+    )
+    assert len(calls) == 2
+    assert "reused" not in changed_layout["walk_forward"]
+
+    # Workspace revision moved → recompute even for the original layout.
+    root = store.job_dir(job_id)
+    script = root / "workspace" / "src" / "strategy.py"
+    script.write_text(
+        script.read_text(encoding="utf-8") + "\n# tweak\n", encoding="utf-8"
+    )
+    moved_revision = _grid_backtest(store, job_id, tmp_path)
+    assert len(calls) == 3
+    assert "reused" not in moved_revision["walk_forward"]
+
+
+def test_walk_forward_kill_switch_forces_recompute(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job_id = _make_bundle(tmp_path)
+    calls = _count_walk_forward_runs(monkeypatch)
+    _grid_backtest(store, job_id, tmp_path)
+    monkeypatch.setenv("WAYFINDER_WF_FOLDS_ALWAYS_RUN", "1")
+
+    second = _grid_backtest(store, job_id, tmp_path)
+    assert len(calls) == 2
+    assert "reused" not in second["walk_forward"]


### PR DESCRIPTION
> **Stacked on #705** (`apply-evidence-reuse`, facb23b5). This branch extends #705's apply-time evidence-reuse mechanism across the rest of the lifecycle; merge #705 first (GitHub will retarget this PR to `wayfinder-jobs-v1` automatically).

## What

#705 stopped the apply path from re-running a ~30-minute candidate backtest against a provably unchanged candidate. This PR applies the same mechanical identity discipline (content hashes + frozen field reads, never trust) to every other place the pipeline re-computes evidence it already has — plus one owner policy bounding how OLD reused evidence may be for live-capable jobs.

**Rule everywhere: non-green evidence is never reused.** A failed validation, a non-ready economic verdict, a failed scenario, a non-ok fold, an invalid grid cell — all recompute fresh, every time.

## The 6 pieces

### 1. Revalidate reuse (`proposals.py::revalidate_proposal` + new `jobs/evidence_reuse.py`)
#705's eligibility check is factored into a shared `evidence_reuse.assess_evidence_reuse(store, job_id, proposal, candidate_dir, phase=...)`; `application.assess_validation_reuse` is now a thin `phase="apply"` wrapper (same signature, same journal contract, same proof shape). Revalidate calls it with `phase="revalidate"`: when the candidate/dataset/baseline are provably unchanged and the frozen **validation** half is green, the expensive candidate backtest is skipped (`validate_candidate_bundle(..., skip_behavior_checks=True)`) and the propose-time backtest artifact feeds the regenerated comparison. Journal: `revalidate_evidence_reused` (proof inline) / `revalidate_evidence_rerun` (reason).

**Reuse never short-circuits the cure**: revalidate exists to cure poisoned reports (#700). The economic block is re-evaluated unconditionally; a failed/poisoned validation half is `report_not_green` → full rerun (that's the point). Phase difference is exactly one condition: apply requires the whole report green (validation + economic), revalidate requires only the validation half green.

### 2. Economic-gate fold persistence (`gating.py::evaluate_economic_gate`)
The paired 2×K-fold replay is persisted to `applications/{pid}/candidate/reports/economic/paired_folds.json` keyed `{candidate_revision, baseline_revision, constitution_revision, dataset_fingerprint, fold_spec}`. Matching key + green (status ok AND readiness ready=True under the current constitution) ⇒ the persisted evaluation is reused (journal `economic_evaluation_reused`, result carries `reused: true`) and only the cheap pure-policy readiness verdict recomputes. Anything else recomputes + re-persists. Approve-time gate behavior unchanged — it still reads the frozen report.

### 3. Scenario-replay cache (`validation.py::_engine_scenario_checks`)
Scenario replays are deterministic in `{scenario set (bars+params+expect), execution spec, candidate revision}`. Results persist inside the candidate bundle (`reports/validation/scenario_cache.json`, outside `workspace/` so the revision is unchanged) and are reused across phases — propose populates, revalidate and the apply cheap-invariant path reuse. Only all-passed sets are ever cached; reused rows carry `"reused": true`. Any change to a scenario definition changes the hash.

### 4. Walk-forward fold artifacts (`execution/walk_forward.py` + `execution/job.py`)
Each fold persists as `results/backtest/grids/{grid_id}/fold_{i}.json` carrying the full key `{fold_spec (grid + WF layout + ranking), dataset_window (content fingerprint + window + quick_bars), revision}`. A later identical walk-forward reconstructs the report from a recent grid's COMPLETE green fold set instead of re-simulating (journal `walk_forward_folds_reused`, report carries `reused.source_grid_id`). Implemented at the outermost seam (`_backtest_execution_job_locked`) as sanctioned — no grid-runner surgery. Partial key matches recompute.

### 5. Experiment dedup at submission (`execution/experiments.py::run_experiment`)
The audit's biggest win (71/107 redundant runs in one burst): every submission computes a pre-run `submission_hash` = `{workspace revision, dataset content fingerprint, normalized search definition (coordinate order is not semantic, per #692), rank_by, optimizer, optuna options, walk_forward def, quick_bars}`, recorded on the ledger row. An identical submission whose most recent matching prior is GREEN (runs > 0, zero invalid cells, ranked best present, all WF folds ok) skips compute entirely: journal `experiment_reused` linking the prior grid_id, and the prior ledger row + grid summary are surfaced (`experiment.reused`, `backtest.reused_from_grid_id`, kept through `summarize_backtest_payload`). #692's post-run `semantic_hash` replication tagging is untouched. Kill-switch `WAYFINDER_EXPERIMENT_ALWAYS_RUN=1`.

### 6. Freshness bound — owner policy (`evidence_reuse.py`)
For **live-capable** jobs (`store._job_is_live_capable`), when the fingerprinted dataset's `metadata.fetched_at` age exceeds `WAYFINDER_EVIDENCE_MAX_AGE_HOURS` (default 24), reuse is refused (`dataset_stale`) — and the **apply** path additionally refuses to blindly recompute against the same stale bars: the apply fails with *"dataset stale — refresh and revalidate"* (journal `apply_refused_stale_dataset`), routing the operator to re-fetch + revalidate (after which the changed fingerprint forces an honest full re-validation on fresh data). Paper jobs reuse regardless of age (containment). Forward/live TTL caches (counterfactual/replication) untouched. A dataset with no `fetched_at` has unknown age and is not treated as stale — the live gate's 30-day backtest ceiling still bounds it.

## Kill-switches (all follow #705's env pattern)

| Surface | Env |
|---|---|
| Apply validation reuse (#705, unchanged) | `WAYFINDER_APPLY_ALWAYS_REVALIDATE=1` |
| Revalidate validation reuse | `WAYFINDER_REVALIDATE_ALWAYS_RERUN=1` |
| Economic fold persistence | `WAYFINDER_ECONOMIC_ALWAYS_RECOMPUTE=1` |
| Scenario cache | `WAYFINDER_SCENARIOS_ALWAYS_RUN=1` |
| WF fold artifacts | `WAYFINDER_WF_FOLDS_ALWAYS_RUN=1` |
| Experiment dedup | `WAYFINDER_EXPERIMENT_ALWAYS_RUN=1` |
| Freshness ceiling (policy dial) | `WAYFINDER_EVIDENCE_MAX_AGE_HOURS` (default 24) |

## Tests

- `test_jobs_apply_evidence_reuse.py` (+18): revalidate reuse-on-match and rerun-on-each-broken-key (candidate mutation, dataset change, non-green frozen validation, kill-switch); **#700 regression with reuse active** — poisoned economic block refreshed while the green validation half reuses with zero backtests; economic folds persisted + reused with constitution-revision / candidate / dataset invalidation, non-green-never-reused, kill-switch; scenario cache reuse + def-change/candidate-change invalidation + failed-scenarios-never-cached + kill-switch; freshness bound (live-capable refuses reuse AND recompute at apply, paper allowed, env override, fresh-dataset allowed, revalidate reruns with `dataset_stale` reason); **full-lifecycle regression: propose → revalidate → approve → claim → apply for an unchanged candidate runs the expensive backtest EXACTLY ONCE** (counted).
- `test_jobs_walk_forward.py` (+3): identical rerun reuses persisted folds (0 re-simulations, journal, identical summary); key invalidation (layout change, workspace revision move); kill-switch.
- `test_jobs_experiments.py` (+3): identical submission dedups (skip compute, link prior grid_id, no duplicate ledger row, coordinate-reorder still dedups); changed grid / moved revision / changed dataset rerun; kill-switch runs and records.
- `test_backtest_profile_and_summary.py`: fake `record_experiment` accepts the new optional `submission_hash` kwarg.

Full `pytest -k "jobs or runner or mcp"`: **1132 passed, 9 skipped** (stacked-base baseline 1103 passed + exactly the 29 tests added here). ruff + ruff format clean on all touched files; scoped mypy introduces zero new errors vs the stacked base.
