### PR TITLE
jobs: venue funding ops (Hyperliquid deposit/withdraw + capital)

### DIFF
--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -83,6 +83,8 @@ from wayfinder_paths.jobs.sync import (
     apply_initial_capital,
     apply_script_mode,
     apply_wallet_label,
+    venue_deposit,
+    venue_withdraw,
     snapshot_job,
     sync_all_jobs,
 )
@@ -1444,6 +1446,38 @@ def set_wallet_label_cmd(job_id: str, label: str) -> None:
 def set_initial_capital_cmd(job_id: str, amount: float) -> None:
     try:
         result = apply_initial_capital(job_id, amount)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+    _echo_json({"ok": True, "result": result})
+
+
+@job_cli.command(
+    name="venue-deposit",
+    help="Bridge USDC (>= 5) from the job's bound wallet into Hyperliquid "
+    "and grow initial_capital by the same amount. Waits for the credit; "
+    "an unconfirmed credit still counts (the deposit is en route).",
+)
+@click.argument("job_id")
+@click.argument("amount", type=float)
+def venue_deposit_cmd(job_id: str, amount: float) -> None:
+    try:
+        result = asyncio.run(venue_deposit(job_id, amount))
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+    _echo_json({"ok": True, "result": result})
+
+
+@job_cli.command(
+    name="venue-withdraw",
+    help="Withdraw USDC (>= 2 gross; Bridge2 nets $1 off) from Hyperliquid "
+    "to the job's bound wallet and shrink initial_capital by the gross "
+    "amount, floored at zero.",
+)
+@click.argument("job_id")
+@click.argument("amount", type=float)
+def venue_withdraw_cmd(job_id: str, amount: float) -> None:
+    try:
+        result = asyncio.run(venue_withdraw(job_id, amount))
     except ValueError as exc:
         raise click.ClickException(str(exc)) from exc
     _echo_json({"ok": True, "result": result})

--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -83,10 +83,10 @@ from wayfinder_paths.jobs.sync import (
     apply_initial_capital,
     apply_script_mode,
     apply_wallet_label,
-    venue_deposit,
-    venue_withdraw,
     snapshot_job,
     sync_all_jobs,
+    venue_deposit,
+    venue_withdraw,
 )
 from wayfinder_paths.jobs.universe import universe_scan_job
 from wayfinder_paths.jobs.worker import run_job_worker

--- a/wayfinder_paths/jobs/sync.py
+++ b/wayfinder_paths/jobs/sync.py
@@ -523,6 +523,67 @@ def apply_initial_capital(
     return {"job_id": job_id, "initial_capital": value, "previous": previous}
 
 
+def _funded_wallet_label(job) -> str:
+    label = str(job.execution_params.get("wallet_label") or "").strip()
+    if not label:
+        raise ValueError(
+            "job has no bound wallet (execution_params.wallet_label) — go "
+            "live first so the strategy wallet exists"
+        )
+    return label
+
+
+async def venue_deposit(
+    job_id: str, amount: float, *, store: JobStore | None = None
+) -> dict[str, Any]:
+    """Fund the strategy where it trades: bridge USDC from the job's bound
+    wallet into Hyperliquid, then grow ``initial_capital`` by the same
+    amount — one op keeps bankroll and accounting in lockstep. An
+    ``unconfirmed`` bridge credit still counts (the deposit is en route);
+    only a failed send aborts before the capital write."""
+    from wayfinder_paths.mcp.tools.hyperliquid import hyperliquid_deposit_usdc
+
+    store = store or JobStore()
+    job = store.load(job_id)
+    label = _funded_wallet_label(job)
+    outcome = await hyperliquid_deposit_usdc(wallet_label=label, amount_usdc=amount)
+    if outcome["status"] == "failed":
+        raise ValueError(f"venue deposit failed: {outcome}")
+    current = float(job.execution_params.get("initial_capital") or 0.0)
+    capital = apply_initial_capital(job_id, current + float(amount), store=store)
+    return {
+        "job_id": job_id,
+        "deposit_status": outcome["status"],
+        "initial_capital": capital["initial_capital"],
+    }
+
+
+async def venue_withdraw(
+    job_id: str, amount: float, *, store: JobStore | None = None
+) -> dict[str, Any]:
+    """Pull bankroll off the venue: withdraw USDC from Hyperliquid to the
+    job's bound wallet (Bridge2 nets $1 off the amount) and shrink
+    ``initial_capital`` by the gross amount, floored at zero — a full
+    withdrawal honestly reads as unfunded and turns the gate red."""
+    from wayfinder_paths.mcp.tools.hyperliquid import hyperliquid_withdraw_usdc
+
+    store = store or JobStore()
+    job = store.load(job_id)
+    label = _funded_wallet_label(job)
+    outcome = await hyperliquid_withdraw_usdc(wallet_label=label, amount_usdc=amount)
+    if outcome["status"] == "failed":
+        raise ValueError(f"venue withdraw failed: {outcome}")
+    current = float(job.execution_params.get("initial_capital") or 0.0)
+    capital = apply_initial_capital(
+        job_id, max(current - float(amount), 0.0), store=store
+    )
+    return {
+        "job_id": job_id,
+        "withdraw_status": outcome["status"],
+        "initial_capital": capital["initial_capital"],
+    }
+
+
 def _shadow_topline(store: JobStore, job_id: str) -> dict[str, Any]:
     """Read-only topline of the post-apply counterfactual for the UI — the
     artifact is computed on the wake path, never during sync."""

--- a/wayfinder_paths/tests/test_jobs_funding_knobs.py
+++ b/wayfinder_paths/tests/test_jobs_funding_knobs.py
@@ -132,3 +132,85 @@ def test_funding_knob_clis_round_trip(tmp_path, monkeypatch) -> None:
     outcome = runner.invoke(cli_module.job_cli, ["set-wallet-label", job_id, " "])
     assert outcome.exit_code != 0
     assert "wallet label" in outcome.output
+
+
+def test_venue_deposit_bridges_then_grows_capital(tmp_path, monkeypatch) -> None:
+    import asyncio
+
+    from wayfinder_paths.jobs import sync as sync_module
+
+    store, job_id = _job(tmp_path)
+    job = store.load(job_id)
+    job.execution_params["wallet_label"] = job_id
+    store.save(job)
+    monkeypatch.setattr(sync_module, "sync_all_jobs", lambda **kwargs: None)
+    calls: list[dict] = []
+
+    async def fake_deposit(*, wallet_label, amount_usdc):
+        calls.append({"wallet_label": wallet_label, "amount_usdc": amount_usdc})
+        return {"status": "confirmed"}
+
+    import wayfinder_paths.mcp.tools.hyperliquid as hl
+
+    monkeypatch.setattr(hl, "hyperliquid_deposit_usdc", fake_deposit)
+
+    result = asyncio.run(sync_module.venue_deposit(job_id, 25.0, store=store))
+    assert calls == [{"wallet_label": job_id, "amount_usdc": 25.0}]
+    assert result["deposit_status"] == "confirmed"
+    assert result["initial_capital"] == 10_025.0
+    assert store.load(job_id).execution_params["initial_capital"] == 10_025.0
+
+
+def test_venue_deposit_failed_send_never_touches_capital(tmp_path, monkeypatch) -> None:
+    import asyncio
+
+    from wayfinder_paths.jobs import sync as sync_module
+
+    store, job_id = _job(tmp_path)
+    job = store.load(job_id)
+    job.execution_params["wallet_label"] = job_id
+    store.save(job)
+
+    async def fake_deposit(*, wallet_label, amount_usdc):
+        return {"status": "failed", "error": "no gas"}
+
+    import wayfinder_paths.mcp.tools.hyperliquid as hl
+
+    monkeypatch.setattr(hl, "hyperliquid_deposit_usdc", fake_deposit)
+
+    with pytest.raises(ValueError):
+        asyncio.run(sync_module.venue_deposit(job_id, 25.0, store=store))
+    assert store.load(job_id).execution_params["initial_capital"] == 10_000.0
+
+
+def test_venue_withdraw_shrinks_capital_floored_at_zero(tmp_path, monkeypatch) -> None:
+    import asyncio
+
+    from wayfinder_paths.jobs import sync as sync_module
+
+    store, job_id = _job(tmp_path)
+    job = store.load(job_id)
+    job.execution_params["wallet_label"] = job_id
+    job.execution_params["initial_capital"] = 50.0
+    store.save(job)
+    monkeypatch.setattr(sync_module, "sync_all_jobs", lambda **kwargs: None)
+
+    async def fake_withdraw(*, wallet_label, amount_usdc):
+        return {"status": "confirmed"}
+
+    import wayfinder_paths.mcp.tools.hyperliquid as hl
+
+    monkeypatch.setattr(hl, "hyperliquid_withdraw_usdc", fake_withdraw)
+
+    result = asyncio.run(sync_module.venue_withdraw(job_id, 80.0, store=store))
+    assert result["initial_capital"] == 0.0
+
+
+def test_venue_ops_require_bound_wallet(tmp_path) -> None:
+    import asyncio
+
+    from wayfinder_paths.jobs import sync as sync_module
+
+    store, job_id = _job(tmp_path)
+    with pytest.raises(ValueError, match="wallet"):
+        asyncio.run(sync_module.venue_deposit(job_id, 25.0, store=store))


### PR DESCRIPTION
### Summary
`wayfinder job venue-deposit <job> <amount>` bridges USDC from the job's bound wallet into Hyperliquid (reusing `hyperliquid_deposit_usdc`: $5 floor, wait-for-credit, account unification) then grows `execution_params.initial_capital` by the same amount — one op keeps bankroll and accounting in lockstep. `venue-withdraw` is the mirror ($2 gross min, Bridge2 nets $1; capital floored at zero = honest unfunded). Failed sends abort before any capital write; an unconfirmed credit still counts. Requires a bound `wallet_label`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)