### PR TITLE
runner: burst admission never postpones live trading ticks

### DIFF
--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -50,6 +50,10 @@ JOB_RESULT_MARKER = "WAYFINDER_JOB_RESULT "
 BURST_CAP_CPU_S = 500.0
 BURST_LOW_WATER_CPU_S = 120.0
 BURST_MAX_POSTPONE_S = 600.0
+# Short starvation floor for trading-adjacent work (paper script ticks, agent
+# wakes, indeterminate-mode jobs) so a drain episode can't hold them for the
+# full BURST_MAX_POSTPONE_S. Env-tunable via WAYFINDER_BURST_SHORT_POSTPONE_S.
+BURST_SHORT_POSTPONE_S = 120.0
 DEFAULT_SYNC_DEBOUNCE_SECONDS = 90.0
 DEFAULT_MAX_RSS_MB = 900.0
 # While a proposal application is applying, the RSS restart exit is deferred
@@ -147,6 +151,47 @@ def _kill_process_group(pid: int, *, sig: int) -> None:
         return
     except Exception as exc:  # noqa: BLE001
         logger.debug(f"Failed to kill process group {pid}: {exc}")
+
+
+def _burst_short_postpone_s() -> float:
+    raw = os.environ.get("WAYFINDER_BURST_SHORT_POSTPONE_S")
+    if raw is None or not str(raw).strip():
+        return BURST_SHORT_POSTPONE_S
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning(
+            f"Invalid WAYFINDER_BURST_SHORT_POSTPONE_S={raw!r}; "
+            f"using {BURST_SHORT_POSTPONE_S}"
+        )
+        return BURST_SHORT_POSTPONE_S
+
+
+def _burst_postpone_tier(job: Mapping[str, Any]) -> tuple[str, float | None]:
+    """Classify a due job for burst admission from the payload env the
+    compiler already bakes (no new plumbing): (tier, max postpone seconds),
+    where None means fully exempt — never postponed.
+
+    - live jobs_v1 script ticks are exempt: tick-resident protections
+      (protective closes, kill-review, pair budgets) only run inside the
+      tick, and live ticks are warm-forked and cheap — not the drain source.
+    - The application watchdog is exempt: it un-sticks paused loops.
+    - Paper ticks, agent wakes, and indeterminate-mode jobs_v1 jobs get the
+      short floor (fail toward trading availability).
+    - Everything else (legacy scripts, strategy jobs, heavy ops) keeps the
+      full BURST_MAX_POSTPONE_S floor.
+    """
+    env = (job.get("payload") or {}).get("env") or {}
+    if env.get("WAYFINDER_WATCHDOG"):
+        return "watchdog-exempt", None
+    if env.get("WAYFINDER_JOB_AGENT_MODE"):
+        return "agent-short", _burst_short_postpone_s()
+    if env.get("WAYFINDER_JOB_EXECUTION_CONTRACT") == "jobs_v1":
+        mode = str(env.get("WAYFINDER_JOB_MODE") or "").strip().lower()
+        if mode == "live":
+            return "live-exempt", None
+        return "script-short", _burst_short_postpone_s()
+    return "default", BURST_MAX_POSTPONE_S
 
 
 def _max_rss_mb_from_env() -> float:
@@ -813,16 +858,23 @@ class RunnerDaemon:
         job_name = job["name"]
         # Burst admission: hold the launch while the machine is draining its
         # shared-cpu budget, so background jobs never pin it. The job stays due
-        # and retries next tick once the budget recovers. Bounded by
-        # BURST_MAX_POSTPONE_S so a persistent backlog can't starve it.
+        # and retries next tick once the budget recovers. Tiered by job class:
+        # live jobs_v1 ticks are never postponed (tick-resident protections —
+        # protective closes, kill-review, pair budgets — only run inside the
+        # tick); trading-adjacent work gets a short floor; everything else is
+        # bounded by BURST_MAX_POSTPONE_S so a backlog can't starve it.
         if self._burst is not None and self._burst.over_quota():
-            first = self._postponed_since.setdefault(job_id, time.monotonic())
-            if time.monotonic() - first < BURST_MAX_POSTPONE_S:
-                logger.debug(
-                    f"Postponing job {job_name}: burst balance "
-                    f"{self._burst.balance:.0f} CPU-s < {BURST_LOW_WATER_CPU_S:.0f}"
-                )
-                return None
+            tier, floor_s = _burst_postpone_tier(job)
+            if floor_s is not None:
+                first = self._postponed_since.setdefault(job_id, time.monotonic())
+                if time.monotonic() - first < floor_s:
+                    logger.debug(
+                        f"Postponing job {job_name}: burst balance "
+                        f"{self._burst.balance:.0f} CPU-s < "
+                        f"{BURST_LOW_WATER_CPU_S:.0f} "
+                        f"(tier={tier} floor={floor_s:.0f}s)"
+                    )
+                    return None
         self._postponed_since.pop(job_id, None)
         scheduled_for = (
             int(job.get("next_run_at") or now) if reason == "schedule" else None

--- a/wayfinder_paths/tests/test_runner_burst_gate.py
+++ b/wayfinder_paths/tests/test_runner_burst_gate.py
@@ -5,7 +5,11 @@ from pathlib import Path
 from unittest.mock import Mock
 
 from wayfinder_paths.runner.constants import JOB_TYPE_SCRIPT
-from wayfinder_paths.runner.daemon import BURST_MAX_POSTPONE_S, RunnerDaemon
+from wayfinder_paths.runner.daemon import (
+    BURST_MAX_POSTPONE_S,
+    BURST_SHORT_POSTPONE_S,
+    RunnerDaemon,
+)
 from wayfinder_paths.runner.paths import RunnerPaths
 
 
@@ -21,7 +25,7 @@ class _FakeBurst:
         return self._over
 
 
-def _daemon(tmp_path: Path) -> RunnerDaemon:
+def _daemon(tmp_path: Path, *, env: dict[str, str] | None = None) -> RunnerDaemon:
     runner_dir = tmp_path / ".wayfinder" / "runner"
     runs_dir = tmp_path / ".wayfinder_runs"
     runs_dir.mkdir(parents=True, exist_ok=True)
@@ -35,17 +39,26 @@ def _daemon(tmp_path: Path) -> RunnerDaemon:
             sock_path=runner_dir / "runner.sock",
         )
     )
+    payload: dict = {"script_path": ".wayfinder_runs/hello.py"}
+    if env is not None:
+        payload["env"] = env
     d.ctl_add_job(
         name="j",
         job_type=JOB_TYPE_SCRIPT,
-        payload={"script_path": ".wayfinder_runs/hello.py"},
+        payload=payload,
         interval_seconds=60,
     )
     return d
 
 
+def _force_burst(d: RunnerDaemon, *, over: bool) -> None:
+    d._burst = _FakeBurst(over)  # type: ignore[assignment]
+
+
 def _job(d: RunnerDaemon) -> dict:
-    job, _ = d._db.get_job(name="j")
+    result = d._db.get_job(name="j")
+    assert result is not None
+    job, _ = result
     return {
         "id": job.id,
         "name": job.name,
@@ -61,18 +74,20 @@ def _job(d: RunnerDaemon) -> dict:
 
 def test_over_quota_postpones_without_reserving(tmp_path: Path) -> None:
     d = _daemon(tmp_path)
-    d._burst = _FakeBurst(over=True)
-    _, before = d._db.get_job(name="j")
+    _force_burst(d, over=True)
+    before = d._db.get_job(name="j")
+    assert before is not None
     run_id = d._maybe_start_job(job=_job(d), now=1_000, reason="schedule")
-    _, after = d._db.get_job(name="j")
+    after = d._db.get_job(name="j")
+    assert after is not None
     assert run_id is None  # postponed
     # Schedule NOT advanced → job stays due and retries next tick once quota recovers.
-    assert after.next_run_at == before.next_run_at
+    assert after[1].next_run_at == before[1].next_run_at
 
 
 def test_recovered_quota_launches(tmp_path: Path, monkeypatch) -> None:
     d = _daemon(tmp_path)
-    d._burst = _FakeBurst(over=False)
+    _force_burst(d, over=False)
     popen = Mock()
     popen.pid = 123
     monkeypatch.setattr("subprocess.Popen", lambda *_a, **_k: popen)
@@ -93,7 +108,7 @@ def test_burst_gate_only_on_opencode_instance(tmp_path: Path, monkeypatch) -> No
 
 def test_floor_force_runs_after_max_postpone(tmp_path: Path, monkeypatch) -> None:
     d = _daemon(tmp_path)
-    d._burst = _FakeBurst(over=True)
+    _force_burst(d, over=True)
     job = _job(d)
     # Pretend it was first postponed longer ago than the starvation floor.
     d._postponed_since[job["id"]] = time.monotonic() - (BURST_MAX_POSTPONE_S + 1)
@@ -102,3 +117,108 @@ def test_floor_force_runs_after_max_postpone(tmp_path: Path, monkeypatch) -> Non
     monkeypatch.setattr("subprocess.Popen", lambda *_a, **_k: popen)
     run_id = d._maybe_start_job(job=job, now=1_000, reason="schedule")
     assert run_id is not None  # forced past the floor despite over-quota
+
+
+def _mock_popen(monkeypatch) -> None:
+    popen = Mock()
+    popen.pid = 123
+    monkeypatch.setattr("subprocess.Popen", lambda *_a, **_k: popen)
+
+
+def test_live_jobs_v1_tick_exempt_from_postpone(tmp_path: Path, monkeypatch) -> None:
+    d = _daemon(
+        tmp_path,
+        env={
+            "WAYFINDER_JOB_EXECUTION_CONTRACT": "jobs_v1",
+            "WAYFINDER_JOB_MODE": "live",
+        },
+    )
+    _force_burst(d, over=True)
+    _mock_popen(monkeypatch)
+    run_id = d._maybe_start_job(job=_job(d), now=1_000, reason="schedule")
+    assert run_id is not None  # live trading tick launches despite over-quota
+
+
+def test_paper_jobs_v1_tick_gets_short_floor(tmp_path: Path, monkeypatch) -> None:
+    d = _daemon(
+        tmp_path,
+        env={
+            "WAYFINDER_JOB_EXECUTION_CONTRACT": "jobs_v1",
+            "WAYFINDER_JOB_MODE": "paper",
+        },
+    )
+    _force_burst(d, over=True)
+    job = _job(d)
+    assert d._maybe_start_job(job=job, now=1_000, reason="schedule") is None
+    # Just past the SHORT floor (still far under BURST_MAX_POSTPONE_S) → runs.
+    d._postponed_since[job["id"]] = time.monotonic() - (BURST_SHORT_POSTPONE_S + 1)
+    _mock_popen(monkeypatch)
+    assert d._maybe_start_job(job=job, now=1_000, reason="schedule") is not None
+
+
+def test_agent_wake_gets_short_floor_even_when_live(
+    tmp_path: Path, monkeypatch
+) -> None:
+    d = _daemon(
+        tmp_path,
+        env={
+            "WAYFINDER_JOB_EXECUTION_CONTRACT": "jobs_v1",
+            "WAYFINDER_JOB_MODE": "live",
+            "WAYFINDER_JOB_AGENT_MODE": "review",
+        },
+    )
+    _force_burst(d, over=True)
+    job = _job(d)
+    assert d._maybe_start_job(job=job, now=1_000, reason="schedule") is None
+    d._postponed_since[job["id"]] = time.monotonic() - (BURST_SHORT_POSTPONE_S + 1)
+    _mock_popen(monkeypatch)
+    assert d._maybe_start_job(job=job, now=1_000, reason="schedule") is not None
+
+
+def test_indeterminate_mode_defaults_to_short_floor(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # jobs_v1 tick with no WAYFINDER_JOB_MODE baked → fail toward availability.
+    d = _daemon(tmp_path, env={"WAYFINDER_JOB_EXECUTION_CONTRACT": "jobs_v1"})
+    _force_burst(d, over=True)
+    job = _job(d)
+    assert d._maybe_start_job(job=job, now=1_000, reason="schedule") is None
+    d._postponed_since[job["id"]] = time.monotonic() - (BURST_SHORT_POSTPONE_S + 1)
+    _mock_popen(monkeypatch)
+    assert d._maybe_start_job(job=job, now=1_000, reason="schedule") is not None
+
+
+def test_heavy_job_keeps_full_floor(tmp_path: Path, monkeypatch) -> None:
+    # No jobs_v1 env (legacy script / heavy op): short floor does NOT apply.
+    d = _daemon(tmp_path)
+    _force_burst(d, over=True)
+    job = _job(d)
+    d._postponed_since[job["id"]] = time.monotonic() - (BURST_SHORT_POSTPONE_S + 1)
+    _mock_popen(monkeypatch)
+    assert d._maybe_start_job(job=job, now=1_000, reason="schedule") is None
+    d._postponed_since[job["id"]] = time.monotonic() - (BURST_MAX_POSTPONE_S + 1)
+    assert d._maybe_start_job(job=job, now=1_000, reason="schedule") is not None
+
+
+def test_application_watchdog_exempt(tmp_path: Path, monkeypatch) -> None:
+    d = _daemon(tmp_path, env={"WAYFINDER_WATCHDOG": "1"})
+    _force_burst(d, over=True)
+    _mock_popen(monkeypatch)
+    run_id = d._maybe_start_job(job=_job(d), now=1_000, reason="schedule")
+    assert run_id is not None  # housekeeping watchdog un-sticks paused loops
+
+
+def test_short_floor_env_tunable(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("WAYFINDER_BURST_SHORT_POSTPONE_S", "5")
+    d = _daemon(
+        tmp_path,
+        env={
+            "WAYFINDER_JOB_EXECUTION_CONTRACT": "jobs_v1",
+            "WAYFINDER_JOB_MODE": "paper",
+        },
+    )
+    _force_burst(d, over=True)
+    job = _job(d)
+    d._postponed_since[job["id"]] = time.monotonic() - 6
+    _mock_popen(monkeypatch)
+    assert d._maybe_start_job(job=job, now=1_000, reason="schedule") is not None


### PR DESCRIPTION
## Problem

#710's burst admission gate in `runner/daemon.py` `_maybe_start_job` postpones **every** due job launch for up to `BURST_MAX_POSTPONE_S` (600s) while the shared-cpu burst balance is below low-water. That includes live-mode jobs_v1 script ticks — the 5-minute-cadence live trading loops. A drain episode can hold live trading for 10 minutes: venue-native stops survive, but tick-resident protections (protective closes, kill-review, pair budgets) don't run while postponed. Live ticks are also warm-forked and cheap — they are not the drain source the gate exists to contain.

## Fix

Tiered admission by job class, classified from the payload env the jobs compiler **already bakes** into every runner job (`payload.env`) — no new plumbing:

| Tier | Signal (payload env) | Floor |
|------|----------------------|-------|
| `live-exempt` | `WAYFINDER_JOB_EXECUTION_CONTRACT=jobs_v1` + `WAYFINDER_JOB_MODE=live` (and not an agent wrapper) | never postponed |
| `watchdog-exempt` | `WAYFINDER_WATCHDOG=1` (the application watchdog is a scheduled runner script job — it un-sticks paused loops, so it must run) | never postponed |
| `agent-short` | `WAYFINDER_JOB_AGENT_MODE` set (agent wakes — checked before the live exemption so a live-mode agent wrapper is not exempt) | 120s |
| `script-short` | `jobs_v1` contract with `WAYFINDER_JOB_MODE=paper` **or missing/indeterminate** (fail toward trading availability) | 120s |
| `default` | everything else (legacy scripts, strategy jobs, heavy ops) | 600s (unchanged) |

The short floor is a new constant `BURST_SHORT_POSTPONE_S = 120.0`, env-tunable via `WAYFINDER_BURST_SHORT_POSTPONE_S` (same parse-with-fallback pattern as `WAYFINDER_RUNNERD_MAX_RSS_MB`).

#710's estimator (`burst.py`) and gating logic are untouched; the postpone debug log line now carries the applied tier and floor (`tier=script-short floor=120s`).

## Tests

`test_runner_burst_gate.py` extended (4 → 11 tests):

- live jobs_v1 tick launches while over-quota (no postpone)
- paper tick postponed, force-runs just past the 120s short floor (still far under 600s)
- agent wake gets the short floor even when `WAYFINDER_JOB_MODE=live`
- indeterminate-mode jobs_v1 job defaults to the short floor
- heavy/legacy job still postponed at 121s, force-runs past 600s
- application watchdog launches while over-quota
- `WAYFINDER_BURST_SHORT_POSTPONE_S` env override honored
- all four #710 tests unchanged in behavior and green

Full `pytest -k "jobs or runner or mcp"`: baseline (base commit) 1149 passed / 9 skipped; with this change 1154 passed / 9 skipped plus 2 `test_mcp_hyperliquid_search.py` failures from concurrent-suite network flake that pass in isolation (net: +7 new tests, no regressions). ruff clean; scoped mypy adds no new errors (test file mypy-clean, daemon.py unchanged at 3 pre-existing errors).
