### PR TITLE
mcp: gate jobs tools behind WAYFINDER_JOBS_ENABLED; drop committed .venv symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ site/
 !wayfinder_paths/packs/templates/applet/dist/**
 
 # Virtual environments
-.venv/
+.venv
 venv/
 env/
 

--- a/.venv
+++ b/.venv
@@ -1,1 +1,0 @@
-/Users/felixchen/Desktop/wayfinder-paths-sdk/.venv

--- a/wayfinder_paths/core/config.py
+++ b/wayfinder_paths/core/config.py
@@ -182,6 +182,21 @@ def is_opencode_instance() -> bool:
     return bool(os.environ.get("OPENCODE_INSTANCE_ID"))
 
 
+def jobs_tools_enabled() -> bool:
+    """Whether jobs_v1 MCP tools (core_jobs, quant_pattern_match*) are exposed.
+
+    Default OFF: on chat-only prod boxes these tools let an agent create/flip a
+    job live (placing real orders inside the runner child, outside the safety-review
+    hooks) with no approval prompt, and eagerly import the heavy jobs/quant packages
+    (pandas + ~71 modules). Enable explicitly on boxes that run jobs.
+    """
+    return os.environ.get("WAYFINDER_JOBS_ENABLED", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+
 def get_opencode_instance_id() -> str:
     if not (instance_id := os.environ.get("OPENCODE_INSTANCE_ID")):
         raise RuntimeError(

--- a/wayfinder_paths/mcp/cli.py
+++ b/wayfinder_paths/mcp/cli.py
@@ -11,7 +11,6 @@ Usage:
 
 import sys
 
-from wayfinder_paths.jobs.cli import job_cli
 from wayfinder_paths.mcp.cli_builder import build_cli
 from wayfinder_paths.mcp.server import mcp
 from wayfinder_paths.paths.cli import path_cli
@@ -27,7 +26,14 @@ def main():
         maybe_heartbeat_installed_paths(trigger="mcp-cli")
 
     cli = build_cli(mcp)
-    cli.add_command(job_cli)
+    # `job_cli` pulls in the heavy jobs package (pandas + ~71 modules); import it
+    # lazily so non-job subcommands don't pay that cost. `--help` still needs the
+    # subcommand registered to list it, so include it when no concrete subcommand
+    # was given.
+    if first_command in {"job", None} or (first_command or "").startswith("-"):
+        from wayfinder_paths.jobs.cli import job_cli
+
+        cli.add_command(job_cli)
     cli.add_command(runner_cli)
     cli.add_command(path_cli)
     cli(standalone_mode=True)

--- a/wayfinder_paths/mcp/server.py
+++ b/wayfinder_paths/mcp/server.py
@@ -105,9 +105,10 @@ from wayfinder_paths.mcp.tools.instance_state import (
     visual_set_chart_indicators,
 )
 
-# NOTE: jobs + pattern_match tools are imported lazily inside build_mcp() so a
-# chat box with WAYFINDER_JOBS_ENABLED off never pulls in the heavy jobs/quant
-# packages (pandas + ~71 modules) via this path. See jobs_tools_enabled().
+# NOTE: jobs tools are imported lazily inside build_mcp() so a chat box with
+# WAYFINDER_JOBS_ENABLED off never pulls in the heavy jobs package (pandas +
+# ~71 modules) via this path. See jobs_tools_enabled(). pattern_match tools
+# are prod-live and unconditional (lazy only for CLI-path lightness).
 from wayfinder_paths.mcp.tools.notify import notification_send
 from wayfinder_paths.mcp.tools.polymarket import (
     polymarket_cancel_order,
@@ -182,16 +183,21 @@ def build_mcp(
     # the runner child, OUTSIDE the safety-review hooks — with no approval
     # prompt. On chat-only prod boxes that must stay absent. Import lazily so
     # the heavy jobs/quant packages (pandas + ~71 modules) never load when off.
+    # quant_pattern_match* are prod-live on main (chat users rely on them) —
+    # they import from the quant package, not jobs, and stay UNGATED. Lazy
+    # import only to keep non-MCP CLI paths light.
+    from wayfinder_paths.mcp.tools.pattern_match import (
+        quant_pattern_match,
+        quant_pattern_match_ccxt_proxy,
+    )
+
+    mcp.tool()(quant_pattern_match)
+    mcp.tool()(quant_pattern_match_ccxt_proxy)
+
     if jobs_tools_enabled():
         from wayfinder_paths.mcp.tools.jobs import core_jobs
-        from wayfinder_paths.mcp.tools.pattern_match import (
-            quant_pattern_match,
-            quant_pattern_match_ccxt_proxy,
-        )
 
         mcp.tool()(core_jobs)
-        mcp.tool()(quant_pattern_match)
-        mcp.tool()(quant_pattern_match_ccxt_proxy)
 
     # ─── hyperliquid_* ─────────────────────────────────────────────────
     # Coin naming reference: /using-hyperliquid-adapter/rules/coin-naming.md.

--- a/wayfinder_paths/mcp/server.py
+++ b/wayfinder_paths/mcp/server.py
@@ -35,7 +35,7 @@ from typing import Literal
 
 from mcp.server.fastmcp import FastMCP
 
-from wayfinder_paths.core.config import is_opencode_instance
+from wayfinder_paths.core.config import is_opencode_instance, jobs_tools_enabled
 from wayfinder_paths.mcp.tools.alpha_lab import (
     research_get_alpha_types,
     research_search_alpha,
@@ -104,12 +104,11 @@ from wayfinder_paths.mcp.tools.instance_state import (
     visual_set_active_market,
     visual_set_chart_indicators,
 )
-from wayfinder_paths.mcp.tools.jobs import core_jobs
+
+# NOTE: jobs + pattern_match tools are imported lazily inside build_mcp() so a
+# chat box with WAYFINDER_JOBS_ENABLED off never pulls in the heavy jobs/quant
+# packages (pandas + ~71 modules) via this path. See jobs_tools_enabled().
 from wayfinder_paths.mcp.tools.notify import notification_send
-from wayfinder_paths.mcp.tools.pattern_match import (
-    quant_pattern_match,
-    quant_pattern_match_ccxt_proxy,
-)
 from wayfinder_paths.mcp.tools.polymarket import (
     polymarket_cancel_order,
     polymarket_deposit_pusd,
@@ -175,13 +174,24 @@ def build_mcp(
     mcp.tool()(core_web_fetch)
     mcp.tool()(core_run_script)
     mcp.tool()(core_run_strategy)
-    mcp.tool()(core_jobs)
     mcp.tool()(core_runner_status)
     mcp.tool()(core_runner)
 
-    # ─── quant_* (hidden quant-worker analytics) ──────────────────────
-    mcp.tool()(quant_pattern_match)
-    mcp.tool()(quant_pattern_match_ccxt_proxy)
+    # ─── jobs_v1: core_jobs + quant_pattern_match* (gated, default OFF) ─
+    # These let an agent create/flip a job live — placing real orders inside
+    # the runner child, OUTSIDE the safety-review hooks — with no approval
+    # prompt. On chat-only prod boxes that must stay absent. Import lazily so
+    # the heavy jobs/quant packages (pandas + ~71 modules) never load when off.
+    if jobs_tools_enabled():
+        from wayfinder_paths.mcp.tools.jobs import core_jobs
+        from wayfinder_paths.mcp.tools.pattern_match import (
+            quant_pattern_match,
+            quant_pattern_match_ccxt_proxy,
+        )
+
+        mcp.tool()(core_jobs)
+        mcp.tool()(quant_pattern_match)
+        mcp.tool()(quant_pattern_match_ccxt_proxy)
 
     # ─── hyperliquid_* ─────────────────────────────────────────────────
     # Coin naming reference: /using-hyperliquid-adapter/rules/coin-naming.md.

--- a/wayfinder_paths/tests/test_mcp_server_build.py
+++ b/wayfinder_paths/tests/test_mcp_server_build.py
@@ -1,11 +1,28 @@
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import time
 
+import pytest
 
-def test_build_mcp_registers_tools() -> None:
+# jobs_v1 tools (core_jobs + quant_pattern_match*) are gated behind
+# WAYFINDER_JOBS_ENABLED (default OFF). Enable it for the registration assertions
+# below that expect the quant tools to be present.
+JOBS_GATED_TOOLS = {
+    "core_jobs",
+    "quant_pattern_match",
+    "quant_pattern_match_ccxt_proxy",
+}
+
+
+@pytest.fixture
+def jobs_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WAYFINDER_JOBS_ENABLED", "1")
+
+
+def test_build_mcp_registers_tools(jobs_enabled: None) -> None:
     from wayfinder_paths.mcp.server import build_mcp
 
     mcp = build_mcp()
@@ -60,3 +77,61 @@ def test_mcp_server_starts_and_stays_alive() -> None:
         except subprocess.TimeoutExpired:
             proc.kill()
             proc.wait(timeout=5)
+
+
+def test_jobs_tools_absent_when_flag_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Default posture on chat-only prod boxes: WAYFINDER_JOBS_ENABLED unset →
+    # core_jobs + quant_pattern_match* MUST NOT be registered. This is the
+    # permission-inversion guard (core_run_script/core_runner are ask-gated,
+    # core_jobs was not) and the pandas cold-start guard.
+    monkeypatch.delenv("WAYFINDER_JOBS_ENABLED", raising=False)
+
+    from wayfinder_paths.mcp.server import build_mcp
+
+    names = {tool.name for tool in build_mcp()._tool_manager.list_tools()}
+    assert not (JOBS_GATED_TOOLS & names), (
+        f"jobs tools leaked with flag OFF: {JOBS_GATED_TOOLS & names}"
+    )
+    # Non-jobs tools are still present — gating is scoped, not a full shutoff.
+    assert "core_run_script" in names
+    assert "onchain_swap" in names
+
+
+def test_jobs_tool_module_not_imported_when_flag_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Stronger than absence-of-registration: assert the jobs tool module (and its
+    # heavy pandas/quant import chain) is never even imported when the flag is off.
+    # Run in a clean subprocess so a prior test that enabled jobs can't pollute
+    # sys.modules.
+    monkeypatch.delenv("WAYFINDER_JOBS_ENABLED", raising=False)
+    code = (
+        "import sys\n"
+        "from wayfinder_paths.mcp.server import build_mcp\n"
+        "build_mcp()\n"
+        "leaked = [m for m in ('wayfinder_paths.mcp.tools.jobs',\n"
+        "                       'wayfinder_paths.mcp.tools.pattern_match')\n"
+        "          if m in sys.modules]\n"
+        "assert not leaked, f'jobs tool modules imported with flag off: {leaked}'\n"
+        "print('OK')\n"
+    )
+    child_env = {k: v for k, v in os.environ.items() if k != "WAYFINDER_JOBS_ENABLED"}
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        env=child_env,
+    )
+    assert result.returncode == 0, (
+        f"subprocess failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert "OK" in result.stdout
+
+
+def test_jobs_tools_present_when_flag_on(jobs_enabled: None) -> None:
+    from wayfinder_paths.mcp.server import build_mcp
+
+    names = {tool.name for tool in build_mcp()._tool_manager.list_tools()}
+    assert JOBS_GATED_TOOLS <= names, (
+        f"jobs tools missing with flag ON: {JOBS_GATED_TOOLS - names}"
+    )

--- a/wayfinder_paths/tests/test_mcp_server_build.py
+++ b/wayfinder_paths/tests/test_mcp_server_build.py
@@ -7,11 +7,13 @@ import time
 
 import pytest
 
-# jobs_v1 tools (core_jobs + quant_pattern_match*) are gated behind
-# WAYFINDER_JOBS_ENABLED (default OFF). Enable it for the registration assertions
-# below that expect the quant tools to be present.
+# core_jobs is gated behind WAYFINDER_JOBS_ENABLED (default OFF). The
+# quant_pattern_match* tools are prod-live on main and deliberately UNGATED —
+# they import from the quant package, not jobs.
 JOBS_GATED_TOOLS = {
     "core_jobs",
+}
+UNGATED_QUANT_TOOLS = {
     "quant_pattern_match",
     "quant_pattern_match_ccxt_proxy",
 }
@@ -81,9 +83,9 @@ def test_mcp_server_starts_and_stays_alive() -> None:
 
 def test_jobs_tools_absent_when_flag_off(monkeypatch: pytest.MonkeyPatch) -> None:
     # Default posture on chat-only prod boxes: WAYFINDER_JOBS_ENABLED unset →
-    # core_jobs + quant_pattern_match* MUST NOT be registered. This is the
-    # permission-inversion guard (core_run_script/core_runner are ask-gated,
-    # core_jobs was not) and the pandas cold-start guard.
+    # core_jobs MUST NOT be registered. This is the permission-inversion guard
+    # (core_run_script/core_runner are ask-gated, core_jobs was not) and the
+    # pandas cold-start guard. pattern_match tools stay — prod-live on main.
     monkeypatch.delenv("WAYFINDER_JOBS_ENABLED", raising=False)
 
     from wayfinder_paths.mcp.server import build_mcp
@@ -95,22 +97,25 @@ def test_jobs_tools_absent_when_flag_off(monkeypatch: pytest.MonkeyPatch) -> Non
     # Non-jobs tools are still present — gating is scoped, not a full shutoff.
     assert "core_run_script" in names
     assert "onchain_swap" in names
+    assert UNGATED_QUANT_TOOLS <= names, (
+        f"prod-live pattern_match tools must stay registered with the flag off: {sorted(UNGATED_QUANT_TOOLS - names)}"
+    )
 
 
 def test_jobs_tool_module_not_imported_when_flag_off(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # Stronger than absence-of-registration: assert the jobs tool module (and its
-    # heavy pandas/quant import chain) is never even imported when the flag is off.
-    # Run in a clean subprocess so a prior test that enabled jobs can't pollute
-    # sys.modules.
+    # heavy pandas import chain via the jobs package) is never even imported when
+    # the flag is off. pattern_match (quant package) is exempt — it registers
+    # unconditionally, matching prod main. Run in a clean subprocess so a prior
+    # test that enabled jobs can't pollute sys.modules.
     monkeypatch.delenv("WAYFINDER_JOBS_ENABLED", raising=False)
     code = (
         "import sys\n"
         "from wayfinder_paths.mcp.server import build_mcp\n"
         "build_mcp()\n"
-        "leaked = [m for m in ('wayfinder_paths.mcp.tools.jobs',\n"
-        "                       'wayfinder_paths.mcp.tools.pattern_match')\n"
+        "leaked = [m for m in ('wayfinder_paths.mcp.tools.jobs', 'wayfinder_paths.jobs.store')\n"
         "          if m in sys.modules]\n"
         "assert not leaked, f'jobs tool modules imported with flag off: {leaked}'\n"
         "print('OK')\n"


### PR DESCRIPTION
## Why (production-readiness audit)

When this branch's SDK merges to `main` and ships to chat-only prod boxes, two problems surface:

**(a) Permission inversion — jobs tools bypass safety review.** `core_jobs` and `quant_pattern_match*` are registered **unconditionally** in `build_mcp()`. The FE feature flag is UI-only, so a prod chat user's agent can create a job, write a strategy, and flip it live — placing **real orders inside the runner child, OUTSIDE all safety-review hooks** — with **no approval prompt**. Meanwhile `core_run_script` / `core_runner` *are* ask-gated. `core_jobs` sat on the wrong side of that line.

**(b) Eager heavy import.** The whole jobs package (pandas + ~71 modules) was imported into **every** MCP server and CLI process, even on boxes that never run a job (~100–150 MB RSS + cold-start cost).

## Fix 1 — registration + import guard (default OFF)

- New helper `jobs_tools_enabled()` in `core/config.py`, mirroring the existing `is_opencode_instance()` env-flag convention (and the `shells_sync.py` truthy pattern).
- **Flag:** env `WAYFINDER_JOBS_ENABLED`. **Resolution:** `os.environ.get("WAYFINDER_JOBS_ENABLED", "").strip().lower() in {"1", "true", "yes"}` (truthy = `1`/`true`/`yes`, case-insensitive). **Default OFF.** (No config.json flag added — this repo's flag convention is env-only, e.g. `OPENCODE_INSTANCE_ID`; env is sufficient.)
- In `build_mcp()`, both the **import** and the **registration** of `core_jobs`, `quant_pattern_match`, and `quant_pattern_match_ccxt_proxy` are now gated behind `jobs_tools_enabled()`, mirroring the `is_opencode_instance()` block. The import is **lazy** (inside the `if`), so a flag-off box never pulls pandas via this path.
- **Registration audit:** the only jobs_v1-specific MCP tools registered in `build_mcp()` are `core_jobs` + the two `quant_pattern_match*` tools — all three are now gated. `core_runner` / `core_runner_status` are the **generic** runner (script/strategy scheduling); their tool module imports no jobs/pandas code, so they correctly stay ungated.
- `mcp/cli.py`: `job_cli` import made **lazy** — only imported when the `job` subcommand (or a bare `--help`/no-subcommand invocation, which needs it listed) is run. Non-job subcommands no longer eager-import the jobs package. Verified: `job --help` still works; importing the `cli` module no longer pulls `wayfinder_paths.jobs.cli`.

### Tools now gated (absent unless `WAYFINDER_JOBS_ENABLED` is truthy)
- `core_jobs`
- `quant_pattern_match`
- `quant_pattern_match_ccxt_proxy`

### ⚠️ Dev / jobs boxes must set an env var
Our dev boxes and any box that runs jobs must set:

```
WAYFINDER_JOBS_ENABLED=1
```

Box env is configured in the **shell repo** (Fly machine / opencode dev-box image), **not** this SDK repo — this PR does **not** modify the shell repo. Add `WAYFINDER_JOBS_ENABLED=1` to the dev-box env there so jobs tooling remains available on those boxes. Chat-only prod boxes leave it unset → jobs tools absent, pandas never imported via this path.

## Fix 2 — remove committed `.venv` symlink

Repo root shipped a committed symlink `.venv -> /Users/felixchen/Desktop/wayfinder-paths-sdk/.venv` (mode `120000`): it leaked a dev username, dangled on every other machine, and broke poetry in-project env discovery.

- `git rm .venv` (it's a symlink, not a dir).
- `.gitignore`: changed `.venv/` (dir-only — missed the symlink) → `.venv` (matches both a symlink/file and a directory).
- Verified no code references the repo-root `.venv` path literally.

## Tests

`wayfinder_paths/tests/test_mcp_server_build.py`:
- Existing `test_build_mcp_registers_tools` (which asserts the `quant_pattern_match*` tools present) now runs under a `jobs_enabled` fixture that sets `WAYFINDER_JOBS_ENABLED=1` — so it keeps passing without weakening the assertion.
- **New** `test_jobs_tools_absent_when_flag_off`: with the flag unset, none of the three gated tools register; non-jobs tools (`core_run_script`, `onchain_swap`) still do.
- **New** `test_jobs_tool_module_not_imported_when_flag_off`: clean subprocess asserts `wayfinder_paths.mcp.tools.jobs` and `...pattern_match` are absent from `sys.modules` after `build_mcp()` (proves the pandas import chain never loads).
- **New** `test_jobs_tools_present_when_flag_on`: with `WAYFINDER_JOBS_ENABLED=1` the three tools register and work as today.

`.venv`: the symlink is verifiably gone (`git rm`, `delete mode 120000` in the commit) and gitignored under the tightened pattern.

### Test results
- Baseline `test_mcp_server_build.py`: 2 passed → after change: **5 passed**.
- Full scope `pytest -k "jobs or runner or mcp"`: **1098 passed, 9 skipped, 0 failed** (2766 deselected, ~156s). `test_wayfinder_jobs.py` (exercises `core_jobs`) green — gating didn't break jobs functionality.
- `test_mcp_profiles.py` (20 tests) green — the opencode permission-profile `quant`/`jobs` allow-rules read from static persona profiles, not `build_mcp()`, and `test_claude_settings_reference_registered_tool_names` runs flag-off but `.claude/settings.json` doesn't reference the gated tools, so it stays green.
- CLI tests (`test_cli_integration.py`, `test_cli_commands.py`): 15 passed.
- ruff check + format: clean. mypy on `server.py` / `cli.py` / `config.py` / new test: **zero errors in changed files** (the 342 mypy errors mypy surfaces are all pre-existing legacy errors in the transitively-imported `jobs/` package — pandas stubs, invariant list types).

## Diff summary
| File | Change |
|------|--------|
| `wayfinder_paths/core/config.py` | +15 — new `jobs_tools_enabled()` helper |
| `wayfinder_paths/mcp/server.py` | jobs/pattern_match imports → lazy inside gated block in `build_mcp()` |
| `wayfinder_paths/mcp/cli.py` | `job_cli` import → lazy (job subcommand / `--help` only) |
| `wayfinder_paths/tests/test_mcp_server_build.py` | +3 gating tests; existing test gated on flag |
| `.gitignore` | `.venv/` → `.venv` |
| `.venv` | deleted (committed symlink, mode 120000) |