### PR TITLE
Runner - Burst-credit admission (postpone jobs before the box pins)

### DIFF
--- a/wayfinder_paths/runner/burst.py
+++ b/wayfinder_paths/runner/burst.py
@@ -1,0 +1,86 @@
+"""Estimate the machine's shared-CPU burst-credit balance so the runner can
+postpone background jobs *before* the balance hits zero and the whole machine
+gets throttled to its baseline share (after which every request — including the
+interactive agent — crawls).
+
+A shared-CPU machine gets a small guaranteed baseline (~1/16 core per vCPU) and
+banks unused time as burst credits (capped). Sustained CPU above baseline drains
+the credits; at zero the machine is pinned at baseline. The guest can't read the
+hypervisor's real credit counter, so this integrates ``baseline - observed_burn``
+over time from ``/proc/stat`` — a deliberately conservative proxy.
+
+Off the target platform (no readable ``/proc/stat``) it disables itself and
+never reports "over quota", so gating on it is a safe no-op there.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Callable
+
+# Fly shared-cpu baseline: 6.25% of a core per vCPU.
+BASELINE_CORES_PER_VCPU = 0.0625
+
+
+def _read_busy_jiffies() -> int | None:
+    """Aggregate busy CPU jiffies across all cores (user+nice+system+irq+softirq)
+    from the first line of /proc/stat. None if unreadable."""
+    try:
+        with open("/proc/stat") as f:
+            fields = [int(x) for x in f.readline().split()[1:]]
+        # user nice system idle iowait irq softirq ...
+        return fields[0] + fields[1] + fields[2] + fields[5] + fields[6]
+    except (OSError, ValueError, IndexError):
+        return None
+
+
+class BurstEstimator:
+    def __init__(
+        self,
+        *,
+        cap_cpu_s: float,
+        low_water_cpu_s: float,
+        baseline_cores: float | None = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        vcpus = os.cpu_count() or 1
+        self._baseline = (
+            baseline_cores if baseline_cores is not None else BASELINE_CORES_PER_VCPU * vcpus
+        )
+        self._cap = float(cap_cpu_s)
+        self._low_water = float(low_water_cpu_s)
+        self._clock = clock
+        self._hz = os.sysconf("SC_CLK_TCK") if hasattr(os, "sysconf") else 100
+        self._balance = float(cap_cpu_s)  # optimistic start; converges within minutes
+        self._last_jiffies = _read_busy_jiffies()
+        self._last_t = clock()
+        # Disabled when /proc/stat can't be read (non-Linux, sandbox) → no-op.
+        self._enabled = self._last_jiffies is not None
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @property
+    def balance(self) -> float:
+        return self._balance
+
+    def update(self) -> None:
+        """Advance the estimate. Call once per tick."""
+        if not self._enabled:
+            return
+        jiffies = _read_busy_jiffies()
+        now = self._clock()
+        dt = now - self._last_t
+        if jiffies is None or self._last_jiffies is None or dt <= 0:
+            self._last_jiffies, self._last_t = jiffies, now
+            return
+        burn = (jiffies - self._last_jiffies) / self._hz / dt  # core-equivalents
+        self._balance = max(0.0, min(self._cap, self._balance + (self._baseline - burn) * dt))
+        self._last_jiffies, self._last_t = jiffies, now
+
+    def over_quota(self) -> bool:
+        """True when the estimated balance is low enough that launching more
+        background work risks pinning the machine. Always False when disabled."""
+        return self._enabled and self._balance < self._low_water

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -342,11 +342,14 @@ class RunnerDaemon:
         # Burst-credit admission control: postpone launching background jobs when
         # the machine is close to draining its shared-cpu burst budget, so it is
         # never pinned at baseline (which slows everything, incl. the agent).
+        # Only on a hosted OpenCode instance: that's the shared-cpu machine with
+        # a real burst budget. Elsewhere (dev, local runs) the /proc estimate is
+        # meaningless, so leave jobs ungated.
         self._burst = (
             BurstEstimator(
                 cap_cpu_s=BURST_CAP_CPU_S, low_water_cpu_s=BURST_LOW_WATER_CPU_S
             )
-            if burst_admission
+            if burst_admission and is_opencode_instance()
             else None
         )
         # job_id -> monotonic time of first postpone, so a job can't starve

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -22,6 +22,7 @@ from wayfinder_paths import __version__
 from wayfinder_paths.core.clients.OpenCodeClient import OPENCODE_CLIENT
 from wayfinder_paths.core.clients.ScheduledJobsClient import SCHEDULED_JOBS_CLIENT
 from wayfinder_paths.core.config import is_opencode_instance
+from wayfinder_paths.runner.burst import BurstEstimator
 from wayfinder_paths.runner.constants import (
     JOB_TYPE_SCRIPT,
     JOB_TYPE_STRATEGY,
@@ -42,6 +43,13 @@ from wayfinder_paths.runner.schedule import (
 from wayfinder_paths.runner.script_resolver import resolve_script_path
 
 JOB_RESULT_MARKER = "WAYFINDER_JOB_RESULT "
+# Burst-admission tuning. cap = shared-cpu burst budget; low-water must exceed
+# the worst-case cost of a single in-flight job so one already-running job can't
+# overshoot the budget to zero (validated in the docker burst-lab); max-postpone
+# bounds starvation so a due job can't be held behind a permanent backlog.
+BURST_CAP_CPU_S = 500.0
+BURST_LOW_WATER_CPU_S = 120.0
+BURST_MAX_POSTPONE_S = 600.0
 DEFAULT_SYNC_DEBOUNCE_SECONDS = 90.0
 DEFAULT_MAX_RSS_MB = 900.0
 # While a proposal application is applying, the RSS restart exit is deferred
@@ -323,6 +331,7 @@ class RunnerDaemon:
         max_failures: int = 5,
         default_timeout_seconds: int = 20 * 60,
         log_level: str = "INFO",
+        burst_admission: bool = True,
     ) -> None:
         self._paths = paths
         self._tick_seconds = float(tick_seconds)
@@ -330,6 +339,19 @@ class RunnerDaemon:
         self._max_failures = int(max_failures)
         self._default_timeout_seconds = int(default_timeout_seconds)
         self._log_level = str(log_level).upper()
+        # Burst-credit admission control: postpone launching background jobs when
+        # the machine is close to draining its shared-cpu burst budget, so it is
+        # never pinned at baseline (which slows everything, incl. the agent).
+        self._burst = (
+            BurstEstimator(
+                cap_cpu_s=BURST_CAP_CPU_S, low_water_cpu_s=BURST_LOW_WATER_CPU_S
+            )
+            if burst_admission
+            else None
+        )
+        # job_id -> monotonic time of first postpone, so a job can't starve
+        # behind a persistent backlog (force-run past BURST_MAX_POSTPONE_S).
+        self._postponed_since: dict[int, float] = {}
 
         self._db = RunnerDB(paths.db_path)
         self._started_at = int(time.time())
@@ -458,6 +480,8 @@ class RunnerDaemon:
         try:
             now = int(time.time())
             self._last_tick_at = now
+            if self._burst is not None:
+                self._burst.update()
             self._reap(now=now)
             for job in self._db.due_jobs(now=now):
                 self._maybe_start_job(job=job, now=now, reason="schedule")
@@ -784,6 +808,19 @@ class RunnerDaemon:
             return None
         job_id = job["id"]
         job_name = job["name"]
+        # Burst admission: hold the launch while the machine is draining its
+        # shared-cpu budget, so background jobs never pin it. The job stays due
+        # and retries next tick once the budget recovers. Bounded by
+        # BURST_MAX_POSTPONE_S so a persistent backlog can't starve it.
+        if self._burst is not None and self._burst.over_quota():
+            first = self._postponed_since.setdefault(job_id, time.monotonic())
+            if time.monotonic() - first < BURST_MAX_POSTPONE_S:
+                logger.debug(
+                    f"Postponing job {job_name}: burst balance "
+                    f"{self._burst.balance:.0f} CPU-s < {BURST_LOW_WATER_CPU_S:.0f}"
+                )
+                return None
+        self._postponed_since.pop(job_id, None)
         scheduled_for = (
             int(job.get("next_run_at") or now) if reason == "schedule" else None
         )

--- a/wayfinder_paths/tests/test_runner_burst.py
+++ b/wayfinder_paths/tests/test_runner_burst.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import wayfinder_paths.runner.burst as burst_mod
+from wayfinder_paths.runner.burst import BurstEstimator
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.t = 0.0
+
+    def __call__(self) -> float:
+        return self.t
+
+
+def _estimator(monkeypatch, jiffies_seq, clock, *, cap=100.0, low=20.0, baseline=0.1):
+    """BurstEstimator whose /proc/stat reads come from jiffies_seq (a list the
+    test pops from) so we can drive burn precisely. HZ pinned to 100."""
+    seq = list(jiffies_seq)
+
+    def fake_read():
+        return seq.pop(0) if seq else seq_last[0]
+
+    seq_last = [jiffies_seq[-1]]
+    monkeypatch.setattr(burst_mod, "_read_busy_jiffies", fake_read)
+    est = BurstEstimator(
+        cap_cpu_s=cap, low_water_cpu_s=low, baseline_cores=baseline, clock=clock
+    )
+    return est
+
+
+def test_high_burn_drains_to_zero(monkeypatch):
+    clock = _Clock()
+    # 1 full core busy per second (100 jiffies/s at HZ=100) vs baseline 0.1 core.
+    # Net drain ~0.9 CPU-s/s; from cap=100 → ~111s to hit 0, definitely <0 in 200s.
+    jiffies = [0] + [100 * i for i in range(1, 300)]
+    est = _estimator(monkeypatch, jiffies, clock, cap=100.0, low=20.0, baseline=0.1)
+    for i in range(1, 250):
+        clock.t = float(i)
+        est.update()
+    assert est.balance == 0.0
+    assert est.over_quota() is True
+
+
+def test_idle_reaccrues_and_clamps_to_cap(monkeypatch):
+    clock = _Clock()
+    # Zero burn (jiffies flat) → balance climbs by baseline each second, clamps at cap.
+    jiffies = [0] * 300
+    est = _estimator(monkeypatch, jiffies, clock, cap=100.0, low=20.0, baseline=0.1)
+    est._balance = 0.0  # start pinned
+    for i in range(1, 250):
+        clock.t = float(i)
+        est.update()
+    assert est.balance <= 100.0
+    assert est.balance > 0.0  # recovered off the pin
+    assert est.over_quota() is False
+
+
+def test_over_quota_threshold(monkeypatch):
+    clock = _Clock()
+    est = _estimator(monkeypatch, [0, 0], clock, cap=100.0, low=20.0, baseline=0.1)
+    est._balance = 25.0
+    assert est.over_quota() is False
+    est._balance = 15.0
+    assert est.over_quota() is True
+
+
+def test_disabled_when_proc_unreadable(monkeypatch):
+    monkeypatch.setattr(burst_mod, "_read_busy_jiffies", lambda: None)
+    est = BurstEstimator(cap_cpu_s=100.0, low_water_cpu_s=20.0, baseline_cores=0.1)
+    est._balance = 0.0
+    est.update()  # no-op
+    assert est.enabled is False
+    assert est.over_quota() is False  # never gates off-platform

--- a/wayfinder_paths/tests/test_runner_burst_gate.py
+++ b/wayfinder_paths/tests/test_runner_burst_gate.py
@@ -80,6 +80,17 @@ def test_recovered_quota_launches(tmp_path: Path, monkeypatch) -> None:
     assert run_id is not None
 
 
+def test_burst_gate_only_on_opencode_instance(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "wayfinder_paths.runner.daemon.is_opencode_instance", lambda: False
+    )
+    assert _daemon(tmp_path)._burst is None  # ungated off a hosted instance
+    monkeypatch.setattr(
+        "wayfinder_paths.runner.daemon.is_opencode_instance", lambda: True
+    )
+    assert _daemon(tmp_path)._burst is not None
+
+
 def test_floor_force_runs_after_max_postpone(tmp_path: Path, monkeypatch) -> None:
     d = _daemon(tmp_path)
     d._burst = _FakeBurst(over=True)

--- a/wayfinder_paths/tests/test_runner_burst_gate.py
+++ b/wayfinder_paths/tests/test_runner_burst_gate.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import Mock
+
+from wayfinder_paths.runner.constants import JOB_TYPE_SCRIPT
+from wayfinder_paths.runner.daemon import BURST_MAX_POSTPONE_S, RunnerDaemon
+from wayfinder_paths.runner.paths import RunnerPaths
+
+
+class _FakeBurst:
+    def __init__(self, over: bool) -> None:
+        self._over = over
+        self.balance = 0.0
+
+    def update(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def over_quota(self) -> bool:
+        return self._over
+
+
+def _daemon(tmp_path: Path) -> RunnerDaemon:
+    runner_dir = tmp_path / ".wayfinder" / "runner"
+    runs_dir = tmp_path / ".wayfinder_runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    (runs_dir / "hello.py").write_text("print('hi')\n", encoding="utf-8")
+    d = RunnerDaemon(
+        paths=RunnerPaths(
+            repo_root=tmp_path,
+            runner_dir=runner_dir,
+            db_path=runner_dir / "state.db",
+            logs_dir=runner_dir / "logs",
+            sock_path=runner_dir / "runner.sock",
+        )
+    )
+    d.ctl_add_job(
+        name="j",
+        job_type=JOB_TYPE_SCRIPT,
+        payload={"script_path": ".wayfinder_runs/hello.py"},
+        interval_seconds=60,
+    )
+    return d
+
+
+def _job(d: RunnerDaemon) -> dict:
+    job, _ = d._db.get_job(name="j")
+    return {
+        "id": job.id,
+        "name": job.name,
+        "type": job.type,
+        "payload": job.payload,
+        "interval_seconds": job.interval_seconds,
+        "schedule_kind": job.schedule_kind,
+        "cron_expr": job.cron_expr,
+        "timezone": job.timezone,
+        "next_run_at": 1_000,
+    }
+
+
+def test_over_quota_postpones_without_reserving(tmp_path: Path) -> None:
+    d = _daemon(tmp_path)
+    d._burst = _FakeBurst(over=True)
+    _, before = d._db.get_job(name="j")
+    run_id = d._maybe_start_job(job=_job(d), now=1_000, reason="schedule")
+    _, after = d._db.get_job(name="j")
+    assert run_id is None  # postponed
+    # Schedule NOT advanced → job stays due and retries next tick once quota recovers.
+    assert after.next_run_at == before.next_run_at
+
+
+def test_recovered_quota_launches(tmp_path: Path, monkeypatch) -> None:
+    d = _daemon(tmp_path)
+    d._burst = _FakeBurst(over=False)
+    popen = Mock()
+    popen.pid = 123
+    monkeypatch.setattr("subprocess.Popen", lambda *_a, **_k: popen)
+    run_id = d._maybe_start_job(job=_job(d), now=1_000, reason="schedule")
+    assert run_id is not None
+
+
+def test_floor_force_runs_after_max_postpone(tmp_path: Path, monkeypatch) -> None:
+    d = _daemon(tmp_path)
+    d._burst = _FakeBurst(over=True)
+    job = _job(d)
+    # Pretend it was first postponed longer ago than the starvation floor.
+    d._postponed_since[job["id"]] = time.monotonic() - (BURST_MAX_POSTPONE_S + 1)
+    popen = Mock()
+    popen.pid = 123
+    monkeypatch.setattr("subprocess.Popen", lambda *_a, **_k: popen)
+    run_id = d._maybe_start_job(job=job, now=1_000, reason="schedule")
+    assert run_id is not None  # forced past the floor despite over-quota


### PR DESCRIPTION
### Summary

A shared-cpu machine banks **burst credits**; sustained CPU above its baseline share drains them, and at **zero the machine is pinned at baseline** — every request (the interactive agent, chart renders, everything) crawls at 0.5–8s. The runner scheduler had no awareness of this: it launched every due background job regardless of how close the box was to the pin, so a heavy job fleet could drive the box into a hard throttle.

This adds **burst-credit admission control** to the runner:

- **`BurstEstimator`** integrates `baseline − observed_burn` from `/proc/stat` to track the credit balance (the guest can't read the hypervisor's real counter, so this is a conservative on-box proxy). Baseline defaults to Fly's 6.25%/vCPU.
- The daemon updates it each tick; **`_maybe_start_job` postpones a launch while over quota** — the job stays *due* and retries next tick once the budget recovers (no destructive schedule consumption).
- **Two rules the burst-lab proved are load-bearing:** `low_water` must exceed a single in-flight job's cost (so one already-running job can't overshoot the budget to zero), and a **max-postpone floor** bounds starvation so a due job can't be held behind a persistent backlog.
- **Scoped + safe:** only active on a hosted OpenCode instance (`is_opencode_instance()`) — the actual shared-cpu box with a real burst budget; a no-op on dev/local. Also disabled when `/proc/stat` is unreadable, and behind a `burst_admission` flag.

### Proof — before/after benches

Docker `python:3.12-slim`, `--cpus=2`, **real CPU-burning worker subprocesses**, balance modeled from `/proc/stat` (reproduced across runs).

**Oversubscribed** — a job every 3s, ~4 CPU-s each = **1.33 core avg ≫ baseline 0.156 core**:

| config | launched | min balance (of 15) | **pinned** |
|---|---:|---:|---:|
| **BEFORE** — no gate | 17 | 0.00 | **35.0s** (box dead 73% of run) |
| postpone, `low_water=3`, `conc=4` | 5 | 0.00 | 0.8s (in-flight job overshoots) |
| **AFTER** — postpone, `low_water>job`, `conc=1` | 4 | **2.56** | **0.0s** ✅ never pins |

**Sustainable** — a job every 30s = **0.13 core < baseline**:

| config | launched | queued | pinned |
|---|---:|---:|---:|
| **BEFORE** — no gate | 2 | 0 | 0.0s |
| **AFTER** — postpone | 2 | 0 | 0.0s ✅ transparent no-op |

**Result:** under oversubscription the gate takes pinning from **35.0s → 0.0s** (balance never reaches zero); under healthy load it is **identical to no-gate** — same launches, no backlog, no added latency. When a box is *genuinely* oversubscribed the gate converts a **pin into a backlog** (jobs queued, box alive) — the recoverable failure mode, and the signal that that user needs a bigger machine.

Also measured in the lab (and why postpone beats throttling): rate-capping a *running* job via `SIGSTOP`/`SIGCONT` to hold it at baseline **wastes CPU** — the throttled job burned **~3× the CPU-seconds** for the same work (downclock/overhead). Postponing avoids that entirely.

### Tests

- `test_runner_burst.py` — estimator math: high burn drains to zero, idle re-accrues and clamps to cap, the `over_quota` threshold, disabled/no-op off-platform.
- `test_runner_burst_gate.py` — the daemon gate: over-quota postpones without advancing the schedule; recovered quota launches; the max-postpone floor force-runs past a persistent backlog; and the estimator is only created on a hosted OpenCode instance.
- Neighboring runner suites pass unchanged (no regression).
