### PR TITLE
Owner attention: two-zone attention block, paper auto-apply tier, paper gate auto-resolution, remediation wake debounce

### DIFF
--- a/wayfinder_paths/conftest.py
+++ b/wayfinder_paths/conftest.py
@@ -16,6 +16,19 @@ _GB = 1024**3
 
 
 @pytest.fixture(autouse=True)
+def _paper_auto_apply_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disable the paper auto-apply tier for every test by default.
+
+    Auto-apply spawns a detached apply-worker process at propose time; the
+    suite's many propose fixtures are not built for that side effect (a
+    green paper params proposal would silently start applying mid-test).
+    Auto-apply tests opt back in with
+    monkeypatch.setenv("WAYFINDER_PAPER_AUTO_APPLY", "1") and stub the
+    launcher."""
+    monkeypatch.setenv("WAYFINDER_PAPER_AUTO_APPLY", "0")
+
+
+@pytest.fixture(autouse=True)
 def _healthy_disk_usage(monkeypatch: pytest.MonkeyPatch) -> None:
     """Pin shutil.disk_usage to a healthy 50% volume for every test.
 

--- a/wayfinder_paths/jobs/application.py
+++ b/wayfinder_paths/jobs/application.py
@@ -867,6 +867,76 @@ def _promote_candidate(store: JobStore, job_id: str, candidate_dir: Path) -> Non
             shutil.copy2(source, destination)
 
 
+def rollback_application(
+    store: JobStore, job_id: str, proposal_id: str, *, by: str = "owner"
+) -> dict[str, Any]:
+    """Owner undo for an APPLIED proposal: restore the pre-apply snapshot.
+
+    Reuses the promotion backup `_complete_applied_application` writes to
+    ``applications/<pid>/backup`` (workspace + job.yaml + improver.yaml) —
+    the same restore the in-flight failure path runs. Guarded: only the
+    proposal whose promoted revision is still the ACTIVE revision can be
+    rolled back; restoring an older backup would silently clobber
+    intervening applies (the stale-candidate promotion incident class)."""
+    proposal = store.load_proposal(job_id, proposal_id)
+    application = proposal["application"]
+    if application.get("status") != "applied":
+        raise ValueError(
+            f"only applied proposals can be rolled back: {proposal_id} is "
+            f"{application.get('status')}"
+        )
+    root = store.job_dir(job_id)
+    backup_dir = root / "applications" / proposal_id / "backup"
+    if not (backup_dir / "job.yaml").exists():
+        raise ValueError(f"no promotion backup exists for {proposal_id}")
+    promoted = str(application.get("promoted_revision") or "")
+    current = compute_workspace_revision(root)
+    if promoted and current != promoted:
+        raise ValueError(
+            "workspace has moved since this apply (promoted "
+            f"{promoted[:12]}, active {current[:12]}) — rolling back would "
+            "clobber intervening work; undo the newer applies first"
+        )
+    active_workspace = root / "workspace"
+    if active_workspace.exists():
+        shutil.rmtree(active_workspace)
+    if (backup_dir / "workspace").exists():
+        shutil.copytree(backup_dir / "workspace", active_workspace)
+    shutil.copy2(backup_dir / "job.yaml", root / "job.yaml")
+    if (backup_dir / IMPROVER_FILENAME).exists():
+        shutil.copy2(backup_dir / IMPROVER_FILENAME, root / IMPROVER_FILENAME)
+    job = store.load(job_id)
+    compile_result = JobCompiler(store=store).compile(job)
+    restored_revision = compute_workspace_revision(root)
+    application["rollback"] = {
+        "restored": True,
+        "backup_dir": str(backup_dir.relative_to(store.repo_root)),
+        "by": by,
+        "ts": utc_now_iso(),
+        "restored_revision": restored_revision,
+    }
+    proposal["updated_at"] = utc_now_iso()
+    store.write_proposal(job_id, proposal)
+    store.append_journal(
+        job_id,
+        {
+            "type": "application_rolled_back",
+            "proposal_id": proposal_id,
+            "by": by,
+            "rolled_back_revision": promoted or None,
+            "restored_revision": restored_revision,
+        },
+    )
+    store.refresh_scorecard(job_id)
+    sync_all_jobs(store=store)
+    return {
+        "job_id": job_id,
+        "proposal_id": proposal_id,
+        "restored_revision": restored_revision,
+        "compile": compile_result,
+    }
+
+
 def _record_promoted_revision(
     store: JobStore,
     job_id: str,

--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -11,6 +11,7 @@ from wayfinder_paths.jobs.application import (
     claim_application,
     complete_application,
     ensure_jobs_v1_contract,
+    rollback_application,
     validate_application_candidate,
 )
 from wayfinder_paths.jobs.apply_launcher import launch_application
@@ -20,6 +21,12 @@ from wayfinder_paths.jobs.backtest_artifacts import (
 )
 from wayfinder_paths.jobs.compiler import JobCompiler, compile_job
 from wayfinder_paths.jobs.counterfactual import counterfactual_job
+from wayfinder_paths.jobs.decision_gates import (
+    load_decision_gates,
+    register_decision_gate,
+    reopen_decision_gate,
+    resolve_decision_gate,
+)
 from wayfinder_paths.jobs.decision_log import build_decision_log
 from wayfinder_paths.jobs.execution.driver import tick_job
 from wayfinder_paths.jobs.execution.experiments import (
@@ -1917,6 +1924,120 @@ def apply_proposal_cmd(job_id: str, proposal_id: str) -> None:
         proposal_id,
         store.queue_proposal_application(job_id, proposal_id),
     )
+
+
+@job_cli.command(
+    name="rollback-apply",
+    help="Owner undo for an applied proposal: restore the pre-apply snapshot "
+    "from the promotion backup. Refused if the workspace has moved since.",
+)
+@click.argument("job_id")
+@click.argument("proposal_id")
+@click.option("--by", "rolled_back_by", default="owner", show_default=True)
+def rollback_apply_cmd(job_id: str, proposal_id: str, rolled_back_by: str) -> None:
+    store = JobStore()
+    try:
+        result = rollback_application(store, job_id, proposal_id, by=rolled_back_by)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+    _echo_json({"ok": True, "result": result})
+
+
+@job_cli.group(
+    name="decision-gate",
+    help="Pre-registered rework-vs-retire gates: register criteria + a scoped "
+    "successor up front; the watchdog auto-resolves PAPER jobs mechanically "
+    "when the criteria are met, live-capable jobs escalate to the owner. "
+    "(`gate` was taken by live-gate evaluation, hence the longer name.)",
+)
+def decision_gate_group() -> None:
+    pass
+
+
+@decision_gate_group.command(
+    name="register", help="Pre-register a decision gate (criteria + successor)."
+)
+@click.argument("job_id")
+@click.option(
+    "--criteria",
+    required=True,
+    help='JSON criteria, e.g. \'{"min_trades": 20, "max_win_rate": 0.4, '
+    '"max_net_pnl": 0}\'.',
+)
+@click.option(
+    "--successor-ref",
+    required=True,
+    help="Scoped successor the pivot opens (lane/region/proposal ref).",
+)
+@click.option("--gate-id", default=None, help="Explicit gate id (default: random).")
+@click.option("--by", "registered_by", default="improver", show_default=True)
+def decision_gate_register_cmd(
+    job_id: str,
+    criteria: str,
+    successor_ref: str,
+    gate_id: str | None,
+    registered_by: str,
+) -> None:
+    store = JobStore()
+    try:
+        gate = register_decision_gate(
+            store,
+            job_id,
+            criteria=json.loads(criteria),
+            successor_ref=successor_ref,
+            gate_id=gate_id,
+            registered_by=registered_by,
+        )
+    except (ValueError, TypeError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    _echo_json({"ok": True, "result": gate})
+
+
+@decision_gate_group.command(
+    name="resolve",
+    help="Owner resolution of a tripped/armed gate; --execute runs the same "
+    "bounded retire flow the paper auto path uses.",
+)
+@click.argument("job_id")
+@click.argument("gate_id")
+@click.option("--by", "resolved_by", default="owner", show_default=True)
+@click.option("--note", default=None)
+@click.option("--execute", is_flag=True, default=False)
+def decision_gate_resolve_cmd(
+    job_id: str, gate_id: str, resolved_by: str, note: str | None, execute: bool
+) -> None:
+    store = JobStore()
+    try:
+        gate = resolve_decision_gate(
+            store, job_id, gate_id, by=resolved_by, note=note, execute=execute
+        )
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+    _echo_json({"ok": True, "result": gate})
+
+
+@decision_gate_group.command(
+    name="reopen",
+    help="Undo an auto-resolution (re-enables the script loop) or dismiss a "
+    "trip. The gate stays reopened until explicitly re-registered.",
+)
+@click.argument("job_id")
+@click.argument("gate_id")
+@click.option("--by", "reopened_by", default="owner", show_default=True)
+def decision_gate_reopen_cmd(job_id: str, gate_id: str, reopened_by: str) -> None:
+    store = JobStore()
+    try:
+        gate = reopen_decision_gate(store, job_id, gate_id, by=reopened_by)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+    _echo_json({"ok": True, "result": gate})
+
+
+@decision_gate_group.command(name="list", help="List registered decision gates.")
+@click.argument("job_id")
+def decision_gate_list_cmd(job_id: str) -> None:
+    store = JobStore()
+    _echo_json({"ok": True, "result": load_decision_gates(store, job_id)})
 
 
 @job_cli.command(

--- a/wayfinder_paths/jobs/decision_gates.py
+++ b/wayfinder_paths/jobs/decision_gates.py
@@ -1,0 +1,330 @@
+"""Pre-registered decision gates: mechanical rework-vs-retire resolution.
+
+An improver that says "if after 20 trades the win rate is still <= X and net
+<= Y, retire this line and pivot" has already made the decision — only the
+click was outstanding. Today that criteria lives as prose in agendas, so
+resolving it needs an owner even though the criteria and the response were
+fixed in advance. This registry makes the gate mechanical: register criteria
+plus a scoped successor BEFORE the evidence window closes
+(``pre_registered_ts`` proves it), the watchdog evaluates the criteria
+against the measured forward summary, and for PAPER jobs executes the
+pre-registered response with journaled evidence and a bounded undo.
+
+Live-capital jobs never auto-resolve: a tripped gate flips to
+``tripped_needs_owner`` and lands in ``owner_attention.needs_you``.
+
+Retire is deliberately bounded (no deep archive-flow reuse): script loop
+disabled + recompiled (runner job deleted), incumbent workspace COPIED to
+``versions/`` (the active tree is left in place so reopen is non-destructive),
+and the pivot written to ``research/agenda.md`` attributed to ``gate-auto`` —
+never to the owner.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import shutil
+import uuid
+from typing import Any
+
+from wayfinder_paths.jobs.models import WayfinderJob, utc_now_iso
+from wayfinder_paths.jobs.store import JobStore
+
+DECISION_GATES_PATH = "research/decision_gates.json"
+GATE_STATUSES = ("armed", "tripped_needs_owner", "resolved", "reopened")
+GATE_ON_MET = ("retire_and_pivot",)
+# Criteria are failure thresholds: the gate trips when the evidence window is
+# full (min_trades reached) AND every declared ceiling still holds.
+CRITERIA_KEYS = ("min_trades", "max_win_rate", "max_net_pnl", "min_runs")
+UNDO_WINDOW_DAYS = 7
+
+
+def load_decision_gates(store: JobStore, job_id: str) -> dict[str, Any]:
+    doc = store.read_json(job_id, DECISION_GATES_PATH) or {}
+    if not isinstance(doc, dict) or not isinstance(doc.get("gates"), list):
+        return {"gates": []}
+    return doc
+
+
+def register_decision_gate(
+    store: JobStore,
+    job_id: str,
+    *,
+    criteria: dict[str, Any],
+    successor_ref: str,
+    on_met: str = "retire_and_pivot",
+    gate_id: str | None = None,
+    registered_by: str = "improver",
+) -> dict[str, Any]:
+    if on_met not in GATE_ON_MET:
+        raise ValueError(f"on_met must be one of {GATE_ON_MET}, got {on_met!r}")
+    if not str(successor_ref).strip():
+        raise ValueError(
+            "a decision gate requires a scoped successor_ref — retiring a line "
+            "with no registered pivot is abandonment, which is owner-only"
+        )
+    unknown = sorted(set(criteria) - set(CRITERIA_KEYS))
+    if unknown:
+        raise ValueError(f"unknown criteria keys {unknown}; supported: {CRITERIA_KEYS}")
+    if int(criteria.get("min_trades") or 0) < 1:
+        raise ValueError("criteria.min_trades must be >= 1 (the evidence window)")
+    if not any(key in criteria for key in ("max_win_rate", "max_net_pnl")):
+        raise ValueError(
+            "criteria must declare at least one ceiling (max_win_rate or "
+            "max_net_pnl) — a gate with only a trade count always trips"
+        )
+    doc = load_decision_gates(store, job_id)
+    gid = str(gate_id or f"gate-{uuid.uuid4().hex[:8]}")
+    if any(gate.get("gate_id") == gid for gate in doc["gates"]):
+        raise ValueError(f"decision gate already registered: {gid}")
+    gate = {
+        "gate_id": gid,
+        "status": "armed",
+        "criteria": {key: criteria[key] for key in CRITERIA_KEYS if key in criteria},
+        "on_met": on_met,
+        "successor_ref": str(successor_ref).strip(),
+        "pre_registered_ts": utc_now_iso(),
+        "registered_by": registered_by,
+    }
+    doc["gates"].append(gate)
+    store.write_json(job_id, DECISION_GATES_PATH, doc)
+    store.append_journal(
+        job_id,
+        {
+            "type": "decision_gate_registered",
+            "gate_id": gid,
+            "criteria": gate["criteria"],
+            "on_met": on_met,
+            "successor_ref": gate["successor_ref"],
+            "registered_by": registered_by,
+        },
+    )
+    return gate
+
+
+def evaluate_gate_criteria(
+    criteria: dict[str, Any], forward_summary: dict[str, Any]
+) -> tuple[bool, dict[str, Any]]:
+    trades = forward_summary.get("trades") or {}
+    runs = forward_summary.get("runs") or {}
+    closed_trades = int(trades.get("closed_count") or 0)
+    win_rate = trades.get("win_rate")
+    net_pnl = float(trades.get("net_pnl") or 0.0)
+    run_count = int(runs.get("count") or 0)
+    measured: dict[str, Any] = {
+        "closed_trades": closed_trades,
+        "win_rate": win_rate,
+        "net_pnl": net_pnl,
+        "runs": run_count,
+    }
+    if closed_trades < int(criteria.get("min_trades") or 0):
+        return False, measured
+    if "min_runs" in criteria and run_count < int(criteria["min_runs"]):
+        return False, measured
+    if "max_win_rate" in criteria and (
+        win_rate is None or float(win_rate) > float(criteria["max_win_rate"])
+    ):
+        return False, measured
+    if "max_net_pnl" in criteria and net_pnl > float(criteria["max_net_pnl"]):
+        return False, measured
+    return True, measured
+
+
+def evaluate_decision_gates(
+    store: JobStore,
+    job: WayfinderJob,
+    *,
+    now: dt.datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Watchdog standing check: evaluate every armed gate against the measured
+    forward summary. Paper job -> execute the pre-registered response; live-
+    capital job -> trip to needs_you. Returns the journaled events."""
+    from wayfinder_paths.jobs.owner_attention import job_live_capital_risk
+
+    doc = load_decision_gates(store, job.id)
+    armed = [gate for gate in doc["gates"] if gate.get("status") == "armed"]
+    if not armed:
+        return []
+    now = now or dt.datetime.now(dt.UTC)
+    summary = store.read_json(job.id, "results/forward/summary.json") or {}
+    events: list[dict[str, Any]] = []
+    for gate in armed:
+        met, measured = evaluate_gate_criteria(gate.get("criteria") or {}, summary)
+        if not met:
+            continue
+        if job_live_capital_risk(job):
+            gate["status"] = "tripped_needs_owner"
+            gate["tripped_at"] = now.isoformat()
+            gate["measured"] = measured
+            event = {
+                "type": "decision_gate_tripped",
+                "gate_id": gate["gate_id"],
+                "criteria": gate.get("criteria"),
+                "measured": measured,
+                "successor_ref": gate.get("successor_ref"),
+            }
+        else:
+            event = _auto_resolve(store, job, gate, measured, now)
+        store.write_json(job.id, DECISION_GATES_PATH, doc)
+        store.append_journal(job.id, event)
+        events.append(event)
+    return events
+
+
+def _auto_resolve(
+    store: JobStore,
+    job: WayfinderJob,
+    gate: dict[str, Any],
+    measured: dict[str, Any],
+    now: dt.datetime,
+) -> dict[str, Any]:
+    gate_id = str(gate["gate_id"])
+    root = store.job_dir(job.id)
+    archived_to = f"versions/retired-{gate_id}-{now.strftime('%Y%m%dT%H%M%SZ')}"
+    workspace = root / "workspace"
+    if workspace.exists():
+        shutil.copytree(workspace, root / archived_to / "workspace")
+    job.script_loop.enabled = False
+    job.touch()
+    store.save(job)
+    compile_error: str | None = None
+    try:
+        # Compile with the loop disabled deletes the runner script job — the
+        # supported way to stop ticking (same path as apply_script_mode).
+        from wayfinder_paths.jobs.compiler import JobCompiler
+
+        JobCompiler(store=store).compile(job)
+    except Exception as exc:  # noqa: BLE001 — retirement state is saved; the
+        # agent-mode drift check reconciles a runner that kept the stale job.
+        compile_error = str(exc)[:300]
+    undo = {
+        "command": f"wayfinder job decision-gate reopen {job.id} {gate_id}",
+        "window_expires_ts": (now + dt.timedelta(days=UNDO_WINDOW_DAYS)).isoformat(),
+    }
+    _append_agenda_note(
+        store,
+        job.id,
+        (
+            f"\n## Decision gate auto-resolution (gate-auto) — {now.isoformat()}\n\n"
+            f"Gate `{gate_id}` (pre-registered {gate.get('pre_registered_ts')}) "
+            f"tripped: {measured['closed_trades']} closed trades, "
+            f"win_rate={measured['win_rate']}, net_pnl={measured['net_pnl']}.\n"
+            f"Incumbent retired: script loop disabled, workspace archived to "
+            f"`{archived_to}`.\n"
+            f"Pivot (pre-registered successor): {gate.get('successor_ref')}\n"
+            f"Undo within {UNDO_WINDOW_DAYS}d: `{undo['command']}`\n"
+        ),
+    )
+    gate.update(
+        {
+            "status": "resolved",
+            "resolved_at": now.isoformat(),
+            "resolution": {
+                "by": "gate-auto",
+                "action": str(gate.get("on_met") or "retire_and_pivot"),
+                "measured": measured,
+                "archived_workspace": archived_to,
+                **({"compile_error": compile_error} if compile_error else {}),
+            },
+        }
+    )
+    return {
+        "type": "gate_auto_resolved",
+        "gate_id": gate_id,
+        "action": str(gate.get("on_met") or "retire_and_pivot"),
+        "criteria": gate.get("criteria"),
+        "measured": measured,
+        "successor_ref": gate.get("successor_ref"),
+        "archived_workspace": archived_to,
+        "undo": undo,
+    }
+
+
+def resolve_decision_gate(
+    store: JobStore,
+    job_id: str,
+    gate_id: str,
+    *,
+    by: str,
+    note: str | None = None,
+    execute: bool = False,
+) -> dict[str, Any]:
+    """Manual resolution — the owner acting on a tripped (or armed) gate.
+    ``execute=True`` runs the same bounded retire flow the paper path uses."""
+    doc = load_decision_gates(store, job_id)
+    gate = _find_gate(doc, gate_id)
+    if gate.get("status") not in {"armed", "tripped_needs_owner"}:
+        raise ValueError(f"gate {gate_id} is {gate.get('status')}; nothing to resolve")
+    if execute:
+        job = store.load(job_id)
+        summary = store.read_json(job_id, "results/forward/summary.json") or {}
+        _, measured = evaluate_gate_criteria(gate.get("criteria") or {}, summary)
+        event = _auto_resolve(store, job, gate, measured, dt.datetime.now(dt.UTC))
+        event["resolved_by"] = by
+        gate["resolution"]["by"] = by
+    else:
+        gate.update(
+            {
+                "status": "resolved",
+                "resolved_at": utc_now_iso(),
+                "resolution": {"by": by, "action": "acknowledged", "note": note},
+            }
+        )
+        event = {
+            "type": "decision_gate_resolved",
+            "gate_id": gate_id,
+            "by": by,
+            "note": note,
+        }
+    store.write_json(job_id, DECISION_GATES_PATH, doc)
+    store.append_journal(job_id, event)
+    return gate
+
+
+def reopen_decision_gate(
+    store: JobStore, job_id: str, gate_id: str, *, by: str = "owner"
+) -> dict[str, Any]:
+    """Undo: reverse an auto-resolution (re-enable the script loop; the active
+    workspace was never destroyed) or dismiss a trip. The gate lands in
+    ``reopened`` — terminal until explicitly re-registered, so it cannot
+    re-trip on the very next watchdog pass."""
+    doc = load_decision_gates(store, job_id)
+    gate = _find_gate(doc, gate_id)
+    status = str(gate.get("status"))
+    if status not in {"resolved", "tripped_needs_owner"}:
+        raise ValueError(f"gate {gate_id} is {status}; nothing to reopen")
+    was_retired = (gate.get("resolution") or {}).get("action") == "retire_and_pivot"
+    if was_retired:
+        job = store.load(job_id)
+        job.script_loop.enabled = True
+        job.touch()
+        store.save(job)
+        from wayfinder_paths.jobs.compiler import JobCompiler
+
+        JobCompiler(store=store).compile(job)
+    gate.update({"status": "reopened", "reopened_at": utc_now_iso(), "reopened_by": by})
+    store.write_json(job_id, DECISION_GATES_PATH, doc)
+    store.append_journal(
+        job_id,
+        {
+            "type": "decision_gate_reopened",
+            "gate_id": gate_id,
+            "by": by,
+            "script_loop_reenabled": was_retired,
+        },
+    )
+    return gate
+
+
+def _find_gate(doc: dict[str, Any], gate_id: str) -> dict[str, Any]:
+    for gate in doc["gates"]:
+        if gate.get("gate_id") == gate_id:
+            return gate
+    raise ValueError(f"decision gate not found: {gate_id}")
+
+
+def _append_agenda_note(store: JobStore, job_id: str, text: str) -> None:
+    path = store.job_dir(job_id) / "research" / "agenda.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(text)

--- a/wayfinder_paths/jobs/owner_attention.py
+++ b/wayfinder_paths/jobs/owner_attention.py
@@ -1,0 +1,388 @@
+"""Owner-attention feed: what actually needs the owner vs what ran itself.
+
+Two-zone doctrine (owner-approved): ``needs_you`` is reserved for
+live-capital decisions (approvals on live-capable jobs, risk-latched halt
+clears, live decision-gate trips), governance escalations surfaced as
+``owner_review_required`` journal markers (successor abandonment, reject-
+refusal escalations, live-mode ratifications), and exhaustion claims the
+mechanical coverage audit could not adjudicate. Everything else is
+mechanical-with-visibility: it lands in ``decided_autonomously`` with
+evidence and a bounded undo instead of an approval queue.
+
+Live-capital risk here is deliberately NOT ``store._job_is_live_capable``
+(that flags any job that has ENTERED paper operation — the fail-closed
+governance trigger, which would route every operating paper job's pending
+proposal to the owner and re-create the approval queue this feed replaces).
+A paper job with no wallet bound cannot lose live capital; the attention
+split keys on the live boundary instead: script mode live, or a funded
+wallet bound (one operator flip from live).
+
+Both arrays ride the sync snapshot top-level (like ``scorecard``), so the
+backend/FE consume them without SDK round-trips. Building the feed is
+read-only and raise-free — a broken artifact must never break a sync.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+from typing import Any
+
+from wayfinder_paths.jobs.halt import RISK_LATCH_SOURCES, read_halt
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.store import JobStore
+
+DECIDED_WINDOW_DAYS = 7
+DECIDED_CAP = 50
+# owner_review_required markers have no mechanical clear event; bound how
+# long an unactioned one stays visible.
+MARKER_WINDOW_DAYS = 30
+# A freshly filed claim legitimately has no audit verdict until the next
+# watchdog pass (5-minute cadence); only escalate after the audit has had
+# ample time to produce one.
+CLAIM_AUDIT_GRACE_SECONDS = 60 * 60
+_JOURNAL_SCAN_LIMIT = 4000
+_MECHANICAL_AUDIT_VERDICTS = frozenset({"pass", "narrow", "reject"})
+
+
+def job_live_capital_risk(job: WayfinderJob) -> bool:
+    """Live capital at stake: running live, or wallet-bound (one flip away)."""
+    if str(job.script_loop.mode or "paper") == "live":
+        return True
+    return bool(job.execution_params.get("wallet_label"))
+
+
+def build_owner_attention(
+    store: JobStore,
+    job_id: str,
+    *,
+    job: WayfinderJob | None = None,
+    now: dt.datetime | None = None,
+) -> dict[str, Any]:
+    try:
+        return _build(store, job_id, job=job, now=now)
+    except Exception:  # noqa: BLE001 — sync must never die on a feed
+        return {"needs_you": [], "decided_autonomously": []}
+
+
+def _build(
+    store: JobStore,
+    job_id: str,
+    *,
+    job: WayfinderJob | None,
+    now: dt.datetime | None,
+) -> dict[str, Any]:
+    job = job or store.load(job_id)
+    now = now or dt.datetime.now(dt.UTC)
+    journal = store.read_jsonl(job_id, "journal.jsonl", limit=_JOURNAL_SCAN_LIMIT)
+    proposals = store.proposals(job_id)
+    return {
+        "needs_you": _needs_you(store, job_id, job, proposals, journal, now),
+        "decided_autonomously": _decided_autonomously(job_id, journal, now),
+    }
+
+
+def _needs_you(
+    store: JobStore,
+    job_id: str,
+    job: WayfinderJob,
+    proposals: list[dict[str, Any]],
+    journal: list[dict[str, Any]],
+    now: dt.datetime,
+) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    created_ts = {
+        str(event.get("proposal_id")): event.get("ts")
+        for event in journal
+        if event.get("type") == "proposal_created"
+    }
+    proposals_by_id = {str(p.get("proposal_id")): p for p in proposals}
+
+    if job_live_capital_risk(job):
+        for proposal in proposals:
+            if proposal.get("status") != "pending":
+                continue
+            pid = str(proposal.get("proposal_id"))
+            summary = str(
+                (proposal.get("proposed_change") or {}).get("summary")
+                or proposal.get("change_summary")
+                or ""
+            )
+            items.append(
+                _item(
+                    kind="live_proposal_approval",
+                    job_id=job_id,
+                    ref_id=pid,
+                    summary=f"pending proposal on a live-capable job: {summary}"[:300],
+                    evidence_ref=f"proposals/{pid}.json",
+                    since_ts=created_ts.get(pid) or proposal.get("updated_at"),
+                )
+            )
+
+    items.extend(_unauditable_claims(store, job_id, now))
+    items.extend(_owner_review_markers(job_id, journal, proposals_by_id, now))
+    items.extend(_tripped_gates(store, job_id))
+
+    halt = read_halt(store.job_dir(job_id))
+    if halt and str(halt.get("source") or "") in RISK_LATCH_SOURCES:
+        source = str(halt.get("source"))
+        items.append(
+            _item(
+                kind="halt_awaiting_owner_clear",
+                job_id=job_id,
+                ref_id=source,
+                summary=(
+                    f"risk-latched halt ({source}): {halt.get('reason')} — "
+                    "clearing requires the owner (wayfinder job resume-from-halt)"
+                )[:300],
+                evidence_ref="state/halt.json",
+                since_ts=halt.get("ts"),
+            )
+        )
+    items.sort(key=lambda item: str(item.get("since_ts") or ""))
+    return items
+
+
+def _unauditable_claims(
+    store: JobStore, job_id: str, now: dt.datetime
+) -> list[dict[str, Any]]:
+    from wayfinder_paths.jobs.exhaustion import list_exhaustion_claims
+
+    items: list[dict[str, Any]] = []
+    for claim in list_exhaustion_claims(store, job_id, status="pending"):
+        verdict = str((claim.get("audit") or {}).get("verdict") or "")
+        if verdict in _MECHANICAL_AUDIT_VERDICTS:
+            # The audit actor produced a verdict — the mechanical path
+            # (settle / required experiments) owns this claim, not the owner.
+            continue
+        filed_at = _parse_time(claim.get("filed_at"))
+        if (
+            not verdict
+            and filed_at
+            and (now - filed_at).total_seconds() < CLAIM_AUDIT_GRACE_SECONDS
+        ):
+            continue  # audit simply hasn't run yet
+        claim_id = str(claim.get("claim_id"))
+        items.append(
+            _item(
+                kind="exhaustion_claim_unauditable",
+                job_id=job_id,
+                ref_id=claim_id,
+                summary=(
+                    f"exhaustion claim on lane {claim.get('lane')!r} has no "
+                    "mechanical audit verdict — owner adjudication required"
+                ),
+                evidence_ref=f"research/exhaustion_claims/{claim_id}.json",
+                since_ts=claim.get("filed_at"),
+            )
+        )
+    return items
+
+
+def _owner_review_markers(
+    job_id: str,
+    journal: list[dict[str, Any]],
+    proposals_by_id: dict[str, dict[str, Any]],
+    now: dt.datetime,
+) -> list[dict[str, Any]]:
+    cutoff = now - dt.timedelta(days=MARKER_WINDOW_DAYS)
+    latest: dict[tuple[str, str], dict[str, Any]] = {}
+    for event in journal:  # append-ordered: later events overwrite
+        if not event.get("owner_review_required"):
+            continue
+        ts = _parse_time(event.get("ts"))
+        if ts and ts < cutoff:
+            continue
+        ref = str(
+            event.get("proposal_id")
+            or event.get("claim_id")
+            or event.get("gate_id")
+            or ""
+        )
+        latest[(str(event.get("type")), ref)] = event
+    items: list[dict[str, Any]] = []
+    for (event_type, ref), event in latest.items():
+        if event_type == "proposal_reject_refused":
+            # Resolved once the restage went through (flag cleared) or the
+            # proposal reached a terminal state — only surface a live stall.
+            proposal = proposals_by_id.get(ref)
+            if not proposal or proposal.get("status") != "approved":
+                continue
+            if not proposal["application"].get("restage_requested"):
+                continue
+        items.append(
+            _item(
+                kind=event_type,
+                job_id=job_id,
+                ref_id=ref,
+                summary=str(event.get("owner_review_required"))[:300],
+                evidence_ref="journal.jsonl",
+                since_ts=event.get("ts"),
+            )
+        )
+    return items
+
+
+def _tripped_gates(store: JobStore, job_id: str) -> list[dict[str, Any]]:
+    from wayfinder_paths.jobs.decision_gates import (
+        DECISION_GATES_PATH,
+        load_decision_gates,
+    )
+
+    items: list[dict[str, Any]] = []
+    for gate in load_decision_gates(store, job_id).get("gates") or []:
+        if gate.get("status") != "tripped_needs_owner":
+            continue
+        gate_id = str(gate.get("gate_id"))
+        items.append(
+            _item(
+                kind="decision_gate_tripped",
+                job_id=job_id,
+                ref_id=gate_id,
+                summary=(
+                    f"decision gate {gate_id} criteria met on a live-capable "
+                    "job — pre-registered response is "
+                    f"{gate.get('on_met')}; owner resolves or re-arms "
+                    "(wayfinder job decision-gate resolve/reopen)"
+                )[:300],
+                evidence_ref=DECISION_GATES_PATH,
+                since_ts=gate.get("tripped_at"),
+            )
+        )
+    return items
+
+
+def _decided_autonomously(
+    job_id: str, journal: list[dict[str, Any]], now: dt.datetime
+) -> list[dict[str, Any]]:
+    cutoff = now - dt.timedelta(days=DECIDED_WINDOW_DAYS)
+    items: list[dict[str, Any]] = []
+    for event in journal:
+        ts = _parse_time(event.get("ts"))
+        if ts is None or ts < cutoff:
+            continue
+        decided = _decided_item(job_id, event)
+        if decided is not None:
+            items.append(decided)
+    items.sort(key=lambda item: str(item.get("ts") or ""), reverse=True)
+    return items[:DECIDED_CAP]
+
+
+def _decided_item(job_id: str, event: dict[str, Any]) -> dict[str, Any] | None:
+    event_type = str(event.get("type") or "")
+    ts = event.get("ts")
+    if event_type == "proposal_auto_applied":
+        return {
+            "kind": "paper_auto_apply",
+            "job_id": job_id,
+            "ref_id": event.get("proposal_id"),
+            "ts": ts,
+            "decision": "auto_applied",
+            "evidence": _compact(event.get("evidence")),
+            "undo": event.get("undo"),
+        }
+    if event_type == "gate_auto_resolved":
+        return {
+            "kind": "decision_gate",
+            "job_id": job_id,
+            "ref_id": event.get("gate_id"),
+            "ts": ts,
+            "decision": str(event.get("action") or "retire_and_pivot"),
+            "evidence": _compact(
+                {"criteria": event.get("criteria"), "measured": event.get("measured")}
+            ),
+            "undo": event.get("undo"),
+        }
+    if event_type == "exhaustion_claim_audit_passed":
+        undo: dict[str, Any] = {
+            "command": (
+                f"wayfinder job exhaustion reopen {job_id} "
+                f"{event.get('claim_id')} --reason '<why>'"
+            )
+        }
+        if event.get("owner_override_until"):
+            undo["window_expires_ts"] = event.get("owner_override_until")
+        return {
+            "kind": "exhaustion_claim_audit",
+            "job_id": job_id,
+            "ref_id": event.get("claim_id"),
+            "ts": ts,
+            "decision": str(event.get("audit_verdict") or "pass"),
+            "evidence": f"coverage-audit certificate {event.get('certificate')}",
+            "undo": undo,
+        }
+    if (
+        event_type == "exhaustion_claim_rejected"
+        and event.get("by") == "coverage-audit"
+    ):
+        return {
+            "kind": "exhaustion_claim_audit",
+            "job_id": job_id,
+            "ref_id": event.get("claim_id"),
+            "ts": ts,
+            "decision": "reject",
+            "evidence": _compact(event.get("reason_codes")),
+        }
+    if event_type in {"probation_leg_opened", "paper_probation_opened"}:
+        return {
+            "kind": "probation",
+            "job_id": job_id,
+            "ref_id": event.get("leg"),
+            "ts": ts,
+            "decision": "opened",
+            "evidence": _compact(event.get("entry")),
+        }
+    if event_type == "probation_leg_graduated":
+        return {
+            "kind": "probation",
+            "job_id": job_id,
+            "ref_id": event.get("leg"),
+            "ts": ts,
+            "decision": "graduated",
+            "evidence": None,
+        }
+    if event_type == "probation_leg_killed":
+        return {
+            "kind": "probation",
+            "job_id": job_id,
+            "ref_id": event.get("leg"),
+            "ts": ts,
+            "decision": "killed",
+            "evidence": None,
+        }
+    return None
+
+
+def _item(
+    *,
+    kind: str,
+    job_id: str,
+    ref_id: str,
+    summary: str,
+    evidence_ref: str,
+    since_ts: Any,
+) -> dict[str, Any]:
+    return {
+        "kind": kind,
+        "job_id": job_id,
+        "ref_id": ref_id,
+        "summary": summary,
+        "evidence_ref": evidence_ref,
+        "since_ts": since_ts,
+    }
+
+
+def _compact(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value[:300]
+    return json.dumps(value, default=str, sort_keys=True)[:300]
+
+
+def _parse_time(value: Any) -> dt.datetime | None:
+    try:
+        parsed = dt.datetime.fromisoformat(str(value))
+    except (TypeError, ValueError):
+        return None
+    return parsed.replace(tzinfo=dt.UTC) if parsed.tzinfo is None else parsed

--- a/wayfinder_paths/jobs/proposals.py
+++ b/wayfinder_paths/jobs/proposals.py
@@ -15,8 +15,10 @@ change that gets promoted.
 
 from __future__ import annotations
 
+import datetime as dt
 import json
 import os
+import re
 import shutil
 import uuid
 from pathlib import Path
@@ -63,6 +65,174 @@ PROPOSAL_KINDS = {"code_change", "params_update", "model_update", "improver_chan
 # propose-time retry of an infrastructure-failed candidate validation.
 PROPOSE_LOCK_WAIT_ENV = "WAYFINDER_PROPOSE_LOCK_WAIT_SECONDS"
 _PROPOSE_LOCK_WAIT_DEFAULT_S = 120.0
+
+# ── Paper auto-apply tier ────────────────────────────────────────────────
+# Owner-approved doctrine: paper proposal approvals are mechanical — a
+# gate-green candidate on a job that cannot touch live capital auto-applies
+# with visibility (journal + owner_attention.decided_autonomously) and a
+# bounded undo, instead of waiting on an owner click. Autonomy changes WHO
+# clicks, not WHAT is checked: the auto path routes through the exact
+# `store.approve_proposal` gate (validation + live-ready + governance +
+# candidate freshness), unchanged.
+PAPER_AUTO_APPLY_ENV = "WAYFINDER_PAPER_AUTO_APPLY"  # "0" disables
+PAPER_AUTO_APPLY_DEFAULT_KINDS = frozenset({"params_update"})
+# improver_change is a criterion/search-policy change — governance-shaped,
+# owner-only regardless of any auto_limits override.
+PAPER_AUTO_APPLY_ALLOWED_KINDS = frozenset(
+    {"params_update", "code_change", "model_update"}
+)
+PAPER_AUTO_APPLY_DAILY_CAP = 3
+PAPER_AUTO_APPLY_UNDO_WINDOW_HOURS = 72
+# Owner-owned knobs may never ride the auto tier, whatever the params look
+# like: sizing (leverage), custody (wallet), execution mode, governance.
+_PAPER_AUTO_APPLY_FORBIDDEN_PARAM = re.compile(
+    r"leverage|wallet|mode|governance", re.IGNORECASE
+)
+
+
+def paper_auto_apply_enabled() -> bool:
+    return os.environ.get(PAPER_AUTO_APPLY_ENV) != "0"
+
+
+def _param_keys(value: Any, prefix: str = "") -> list[str]:
+    if not isinstance(value, dict):
+        return []
+    keys: list[str] = []
+    for key, child in value.items():
+        path = f"{prefix}.{key}" if prefix else str(key)
+        keys.append(path)
+        keys.extend(_param_keys(child, path))
+    return keys
+
+
+def _auto_applies_last_day(store: JobStore, job_id: str) -> int:
+    cutoff = dt.datetime.now(dt.UTC) - dt.timedelta(days=1)
+    count = 0
+    for event in store.read_jsonl(job_id, "journal.jsonl"):
+        if event.get("type") != "proposal_auto_applied":
+            continue
+        try:
+            ts = dt.datetime.fromisoformat(str(event.get("ts")))
+        except (TypeError, ValueError):
+            continue
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=dt.UTC)
+        if ts >= cutoff:
+            count += 1
+    return count
+
+
+def paper_auto_apply_blockers(
+    store: JobStore, job_id: str, proposal: dict[str, Any]
+) -> list[str]:
+    """Why this proposal must wait for an owner click. Empty = auto-eligible."""
+    from wayfinder_paths.jobs.owner_attention import job_live_capital_risk
+
+    blockers: list[str] = []
+    job = store.load(job_id)
+    if job.execution_contract != "jobs_v1":
+        blockers.append("legacy execution contract")
+    if str(job.script_loop.mode or "paper") != "paper":
+        blockers.append("script mode is not paper")
+    if job_live_capital_risk(job):
+        blockers.append("job is live-capable (live mode or wallet bound)")
+    limits = dict(job.agent_loop.auto_limits or {})
+    allowed_kinds = (
+        set(limits.get("auto_apply_kinds") or PAPER_AUTO_APPLY_DEFAULT_KINDS)
+        & PAPER_AUTO_APPLY_ALLOWED_KINDS
+    )
+    kind = str(proposal.get("kind") or "")
+    if kind not in allowed_kinds:
+        blockers.append(f"kind {kind} not auto-appliable ({sorted(allowed_kinds)})")
+    params = (proposal.get("proposed_change") or {}).get("execution_params") or {}
+    forbidden = sorted(
+        key
+        for key in _param_keys(params)
+        if _PAPER_AUTO_APPLY_FORBIDDEN_PARAM.search(key)
+    )
+    if forbidden:
+        blockers.append(f"params touch owner-owned keys: {forbidden}")
+    report = proposal.get("candidate_report") or {}
+    if (report.get("validation_summary") or {}).get("status") != "passed":
+        blockers.append("candidate validation not passed")
+    if report.get("mode") != "validation_only":
+        if (report.get("gate") or {}).get("live_ready") is not True:
+            blockers.append("candidate gate not green")
+        # Paper tier mirrors the paper approve gate's advisory semantics: an
+        # explicit economic ready=False blocks; absent/unevaluated does not.
+        if (report.get("economic") or {}).get("ready") is False:
+            blockers.append("candidate not economic-ready")
+    cap = int(limits.get("max_auto_applies_per_day") or PAPER_AUTO_APPLY_DAILY_CAP)
+    if _auto_applies_last_day(store, job_id) >= cap:
+        blockers.append(f"daily auto-apply cap reached ({cap}/day)")
+    return blockers
+
+
+def maybe_auto_apply_paper_proposal(
+    store: JobStore, job_id: str, proposal_id: str
+) -> dict[str, Any] | None:
+    """Auto-approve and queue a gate-green paper proposal at staging time.
+
+    Returns the auto-apply record when taken, None when the proposal stays on
+    the owner-approval path. Reuses the restage approval-carryover machinery:
+    `store.approve_proposal` (full gate, unchanged) + `launch_application`
+    (detached completer, watchdog-backstopped)."""
+    if not paper_auto_apply_enabled():
+        return None
+    proposal = store.load_proposal(job_id, proposal_id)
+    if proposal.get("status") != "pending":
+        return None
+    if paper_auto_apply_blockers(store, job_id, proposal):
+        return None
+    try:
+        proposal = store.approve_proposal(job_id, proposal_id)
+    except ValueError:
+        # The real gate said no — our eligibility precheck was optimistic.
+        # The proposal stays pending on the owner path; nothing to unwind.
+        return None
+    proposal["approval"]["required"] = False
+    proposal["approval"]["by"] = "paper-auto-apply"
+    proposal["updated_at"] = utc_now_iso()
+    store.write_proposal(job_id, proposal)
+    report = proposal.get("candidate_report") or {}
+    undo = {
+        "command": f"wayfinder job rollback-apply {job_id} {proposal_id}",
+        "window_expires_ts": (
+            dt.datetime.now(dt.UTC)
+            + dt.timedelta(hours=PAPER_AUTO_APPLY_UNDO_WINDOW_HOURS)
+        ).isoformat(),
+    }
+    store.append_journal(
+        job_id,
+        {
+            "type": "proposal_auto_applied",
+            "proposal_id": proposal_id,
+            "kind": proposal.get("kind"),
+            "tier": "paper",
+            "evidence": {
+                "validation_status": "passed",
+                "gate_live_ready": (report.get("gate") or {}).get("live_ready"),
+                "economic_ready": (report.get("economic") or {}).get("ready"),
+                "candidate_revision": report.get("revision"),
+            },
+            "undo": undo,
+        },
+    )
+    from wayfinder_paths.jobs.apply_launcher import launch_application
+
+    try:
+        launch_application(store, job_id, proposal_id)
+    except Exception as exc:  # noqa: BLE001 — the proposal is approved+queued;
+        # the application watchdog backstops a failed launch (_recover_queued).
+        store.append_journal(
+            job_id,
+            {
+                "type": "proposal_auto_apply_launch_failed",
+                "proposal_id": proposal_id,
+                "error": str(exc)[:300],
+            },
+        )
+    return {"proposal_id": proposal_id, "auto_applied": True, "undo": undo}
 
 
 def propose_change(
@@ -254,6 +424,18 @@ def propose_change(
         )
     except Exception:  # noqa: BLE001 — archive bookkeeping never breaks propose
         pass
+    try:
+        maybe_auto_apply_paper_proposal(store, job_id, pid)
+    except Exception as exc:  # noqa: BLE001 — the pending proposal is intact
+        # and the owner-approval path unaffected; record the miss.
+        store.append_journal(
+            job_id,
+            {
+                "type": "proposal_auto_apply_error",
+                "proposal_id": pid,
+                "error": str(exc)[:300],
+            },
+        )
     store.refresh_scorecard(job_id)
     sync_all_jobs(store=store)
     # Surface a chat affordance (contract C5): the opencode harness turns this

--- a/wayfinder_paths/jobs/remediation.py
+++ b/wayfinder_paths/jobs/remediation.py
@@ -21,7 +21,14 @@ from wayfinder_paths.jobs.store import JobStore
 
 REMEDIATION_PATH = "state/regime_remediation.json"
 REMEDIATION_SCHEMA_VERSION = "1.0"
-REMEDIATION_RETRY_SECONDS = 30 * 60
+# Re-wake pacing for an open case WITHOUT new material evidence. 30 minutes
+# churned in production: nearly every scheduled tick re-woke the agent
+# (42/45 trigger wakes were scheduled-tick retries; 27 progress notes vs 2
+# evidence updates), and each wake produced another bounded progress note
+# that changed nothing before the next retry. Material evidence still wakes
+# immediately (the branch above the retry path), a recorded progress/blocker
+# note now counts as activity, and quiet retries wait 6 hours.
+REMEDIATION_RETRY_SECONDS = 6 * 60 * 60
 
 _ALERT_STATUSES = frozenset({"warning", "critical"})
 _STATUS_RANK = {
@@ -143,8 +150,12 @@ def sync_remediation_with_health(
     state = str(current.get("state") or "open")
     if state not in _ACTIONABLE_STATES:
         return None
+    # Progress-only ticks must not re-wake: a bounded evaluation/blocker note
+    # recorded since the last wake is the agent already working the case.
     last_wake = _parse_time(current.get("last_wake_requested_at"))
-    if last_wake and (now - last_wake).total_seconds() < REMEDIATION_RETRY_SECONDS:
+    progress_at = _parse_time((current.get("progress") or {}).get("recorded_at"))
+    anchors = [ts for ts in (last_wake, progress_at) if ts is not None]
+    if anchors and (now - max(anchors)).total_seconds() < REMEDIATION_RETRY_SECONDS:
         return None
 
     current["updated_at"] = now_iso

--- a/wayfinder_paths/jobs/sync.py
+++ b/wayfinder_paths/jobs/sync.py
@@ -289,7 +289,21 @@ def snapshot_job(job_id: str, *, store: JobStore | None = None) -> dict[str, Any
         # live_execution_status="halted" while set; this carries reason/ts.
         "halt": read_halt(store.job_dir(job_id)),
         "features": features,
+        # Two-zone attention split (owner doctrine): needs_you = owner-blocking
+        # live-capital/governance items; decided_autonomously = the last 7d of
+        # mechanical decisions with evidence + bounded undo. Top-level (like
+        # scorecard) so backend/FE consume it without SDK round-trips.
+        "owner_attention": _owner_attention(store, job_id, job),
     }
+
+
+def _owner_attention(store: JobStore, job_id: str, job: Any) -> dict[str, Any]:
+    from wayfinder_paths.jobs.owner_attention import build_owner_attention
+
+    try:
+        return build_owner_attention(store, job_id, job=job)
+    except Exception:  # noqa: BLE001 — sync must never die on a feed
+        return {"needs_you": [], "decided_autonomously": []}
 
 
 def sync_all_jobs(*, store: JobStore | None = None) -> None:

--- a/wayfinder_paths/jobs/watchdog.py
+++ b/wayfinder_paths/jobs/watchdog.py
@@ -1221,6 +1221,16 @@ def _check_research_impasse(
 
 # Pending claims are controller work: every watchdog pass runs the structured
 # coverage audit and applies pass/narrow/reject without waiting on an owner.
+def _check_decision_gates(
+    store: JobStore, job: Any, now: datetime
+) -> list[dict[str, Any]]:
+    """Pre-registered rework-vs-retire gates: paper jobs auto-resolve when
+    their criteria are met; live-capital jobs trip to owner_attention."""
+    from wayfinder_paths.jobs.decision_gates import evaluate_decision_gates
+
+    return evaluate_decision_gates(store, job, now=now)
+
+
 def _audit_pending_claims(store: JobStore, job_id: str) -> dict[str, Any] | None:
     from wayfinder_paths.jobs.exhaustion import (
         audit_and_adjudicate_exhaustion_claim,
@@ -1498,6 +1508,11 @@ def recover_stalled_applications(
                 recovered.append({"job_id": job.id, **lifecycle_event})
         except Exception as exc:
             errors.append({"job_id": job.id, "error": f"lifecycle: {exc}"})
+        try:
+            for gate_event in _check_decision_gates(store, job, now):
+                recovered.append({"job_id": job.id, **gate_event})
+        except Exception as exc:  # noqa: BLE001
+            errors.append({"job_id": job.id, "error": f"decision_gates: {exc}"})
         try:
             audit_event = _audit_live_mode(store, job)
         except Exception as exc:  # noqa: BLE001

--- a/wayfinder_paths/tests/test_jobs_decision_gates.py
+++ b/wayfinder_paths/tests/test_jobs_decision_gates.py
@@ -1,0 +1,281 @@
+"""Pre-registered decision gates: mechanical rework-vs-retire resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from wayfinder_paths.jobs import compiler as compiler_mod
+from wayfinder_paths.jobs.decision_gates import (
+    evaluate_decision_gates,
+    evaluate_gate_criteria,
+    load_decision_gates,
+    register_decision_gate,
+    reopen_decision_gate,
+    resolve_decision_gate,
+)
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.owner_attention import build_owner_attention
+from wayfinder_paths.jobs.store import JobStore
+
+FAILING_SUMMARY = {
+    "runs": {"count": 40},
+    "trades": {
+        "closed_count": 20,
+        "wins": 6,
+        "losses": 14,
+        "win_rate": 0.3,
+        "net_pnl": -12.5,
+    },
+}
+CRITERIA = {"min_trades": 20, "max_win_rate": 0.4, "max_net_pnl": 0}
+
+
+@pytest.fixture()
+def compiled(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    compiles: list[str] = []
+
+    class FakeCompiler:
+        def __init__(self, *, store=None) -> None:
+            self.store = store
+
+        def compile(self, job, **kwargs):
+            compiles.append(job.id)
+            return {"ok": True}
+
+    monkeypatch.setattr(compiler_mod, "JobCompiler", FakeCompiler)
+    return compiles
+
+
+def _store(
+    tmp_path: Path, *, wallet_label: str | None = None
+) -> tuple[JobStore, WayfinderJob]:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        "gate-demo",
+        script=".wayfinder_runs/demo.py",
+        interval_seconds=60,
+        agent_mode="intervene",
+        execution_contract="jobs_v1",
+    )
+    if wallet_label:
+        job.execution_params["wallet_label"] = wallet_label
+    store.save(job)
+    workspace = store.job_dir(job.id) / "workspace" / "src"
+    workspace.mkdir(parents=True, exist_ok=True)
+    (workspace / "strategy.py").write_text("print('imx')\n", encoding="utf-8")
+    return store, job
+
+
+def _journal_types(store: JobStore, job_id: str) -> list[str]:
+    return [
+        str(event.get("type")) for event in store.read_jsonl(job_id, "journal.jsonl")
+    ]
+
+
+# ── registry lifecycle ───────────────────────────────────────────────────
+
+
+def test_register_requires_window_ceiling_and_successor(tmp_path: Path) -> None:
+    store, job = _store(tmp_path)
+    with pytest.raises(ValueError, match="min_trades"):
+        register_decision_gate(
+            store, job.id, criteria={"max_win_rate": 0.4}, successor_ref="lane-b"
+        )
+    with pytest.raises(ValueError, match="ceiling"):
+        register_decision_gate(
+            store, job.id, criteria={"min_trades": 20}, successor_ref="lane-b"
+        )
+    with pytest.raises(ValueError, match="successor_ref"):
+        register_decision_gate(store, job.id, criteria=CRITERIA, successor_ref="  ")
+    with pytest.raises(ValueError, match="unknown criteria"):
+        register_decision_gate(
+            store,
+            job.id,
+            criteria={**CRITERIA, "vibes": 1},
+            successor_ref="lane-b",
+        )
+
+    gate = register_decision_gate(
+        store, job.id, criteria=CRITERIA, successor_ref="lane-b", gate_id="gate-imx"
+    )
+    assert gate["status"] == "armed"
+    assert gate["pre_registered_ts"]
+    assert "decision_gate_registered" in _journal_types(store, job.id)
+    with pytest.raises(ValueError, match="already registered"):
+        register_decision_gate(
+            store, job.id, criteria=CRITERIA, successor_ref="lane-b", gate_id="gate-imx"
+        )
+
+
+def test_criteria_need_the_full_evidence_window(tmp_path: Path) -> None:
+    met, measured = evaluate_gate_criteria(
+        CRITERIA, {"trades": {"closed_count": 12, "win_rate": 0.1, "net_pnl": -50}}
+    )
+    assert met is False and measured["closed_trades"] == 12
+    met, _ = evaluate_gate_criteria(CRITERIA, FAILING_SUMMARY)
+    assert met is True
+    # A recovered line does not trip.
+    met, _ = evaluate_gate_criteria(
+        CRITERIA,
+        {"trades": {"closed_count": 25, "win_rate": 0.55, "net_pnl": 40.0}},
+    )
+    assert met is False
+
+
+# ── paper auto-resolution ────────────────────────────────────────────────
+
+
+def test_paper_job_auto_resolves_when_criteria_met(
+    tmp_path: Path, compiled: list[str]
+) -> None:
+    store, job = _store(tmp_path)
+    register_decision_gate(
+        store, job.id, criteria=CRITERIA, successor_ref="lane-b", gate_id="gate-imx"
+    )
+    store.write_json(job.id, "results/forward/summary.json", FAILING_SUMMARY)
+
+    events = evaluate_decision_gates(store, job)
+
+    assert [event["type"] for event in events] == ["gate_auto_resolved"]
+    event = events[0]
+    assert event["measured"]["closed_trades"] == 20
+    assert event["undo"]["command"] == (
+        f"wayfinder job decision-gate reopen {job.id} gate-imx"
+    )
+    # Incumbent retired: loop disabled + recompiled, workspace archived.
+    assert store.load(job.id).script_loop.enabled is False
+    assert compiled == [job.id]
+    archived = store.job_dir(job.id) / event["archived_workspace"] / "workspace"
+    assert (archived / "src" / "strategy.py").exists()
+    # Active workspace left in place — reopen is non-destructive.
+    assert (store.job_dir(job.id) / "workspace" / "src" / "strategy.py").exists()
+    # Pivot note is operator-visible and attributed to gate-auto, not owner.
+    agenda = (store.job_dir(job.id) / "research" / "agenda.md").read_text()
+    assert "gate-auto" in agenda and "lane-b" in agenda
+    gate = load_decision_gates(store, job.id)["gates"][0]
+    assert gate["status"] == "resolved"
+    assert gate["resolution"]["by"] == "gate-auto"
+    # Resolved gates do not re-fire.
+    assert evaluate_decision_gates(store, job) == []
+
+
+def test_unmet_criteria_leave_the_gate_armed(
+    tmp_path: Path, compiled: list[str]
+) -> None:
+    store, job = _store(tmp_path)
+    register_decision_gate(
+        store, job.id, criteria=CRITERIA, successor_ref="lane-b", gate_id="gate-imx"
+    )
+    store.write_json(
+        job.id,
+        "results/forward/summary.json",
+        {"trades": {"closed_count": 5, "win_rate": 0.2, "net_pnl": -3}},
+    )
+
+    assert evaluate_decision_gates(store, job) == []
+    assert load_decision_gates(store, job.id)["gates"][0]["status"] == "armed"
+    assert store.load(job.id).script_loop.enabled is True
+    assert compiled == []
+
+
+# ── live jobs escalate instead ───────────────────────────────────────────
+
+
+def test_live_capable_job_trips_to_needs_you(
+    tmp_path: Path, compiled: list[str]
+) -> None:
+    store, job = _store(tmp_path, wallet_label="main")
+    register_decision_gate(
+        store, job.id, criteria=CRITERIA, successor_ref="lane-b", gate_id="gate-imx"
+    )
+    store.write_json(job.id, "results/forward/summary.json", FAILING_SUMMARY)
+
+    events = evaluate_decision_gates(store, job)
+
+    assert [event["type"] for event in events] == ["decision_gate_tripped"]
+    assert store.load(job.id).script_loop.enabled is True  # nothing executed
+    assert compiled == []
+    gate = load_decision_gates(store, job.id)["gates"][0]
+    assert gate["status"] == "tripped_needs_owner"
+    needs_you = build_owner_attention(store, job.id)["needs_you"]
+    assert [item["kind"] for item in needs_you] == ["decision_gate_tripped"]
+    assert needs_you[0]["ref_id"] == "gate-imx"
+    # A tripped gate does not re-trip on the next watchdog pass.
+    assert evaluate_decision_gates(store, job) == []
+
+
+# ── undo and manual resolution ───────────────────────────────────────────
+
+
+def test_reopen_reverses_an_auto_resolution(
+    tmp_path: Path, compiled: list[str]
+) -> None:
+    store, job = _store(tmp_path)
+    register_decision_gate(
+        store, job.id, criteria=CRITERIA, successor_ref="lane-b", gate_id="gate-imx"
+    )
+    store.write_json(job.id, "results/forward/summary.json", FAILING_SUMMARY)
+    evaluate_decision_gates(store, job)
+    assert store.load(job.id).script_loop.enabled is False
+
+    gate = reopen_decision_gate(store, job.id, "gate-imx", by="owner")
+
+    assert gate["status"] == "reopened"
+    assert store.load(job.id).script_loop.enabled is True
+    assert compiled == [job.id, job.id]  # retire + reopen recompiles
+    assert "decision_gate_reopened" in _journal_types(store, job.id)
+    # Reopened is terminal until re-registered: criteria still met, no re-trip.
+    assert evaluate_decision_gates(store, store.load(job.id)) == []
+
+
+def test_owner_resolves_a_tripped_gate(tmp_path: Path, compiled: list[str]) -> None:
+    store, job = _store(tmp_path, wallet_label="main")
+    register_decision_gate(
+        store, job.id, criteria=CRITERIA, successor_ref="lane-b", gate_id="gate-imx"
+    )
+    store.write_json(job.id, "results/forward/summary.json", FAILING_SUMMARY)
+    evaluate_decision_gates(store, job)
+
+    gate = resolve_decision_gate(store, job.id, "gate-imx", by="owner", note="agreed")
+
+    assert gate["status"] == "resolved"
+    assert gate["resolution"]["by"] == "owner"
+    assert "decision_gate_resolved" in _journal_types(store, job.id)
+    # Acknowledged, not executed: the loop keeps running.
+    assert store.load(job.id).script_loop.enabled is True
+    assert compiled == []
+
+
+# ── watchdog integration ─────────────────────────────────────────────────
+
+
+def test_watchdog_pass_runs_the_gate_check(
+    tmp_path: Path, compiled: list[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from wayfinder_paths.jobs import watchdog as watchdog_mod
+
+    class FakeBridge:
+        def __init__(self, *, repo_root=None) -> None:
+            self.repo_root = repo_root
+
+        def job_states(self) -> dict:
+            return {}
+
+    monkeypatch.setattr(watchdog_mod, "RunnerBridge", FakeBridge)
+    store, job = _store(tmp_path)
+    register_decision_gate(
+        store, job.id, criteria=CRITERIA, successor_ref="lane-b", gate_id="gate-imx"
+    )
+    store.write_json(job.id, "results/forward/summary.json", FAILING_SUMMARY)
+
+    result = watchdog_mod.recover_stalled_applications(store=store)
+
+    gate_events = [
+        event
+        for event in result["recovered"]
+        if event.get("type") == "gate_auto_resolved"
+    ]
+    assert len(gate_events) == 1
+    assert load_decision_gates(store, job.id)["gates"][0]["status"] == "resolved"

--- a/wayfinder_paths/tests/test_jobs_owner_attention.py
+++ b/wayfinder_paths/tests/test_jobs_owner_attention.py
@@ -1,0 +1,331 @@
+"""Two-zone owner attention: needs_you routing and the decided feed."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+from pathlib import Path
+
+from wayfinder_paths.jobs import sync as sync_mod
+from wayfinder_paths.jobs.halt import request_halt
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.owner_attention import (
+    build_owner_attention,
+    job_live_capital_risk,
+)
+from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.jobs.sync import snapshot_job
+
+
+def _store(
+    tmp_path: Path,
+    *,
+    mode: str = "paper",
+    wallet_label: str | None = None,
+    job_id: str = "attn-demo",
+) -> tuple[JobStore, str]:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        job_id,
+        script=".wayfinder_runs/demo.py",
+        interval_seconds=60,
+        agent_mode="intervene",
+        execution_contract="jobs_v1",
+    )
+    job.script_loop.mode = mode
+    if wallet_label:
+        job.execution_params["wallet_label"] = wallet_label
+    store.save(job)
+    return store, job.id
+
+
+def _write_pending_proposal(store: JobStore, job_id: str, pid: str) -> None:
+    store.write_proposal(
+        job_id,
+        {
+            "proposal_id": pid,
+            "job_id": job_id,
+            "status": "pending",
+            "kind": "params_update",
+            "proposed_change": {"summary": "raise threshold"},
+            "application": {"status": "not_requested"},
+        },
+    )
+
+
+def _journal(store: JobStore, job_id: str, event: dict) -> None:
+    store.append_journal(job_id, event)
+
+
+def _kinds(items: list[dict]) -> list[str]:
+    return [item["kind"] for item in items]
+
+
+# ── needs_you routing ────────────────────────────────────────────────────
+
+
+def test_live_capital_risk_is_mode_or_wallet() -> None:
+    paper = WayfinderJob.new("a", script="s.py", interval_seconds=60)
+    assert job_live_capital_risk(paper) is False
+    live = WayfinderJob.new("b", script="s.py", interval_seconds=60)
+    live.script_loop.mode = "live"
+    assert job_live_capital_risk(live) is True
+    bound = WayfinderJob.new("c", script="s.py", interval_seconds=60)
+    bound.execution_params["wallet_label"] = "main"
+    assert job_live_capital_risk(bound) is True
+
+
+def test_pending_proposal_on_live_capable_job_needs_owner(tmp_path: Path) -> None:
+    store, job_id = _store(tmp_path, wallet_label="main")
+    _write_pending_proposal(store, job_id, "prop-live")
+    _journal(store, job_id, {"type": "proposal_created", "proposal_id": "prop-live"})
+
+    attention = build_owner_attention(store, job_id)
+
+    items = attention["needs_you"]
+    assert _kinds(items) == ["live_proposal_approval"]
+    assert items[0]["ref_id"] == "prop-live"
+    assert items[0]["evidence_ref"] == "proposals/prop-live.json"
+    assert items[0]["since_ts"]
+
+
+def test_pending_proposal_on_pure_paper_job_is_mechanical(tmp_path: Path) -> None:
+    store, job_id = _store(tmp_path)  # paper, no wallet
+    _write_pending_proposal(store, job_id, "prop-paper")
+
+    attention = build_owner_attention(store, job_id)
+
+    assert attention["needs_you"] == []
+
+
+def test_risk_latched_halt_needs_owner_but_manual_does_not(tmp_path: Path) -> None:
+    store, job_id = _store(tmp_path)
+    request_halt(store, job_id, reason="dd breach", source="risk_limits")
+    items = build_owner_attention(store, job_id)["needs_you"]
+    assert _kinds(items) == ["halt_awaiting_owner_clear"]
+    assert items[0]["ref_id"] == "risk_limits"
+
+    store2, job2 = _store(tmp_path / "b", job_id="attn-manual")
+    request_halt(store2, job2, reason="pause please", source="manual")
+    assert build_owner_attention(store2, job2)["needs_you"] == []
+
+
+def test_owner_review_markers_surface_and_resolve(tmp_path: Path) -> None:
+    store, job_id = _store(tmp_path)
+    _journal(
+        store,
+        job_id,
+        {
+            "type": "successor_abandoned",
+            "proposal_id": "prop-dead",
+            "rearms": 3,
+            "owner_review_required": "successor was self-rejected 3 times",
+        },
+    )
+    # Reject-refusal escalation on a proposal still stuck in restage.
+    store.write_proposal(
+        job_id,
+        {
+            "proposal_id": "prop-stuck",
+            "job_id": job_id,
+            "status": "approved",
+            "proposed_change": {"summary": "x"},
+            "application": {"status": "not_requested", "restage_requested": True},
+        },
+    )
+    _journal(
+        store,
+        job_id,
+        {
+            "type": "proposal_reject_refused",
+            "proposal_id": "prop-stuck",
+            "failure_kind": "escalate",
+            "owner_review_required": "a fail-closed gate ESCALATED",
+        },
+    )
+
+    kinds = _kinds(build_owner_attention(store, job_id)["needs_you"])
+    assert sorted(kinds) == ["proposal_reject_refused", "successor_abandoned"]
+
+    # Once the restage flag clears, the reject-refusal marker resolves.
+    proposal = store.load_proposal(job_id, "prop-stuck")
+    proposal["application"]["restage_requested"] = False
+    store.write_proposal(job_id, proposal)
+    kinds = _kinds(build_owner_attention(store, job_id)["needs_you"])
+    assert kinds == ["successor_abandoned"]
+
+
+def test_unauditable_pending_claim_needs_owner(tmp_path: Path) -> None:
+    store, job_id = _store(tmp_path)
+    old = (dt.datetime.now(dt.UTC) - dt.timedelta(hours=3)).isoformat()
+    claims = {
+        # No mechanical verdict after the grace window → owner.
+        "claim-stuck": {"status": "pending", "lane": "imx-gap", "filed_at": old},
+        # Audit produced a verdict → mechanical path owns it.
+        "claim-rejected": {
+            "status": "pending",
+            "lane": "other",
+            "filed_at": old,
+            "audit": {"verdict": "reject"},
+        },
+        # Freshly filed → the audit simply hasn't run yet.
+        "claim-fresh": {
+            "status": "pending",
+            "lane": "new",
+            "filed_at": dt.datetime.now(dt.UTC).isoformat(),
+        },
+    }
+    for claim_id, claim in claims.items():
+        store.write_json(
+            job_id,
+            f"research/exhaustion_claims/{claim_id}.json",
+            {"claim_id": claim_id, **claim},
+        )
+
+    items = build_owner_attention(store, job_id)["needs_you"]
+    assert _kinds(items) == ["exhaustion_claim_unauditable"]
+    assert items[0]["ref_id"] == "claim-stuck"
+
+
+def test_tripped_decision_gate_needs_owner(tmp_path: Path) -> None:
+    store, job_id = _store(tmp_path, wallet_label="main")
+    store.write_json(
+        job_id,
+        "research/decision_gates.json",
+        {
+            "gates": [
+                {
+                    "gate_id": "gate-imx",
+                    "status": "tripped_needs_owner",
+                    "on_met": "retire_and_pivot",
+                    "tripped_at": "2026-08-24T00:00:00+00:00",
+                },
+                {"gate_id": "gate-armed", "status": "armed"},
+            ]
+        },
+    )
+
+    items = build_owner_attention(store, job_id)["needs_you"]
+    assert _kinds(items) == ["decision_gate_tripped"]
+    assert items[0]["ref_id"] == "gate-imx"
+
+
+# ── decided_autonomously feed ────────────────────────────────────────────
+
+
+def test_decided_feed_carries_undo_refs(tmp_path: Path) -> None:
+    store, job_id = _store(tmp_path)
+    _journal(
+        store,
+        job_id,
+        {
+            "type": "proposal_auto_applied",
+            "proposal_id": "prop-auto",
+            "kind": "params_update",
+            "tier": "paper",
+            "evidence": {"validation_status": "passed"},
+            "undo": {
+                "command": f"wayfinder job rollback-apply {job_id} prop-auto",
+                "window_expires_ts": "2026-08-27T00:00:00+00:00",
+            },
+        },
+    )
+    _journal(
+        store,
+        job_id,
+        {
+            "type": "gate_auto_resolved",
+            "gate_id": "gate-imx",
+            "action": "retire_and_pivot",
+            "criteria": {"min_trades": 20},
+            "measured": {"closed_trades": 20},
+            "undo": {
+                "command": f"wayfinder job decision-gate reopen {job_id} gate-imx",
+                "window_expires_ts": "2026-08-31T00:00:00+00:00",
+            },
+        },
+    )
+    _journal(
+        store,
+        job_id,
+        {
+            "type": "exhaustion_claim_audit_passed",
+            "claim_id": "claim-1",
+            "by": "coverage-audit",
+            "audit_verdict": "narrow",
+            "certificate": "research/coverage/cert-1.json",
+            "owner_override_until": "2026-08-26T00:00:00+00:00",
+        },
+    )
+    _journal(store, job_id, {"type": "probation_leg_opened", "leg": "hype-leg"})
+    _journal(store, job_id, {"type": "probation_leg_killed", "leg": "hype-leg"})
+
+    decided = build_owner_attention(store, job_id)["decided_autonomously"]
+
+    by_kind = {item["kind"]: item for item in decided}
+    assert by_kind["paper_auto_apply"]["decision"] == "auto_applied"
+    assert "rollback-apply" in by_kind["paper_auto_apply"]["undo"]["command"]
+    assert by_kind["decision_gate"]["decision"] == "retire_and_pivot"
+    assert "decision-gate reopen" in by_kind["decision_gate"]["undo"]["command"]
+    claim = by_kind["exhaustion_claim_audit"]
+    assert claim["decision"] == "narrow"
+    assert claim["undo"]["window_expires_ts"] == "2026-08-26T00:00:00+00:00"
+    probation = [item for item in decided if item["kind"] == "probation"]
+    assert {item["decision"] for item in probation} == {"opened", "killed"}
+    # Feed is newest-first.
+    timestamps = [item["ts"] for item in decided]
+    assert timestamps == sorted(timestamps, reverse=True)
+
+
+def test_decided_feed_is_windowed_and_capped(tmp_path: Path) -> None:
+    store, job_id = _store(tmp_path)
+    journal_path = store.job_dir(job_id) / "journal.jsonl"
+    journal_path.parent.mkdir(parents=True, exist_ok=True)
+    stale_ts = (dt.datetime.now(dt.UTC) - dt.timedelta(days=8)).isoformat()
+    rows = [
+        {"ts": stale_ts, "type": "proposal_auto_applied", "proposal_id": "prop-old"}
+    ]
+    fresh_ts = dt.datetime.now(dt.UTC).isoformat()
+    rows.extend(
+        {"ts": fresh_ts, "type": "proposal_auto_applied", "proposal_id": f"p{i}"}
+        for i in range(60)
+    )
+    journal_path.write_text(
+        "".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8"
+    )
+
+    decided = build_owner_attention(store, job_id)["decided_autonomously"]
+
+    assert len(decided) == 50  # capped
+    assert all(item["ref_id"] != "prop-old" for item in decided)  # 7d window
+
+
+# ── snapshot integration ─────────────────────────────────────────────────
+
+
+class _FakeBridge:
+    def __init__(self, *, repo_root=None) -> None:
+        self.repo_root = repo_root
+
+    def job_states(self) -> dict:
+        return {}
+
+
+def test_snapshot_ships_owner_attention_top_level(tmp_path: Path, monkeypatch) -> None:
+    store, job_id = _store(tmp_path, wallet_label="main")
+    monkeypatch.setattr(sync_mod, "RunnerBridge", _FakeBridge)
+    _write_pending_proposal(store, job_id, "prop-live")
+
+    snapshot = snapshot_job(job_id, store=store)
+
+    attention = snapshot["owner_attention"]
+    assert _kinds(attention["needs_you"]) == ["live_proposal_approval"]
+    assert attention["decided_autonomously"] == []
+
+
+def test_builder_never_raises(tmp_path: Path) -> None:
+    store = JobStore(repo_root=tmp_path)
+    assert build_owner_attention(store, "missing-job") == {
+        "needs_you": [],
+        "decided_autonomously": [],
+    }

--- a/wayfinder_paths/tests/test_jobs_paper_auto_apply.py
+++ b/wayfinder_paths/tests/test_jobs_paper_auto_apply.py
@@ -1,0 +1,280 @@
+"""Paper auto-apply tier: gate-green paper proposals apply without a click.
+
+Autonomy changes WHO clicks, not WHAT is checked — every test that auto-
+applies still routes through the full `store.approve_proposal` gate.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from wayfinder_paths.jobs import apply_launcher
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.proposals import (
+    PAPER_AUTO_APPLY_ENV,
+    maybe_auto_apply_paper_proposal,
+    paper_auto_apply_blockers,
+)
+from wayfinder_paths.jobs.store import JobStore
+
+
+def _store(
+    tmp_path: Path,
+    *,
+    mode: str = "paper",
+    wallet_label: str | None = None,
+    auto_limits: dict | None = None,
+) -> tuple[JobStore, str]:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        "auto-demo",
+        script=".wayfinder_runs/demo.py",
+        interval_seconds=60,
+        agent_mode="intervene",
+        execution_contract="jobs_v1",
+    )
+    job.script_loop.mode = mode
+    if wallet_label:
+        job.execution_params["wallet_label"] = wallet_label
+    if auto_limits is not None:
+        job.agent_loop.auto_limits = auto_limits
+    store.save(job)
+    return store, job.id
+
+
+def _green_proposal(
+    store: JobStore,
+    job_id: str,
+    pid: str = "prop-green",
+    *,
+    kind: str = "params_update",
+    params: dict | None = None,
+    scenarios: list | None = None,
+) -> str:
+    store.write_proposal(
+        job_id,
+        {
+            "proposal_id": pid,
+            "job_id": job_id,
+            "status": "pending",
+            "kind": kind,
+            "proposed_change": {
+                "summary": "tighten threshold",
+                "execution_params": params if params is not None else {"threshold": 2},
+            },
+            "intent_contract": {"goal": "improve net"},
+            "scenario_plan": {
+                "scenarios": [{"name": "s1"}] if scenarios is None else scenarios
+            },
+            "application": {
+                "status": "not_requested",
+                "candidate_dir": f"applications/{pid}/candidate",
+            },
+            "candidate_report": {
+                "revision": "rev-cand",
+                "generated_at": "2026-08-24T00:00:00+00:00",
+                "validation_summary": {"status": "passed"},
+                "gate": {"live_ready": True, "reasons": []},
+                "economic": {"ready": True, "enforcement": "advisory"},
+            },
+        },
+    )
+    return pid
+
+
+@pytest.fixture()
+def launched(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, str]]:
+    monkeypatch.setenv(PAPER_AUTO_APPLY_ENV, "1")
+    calls: list[tuple[str, str]] = []
+
+    def fake_launch(store, job_id, proposal_id):
+        calls.append((job_id, proposal_id))
+        return {"mode": "deterministic", "spawned": True}
+
+    monkeypatch.setattr(apply_launcher, "launch_application", fake_launch)
+    return calls
+
+
+def _journal_events(store: JobStore, job_id: str, event_type: str) -> list[dict]:
+    return [
+        event
+        for event in store.read_jsonl(job_id, "journal.jsonl")
+        if event.get("type") == event_type
+    ]
+
+
+def test_green_paper_proposal_auto_applies(tmp_path: Path, launched) -> None:
+    store, job_id = _store(tmp_path)
+    pid = _green_proposal(store, job_id)
+
+    result = maybe_auto_apply_paper_proposal(store, job_id, pid)
+
+    assert result and result["auto_applied"] is True
+    proposal = store.load_proposal(job_id, pid)
+    assert proposal["status"] == "approved"
+    assert proposal["approval"]["required"] is False
+    assert proposal["approval"]["by"] == "paper-auto-apply"
+    assert proposal["application"]["status"] == "queued"
+    assert launched == [(job_id, pid)]
+    events = _journal_events(store, job_id, "proposal_auto_applied")
+    assert len(events) == 1
+    assert events[0]["tier"] == "paper"
+    assert events[0]["evidence"]["candidate_revision"] == "rev-cand"
+    assert (
+        f"wayfinder job rollback-apply {job_id} {pid}" == (events[0]["undo"]["command"])
+    )
+    assert events[0]["undo"]["window_expires_ts"]
+
+
+def test_kill_switch_disables_auto_apply(
+    tmp_path: Path, launched, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(PAPER_AUTO_APPLY_ENV, "0")
+    store, job_id = _store(tmp_path)
+    pid = _green_proposal(store, job_id)
+
+    assert maybe_auto_apply_paper_proposal(store, job_id, pid) is None
+    assert store.load_proposal(job_id, pid)["status"] == "pending"
+    assert launched == []
+
+
+def test_live_capable_jobs_never_auto_apply(tmp_path: Path, launched) -> None:
+    for variant, kwargs in (
+        ("wallet", {"wallet_label": "main"}),
+        ("live", {"mode": "live"}),
+    ):
+        store, job_id = _store(tmp_path / variant, **kwargs)
+        pid = _green_proposal(store, job_id)
+        assert maybe_auto_apply_paper_proposal(store, job_id, pid) is None
+        assert store.load_proposal(job_id, pid)["status"] == "pending"
+        blockers = paper_auto_apply_blockers(
+            store, job_id, store.load_proposal(job_id, pid)
+        )
+        assert any("live-capable" in blocker for blocker in blockers) or any(
+            "not paper" in blocker for blocker in blockers
+        )
+    assert launched == []
+
+
+def test_non_green_reports_require_approval(tmp_path: Path, launched) -> None:
+    store, job_id = _store(tmp_path)
+    pid = _green_proposal(store, job_id)
+    proposal = store.load_proposal(job_id, pid)
+    proposal["candidate_report"]["gate"] = {"live_ready": False, "reasons": ["red"]}
+    store.write_proposal(job_id, proposal)
+
+    assert maybe_auto_apply_paper_proposal(store, job_id, pid) is None
+    assert store.load_proposal(job_id, pid)["status"] == "pending"
+    assert launched == []
+
+
+def test_kind_limits_default_to_params_update_only(tmp_path: Path, launched) -> None:
+    store, job_id = _store(tmp_path)
+    pid = _green_proposal(store, job_id, "prop-code", kind="code_change")
+    assert maybe_auto_apply_paper_proposal(store, job_id, pid) is None
+
+    # auto_limits may widen the tier — but never to improver_change.
+    store2, job2 = _store(
+        tmp_path / "widened",
+        auto_limits={"auto_apply_kinds": ["code_change", "improver_change"]},
+    )
+    pid_code = _green_proposal(store2, job2, "prop-code", kind="code_change")
+    assert maybe_auto_apply_paper_proposal(store2, job2, pid_code) is not None
+    pid_improver = _green_proposal(store2, job2, "prop-imp", kind="improver_change")
+    assert maybe_auto_apply_paper_proposal(store2, job2, pid_improver) is None
+
+
+def test_owner_owned_param_names_require_approval(tmp_path: Path, launched) -> None:
+    store, job_id = _store(tmp_path)
+    for pid, params in (
+        ("prop-lev", {"leverage": 3}),
+        ("prop-wallet", {"wallet_label": "main"}),
+        ("prop-mode", {"protection_mode": "off"}),
+        ("prop-gov", {"governance_window": 7}),
+    ):
+        _green_proposal(store, job_id, pid, params=params)
+        assert maybe_auto_apply_paper_proposal(store, job_id, pid) is None, pid
+    assert launched == []
+
+
+def test_daily_cap_bounds_the_tier(tmp_path: Path, launched) -> None:
+    store, job_id = _store(tmp_path)
+    for i in range(3):
+        store.append_journal(
+            job_id, {"type": "proposal_auto_applied", "proposal_id": f"old-{i}"}
+        )
+    pid = _green_proposal(store, job_id)
+
+    assert maybe_auto_apply_paper_proposal(store, job_id, pid) is None
+    blockers = paper_auto_apply_blockers(
+        store, job_id, store.load_proposal(job_id, pid)
+    )
+    assert any("cap" in blocker for blocker in blockers)
+    assert launched == []
+
+
+def test_approve_gate_refusal_leaves_proposal_pending(tmp_path: Path, launched) -> None:
+    """Eligibility precheck can be optimistic; the REAL approve gate decides.
+
+    An empty scenario plan passes the blockers but fails
+    `_validate_applicable_proposal` inside approve — the proposal must stay
+    pending on the owner path, un-mangled."""
+    store, job_id = _store(tmp_path)
+    pid = _green_proposal(store, job_id, scenarios=[])
+
+    assert maybe_auto_apply_paper_proposal(store, job_id, pid) is None
+    proposal = store.load_proposal(job_id, pid)
+    assert proposal["status"] == "pending"
+    assert proposal["approval"]["required"] is True
+    assert launched == []
+
+
+def test_auto_apply_launch_failure_is_watchdog_recoverable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(PAPER_AUTO_APPLY_ENV, "1")
+
+    def broken_launch(store, job_id, proposal_id):
+        raise RuntimeError("spawn failed")
+
+    monkeypatch.setattr(apply_launcher, "launch_application", broken_launch)
+    store, job_id = _store(tmp_path)
+    pid = _green_proposal(store, job_id)
+
+    result = maybe_auto_apply_paper_proposal(store, job_id, pid)
+
+    assert result and result["auto_applied"] is True
+    proposal = store.load_proposal(job_id, pid)
+    # Approved + queued is exactly the state _recover_queued backstops.
+    assert proposal["status"] == "approved"
+    assert proposal["application"]["status"] == "queued"
+    assert _journal_events(store, job_id, "proposal_auto_apply_launch_failed")
+
+
+def test_forbidden_params_regex_matches_documented_families(tmp_path: Path) -> None:
+    store, job_id = _store(tmp_path)
+    pid = _green_proposal(
+        store, job_id, params={"nested": {"max_leverage": 5}, "threshold": 1}
+    )
+    blockers = paper_auto_apply_blockers(
+        store, job_id, store.load_proposal(job_id, pid)
+    )
+    assert any("nested.max_leverage" in blocker for blocker in blockers)
+
+
+def test_undo_command_round_trips_through_journal(tmp_path: Path, launched) -> None:
+    store, job_id = _store(tmp_path)
+    pid = _green_proposal(store, job_id)
+    maybe_auto_apply_paper_proposal(store, job_id, pid)
+
+    from wayfinder_paths.jobs.owner_attention import build_owner_attention
+
+    decided = build_owner_attention(store, job_id)["decided_autonomously"]
+    auto = [item for item in decided if item["kind"] == "paper_auto_apply"]
+    assert auto and auto[0]["ref_id"] == pid
+    assert json.loads(json.dumps(auto[0]["undo"]))["command"].startswith(
+        "wayfinder job rollback-apply"
+    )

--- a/wayfinder_paths/tests/test_jobs_remediation.py
+++ b/wayfinder_paths/tests/test_jobs_remediation.py
@@ -51,18 +51,72 @@ def test_case_opens_once_and_retries_until_accountable_outcome(
 
     opened = sync_remediation_with_health(store, job_id, _health(), now=now)
     assert opened and opened["event"] == "regime_shift"
+    # Quiet retries are debounced for 6 hours: the 30-minute cadence churned
+    # (~every scheduled tick re-woke the agent over unchanged evidence).
+    for minutes in (10, 31, 5 * 60):
+        assert (
+            sync_remediation_with_health(
+                store, job_id, _health(), now=now + dt.timedelta(minutes=minutes)
+            )
+            is None
+        )
+
+    retry = sync_remediation_with_health(
+        store, job_id, _health(), now=now + dt.timedelta(hours=6, minutes=1)
+    )
+    assert retry and retry["event"] == "regime_remediation_due"
+    assert load_remediation(store, job_id)["attempts"] == 2  # type: ignore[index]
+
+
+def test_recorded_progress_defers_the_retry_wake(tmp_path: Path) -> None:
+    """A bounded progress note is the agent already working the case — the
+    next quiet retry anchors on the note, not the original wake."""
+    store, job_id = _store(tmp_path)
+    now = dt.datetime(2026, 8, 21, 12, tzinfo=dt.UTC)
+    sync_remediation_with_health(store, job_id, _health(), now=now)
+
+    # Progress recorded 5h50m in (recorded_at = real now; anchor on max()).
+    update_remediation_progress(
+        store,
+        job_id,
+        state="evaluating",
+        note="Running HYPE ablation on all OOS folds",
+    )
+
+    # 6h+ after the wake but minutes after the progress note: no re-wake.
     assert (
         sync_remediation_with_health(
-            store, job_id, _health(), now=now + dt.timedelta(minutes=10)
+            store, job_id, _health(), now=dt.datetime.now(dt.UTC)
         )
         is None
     )
 
+    # 6h+ after the progress note: the quiet retry fires again.
     retry = sync_remediation_with_health(
-        store, job_id, _health(), now=now + dt.timedelta(minutes=31)
+        store,
+        job_id,
+        _health(),
+        now=dt.datetime.now(dt.UTC) + dt.timedelta(hours=6, minutes=1),
     )
     assert retry and retry["event"] == "regime_remediation_due"
-    assert load_remediation(store, job_id)["attempts"] == 2  # type: ignore[index]
+
+
+def test_material_evidence_still_wakes_through_the_debounce(tmp_path: Path) -> None:
+    store, job_id = _store(tmp_path)
+    now = dt.datetime(2026, 8, 21, 12, tzinfo=dt.UTC)
+    sync_remediation_with_health(store, job_id, _health(), now=now)
+    update_remediation_progress(
+        store, job_id, state="evaluating", note="ablating", artifact_path=None
+    )
+
+    refreshed = sync_remediation_with_health(
+        store,
+        job_id,
+        _health(score=6, fingerprint="health-b"),
+        now=now + dt.timedelta(minutes=2),
+    )
+
+    assert refreshed and refreshed["event"] == "regime_shift"
 
 
 def test_material_evidence_bypasses_retry_debounce(tmp_path: Path) -> None:


### PR DESCRIPTION
Part 1 of the owner-attention trio (SDK now; backend + FE consume the payload next). Implements the owner-approved doctrine: **"needs you" is reserved for live-capital and governance decisions; everything else is mechanical with visibility and bounded undo.**

## 1. `owner_attention` block in the sync snapshot

`snapshot_job` now ships a top-level `owner_attention` key (like `scorecard`), built read-only and raise-free by the new `wayfinder_paths/jobs/owner_attention.py`.

### Payload schema (backend/FE contract)

```jsonc
"owner_attention": {
  "needs_you": [            // owner-blocking, rare; sorted oldest-first
    {
      "kind": "live_proposal_approval"      // pending proposal, live-capable job
            | "exhaustion_claim_unauditable" // pending claim, no mechanical audit verdict
            | "successor_abandoned"          // journal owner_review_required marker
            | "proposal_reject_refused"      //   (escalate-kind, still restage-stuck)
            | "live_mode_audit"              //   (ratify an owner stamp)
            | "decision_gate_tripped"        // gate criteria met on live-capable job
            | "halt_awaiting_owner_clear",   // risk-latched halt (owner-only clear)
      "job_id": "…",
      "ref_id": "…",        // proposal_id | claim_id | gate_id | halt source
      "summary": "…",       // <=300 chars, human-readable
      "evidence_ref": "…",  // job-relative artifact path (proposals/<id>.json, journal.jsonl, …)
      "since_ts": "…"       // ISO 8601
    }
  ],
  "decided_autonomously": [ // last 7 days, newest-first, capped at 50
    {
      "kind": "paper_auto_apply" | "decision_gate" | "exhaustion_claim_audit" | "probation",
      "job_id": "…",
      "ref_id": "…",
      "ts": "…",
      "decision": "auto_applied" | "retire_and_pivot" | "pass" | "narrow" | "reject"
                | "opened" | "graduated" | "killed",
      "evidence": "…",      // <=300-char summary (string or compact JSON)
      "undo": {             // present only where undoable
        "command": "wayfinder job rollback-apply <job> <pid>"
                 | "wayfinder job decision-gate reopen <job> <gate>"
                 | "wayfinder job exhaustion reopen <job> <claim> --reason '<why>'",
        "window_expires_ts": "…"   // advisory; absent when open-ended
      }
    }
  ]
}
```

### What feeds each array (exact sources)

**`needs_you` kinds → source of truth:**

| kind | source | ref_id | since_ts |
|---|---|---|---|
| `live_proposal_approval` | `store.proposals()` status=`pending`, job live-capable | `proposal_id` | `proposal_created` journal ts (fallback `updated_at`) |
| `exhaustion_claim_unauditable` | pending claims, `audit.verdict` not in pass/narrow/reject, >1h after filing | `claim_id` | `filed_at` |
| `successor_abandoned` / `proposal_reject_refused` / `live_mode_audit` (or any event type bearing the marker) | journal events with truthy `owner_review_required` (30d window, latest per type+ref; reject-refused drops once `application.restage_requested` clears) | `proposal_id`/`claim_id`/`gate_id` | event `ts` |
| `decision_gate_tripped` | `research/decision_gates.json` gates with status `tripped_needs_owner` | `gate_id` | gate `tripped_at` |
| `halt_awaiting_owner_clear` | `state/halt.json` with `source` in `RISK_LATCH_SOURCES` (`risk_limits`, `native_protection`, `regime_health`) | halt `source` | halt `ts` |

**`decided_autonomously` kinds → journal event types:**

| kind | journal event(s) | decision values | undo |
|---|---|---|---|
| `paper_auto_apply` | `proposal_auto_applied` | `auto_applied` | event's `undo` verbatim (`rollback-apply`, 72h advisory window) |
| `decision_gate` | `gate_auto_resolved` | event `action` (`retire_and_pivot`) | event's `undo` verbatim (`decision-gate reopen`, 7d advisory window) |
| `exhaustion_claim_audit` | `exhaustion_claim_audit_passed`; `exhaustion_claim_rejected` where `by == "coverage-audit"` | `pass`/`narrow`; `reject` | reopen command; `window_expires_ts` = event `owner_override_until` (48h). No undo on reject |
| `probation` | `probation_leg_opened`, `paper_probation_opened`, `probation_leg_graduated`, `probation_leg_killed` | `opened`/`graduated`/`killed` | none (audit trail) |

Field types: all strings (ISO 8601 for `*_ts`), `undo` optional object `{command: string, window_expires_ts?: string}`; `evidence` is a <=300-char string (may be compact JSON); `since_ts` may be null if no timestamp could be recovered.

**Live-capable** for attention routing = `script_loop.mode == "live"` OR `execution_params.wallet_label` bound (one operator flip from live). This is deliberately NOT `store._job_is_live_capable` — see judgment calls.

## 2. Paper auto-apply tier (`proposals.py`)

At staging time (`propose_change`), a proposal on a paper-tier job (paper mode AND wallet not bound, jobs_v1) with a fully green `candidate_report` (validation passed + gate live-ready + not economic-red) and within auto-limits is approved through the **unchanged** `store.approve_proposal` gate, marked `approval.required=false` / `approval.by="paper-auto-apply"`, journaled as `proposal_auto_applied` (evidence + undo ref), and queued via the existing restage carryover machinery (`launch_application`; the application watchdog backstops a failed launch).

- Default limits: `params_update` only, <=3 auto-applies/day/job, and params may never match `leverage|wallet|mode|governance` (recursive key scan).
- `agent_loop.auto_limits` overrides: `auto_apply_kinds` (never widenable to `improver_change` — that is a criterion/governance change) and `max_auto_applies_per_day`.
- Kill-switch: `WAYFINDER_PAPER_AUTO_APPLY=0`.
- Undo is real: new `wayfinder job rollback-apply <job> <pid>` (`application.rollback_application`) restores the promotion backup at `applications/<pid>/backup`, guarded to the most-recent apply (refuses if the workspace moved — the stale-candidate clobber class), recompiles, journals `application_rolled_back`.

## 3. Paper rework-vs-retire auto-resolution (`decision_gates.py`)

`research/decision_gates.json` registry + CLI (`wayfinder job decision-gate register/resolve/reopen/list`) + a watchdog standing check in `recover_stalled_applications`:

- `register` requires `min_trades` (evidence window), at least one ceiling (`max_win_rate` fraction / `max_net_pnl`), and a scoped `successor_ref`; stamps `pre_registered_ts`.
- The watchdog evaluates armed gates against `results/forward/summary.json`. Criteria met on a **paper** job ⇒ bounded retire: script loop disabled + recompiled (runner job deleted), workspace **copied** to `versions/retired-<gate>-<ts>/` (active tree untouched — reopen is non-destructive), pivot appended to `research/agenda.md` attributed **gate-auto** (never owner-attributed), journal `gate_auto_resolved` with undo. On a **live-capable** job ⇒ `tripped_needs_owner`, lands in `needs_you`.
- `reopen` re-enables the loop and leaves the gate terminal (`reopened`) so it cannot re-trip next pass; re-arming requires an explicit re-register.

## 4. Remediation wake debounce (`remediation.py`)

The 30-minute open-case retry churned (42/45 trigger wakes were scheduled-tick retries; 27 progress notes vs 2 evidence updates). Quiet retries now wait **6 hours**, and a recorded progress/blocker note counts as activity (the re-wake anchors on `max(last_wake, progress.recorded_at)`). Material evidence still wakes immediately; journal behavior otherwise unchanged.

## Judgment calls

- **needs_you routing does not use `store._job_is_live_capable`**: that helper flags any job that has entered paper operation (fail-closed governance trigger) and would route every operating paper job's pending proposal to the owner — re-creating the approval queue this feed replaces. The live/wallet boundary is the doctrine split; piece 2 uses its exact inversion, so every pending proposal is either paper-mechanical or live-owner class.
- **"unauditable" claims**: no such literal verdict exists in `coverage.py` (verdicts are pass/narrow/reject). Implemented as: pending claims whose latest audit produced **no mechanical verdict** (missing/unknown), with a 1h grace after filing so the 5-minute watchdog audit has time to run. Reject-verdict claims stay mechanical (required experiments drive the agent).
- **Economic gate for the paper tier**: blockers use the paper approve gate's advisory semantics (explicit `ready=false` blocks; absent/unevaluated does not) rather than requiring literal `ready=true`, which would permanently block paper jobs whose advisory economic block is unevaluated. The real approve gate still runs unchanged.
- **CLI naming**: `wayfinder job gate` was already taken (live-gate evaluation), so the registry group is `wayfinder job decision-gate …`.
- **Undo command had to be built**: no rollback CLI existed; the journaled undo ref would have named a fiction. `rollback-apply` wraps the exact restore the in-flight failure path already performs, with a moved-workspace guard.
- **Tests default the kill-switch off** (conftest autouse fixture): auto-apply spawns a detached apply worker at propose time, which the suite's many green-propose fixtures are not built for. Feature tests opt back in explicitly and stub the launcher.
- **Marker window**: `owner_review_required` journal markers have no mechanical clear event; bounded to 30 days, latest-per-(type, ref), with reject-refusal markers additionally auto-resolving when the restage flag clears.

## Tests

- New: `test_jobs_owner_attention.py` (11), `test_jobs_paper_auto_apply.py` (11), `test_jobs_decision_gates.py` (8); `test_jobs_remediation.py` 5→7 (debounce + progress-defers-wake + evidence-bypasses).
- Full `pytest -k "jobs or runner or mcp"` on the CURRENT base (merged #712 + #707): **1169 passed, 3 skipped** (new-base baseline 1137; +32, zero regressions). On the pre-move base: 1140 vs 1108 baseline.
- ruff check/format clean on all touched files; scoped mypy introduces no new errors (pre-existing legacy errors untouched).


Branch merged with the moved base tip (`9f38cf5e`, #712 evidence-reuse extension) — the merge tree is byte-identical to the rebase that ran the suite.