### PR TITLE
jobs: add factor toolkit and mixed factor starter

### DIFF
--- a/.claude/skills/developing-jobs-v1-strategies/SKILL.md
+++ b/.claude/skills/developing-jobs-v1-strategies/SKILL.md
@@ -76,6 +76,8 @@ For every iteration:
 - Designing or evolving an idea: `rules/strategy-search.md`
 - Pairs, baskets, breadth, or multi-leg sizing:
   `rules/pairs-and-baskets.md`
+- Cross-sectional factors, residualization, pooled IC screens, and factor
+  regimes: `rules/factor-research.md`
 - Gates, funding coverage, scenario roles, or robustness interpretation:
   `rules/robustness-and-gates.md`
 - Candidate proposals, agent modes, and post-apply monitoring:

--- a/.claude/skills/developing-jobs-v1-strategies/rules/factor-research.md
+++ b/.claude/skills/developing-jobs-v1-strategies/rules/factor-research.md
@@ -1,0 +1,69 @@
+# Factor research in jobs_v1
+
+Use this page when the hypothesis ranks a multi-asset universe with continuous
+scores. A factor is an ordering hypothesis, not a strategy or a binary trigger.
+Keep cross-sectional factors distinct from time-series signals on one asset.
+
+## Build a causal panel
+
+Start with a liquid, explicitly declared universe and benchmark. Prefer at
+least eight synchronized assets and enough history to include several regimes;
+record listing dates, missing bars, venue, cadence, and whether the universe is
+current-membership (survivorship biased). The last in-progress candle is never
+a feature row.
+
+Reuse `wayfinder_paths.jobs.factors`:
+
+- `cross_sectional_rank`: symmetric `[-1, 1]` ranks with eligibility masks.
+- `cross_sectional_robust_zscore`: timestamp-local median/MAD normalization.
+- `rolling_beta` and `residual_return`: benchmark-relative transforms.
+- `blend_factor_scores`: aligned, normalized blends with optional final rank.
+
+Reuse `trailing_return`, `realized_volatility`, and `panel_breadth` from
+`wayfinder_paths.jobs.indicators`. Do not add local copies of these transforms.
+Compute panels once in `precompute(frames)` and attach each score back to its
+symbol frame. `decide(ctx)` should only read the latest synchronized scores,
+apply cadence/risk gates, and emit target-weight intents.
+
+Useful starting families are residual momentum/reversal, funding carry,
+participation (price move confirmed by relative volume), catch-up, and low
+residual volatility. Positive perp funding means longs pay shorts, so a pure
+carry score is normally the negative of smoothed funding. Funding missingness
+is not zero carry.
+
+## Treat the blend as one declared test family
+
+Define a small set of economically distinct single-factor controls and blends
+before looking at forward returns. Run:
+
+```text
+wayfinder job factor-scan <id> --columns factor_momentum,factor_carry,blend_core
+```
+
+The scan evaluates completed-bar scores from the next open, applies Newey-West
+standard errors, pools every column x horizon under Benjamini-Hochberg, checks
+four chronological fold signs, and leaves the final 15% unopened. A negative IC
+is an observed orientation, not permission to flip the sign after seeing the
+tail. Freeze at most three candidates, then spend the reserved tail once with
+`factor-holdout` using the scan's column, horizon, and orientation.
+
+Rank IC is only admission evidence. It says the score orders future relative
+returns; it does not show that a tradable tail clears turnover, fees, slippage,
+funding, borrow, or capacity. After a tail confirmation, build the minimal
+basket and use the exact jobs_v1 simulator plus walk-forward and robustness
+checks. Keep single-factor controls beside the blend so attribution stays
+legible.
+
+## Regimes are exposure controls
+
+Predeclare causal states from benchmark trend/volatility, breadth, dispersion,
+and median benchmark correlation. Name every consumed condition `gate_*` so the
+trace audits the exact gate. Prefer scaling gross/net exposure or selecting a
+predeclared sleeve inside a regime; do not mine a different factor sign in each
+cell. A regime with no observed activations is unvalidated.
+
+Report results by regime and fold, but select on the training prefix. A recent
+run-up used to invent a gate is development evidence, not a holdout. If the
+frozen tail rejects the factor family, close it: do not tune weights or regimes
+against the opened tail. Shipping no new starter is better than cataloging an
+unstable backtest.

--- a/.opencode/agents/wayfinder-job-worker.md
+++ b/.opencode/agents/wayfinder-job-worker.md
@@ -233,7 +233,9 @@ every wake.
      family — never a serial one-off `signal-check` mining loop. Sanctioned
      external axes: funding (`job fetch-funding`), session/time-of-day
      (canonical session triggers), cross-asset via the multi-symbol view and
-     `rank-check`. Open interest is DEFERRED — no history source exists yet;
+     `rank-check`, or a declared continuous-score family via pooled
+     `factor_scan` followed by one frozen `factor_holdout`. Open interest is
+     DEFERRED — no history source exists yet;
      do not improvise one.
 
 2b. CONSULT the research agenda (`research/agenda.md`) before generating

--- a/.opencode/agents/wayfinder-quant.md
+++ b/.opencode/agents/wayfinder-quant.md
@@ -61,6 +61,10 @@ supplied revision-bound artifacts and question. Do not recreate execution PnL,
 fills, funding cashflows, or promotion rules in a parallel simulator. Return
 bounded metrics and caveats to the parent; the parent owns `robustness_check`,
 candidate comparison, approval interpretation, and deployment decisions.
+For cross-sectional factor briefs, reuse `wayfinder_paths.jobs.factors`, keep
+the declared columns x horizons in one pooled `factor_scan`, and report IC,
+HAC t-stat, BH q-value, fold signs, orientation, coverage, and turnover inputs.
+Never open or retune on the reserved tail; the parent spends `factor_holdout`.
 
 ## Data and Scripts
 

--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -69,6 +69,8 @@ from wayfinder_paths.jobs.proposals import (
 from wayfinder_paths.jobs.regime_health import regime_health_job
 from wayfinder_paths.jobs.replication import replication_job
 from wayfinder_paths.jobs.research import (
+    factor_holdout_check_job,
+    factor_scan_job,
     holdout_check_job,
     pair_check_job,
     rank_check_job,
@@ -1044,6 +1046,69 @@ def rank_check_cmd(job_id: str, column: str, horizons: str | None) -> None:
         column=column,
         horizons=[int(h) for h in horizons.split(",")] if horizons else None,
         store=store,
+    )
+    _echo_json({"ok": True, "result": result})
+
+
+@job_cli.command(
+    name="factor-scan",
+    help="Pooled rank-IC screen of declared precomputed factor columns. Uses "
+    "next-open outcomes, BH correction, chronological folds, and reserves "
+    "the final tail.",
+)
+@click.argument("job_id")
+@click.option(
+    "--columns", required=True, help="Comma-separated precomputed factor columns."
+)
+@click.option(
+    "--horizons", default=None, help="Comma-separated forward horizons in bars."
+)
+@click.option(
+    "--holdout-fraction", type=float, default=0.15, show_default=True
+)
+def factor_scan_cmd(
+    job_id: str, columns: str, horizons: str | None, holdout_fraction: float
+) -> None:
+    result = factor_scan_job(
+        job_id,
+        columns=[value.strip() for value in columns.split(",") if value.strip()],
+        horizons=[int(value) for value in horizons.split(",")] if horizons else None,
+        holdout_fraction=holdout_fraction,
+        store=JobStore(),
+    )
+    _echo_json({"ok": True, "result": result})
+
+
+@job_cli.command(
+    name="factor-holdout",
+    help="Spend the reserved tail once for one frozen factor cell. Repeats "
+    "return the original artifact without recomputing it.",
+)
+@click.argument("job_id")
+@click.option("--column", required=True)
+@click.option("--horizon", type=int, required=True)
+@click.option(
+    "--orientation",
+    type=click.Choice(["high_score_outperforms", "low_score_outperforms"]),
+    required=True,
+)
+@click.option(
+    "--holdout-fraction", type=float, default=0.15, show_default=True
+)
+def factor_holdout_cmd(
+    job_id: str,
+    column: str,
+    horizon: int,
+    orientation: str,
+    holdout_fraction: float,
+) -> None:
+    result = factor_holdout_check_job(
+        job_id,
+        column=column,
+        horizon=horizon,
+        orientation=orientation,
+        holdout_fraction=holdout_fraction,
+        store=JobStore(),
     )
     _echo_json({"ok": True, "result": result})
 

--- a/wayfinder_paths/jobs/execution/op_runner.py
+++ b/wayfinder_paths/jobs/execution/op_runner.py
@@ -32,6 +32,8 @@ _EVIDENCE_OPS = {
     "experiments",
     "signal_scan",
     "holdout_check",
+    "factor_scan",
+    "factor_holdout",
     "restamp",
     "robustness_check",
 }
@@ -119,6 +121,14 @@ def _run_op(op: str, kwargs: dict[str, Any]) -> Any:
         from wayfinder_paths.jobs.research import rank_check_job
 
         return rank_check_job(kwargs.pop("job_id"), **kwargs)
+    if op == "factor_scan":
+        from wayfinder_paths.jobs.research import factor_scan_job
+
+        return factor_scan_job(kwargs.pop("job_id"), **kwargs)
+    if op == "factor_holdout":
+        from wayfinder_paths.jobs.research import factor_holdout_check_job
+
+        return factor_holdout_check_job(kwargs.pop("job_id"), **kwargs)
     if op == "robustness_check":
         from wayfinder_paths.jobs.robustness import robustness_check_job
 

--- a/wayfinder_paths/jobs/factors.py
+++ b/wayfinder_paths/jobs/factors.py
@@ -6,10 +6,31 @@ drawdowns remain owned by the jobs_v1 execution simulator.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 
 import numpy as np
 import pandas as pd
+
+
+def panel_from_frames(
+    frames: Mapping[str, pd.DataFrame],
+    column: str,
+    *,
+    symbols: Sequence[str] | None = None,
+) -> pd.DataFrame:
+    """Align one column from per-symbol frames on their UTC timestamps."""
+    selected = list(symbols) if symbols is not None else list(frames)
+    series: dict[str, pd.Series] = {}
+    for symbol in selected:
+        frame = frames.get(symbol)
+        if frame is None or column not in frame:
+            continue
+        timestamps = pd.to_datetime(frame["timestamp"], utc=True)
+        values = pd.to_numeric(frame[column], errors="coerce")
+        series[symbol] = pd.Series(values.to_numpy(), index=timestamps)
+    if not series:
+        return pd.DataFrame()
+    return pd.concat(series, axis=1).sort_index()
 
 
 def _numeric_panel(values: pd.DataFrame) -> pd.DataFrame:
@@ -102,9 +123,7 @@ def residual_return(
     if horizon <= 0:
         raise ValueError("residual return horizon must be positive")
     prices = _numeric_panel(close)
-    benchmark = pd.to_numeric(
-        benchmark_close.reindex(prices.index), errors="coerce"
-    )
+    benchmark = pd.to_numeric(benchmark_close.reindex(prices.index), errors="coerce")
     asset_bar_returns = prices.pct_change(fill_method=None)
     benchmark_bar_returns = benchmark.pct_change(fill_method=None)
     beta = rolling_beta(

--- a/wayfinder_paths/jobs/factors.py
+++ b/wayfinder_paths/jobs/factors.py
@@ -1,0 +1,155 @@
+"""Causal panel transforms for jobs_v1 factor research.
+
+These helpers build scores only. Economic PnL, fills, fees, funding, and
+drawdowns remain owned by the jobs_v1 execution simulator.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import numpy as np
+import pandas as pd
+
+
+def _numeric_panel(values: pd.DataFrame) -> pd.DataFrame:
+    numeric = values.apply(pd.to_numeric, errors="coerce")
+    return numeric.where(np.isfinite(numeric))
+
+
+def _eligible_values(
+    values: pd.DataFrame, eligible: pd.DataFrame | None
+) -> pd.DataFrame:
+    numeric = _numeric_panel(values)
+    if eligible is None:
+        return numeric
+    mask = eligible.reindex(index=numeric.index, columns=numeric.columns)
+    return numeric.where(mask.fillna(False).astype(bool))
+
+
+def cross_sectional_rank(
+    values: pd.DataFrame, eligible: pd.DataFrame | None = None
+) -> pd.DataFrame:
+    """Rank each timestamp symmetrically from -1 (low) to +1 (high).
+
+    Ties receive their average rank. A row needs at least two eligible finite
+    assets; a one-asset "cross-section" is undefined and remains missing.
+    """
+    masked = _eligible_values(values, eligible)
+    ranks = masked.rank(axis=1, method="average")
+    denominator = masked.notna().sum(axis=1).sub(1).replace(0, np.nan)
+    return ranks.sub(1).div(denominator, axis=0).mul(2).sub(1).where(masked.notna())
+
+
+def cross_sectional_robust_zscore(
+    values: pd.DataFrame,
+    eligible: pd.DataFrame | None = None,
+    *,
+    clip: float | None = 5.0,
+) -> pd.DataFrame:
+    """Median/MAD normalize each timestamp without full-sample leakage."""
+    if clip is not None and clip <= 0:
+        raise ValueError("robust z-score clip must be positive")
+    masked = _eligible_values(values, eligible)
+    median = masked.median(axis=1, skipna=True)
+    deviation = masked.sub(median, axis=0).abs()
+    scale = deviation.median(axis=1, skipna=True).mul(1.4826).replace(0, np.nan)
+    result = masked.sub(median, axis=0).div(scale, axis=0)
+    return result.clip(-clip, clip) if clip is not None else result
+
+
+def rolling_beta(
+    returns: pd.DataFrame,
+    benchmark_returns: pd.Series,
+    period: int,
+    *,
+    min_periods: int | None = None,
+    clip: tuple[float, float] | None = (-3.0, 3.0),
+) -> pd.DataFrame:
+    """Rolling asset beta to a benchmark using information through each row."""
+    if period <= 1:
+        raise ValueError("rolling beta period must be greater than one")
+    minimum = period if min_periods is None else int(min_periods)
+    if minimum <= 1 or minimum > period:
+        raise ValueError("rolling beta min_periods must be in [2, period]")
+    assets = _numeric_panel(returns)
+    benchmark = pd.to_numeric(
+        benchmark_returns.reindex(assets.index), errors="coerce"
+    ).where(lambda series: np.isfinite(series))
+    asset_mean = assets.rolling(period, min_periods=minimum).mean()
+    benchmark_mean = benchmark.rolling(period, min_periods=minimum).mean()
+    covariance = assets.mul(benchmark, axis=0).rolling(
+        period, min_periods=minimum
+    ).mean() - asset_mean.mul(benchmark_mean, axis=0)
+    variance = (
+        benchmark.pow(2).rolling(period, min_periods=minimum).mean()
+        - benchmark_mean.pow(2)
+    ).replace(0, np.nan)
+    result = covariance.div(variance, axis=0)
+    return result.clip(*clip) if clip is not None else result
+
+
+def residual_return(
+    close: pd.DataFrame,
+    benchmark_close: pd.Series,
+    horizon: int,
+    *,
+    beta_period: int,
+    beta_min_periods: int | None = None,
+    beta_clip: tuple[float, float] | None = (-3.0, 3.0),
+) -> pd.DataFrame:
+    """Benchmark-beta residual simple return over a trailing horizon."""
+    if horizon <= 0:
+        raise ValueError("residual return horizon must be positive")
+    prices = _numeric_panel(close)
+    benchmark = pd.to_numeric(
+        benchmark_close.reindex(prices.index), errors="coerce"
+    )
+    asset_bar_returns = prices.pct_change(fill_method=None)
+    benchmark_bar_returns = benchmark.pct_change(fill_method=None)
+    beta = rolling_beta(
+        asset_bar_returns,
+        benchmark_bar_returns,
+        beta_period,
+        min_periods=beta_min_periods,
+        clip=beta_clip,
+    )
+    asset_horizon = prices.pct_change(horizon, fill_method=None)
+    benchmark_horizon = benchmark.pct_change(horizon, fill_method=None)
+    return asset_horizon - beta.mul(benchmark_horizon, axis=0)
+
+
+def blend_factor_scores(
+    factors: Mapping[str, pd.DataFrame],
+    weights: Mapping[str, float],
+    eligible: pd.DataFrame | None = None,
+    *,
+    rerank: bool = True,
+) -> pd.DataFrame:
+    """Blend aligned factor panels with absolute weights normalized to one."""
+    if not factors:
+        raise ValueError("factor blend requires at least one factor")
+    unknown = set(weights) - set(factors)
+    missing = set(factors) - set(weights)
+    if unknown or missing:
+        raise ValueError(
+            f"factor weights must match factors; missing={sorted(missing)}, "
+            f"unknown={sorted(unknown)}"
+        )
+    scale = sum(abs(float(weight)) for weight in weights.values())
+    if not np.isfinite(scale) or scale <= 0:
+        raise ValueError("factor blend weights must have positive finite magnitude")
+    first = next(iter(factors.values()))
+    blended = pd.DataFrame(0.0, index=first.index, columns=first.columns)
+    valid = pd.DataFrame(True, index=first.index, columns=first.columns)
+    for name, panel in factors.items():
+        aligned = _numeric_panel(panel).reindex(
+            index=first.index, columns=first.columns
+        )
+        blended = blended + aligned.fillna(0.0) * (float(weights[name]) / scale)
+        valid &= aligned.notna()
+    blended = blended.where(valid)
+    if eligible is not None:
+        mask = eligible.reindex(index=first.index, columns=first.columns)
+        blended = blended.where(mask.fillna(False).astype(bool))
+    return cross_sectional_rank(blended) if rerank else blended

--- a/wayfinder_paths/jobs/prompts/research_contract.md
+++ b/wayfinder_paths/jobs/prompts/research_contract.md
@@ -15,6 +15,9 @@ This contract is stable across job-worker wakes and compaction.
   and paired candidate-versus-incumbent results as applicable.
 - Recent/event windows used to generate or select a candidate are development
   evidence and cannot also serve as its audit holdout.
+- Factor research declares a small pooled column x horizon family, uses
+  `factor_scan` before basket construction, and spends `factor_holdout` once
+  per frozen orientation. Rank IC is admission evidence, not economic PnL.
 - Robustness is advisory in contract v1. It enriches candidate evidence but does
   not change or bypass the existing approval gate.
 - The parent strategy/job agent orchestrates and decides. Quant delegation is

--- a/wayfinder_paths/jobs/prompts/research_priors.md
+++ b/wayfinder_paths/jobs/prompts/research_priors.md
@@ -14,6 +14,7 @@ the framework path in the last column.
 | Volatility term structure / event clocks | MODERATE | noise stopout, regime anomaly | campaign def + scenario |
 | Correlation state / beta residual | MODERATE | trend fight | cross features + rank check |
 | Cross-symbol structure (ratio z, lead-lag, breadth) | MODERATE | portfolio anomaly | pair/rank check + gate diagnostics |
+| Cross-sectional factors (residual trend/reversal, carry, participation, low vol) | MODERATE | relative ordering, regime anomaly | pooled factor scan + one-shot factor holdout |
 | Exogenous market regime | STRONG for alts | regime anomaly | exogenous features + gate |
 | Cross-venue basis / funding divergence | SPECULATIVE | execution anomaly | venue features + scenario |
 | Exit structure (MFE target, trail, breakeven, scale-out) | STRONG when forensics support it | early exit | factorial grid + walk-forward |

--- a/wayfinder_paths/jobs/research.py
+++ b/wayfinder_paths/jobs/research.py
@@ -47,6 +47,7 @@ from typing import Any
 import numpy as np
 import pandas as pd
 
+from wayfinder_paths.jobs.factors import panel_from_frames
 from wayfinder_paths.jobs.signal_library import (
     SIGNAL_LIBRARY,
     SignalDef,
@@ -1334,26 +1335,10 @@ def _hac_t_stat(values: np.ndarray, lag: int) -> float:
     long_run_variance = float(np.dot(centered, centered) / size)
     for offset in range(1, min(max(lag, 0), size - 1) + 1):
         weight = 1.0 - offset / (lag + 1.0)
-        covariance = float(
-            np.dot(centered[offset:], centered[:-offset]) / size
-        )
+        covariance = float(np.dot(centered[offset:], centered[:-offset]) / size)
         long_run_variance += 2.0 * weight * covariance
     standard_error = math.sqrt(max(long_run_variance, 0.0) / size)
     return float(finite.mean() / standard_error) if standard_error > 0 else 0.0
-
-
-def _factor_panel(
-    frames: Mapping[str, pd.DataFrame], column: str
-) -> pd.DataFrame:
-    return pd.concat(
-        {
-            symbol: frame.assign(
-                timestamp=pd.to_datetime(frame["timestamp"], utc=True)
-            ).set_index("timestamp")[column]
-            for symbol, frame in frames.items()
-        },
-        axis=1,
-    ).sort_index()
 
 
 def _factor_ic_values(
@@ -1415,7 +1400,7 @@ def factor_rank_scan(
     missing = {column: symbols for column, symbols in missing.items() if symbols}
     if missing:
         raise KeyError(f"factor columns missing after precompute: {missing}")
-    open_prices = _factor_panel(frames, "open").apply(
+    open_prices = panel_from_frames(frames, "open").apply(
         pd.to_numeric, errors="coerce"
     )
     index = open_prices.index
@@ -1424,15 +1409,15 @@ def factor_rank_scan(
     cutoff_position = int(len(index) * (1.0 - holdout_fraction))
     train_index = index[:cutoff_position]
     forward_returns = {
-        horizon: (
-            open_prices.shift(-(horizon + 1)) / open_prices.shift(-1) - 1.0
-        )
+        horizon: (open_prices.shift(-(horizon + 1)) / open_prices.shift(-1) - 1.0)
         for horizon in tested_horizons
     }
     rows: list[dict[str, Any]] = []
     for column in requested:
-        scores = _factor_panel(frames, column).reindex(index).apply(
-            pd.to_numeric, errors="coerce"
+        scores = (
+            panel_from_frames(frames, column)
+            .reindex(index)
+            .apply(pd.to_numeric, errors="coerce")
         )
         for horizon in tested_horizons:
             values = _factor_ic_values(
@@ -1477,9 +1462,7 @@ def factor_rank_scan(
     ):
         row["q_value"] = float(q_value)
         row["passed"] = bool(
-            int(row["n"]) >= 30
-            and q_value <= q_threshold
-            and row["fold_stable"]
+            int(row["n"]) >= 30 and q_value <= q_threshold and row["fold_stable"]
         )
     rows.sort(key=lambda row: (float(row["q_value"]), -abs(float(row["t_stat_hac"]))))
     passed = [row for row in rows if row["passed"]]
@@ -1542,13 +1525,15 @@ def factor_rank_holdout(
     )
     if missing:
         raise KeyError(f"factor column {column!r} missing after precompute: {missing}")
-    open_prices = _factor_panel(frames, "open").apply(
+    open_prices = panel_from_frames(frames, "open").apply(
         pd.to_numeric, errors="coerce"
     )
     if len(open_prices.index) < 40:
         raise ValueError("factor holdout needs at least 40 synchronized timestamps")
-    scores = _factor_panel(frames, column).reindex(open_prices.index).apply(
-        pd.to_numeric, errors="coerce"
+    scores = (
+        panel_from_frames(frames, column)
+        .reindex(open_prices.index)
+        .apply(pd.to_numeric, errors="coerce")
     )
     if cutoff_ts is None:
         cutoff_position = int(len(open_prices.index) * (1.0 - holdout_fraction))
@@ -1560,9 +1545,7 @@ def factor_rank_holdout(
                 "factor holdout cutoff must fall inside the synchronized panel"
             )
     holdout_index = open_prices.index[cutoff_position:]
-    forward_returns = (
-        open_prices.shift(-(horizon + 1)) / open_prices.shift(-1) - 1.0
-    )
+    forward_returns = open_prices.shift(-(horizon + 1)) / open_prices.shift(-1) - 1.0
     values = _factor_ic_values(
         scores,
         forward_returns,
@@ -2918,6 +2901,7 @@ def _precomputed_job_frames(
     from wayfinder_paths.jobs.execution.primitives import ExecutionSpec
     from wayfinder_paths.jobs.execution.simulator import _load_strategy
     from wayfinder_paths.jobs.execution.validation import resolve_execution_spec
+
     root = store.job_dir(job_id)
     job_data = _load_job_yaml(root)
     spec_data, _ = resolve_execution_spec(root, job_data)

--- a/wayfinder_paths/jobs/research.py
+++ b/wayfinder_paths/jobs/research.py
@@ -24,8 +24,9 @@ Statistical caveats (documented, deliberate):
   the scan's multiplicity control is Benjamini-Hochberg over the full test
   family, and event decimation (horizon-spaced) removes forward-window
   overlap — the dominant dependence source at these frequencies.
-- Deferred rigor (recorded, not built): HAC/Newey-West + block-bootstrap
-  standard errors (revisit if the null-world tests start failing), Deflated
+- Factor rank screens use Newey-West standard errors for overlapping forward
+  horizons. Deferred for event scans: HAC/block-bootstrap standard errors
+  (revisit if the null-world tests start failing), Deflated
   Sharpe / PBO-CSCV strategy-level overfit stats, BTC/ETH market-relative
   controls + matched regime baselines, funding/carry scan family.
 
@@ -1319,6 +1320,276 @@ def scan_signals(
             "standalone timing alpha here; a complete trade SYSTEM can still "
             "work (gates + exits + regime), but new signal mining on this "
             "series is unlikely to pay"
+        ),
+    }
+
+
+def _hac_t_stat(values: np.ndarray, lag: int) -> float:
+    """Newey-West t-stat for a mean with a bounded overlap lag."""
+    finite = values[np.isfinite(values)]
+    size = len(finite)
+    if size < 3:
+        return 0.0
+    centered = finite - finite.mean()
+    long_run_variance = float(np.dot(centered, centered) / size)
+    for offset in range(1, min(max(lag, 0), size - 1) + 1):
+        weight = 1.0 - offset / (lag + 1.0)
+        covariance = float(
+            np.dot(centered[offset:], centered[:-offset]) / size
+        )
+        long_run_variance += 2.0 * weight * covariance
+    standard_error = math.sqrt(max(long_run_variance, 0.0) / size)
+    return float(finite.mean() / standard_error) if standard_error > 0 else 0.0
+
+
+def _factor_panel(
+    frames: Mapping[str, pd.DataFrame], column: str
+) -> pd.DataFrame:
+    return pd.concat(
+        {
+            symbol: frame.assign(
+                timestamp=pd.to_datetime(frame["timestamp"], utc=True)
+            ).set_index("timestamp")[column]
+            for symbol, frame in frames.items()
+        },
+        axis=1,
+    ).sort_index()
+
+
+def _factor_ic_values(
+    scores: pd.DataFrame,
+    forward_returns: pd.DataFrame,
+    timestamps: pd.Index,
+    *,
+    min_assets: int,
+) -> np.ndarray:
+    signal = scores.reindex(timestamps)
+    outcome = forward_returns.reindex(timestamps)
+    valid = signal.notna() & outcome.notna()
+    signal_rank = signal.where(valid).rank(axis=1, method="average")
+    outcome_rank = outcome.where(valid).rank(axis=1, method="average")
+    correlations = signal_rank.corrwith(outcome_rank, axis=1)
+    correlations = correlations.where(valid.sum(axis=1).ge(min_assets)).dropna()
+    return correlations.to_numpy(dtype=float)
+
+
+def factor_rank_scan(
+    frames: Mapping[str, pd.DataFrame],
+    columns: Sequence[str],
+    *,
+    horizons: Sequence[int] | None = None,
+    holdout_fraction: float = 0.15,
+    folds: int = 4,
+    q_threshold: float = 0.10,
+    min_folds_agree: int = 3,
+    min_assets: int = 4,
+) -> dict[str, Any]:
+    """Pooled cross-sectional factor admission screen on a training prefix.
+
+    Scores are formed on completed bar ``t`` and evaluated from the next bar's
+    open. The final ``holdout_fraction`` is described but never scored here.
+    Columns x horizons form one Benjamini-Hochberg family.
+    """
+    requested = list(dict.fromkeys(str(column) for column in columns if column))
+    if not requested:
+        raise ValueError("factor scan requires at least one column")
+    tested_horizons = sorted({int(value) for value in (horizons or (1, 4, 12, 24))})
+    if not tested_horizons or tested_horizons[0] <= 0:
+        raise ValueError("factor scan horizons must be positive")
+    if not 0.0 < holdout_fraction < 0.5:
+        raise ValueError("factor scan holdout_fraction must be between 0 and 0.5")
+    if folds < 2 or min_folds_agree < 1 or min_folds_agree > folds:
+        raise ValueError("factor scan requires 2+ folds and a valid fold gate")
+    if min_assets < 4:
+        raise ValueError("factor scan min_assets must be at least 4")
+    if len(frames) < min_assets:
+        raise ValueError(
+            f"factor scan needs >={min_assets} symbols; received {sorted(frames)}"
+        )
+    missing = {
+        column: sorted(
+            symbol for symbol, frame in frames.items() if column not in frame.columns
+        )
+        for column in requested
+    }
+    missing = {column: symbols for column, symbols in missing.items() if symbols}
+    if missing:
+        raise KeyError(f"factor columns missing after precompute: {missing}")
+    open_prices = _factor_panel(frames, "open").apply(
+        pd.to_numeric, errors="coerce"
+    )
+    index = open_prices.index
+    if len(index) < 40:
+        raise ValueError("factor scan needs at least 40 synchronized timestamps")
+    cutoff_position = int(len(index) * (1.0 - holdout_fraction))
+    train_index = index[:cutoff_position]
+    forward_returns = {
+        horizon: (
+            open_prices.shift(-(horizon + 1)) / open_prices.shift(-1) - 1.0
+        )
+        for horizon in tested_horizons
+    }
+    rows: list[dict[str, Any]] = []
+    for column in requested:
+        scores = _factor_panel(frames, column).reindex(index).apply(
+            pd.to_numeric, errors="coerce"
+        )
+        for horizon in tested_horizons:
+            values = _factor_ic_values(
+                scores,
+                forward_returns[horizon],
+                train_index,
+                min_assets=min_assets,
+            )
+            size = len(values)
+            mean_ic = float(values.mean()) if size else 0.0
+            t_stat = _hac_t_stat(values, horizon)
+            fold_values = [part for part in np.array_split(values, folds) if len(part)]
+            fold_means = [float(part.mean()) for part in fold_values]
+            sign = np.sign(mean_ic)
+            agreeing = sum(np.sign(value) == sign for value in fold_means)
+            rows.append(
+                {
+                    "column": column,
+                    "horizon": horizon,
+                    "n": size,
+                    "mean_ic": mean_ic,
+                    "t_stat_hac": t_stat,
+                    "p_value": _t_to_pvalue(t_stat),
+                    "orientation": (
+                        "high_score_outperforms"
+                        if mean_ic > 0
+                        else "low_score_outperforms"
+                        if mean_ic < 0
+                        else None
+                    ),
+                    "fold_means": fold_means,
+                    "folds_agreeing": int(agreeing),
+                    "fold_stable": bool(
+                        len(fold_values) == folds and agreeing >= min_folds_agree
+                    ),
+                }
+            )
+    for row, q_value in zip(
+        rows,
+        bh_qvalues([float(row["p_value"]) for row in rows]),
+        strict=True,
+    ):
+        row["q_value"] = float(q_value)
+        row["passed"] = bool(
+            int(row["n"]) >= 30
+            and q_value <= q_threshold
+            and row["fold_stable"]
+        )
+    rows.sort(key=lambda row: (float(row["q_value"]), -abs(float(row["t_stat_hac"]))))
+    passed = [row for row in rows if row["passed"]]
+    return {
+        "columns": requested,
+        "horizons": tested_horizons,
+        "symbols": sorted(str(symbol) for symbol in frames),
+        "tests_run": len(rows),
+        "method": {
+            "signal_time": "completed bar close",
+            "forward_return": "next open to horizon open",
+            "t_stat": "Newey-West",
+            "multiplicity": "Benjamini-Hochberg over columns x horizons",
+            "q_threshold": q_threshold,
+            "folds": folds,
+            "min_folds_agree": min_folds_agree,
+        },
+        "holdout": {
+            "fraction": holdout_fraction,
+            "cutoff_ts": str(index[cutoff_position]),
+            "train_bars": len(train_index),
+            "holdout_bars": len(index) - len(train_index),
+            "opened": False,
+        },
+        "passed": passed,
+        "results": rows,
+        "read": (
+            f"{len(passed)} of {len(rows)} factor cells passed pooled q<="
+            f"{q_threshold:.2f}, n>=30, and {min_folds_agree}/{folds} fold "
+            "sign agreement. Rank admission is not an economic backtest: "
+            "freeze at most three candidates, spend factor-holdout once, "
+            "then test turnover, costs, funding, and drawdown in jobs_v1."
+        ),
+    }
+
+
+def factor_rank_holdout(
+    frames: Mapping[str, pd.DataFrame],
+    column: str,
+    horizon: int,
+    orientation: str,
+    *,
+    holdout_fraction: float = 0.15,
+    cutoff_ts: str | pd.Timestamp | None = None,
+    min_assets: int = 4,
+) -> dict[str, Any]:
+    """Open the reserved tail once for one frozen factor cell."""
+    if orientation not in {"high_score_outperforms", "low_score_outperforms"}:
+        raise ValueError("factor holdout requires a frozen score orientation")
+    if horizon <= 0:
+        raise ValueError("factor holdout horizon must be positive")
+    if not 0.0 < holdout_fraction < 0.5:
+        raise ValueError("factor holdout_fraction must be between 0 and 0.5")
+    if len(frames) < min_assets:
+        raise ValueError(
+            f"factor holdout needs >={min_assets} symbols; received {sorted(frames)}"
+        )
+    missing = sorted(
+        symbol for symbol, frame in frames.items() if column not in frame.columns
+    )
+    if missing:
+        raise KeyError(f"factor column {column!r} missing after precompute: {missing}")
+    open_prices = _factor_panel(frames, "open").apply(
+        pd.to_numeric, errors="coerce"
+    )
+    if len(open_prices.index) < 40:
+        raise ValueError("factor holdout needs at least 40 synchronized timestamps")
+    scores = _factor_panel(frames, column).reindex(open_prices.index).apply(
+        pd.to_numeric, errors="coerce"
+    )
+    if cutoff_ts is None:
+        cutoff_position = int(len(open_prices.index) * (1.0 - holdout_fraction))
+    else:
+        frozen_cutoff = pd.to_datetime(cutoff_ts, utc=True)
+        cutoff_position = int(open_prices.index.searchsorted(frozen_cutoff))
+        if cutoff_position <= 0 or cutoff_position >= len(open_prices.index):
+            raise ValueError(
+                "factor holdout cutoff must fall inside the synchronized panel"
+            )
+    holdout_index = open_prices.index[cutoff_position:]
+    forward_returns = (
+        open_prices.shift(-(horizon + 1)) / open_prices.shift(-1) - 1.0
+    )
+    values = _factor_ic_values(
+        scores,
+        forward_returns,
+        holdout_index,
+        min_assets=min_assets,
+    )
+    mean_ic = float(values.mean()) if len(values) else 0.0
+    t_stat = _hac_t_stat(values, horizon)
+    expected_sign = 1.0 if orientation == "high_score_outperforms" else -1.0
+    confirmed = bool(len(values) >= 10 and expected_sign * t_stat >= 1.645)
+    return {
+        "column": column,
+        "horizon": horizon,
+        "orientation": orientation,
+        "n": len(values),
+        "mean_ic": mean_ic,
+        "t_stat_hac": t_stat,
+        "cutoff_ts": str(open_prices.index[cutoff_position]),
+        "holdout_bars": len(holdout_index),
+        "confirmation_threshold": {"min_n": 10, "one_sided_t": 1.645},
+        "verdict": "confirm" if confirmed else "reject",
+        "read": (
+            "tail IC confirms the frozen orientation; proceed to the exact "
+            "jobs_v1 economic simulation"
+            if confirmed
+            else "reserved-tail IC did not confirm the frozen orientation; "
+            "do not retune this factor family on the opened tail"
         ),
     }
 
@@ -2638,24 +2909,15 @@ def holdout_check_job(
     return result
 
 
-def rank_check_job(
-    job_id: str,
-    *,
-    column: str,
-    horizons: list[int] | None = None,
-    store: Any | None = None,
-) -> dict[str, Any]:
-    """Rank-IC study of a strategy's precomputed ranking column across the
-    job's symbols — the pre-build test for basket/cross-sectional ideas
-    (event_study covers per-symbol entry signals; this covers rankings)."""
+def _precomputed_job_frames(
+    job_id: str, store: Any
+) -> tuple[Any, list[str], dict[str, pd.DataFrame]]:
+    """Load one job's bars with its strategy precompute columns applied."""
     from wayfinder_paths.jobs.execution.features import apply_precompute
     from wayfinder_paths.jobs.execution.job import _load_dataset, _load_job_yaml
     from wayfinder_paths.jobs.execution.primitives import ExecutionSpec
     from wayfinder_paths.jobs.execution.simulator import _load_strategy
     from wayfinder_paths.jobs.execution.validation import resolve_execution_spec
-    from wayfinder_paths.jobs.store import JobStore
-
-    store = store or JobStore()
     root = store.job_dir(job_id)
     job_data = _load_job_yaml(root)
     spec_data, _ = resolve_execution_spec(root, job_data)
@@ -2676,10 +2938,27 @@ def rank_check_job(
         symbol: frame[frame["symbol"] == symbol].reset_index(drop=True)
         for symbol in symbols
     }
+    return root, symbols, frames
+
+
+def rank_check_job(
+    job_id: str,
+    *,
+    column: str,
+    horizons: list[int] | None = None,
+    store: Any | None = None,
+) -> dict[str, Any]:
+    """Rank-IC study of a strategy's precomputed ranking column across the
+    job's symbols — the pre-build test for basket/cross-sectional ideas
+    (event_study covers per-symbol entry signals; this covers rankings)."""
+    from wayfinder_paths.jobs.store import JobStore
+
+    store = store or JobStore()
+    root, symbols, frames = _precomputed_job_frames(job_id, store)
     missing = [s for s, f in frames.items() if column not in f.columns]
     if missing:
         non_bar = sorted(
-            set(frame.columns)
+            set().union(*(set(frame.columns) for frame in frames.values()))
             - {"timestamp", "symbol", "open", "high", "low", "close", "volume"}
         )
         raise KeyError(
@@ -2707,6 +2986,146 @@ def rank_check_job(
             "type": "rank_check_completed",
             "column": column,
             "horizons": list(horizons or []),
+            "artifact": relative_artifact,
+        },
+    )
+    result["artifact"] = str(artifact)
+    return result
+
+
+def factor_scan_job(
+    job_id: str,
+    *,
+    columns: list[str],
+    horizons: list[int] | None = None,
+    holdout_fraction: float = 0.15,
+    store: Any | None = None,
+) -> dict[str, Any]:
+    """Screen a declared factor family with pooled multiplicity control."""
+    from wayfinder_paths.jobs.models import utc_now_iso
+    from wayfinder_paths.jobs.research_contract import RESEARCH_CONTRACT_VERSION
+    from wayfinder_paths.jobs.store import JobStore
+
+    store = store or JobStore()
+    _, _, frames = _precomputed_job_frames(job_id, store)
+    result = factor_rank_scan(
+        frames,
+        columns,
+        horizons=horizons,
+        holdout_fraction=holdout_fraction,
+    )
+    result["research_contract_version"] = RESEARCH_CONTRACT_VERSION
+    result["generated_at"] = utc_now_iso()
+    relative_artifact = "results/research/factor_scan.json"
+    artifact = store.write_json(job_id, relative_artifact, result)
+    store.append_journal(
+        job_id,
+        {
+            "type": "factor_scan_completed",
+            "columns": list(result["columns"]),
+            "horizons": list(result["horizons"]),
+            "passed": len(result["passed"]),
+            "artifact": relative_artifact,
+        },
+    )
+    result["artifact"] = str(artifact)
+    return result
+
+
+def factor_holdout_check_job(
+    job_id: str,
+    *,
+    column: str,
+    horizon: int,
+    orientation: str,
+    holdout_fraction: float = 0.15,
+    store: Any | None = None,
+) -> dict[str, Any]:
+    """Spend the factor tail once; repeat calls return the original result."""
+    import hashlib
+
+    from wayfinder_paths.jobs.models import utc_now_iso
+    from wayfinder_paths.jobs.research_contract import RESEARCH_CONTRACT_VERSION
+    from wayfinder_paths.jobs.store import JobStore
+
+    store = store or JobStore()
+    root = store.job_dir(job_id)
+    key = f"{column}|{horizon}|{orientation}|{holdout_fraction:.8f}"
+    trial = hashlib.sha1(key.encode()).hexdigest()[:12]
+    relative_artifact = f"results/research/factor_holdout_{trial}.json"
+    artifact = root / relative_artifact
+    if artifact.exists():
+        cached = store.read_json(job_id, relative_artifact)
+        if not isinstance(cached, dict):
+            raise ValueError(f"invalid factor holdout artifact: {relative_artifact}")
+        result = cached
+        result["already_spent"] = True
+        result["read"] = (
+            "this factor tail was already spent; returning the original "
+            "artifact without recomputing it"
+        )
+        result["artifact"] = str(artifact)
+        return result
+    scan_artifact = root / "results/research/factor_scan.json"
+    if not scan_artifact.exists():
+        raise FileNotFoundError(
+            "factor holdout requires results/research/factor_scan.json; "
+            "run factor-scan and freeze a passing cell first"
+        )
+    scan = store.read_json(job_id, "results/research/factor_scan.json")
+    if not isinstance(scan, dict):
+        raise ValueError("persisted factor scan is not a JSON object")
+    passed_cell = next(
+        (
+            row
+            for row in scan.get("passed", [])
+            if row.get("column") == column
+            and int(row.get("horizon", 0)) == horizon
+            and row.get("orientation") == orientation
+        ),
+        None,
+    )
+    if passed_cell is None:
+        raise ValueError(
+            "factor holdout may only open a column, horizon, and orientation "
+            "that passed the persisted factor scan"
+        )
+    scan_holdout = scan.get("holdout", {})
+    scan_fraction = float(scan_holdout.get("fraction", holdout_fraction))
+    if not math.isclose(scan_fraction, holdout_fraction):
+        raise ValueError(
+            "factor holdout_fraction must match the persisted factor scan "
+            f"({scan_fraction})"
+        )
+    cutoff_ts = scan_holdout.get("cutoff_ts")
+    if not cutoff_ts:
+        raise ValueError("persisted factor scan is missing its holdout cutoff")
+    _, _, frames = _precomputed_job_frames(job_id, store)
+    result = factor_rank_holdout(
+        frames,
+        column,
+        horizon,
+        orientation,
+        holdout_fraction=holdout_fraction,
+        cutoff_ts=cutoff_ts,
+    )
+    result.update(
+        {
+            "research_contract_version": RESEARCH_CONTRACT_VERSION,
+            "generated_at": utc_now_iso(),
+            "already_spent": False,
+            "training_scan_artifact": "results/research/factor_scan.json",
+        }
+    )
+    artifact = store.write_json(job_id, relative_artifact, result)
+    store.append_journal(
+        job_id,
+        {
+            "type": "factor_holdout_completed",
+            "column": column,
+            "horizon": horizon,
+            "orientation": orientation,
+            "verdict": result["verdict"],
             "artifact": relative_artifact,
         },
     )

--- a/wayfinder_paths/jobs/starter_leverage_evidence.py
+++ b/wayfinder_paths/jobs/starter_leverage_evidence.py
@@ -32,6 +32,13 @@ MAKER_MEAN_REVERSION_HALT = -0.08
 OTHER_STARTER_HALT = -0.20
 
 STARTER_LEVERAGE_RESULTS: dict[str, tuple[dict[str, Any], ...]] = {
+    "mixed-factor-balance-4h": (
+        _result(1, 0.3245, 2.0015, -0.1380, 192, 201.83, OTHER_STARTER_HALT),
+        _result(2, 0.6849, 2.0226, -0.2692, 189, 446.87, OTHER_STARTER_HALT),
+        _result(3, 1.0564, 2.0498, -0.3822, 193, 734.12, OTHER_STARTER_HALT),
+        _result(4, 1.3445, 2.0269, -0.4950, 205, 1054.75, OTHER_STARTER_HALT),
+        _result(5, 1.6097, 2.0424, -0.5895, 219, 1373.12, OTHER_STARTER_HALT),
+    ),
     "mixed-rsi-snapback-1h": (
         _result(1, 0.0815, 1.6318, -0.0279, 182, 213.81, MEAN_REVERSION_HALT),
         _result(2, 0.1670, 1.6406, -0.0554, 182, 445.13, MEAN_REVERSION_HALT),

--- a/wayfinder_paths/jobs/starters.py
+++ b/wayfinder_paths/jobs/starters.py
@@ -29,7 +29,7 @@ from wayfinder_paths.jobs.strategies._starter_utils import (
     RANKING_STOP_DEFAULTS,
 )
 
-STARTER_CATALOG_VERSION = "1.9.0"
+STARTER_CATALOG_VERSION = "2.0.0"
 STARTER_STRATEGY_INCEPTION_AT = "2026-08-24T00:00:00+00:00"
 # Catalog launch policy: every off-the-shelf starter launches with the agent
 # loop ON in intervene mode. Fleet evidence (two launches of the identical
@@ -40,7 +40,7 @@ STARTER_STRATEGY_INCEPTION_AT = "2026-08-24T00:00:00+00:00"
 # deliberately, but the default is intervene.
 STARTER_AGENT_MODE_DEFAULT: AgentMode = "intervene"
 STARTER_AGENT_WAKE_SECONDS = 3600
-STARTER_EVIDENCE_REVISION = "1.8.0"
+STARTER_EVIDENCE_REVISION = "2.0.0"
 STARTER_LEVERAGE_DEFAULT = 1
 STARTER_LEVERAGE_MINIMUM = 1
 STARTER_LEVERAGE_MAXIMUM = 5
@@ -51,13 +51,19 @@ STARTER_DATASET_DAYS = 120
 # window always clears warmup even when the feed drops a few leading bars.
 STARTER_LOOKBACK_MARGIN_BARS = 20
 STARTER_ROBUSTNESS_PLANS: dict[str, dict[str, Any]] = {
+    "mixed-factor-balance-4h": {
+        "phase": {"param": "rebalance_offset", "values": [0, 1, 2, 3, 4, 5]},
+        "leverage": [1, 2, 3, 4, 5],
+        "walk_forward": {"train_bars": 540, "test_bars": 270, "folds": 3},
+        "scenarios": [{"name": "recent_7d", "lookback_days": 7, "role": "development"}],
+    },
     "crypto-momentum-persistence-4h": {
         "neighbors": {"broad_bull_momentum_threshold": [0.05, 0.10, 0.15]},
         "phase": {"param": "rebalance_offset", "values": [0, 1, 2, 3, 4, 5]},
         "leverage": [1, 2, 3, 4, 5],
         "walk_forward": {"train_bars": 1440, "test_bars": 360, "folds": 4},
         "scenarios": [{"name": "recent_7d", "lookback_days": 7, "role": "development"}],
-    }
+    },
 }
 
 
@@ -241,6 +247,9 @@ class StarterDefinition:
                     "close-of-bar cross margin using venue maintenance defaults"
                 ),
                 "account_halt_simulated": False,
+                "funding_included": bool(
+                    payload["research_evidence"]["jobs_v1_engine"]["funding_included"]
+                ),
                 "results": copy.deepcopy(STARTER_LEVERAGE_RESULTS[self.id]),
             },
         }
@@ -324,6 +333,47 @@ _RESEARCH_METHOD = {
     ),
 }
 
+_FACTOR_RESEARCH_METHOD = {
+    "source": "Hyperliquid info API 4h candles and hourly funding",
+    "window_start": "2026-02-26T00:00:00+00:00",
+    "window_end": "2026-08-25T00:00:00+00:00",
+    "calendar_days": 180.0,
+    "fill_model": "decision on completed close; fill at next 4h bar open",
+    "costs": {"taker_fee_bps_per_side": 4.5, "slippage_bps_per_side": 3.5},
+    "funding_included": True,
+    "funding": "hourly Hyperliquid rates causally aggregated into completed 4h buckets",
+    "validation": (
+        "70% selection / 15% validation / 15% frozen tail by sleeve, followed by "
+        "an exact jobs_v1 replay, four chronological segments, all six 4h phases, "
+        "and a 1x-5x leverage sweep"
+    ),
+}
+
+_FACTOR_CRYPTO_ASSETS = ("BTC", "ETH", "SOL", "HYPE", "DOGE", "AAVE", "NEAR", "ENA")
+_FACTOR_ONCHAIN_ASSETS = (
+    "xyz:MU",
+    "xyz:GOOGL",
+    "xyz:NVDA",
+    "xyz:CRCL",
+    "xyz:TSLA",
+    "xyz:META",
+    "xyz:MSTR",
+    "xyz:INTC",
+    "xyz:AAPL",
+    "xyz:COIN",
+    "xyz:AMD",
+    "xyz:AMZN",
+    "xyz:GOLD",
+    "xyz:SILVER",
+    "xyz:CL",
+    "xyz:BRENTOIL",
+    "xyz:COPPER",
+    "xyz:NATGAS",
+    "xyz:PLATINUM",
+    "xyz:PALLADIUM",
+)
+_FACTOR_BENCHMARK = "xyz:SP500"
+
 _CRYPTO_MOMENTUM_RESEARCH_METHOD = {
     "source": "Hyperliquid info API 4h candles via HyperliquidDataClient",
     "window_start": "2024-09-04T00:00:00+00:00",
@@ -382,6 +432,100 @@ _MAKER_RESEARCH_METHOD = {
 
 
 STARTER_DEFINITIONS: tuple[StarterDefinition, ...] = (
+    StarterDefinition(
+        id="mixed-factor-balance-4h",
+        name="Mixed Factor Balance · 4h",
+        family="multi_factor",
+        summary=(
+            "A long-only factor allocator that balances crypto trend, quality, and "
+            "carry with relative-value equity and commodity perps."
+        ),
+        timeframe="4h",
+        module="wayfinder_paths.jobs.strategies.mixed_factor_balance",
+        symbols=(*_FACTOR_CRYPTO_ASSETS, *_FACTOR_ONCHAIN_ASSETS, _FACTOR_BENCHMARK),
+        crypto_assets=_FACTOR_CRYPTO_ASSETS,
+        tokenized_equities=(*_FACTOR_ONCHAIN_ASSETS, _FACTOR_BENCHMARK),
+        rules=(
+            "Rank crypto by 3-day and 7-day BTC-residual strength, low volatility, and funding carry; hold the top two at 20% each.",
+            "Rank HIP-3 equities and commodities by 7-day-versus-1-day relative value, 7-day SP500-residual strength, and low volatility; hold the top two at 25% each.",
+            "Rebalance crypto daily and the onchain sleeve every three days on the 16:00 UTC completed bar; buffer incumbents while they remain above the 55th percentile.",
+            "Hold the onchain sleeve in cash unless both 3-day and 7-day SP500 trends are positive with at least 55% market breadth; xyz:SP500 is signal-only.",
+            "Maximum unlevered target gross is 90%, leaving a 10% cash reserve.",
+        ),
+        params={
+            "beta_bars": 42,
+            "min_assets": 8,
+            "minimum_dollar_volume": 1_000_000.0,
+            "side_count": 2,
+            "sleeve_gross": {"crypto": 0.40, "onchain": 0.50},
+            "factor_weights": {
+                "crypto": {
+                    "medium_strength": 0.35,
+                    "slow_strength": 0.25,
+                    "low_volatility": 0.25,
+                    "carry": 0.15,
+                },
+                "onchain": {
+                    "relative_value": 0.45,
+                    "slow_strength": 0.35,
+                    "low_volatility": 0.20,
+                },
+            },
+            "rebalance_bars": {"crypto": 6, "onchain": 18},
+            "rebalance_offset": 4,
+            "rebalance_threshold": 0.025,
+            "min_trade_notional": 25.0,
+            "stop_atr_period": 24,
+        },
+        research_evidence={
+            **_FACTOR_RESEARCH_METHOD,
+            "return_after_costs_and_funding": 0.3245,
+            "funding_return_contribution": -0.0161,
+            "sharpe": 2.0015,
+            "max_drawdown": -0.1380,
+            "buy_hold_return": 0.2364,
+            "chronological_fold_returns": [0.0313, 0.1595, -0.0334, 0.1458],
+            "recent_7d_return": 0.1095,
+            "rebalance_phase_returns": {
+                "0": 0.0891,
+                "1": 0.2789,
+                "2": 0.3150,
+                "3": 0.4899,
+                "4": 0.3245,
+                "5": 0.5197,
+            },
+            "selection_holdouts": {
+                "crypto": {
+                    "candidate": "trend_quality",
+                    "return_after_costs_and_funding": 0.0860,
+                    "sharpe": 4.09,
+                },
+                "onchain": {
+                    "candidate": "relative_value_quality",
+                    "return_after_costs_and_funding": 0.0056,
+                    "sharpe": 2.31,
+                },
+            },
+            "jobs_v1_engine": {
+                "return_after_fees_and_slippage": 0.3245,
+                "sharpe": 2.0015,
+                "max_drawdown": -0.1380,
+                "trade_count": 192,
+                "total_fees_usd": 201.83,
+                "total_funding_usd": -160.73,
+                "stop_count": 0,
+                "full_period_vs_no_stop": "unchanged",
+                "chronological_folds_non_regressing": 3,
+                "funding_included": True,
+                "trace_valid": True,
+            },
+        },
+        cautions=(
+            "The evidence window is 180 days and overlaps the recent crypto run-up; forward paper tracking remains required.",
+            "The onchain sleeve is inactive when the broad trend-and-breadth gate is off.",
+            "Leverage above 1x exceeded the catalog's -20% account-halt threshold in the historical sweep.",
+        ),
+    ),
     StarterDefinition(
         id="mixed-rsi-snapback-1h",
         name="Mixed RSI Snapback · 1h",

--- a/wayfinder_paths/jobs/strategies/_starter_utils.py
+++ b/wayfinder_paths/jobs/strategies/_starter_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
 from typing import Any
@@ -194,6 +195,70 @@ def ranked_weights(
     midpoint = len(ranked) // 2
     weights = dict.fromkeys(ranked[:midpoint], -weight_per_leg)
     weights.update(dict.fromkeys(ranked[midpoint:], weight_per_leg))
+    return weights
+
+
+def buffered_rank_weights(
+    scores: Mapping[str, float],
+    previous: Mapping[str, float],
+    *,
+    side_count: int,
+    gross: float,
+    long_only: bool = False,
+) -> dict[str, float]:
+    """Build a buffered rank basket with deterministic tie breaks.
+
+    By default, half of ``gross`` is assigned to each side. ``long_only``
+    assigns the full budget to the top-ranked names and does not require a
+    short cross-section.
+    """
+    if side_count <= 0 or not math.isfinite(gross) or gross < 0:
+        raise ValueError("rank side_count must be positive and gross non-negative")
+    finite: dict[str, float] = {}
+    for symbol, value in scores.items():
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            continue
+        if math.isfinite(numeric):
+            finite[str(symbol)] = numeric
+    required = side_count if long_only else 2 * side_count
+    if len(finite) < required:
+        return {}
+    ranks = pd.Series(finite, dtype=float).rank(method="average", pct=True)
+    longs = [
+        symbol
+        for symbol, weight in previous.items()
+        if weight > 0 and symbol in ranks and ranks[symbol] >= 0.55
+    ][:side_count]
+    for symbol in sorted(ranks.index, key=lambda item: (-ranks[item], item)):
+        if len(longs) >= side_count:
+            break
+        if symbol not in longs:
+            longs.append(symbol)
+    weights = dict.fromkeys(finite, 0.0)
+    if long_only:
+        weights.update(dict.fromkeys(longs, gross / side_count))
+        return weights
+
+    shorts = [
+        symbol
+        for symbol, weight in previous.items()
+        if weight < 0
+        and symbol in ranks
+        and ranks[symbol] <= 0.45
+        and symbol not in longs
+    ][:side_count]
+    for symbol in sorted(ranks.index, key=lambda item: (ranks[item], item)):
+        if len(shorts) >= side_count:
+            break
+        if symbol not in shorts and symbol not in longs:
+            shorts.append(symbol)
+    if len(longs) < side_count or len(shorts) < side_count:
+        return {}
+    weight_per_leg = gross / (2.0 * side_count)
+    weights.update(dict.fromkeys(longs, weight_per_leg))
+    weights.update(dict.fromkeys(shorts, -weight_per_leg))
     return weights
 
 

--- a/wayfinder_paths/jobs/strategies/mixed_factor_balance.py
+++ b/wayfinder_paths/jobs/strategies/mixed_factor_balance.py
@@ -1,0 +1,279 @@
+"""Long-only factor balance across crypto and HIP-3 equity/commodity perps."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import pandas as pd
+
+from wayfinder_paths.jobs.execution.primitives import ExecutionContext
+from wayfinder_paths.jobs.factors import (
+    blend_factor_scores,
+    cross_sectional_rank,
+    panel_from_frames,
+    residual_return,
+)
+from wayfinder_paths.jobs.indicators import (
+    panel_breadth,
+    realized_volatility,
+    trailing_return,
+)
+from wayfinder_paths.jobs.strategies._starter_utils import (
+    RANKING_STOP_DEFAULTS,
+    add_stop_atr,
+    buffered_rank_weights,
+    current_rows,
+    merge_params,
+    stop_brackets,
+)
+from wayfinder_paths.jobs.strategies.portfolio import target_weights_to_intents
+
+_CRYPTO = ["BTC", "ETH", "SOL", "HYPE", "DOGE", "AAVE", "NEAR", "ENA"]
+_ONCHAIN = [
+    "xyz:MU",
+    "xyz:GOOGL",
+    "xyz:NVDA",
+    "xyz:CRCL",
+    "xyz:TSLA",
+    "xyz:META",
+    "xyz:MSTR",
+    "xyz:INTC",
+    "xyz:AAPL",
+    "xyz:COIN",
+    "xyz:AMD",
+    "xyz:AMZN",
+    "xyz:GOLD",
+    "xyz:SILVER",
+    "xyz:CL",
+    "xyz:BRENTOIL",
+    "xyz:COPPER",
+    "xyz:NATGAS",
+    "xyz:PLATINUM",
+    "xyz:PALLADIUM",
+]
+_EQUITY_BENCHMARK = "xyz:SP500"
+
+
+def _factor_panels(
+    close: pd.DataFrame,
+    volume: pd.DataFrame,
+    benchmark: pd.Series,
+    funding: pd.DataFrame,
+    *,
+    beta_bars: int,
+    minimum_dollar_volume: float,
+    min_assets: int,
+) -> tuple[dict[str, pd.DataFrame], pd.Series]:
+    valid_history = close.notna().rolling(beta_bars).sum().ge(beta_bars)
+    dollar_volume = (close * volume).rolling(6, min_periods=5).sum()
+    eligible = valid_history & close.notna() & dollar_volume.gt(minimum_dollar_volume)
+    residuals = {
+        bars: residual_return(
+            close,
+            benchmark,
+            bars,
+            beta_period=beta_bars,
+        )
+        for bars in (6, 18, 42)
+    }
+    low_volatility = close.apply(lambda series: realized_volatility(series, 6))
+    factors = {
+        "medium_strength": cross_sectional_rank(residuals[18], eligible),
+        "slow_strength": cross_sectional_rank(residuals[42], eligible),
+        "relative_value": cross_sectional_rank(residuals[42] - residuals[6], eligible),
+        "low_volatility": cross_sectional_rank(-low_volatility, eligible),
+    }
+    smoothed_funding = funding.ewm(span=18, min_periods=6, adjust=False).mean()
+    factors["carry"] = cross_sectional_rank(
+        -smoothed_funding, eligible & smoothed_funding.notna()
+    )
+
+    above_average = close.div(close.rolling(18, min_periods=18).mean()).sub(1.0)
+    breadth = panel_breadth(above_average.where(eligible), 0.0, min_assets=min_assets)
+    broad_trend = trailing_return(benchmark, 18).gt(0.0) & breadth.ge(0.55)
+    slow_trend = trailing_return(benchmark, 42).gt(0.0) & breadth.ge(0.55)
+    return factors, broad_trend & slow_trend
+
+
+class MixedFactorBalanceStrategy:
+    """Allocate to top-ranked factor exposures while retaining a cash reserve."""
+
+    default_params: dict[str, Any] = {
+        "symbols": [*_CRYPTO, *_ONCHAIN, _EQUITY_BENCHMARK],
+        "sleeves": {"crypto": _CRYPTO, "onchain": _ONCHAIN},
+        "venue": "hyperliquid",
+        "equity_benchmark": _EQUITY_BENCHMARK,
+        "beta_bars": 42,
+        "min_assets": 8,
+        "minimum_dollar_volume": 1_000_000.0,
+        "side_count": 2,
+        "sleeve_gross": {"crypto": 0.40, "onchain": 0.50},
+        "factor_weights": {
+            "crypto": {
+                "medium_strength": 0.35,
+                "slow_strength": 0.25,
+                "low_volatility": 0.25,
+                "carry": 0.15,
+            },
+            "onchain": {
+                "relative_value": 0.45,
+                "slow_strength": 0.35,
+                "low_volatility": 0.20,
+            },
+        },
+        "rebalance_bars": {"crypto": 6, "onchain": 18},
+        "rebalance_offset": 4,
+        "rebalance_threshold": 0.025,
+        "min_trade_notional": 25.0,
+        **RANKING_STOP_DEFAULTS,
+        "stop_atr_period": 24,
+    }
+
+    def __init__(self, params: dict[str, Any] | None = None) -> None:
+        self.params = merge_params(self.default_params, params)
+        self.params["sleeves"] = {
+            str(name): [str(symbol) for symbol in symbols]
+            for name, symbols in dict(self.params["sleeves"]).items()
+        }
+        self.params["factor_weights"] = {
+            str(sleeve): {
+                str(factor): float(weight) for factor, weight in dict(weights).items()
+            }
+            for sleeve, weights in dict(self.params["factor_weights"]).items()
+        }
+        self.warmup_bars = max(int(self.params["beta_bars"]), 42) + 4
+
+    def precompute(self, frames: dict[str, pd.DataFrame]) -> dict[str, pd.DataFrame]:
+        derived = {
+            symbol: pd.DataFrame(index=frame.index) for symbol, frame in frames.items()
+        }
+        for sleeve, symbols in self.params["sleeves"].items():
+            close = panel_from_frames(frames, "close", symbols=symbols)
+            if close.empty:
+                continue
+            volume = panel_from_frames(frames, "volume", symbols=symbols).reindex(
+                index=close.index, columns=close.columns
+            )
+            funding = panel_from_frames(frames, "funding", symbols=symbols).reindex(
+                index=close.index, columns=close.columns
+            )
+            benchmark = self._benchmark(frames, close, sleeve)
+            if benchmark is None:
+                continue
+            factors, broad_trend = _factor_panels(
+                close,
+                volume,
+                benchmark,
+                funding,
+                beta_bars=int(self.params["beta_bars"]),
+                minimum_dollar_volume=float(self.params["minimum_dollar_volume"]),
+                min_assets=int(self.params["min_assets"]),
+            )
+            weights = self.params["factor_weights"][sleeve]
+            score = blend_factor_scores(
+                {name: factors[name] for name in weights},
+                weights,
+            )
+            if sleeve == "crypto":
+                scale = pd.Series(1.0, index=score.index)
+            else:
+                scale = broad_trend.astype(float)
+            self._attach_sleeve(derived, frames, symbols, score, scale)
+        return add_stop_atr(derived, frames, period=int(self.params["stop_atr_period"]))
+
+    def _benchmark(
+        self,
+        frames: Mapping[str, pd.DataFrame],
+        close: pd.DataFrame,
+        sleeve: str,
+    ) -> pd.Series | None:
+        if sleeve == "crypto":
+            return close["BTC"] if "BTC" in close else None
+        panel = panel_from_frames(
+            frames,
+            "close",
+            symbols=(str(self.params["equity_benchmark"]),),
+        )
+        return None if panel.empty else panel.iloc[:, 0].reindex(close.index)
+
+    @staticmethod
+    def _attach_sleeve(
+        derived: dict[str, pd.DataFrame],
+        frames: Mapping[str, pd.DataFrame],
+        symbols: Sequence[str],
+        score: pd.DataFrame,
+        scale: pd.Series,
+    ) -> None:
+        for symbol in symbols:
+            frame = frames.get(symbol)
+            if frame is None or symbol not in score:
+                continue
+            timestamps = pd.to_datetime(frame["timestamp"], utc=True)
+            derived[symbol]["starter_factor_score"] = (
+                score[symbol].reindex(timestamps).to_numpy()
+            )
+            derived[symbol]["starter_factor_scale"] = scale.reindex(
+                timestamps
+            ).to_numpy()
+
+    def decide(self, ctx: ExecutionContext) -> list[dict[str, Any]]:
+        if ctx.bar_index < self.warmup_bars:
+            return []
+        intents: list[dict[str, Any]] = []
+        for sleeve, symbols in self.params["sleeves"].items():
+            if not ctx.every_n_bars(
+                int(self.params["rebalance_bars"][sleeve]),
+                offset=int(self.params["rebalance_offset"]),
+            ):
+                continue
+            rows = current_rows(
+                ctx,
+                symbols,
+                required_columns=("starter_factor_score", "starter_factor_scale"),
+            )
+            if rows is None:
+                continue
+            scores = {
+                symbol: float(rows[symbol]["starter_factor_score"])
+                for symbol in symbols
+            }
+            scale = float(next(iter(rows.values()))["starter_factor_scale"])
+            if not math.isfinite(scale):
+                continue
+            previous = {
+                symbol: (
+                    0.0
+                    if (position := ctx.ledger.positions.get(symbol)) is None
+                    else 1.0
+                    if position.side == "long"
+                    else -1.0
+                )
+                for symbol in symbols
+            }
+            weights = buffered_rank_weights(
+                scores,
+                previous,
+                side_count=int(self.params["side_count"]),
+                gross=float(self.params["sleeve_gross"][sleeve]) * scale,
+                long_only=True,
+            )
+            if not weights:
+                continue
+            intents.extend(
+                target_weights_to_intents(
+                    ctx,
+                    weights,
+                    venue=str(self.params["venue"]),
+                    rebalance_threshold=float(self.params["rebalance_threshold"]),
+                    min_trade_notional=float(self.params["min_trade_notional"]),
+                    brackets=stop_brackets(ctx, symbols, self.params),
+                    scope=symbols,
+                )
+            )
+        return intents
+
+
+def build_strategy(params: dict[str, Any] | None = None) -> MixedFactorBalanceStrategy:
+    return MixedFactorBalanceStrategy(params)

--- a/wayfinder_paths/jobs/strategies/portfolio.py
+++ b/wayfinder_paths/jobs/strategies/portfolio.py
@@ -16,7 +16,7 @@ the same leverage a second time.
 from __future__ import annotations
 
 import math
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 from wayfinder_paths.jobs.execution.primitives import (
@@ -38,6 +38,7 @@ def target_weights_to_intents(
     normalize_gross: bool = True,
     min_trade_notional: float = 0.0,
     brackets: Mapping[str, Mapping[str, Any]] | None = None,
+    scope: Sequence[str] | None = None,
 ) -> list[dict[str, Any]]:
     """Diff target weights against the current ledger and emit intents.
 
@@ -51,7 +52,8 @@ def target_weights_to_intents(
     Gross normalization (legacy convention, backtester.py): when the summed
     |weights| exceed 1 and normalize_gross is True, weights are divided by
     gross so the portfolio never implicitly levers. Pass False when leverage
-    via weights is intentional.
+    via weights is intentional. ``scope`` limits position diffing to one
+    independently rebalanced sleeve; targets outside that sleeve are rejected.
     """
     leverage = 1.0
     try:
@@ -69,6 +71,9 @@ def target_weights_to_intents(
         return []
 
     targets = {str(symbol): float(weight) for symbol, weight in weights.items()}
+    scoped_symbols = {str(symbol) for symbol in scope} if scope is not None else None
+    if scoped_symbols is not None and not set(targets).issubset(scoped_symbols):
+        raise ValueError("target weights contain a symbol outside the requested scope")
     gross = sum(abs(weight) for weight in targets.values())
     if normalize_gross and gross > 1.0:
         targets = {symbol: weight / gross for symbol, weight in targets.items()}
@@ -76,6 +81,8 @@ def target_weights_to_intents(
     current: dict[str, float] = {}
     closes: dict[str, float] = {}
     for symbol, position in ctx.ledger.positions.items():
+        if scoped_symbols is not None and symbol not in scoped_symbols:
+            continue
         frame = ctx.view.symbol_frame(symbol)
         # avg_price fallback when the view has no bars — same as the equity mark
         close = (

--- a/wayfinder_paths/mcp/tools/jobs.py
+++ b/wayfinder_paths/mcp/tools/jobs.py
@@ -59,6 +59,8 @@ JobAction = Literal[
     "derive_features",
     "holdout_check",
     "rank_check",
+    "factor_scan",
+    "factor_holdout",
     "strategy_library",
     "backtest_job",
     "op_status",
@@ -344,9 +346,14 @@ async def core_jobs(
     via_proposal: bool = False,
     symbols: list[str] | None = None,
     column: str | None = None,
+    columns: list[str] | None = None,
     horizons: list[int] | None = None,
     bar_interval: str | None = None,
     direction: Literal["long", "short", "auto"] | None = None,
+    orientation: Literal[
+        "high_score_outperforms", "low_score_outperforms"
+    ]
+    | None = None,
     timeframes: list[str] | None = None,
     holdout_fraction: float = 0.15,
     signal: str | None = None,
@@ -412,6 +419,10 @@ async def core_jobs(
         script), `holdout_check` (one-shot confirmation of a FROZEN scan
         candidate — signal + horizon + direction — on the reserved tail;
         spend it once per candidate, the trial ledger remembers),
+        `factor_scan` (pooled rank-IC admission for a declared family of
+        precomputed factor columns, with BH correction, chronological folds,
+        next-open outcomes, and a reserved tail), `factor_holdout` (spend
+        that tail once for one frozen column/horizon/orientation),
         `strategy_library` (list the
         shipped reference strategies — verbatim ports of audited live
         scripts; when the user references a known/live strategy, start here
@@ -731,6 +742,36 @@ async def core_jobs(
         return await _run_job_op(
             "rank_check",
             {"job_id": job_id, "column": column, "horizons": horizons},
+        )
+
+    if action == "factor_scan":
+        if not columns:
+            return err("invalid_request", "factor_scan requires columns")
+        return await _run_job_op(
+            "factor_scan",
+            {
+                "job_id": job_id,
+                "columns": columns,
+                "horizons": horizons,
+                "holdout_fraction": holdout_fraction,
+            },
+        )
+
+    if action == "factor_holdout":
+        if not column or horizon is None or orientation is None:
+            return err(
+                "invalid_request",
+                "factor_holdout requires column, horizon, and orientation",
+            )
+        return await _run_job_op(
+            "factor_holdout",
+            {
+                "job_id": job_id,
+                "column": column,
+                "horizon": horizon,
+                "orientation": orientation,
+                "holdout_fraction": holdout_fraction,
+            },
         )
 
     if action == "experiments":

--- a/wayfinder_paths/tests/test_jobs_factors.py
+++ b/wayfinder_paths/tests/test_jobs_factors.py
@@ -10,16 +10,29 @@ from wayfinder_paths.jobs.factors import (
     blend_factor_scores,
     cross_sectional_rank,
     cross_sectional_robust_zscore,
+    panel_from_frames,
     residual_return,
     rolling_beta,
 )
 from wayfinder_paths.jobs.research import factor_rank_holdout, factor_rank_scan
 
 
+def test_panel_from_frames_aligns_requested_numeric_columns() -> None:
+    frames = {
+        "B": pd.DataFrame({"timestamp": ["2026-01-01T04:00:00Z"], "close": ["2.0"]}),
+        "A": pd.DataFrame({"timestamp": ["2026-01-01T00:00:00Z"], "close": [1.0]}),
+    }
+
+    panel = panel_from_frames(frames, "close", symbols=("A", "B", "missing"))
+
+    assert list(panel.columns) == ["A", "B"]
+    assert str(panel.index.tz) == "UTC"
+    assert panel.loc[pd.Timestamp("2026-01-01T00:00:00Z"), "A"] == 1.0
+    assert panel.loc[pd.Timestamp("2026-01-01T04:00:00Z"), "B"] == 2.0
+
+
 def test_cross_sectional_rank_is_symmetric_and_respects_eligibility() -> None:
-    values = pd.DataFrame(
-        [[1.0, 2.0, 3.0], [5.0, 5.0, 9.0]], columns=["A", "B", "C"]
-    )
+    values = pd.DataFrame([[1.0, 2.0, 3.0], [5.0, 5.0, 9.0]], columns=["A", "B", "C"])
     eligible = pd.DataFrame(
         [[True, True, True], [True, True, False]], columns=values.columns
     )
@@ -97,14 +110,14 @@ def test_blend_factor_scores_validates_and_reranks() -> None:
 
 
 def _predictive_factor_frames() -> dict[str, pd.DataFrame]:
-    rng = np.random.default_rng(17)
     symbols = [f"S{index}" for index in range(8)]
     timestamps = pd.date_range("2025-01-01", periods=260, freq="4h", tz="UTC")
-    alpha = rng.normal(size=(len(timestamps), len(symbols)))
-    noise = rng.normal(size=alpha.shape)
+    alpha = np.random.default_rng(17).normal(size=(len(timestamps), len(symbols)))
+    noise = np.random.default_rng(4).normal(size=alpha.shape)
+    outcome_rng = np.random.default_rng(31)
     opens = np.full(alpha.shape, 100.0)
     for row in range(len(timestamps) - 2):
-        outcome = 0.004 * alpha[row] + rng.normal(0.0, 0.003, len(symbols))
+        outcome = 0.004 * alpha[row] + outcome_rng.normal(0.0, 0.003, len(symbols))
         opens[row + 2] = opens[row + 1] * (1.0 + outcome)
     return {
         symbol: pd.DataFrame(
@@ -286,9 +299,7 @@ async def test_core_jobs_routes_factor_scan(monkeypatch: pytest.MonkeyPatch) -> 
 
     captured: dict[str, object] = {}
 
-    async def fake_run(
-        op: str, kwargs: dict[str, object]
-    ) -> dict[str, object]:
+    async def fake_run(op: str, kwargs: dict[str, object]) -> dict[str, object]:
         captured.update({"op": op, "kwargs": kwargs})
         return {"ok": True, "result": {"passed": []}}
 

--- a/wayfinder_paths/tests/test_jobs_factors.py
+++ b/wayfinder_paths/tests/test_jobs_factors.py
@@ -1,0 +1,326 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from wayfinder_paths.jobs.factors import (
+    blend_factor_scores,
+    cross_sectional_rank,
+    cross_sectional_robust_zscore,
+    residual_return,
+    rolling_beta,
+)
+from wayfinder_paths.jobs.research import factor_rank_holdout, factor_rank_scan
+
+
+def test_cross_sectional_rank_is_symmetric_and_respects_eligibility() -> None:
+    values = pd.DataFrame(
+        [[1.0, 2.0, 3.0], [5.0, 5.0, 9.0]], columns=["A", "B", "C"]
+    )
+    eligible = pd.DataFrame(
+        [[True, True, True], [True, True, False]], columns=values.columns
+    )
+    ranked = cross_sectional_rank(values, eligible)
+    assert ranked.iloc[0].tolist() == pytest.approx([-1.0, 0.0, 1.0])
+    assert ranked.iloc[1, :2].tolist() == pytest.approx([0.0, 0.0])
+    assert pd.isna(ranked.iloc[1, 2])
+
+
+def test_cross_sectional_robust_zscore_is_row_local_and_clipped() -> None:
+    values = pd.DataFrame(
+        [[1.0, 2.0, 100.0], [10.0, 20.0, 30.0]], columns=["A", "B", "C"]
+    )
+    score = cross_sectional_robust_zscore(values, clip=2.0)
+    assert score.iloc[0, 2] == 2.0
+    assert score.iloc[1, 1] == pytest.approx(0.0)
+    changed = values.copy()
+    changed.iloc[1] = [1_000.0, 2_000.0, 3_000.0]
+    pd.testing.assert_series_equal(
+        cross_sectional_robust_zscore(changed).iloc[0],
+        cross_sectional_robust_zscore(values).iloc[0],
+    )
+
+
+def test_rolling_beta_and_residual_return_are_causal() -> None:
+    benchmark_returns = pd.Series([0.01, -0.02, 0.03, 0.01, -0.01, 0.02])
+    asset_returns = pd.DataFrame(
+        {"A": 2.0 * benchmark_returns, "B": -benchmark_returns}
+    )
+    beta = rolling_beta(asset_returns, benchmark_returns, 4, clip=None)
+    assert beta.iloc[-1].tolist() == pytest.approx([2.0, -1.0])
+
+    benchmark_close = (1.0 + benchmark_returns).cumprod() * 100
+    close = pd.DataFrame(
+        {
+            "A": (1.0 + 2.0 * benchmark_returns).cumprod() * 50,
+            "B": (1.0 - benchmark_returns).cumprod() * 80,
+        }
+    )
+    residual = residual_return(
+        close,
+        benchmark_close,
+        1,
+        beta_period=4,
+        beta_min_periods=4,
+        beta_clip=None,
+    )
+    assert residual.iloc[-1].tolist() == pytest.approx([0.0, 0.0], abs=1e-12)
+
+    extended = pd.concat([close, pd.DataFrame({"A": [9_999.0], "B": [1.0]})])
+    benchmark_extended = pd.concat([benchmark_close, pd.Series([500.0])])
+    pd.testing.assert_frame_equal(
+        residual_return(
+            extended,
+            benchmark_extended,
+            1,
+            beta_period=4,
+            beta_min_periods=4,
+            beta_clip=None,
+        ).iloc[: len(close)],
+        residual,
+    )
+
+
+def test_blend_factor_scores_validates_and_reranks() -> None:
+    momentum = pd.DataFrame([[1.0, 0.0, -1.0]], columns=["A", "B", "C"])
+    quality = pd.DataFrame([[0.0, 1.0, -1.0]], columns=momentum.columns)
+    blended = blend_factor_scores(
+        {"momentum": momentum, "quality": quality},
+        {"momentum": 3.0, "quality": 1.0},
+    )
+    assert blended.iloc[0].tolist() == pytest.approx([1.0, 0.0, -1.0])
+    with pytest.raises(ValueError, match="must match"):
+        blend_factor_scores({"momentum": momentum}, {"quality": 1.0})
+
+
+def _predictive_factor_frames() -> dict[str, pd.DataFrame]:
+    rng = np.random.default_rng(17)
+    symbols = [f"S{index}" for index in range(8)]
+    timestamps = pd.date_range("2025-01-01", periods=260, freq="4h", tz="UTC")
+    alpha = rng.normal(size=(len(timestamps), len(symbols)))
+    noise = rng.normal(size=alpha.shape)
+    opens = np.full(alpha.shape, 100.0)
+    for row in range(len(timestamps) - 2):
+        outcome = 0.004 * alpha[row] + rng.normal(0.0, 0.003, len(symbols))
+        opens[row + 2] = opens[row + 1] * (1.0 + outcome)
+    return {
+        symbol: pd.DataFrame(
+            {
+                "timestamp": timestamps,
+                "symbol": symbol,
+                "open": opens[:, index],
+                "high": opens[:, index] * 1.001,
+                "low": opens[:, index] * 0.999,
+                "close": opens[:, index],
+                "volume": 1_000.0,
+                "alpha": alpha[:, index],
+                "noise": noise[:, index],
+            }
+        )
+        for index, symbol in enumerate(symbols)
+    }
+
+
+def test_factor_rank_scan_pools_family_and_keeps_tail_closed() -> None:
+    report = factor_rank_scan(
+        _predictive_factor_frames(),
+        ["alpha", "noise"],
+        horizons=[1],
+        holdout_fraction=0.2,
+    )
+    assert report["holdout"]["opened"] is False
+    assert report["tests_run"] == 2
+    alpha = next(row for row in report["results"] if row["column"] == "alpha")
+    noise = next(row for row in report["results"] if row["column"] == "noise")
+    assert alpha["orientation"] == "high_score_outperforms"
+    assert alpha["folds_agreeing"] == 4
+    assert alpha["passed"] is True
+    assert noise["passed"] is False
+
+
+def test_factor_rank_holdout_checks_frozen_orientation() -> None:
+    report = factor_rank_holdout(
+        _predictive_factor_frames(),
+        "alpha",
+        1,
+        "high_score_outperforms",
+        holdout_fraction=0.2,
+    )
+    assert report["n"] >= 10
+    assert report["mean_ic"] > 0
+    assert report["verdict"] == "confirm"
+
+
+def test_factor_jobs_persist_scan_and_do_not_recompute_spent_tail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import json
+
+    import wayfinder_paths.jobs.research as research_module
+    from wayfinder_paths.jobs.models import WayfinderJob
+    from wayfinder_paths.jobs.store import JobStore
+
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("factor-demo", agent_mode="intervene")
+    store.save(job)
+    root = store.job_dir(job.id)
+    frames = _predictive_factor_frames()
+    monkeypatch.setattr(
+        research_module,
+        "_precomputed_job_frames",
+        lambda _job_id, _store: (root, sorted(frames), frames),
+    )
+    scan = research_module.factor_scan_job(
+        job.id,
+        columns=["alpha", "noise"],
+        horizons=[1],
+        holdout_fraction=0.2,
+        store=store,
+    )
+    assert scan["passed"]
+    persisted = json.loads(
+        (root / "results/research/factor_scan.json").read_text(encoding="utf-8")
+    )
+    assert persisted["holdout"]["opened"] is False
+    with pytest.raises(ValueError, match="passed the persisted factor scan"):
+        research_module.factor_holdout_check_job(
+            job.id,
+            column="unseen",
+            horizon=1,
+            orientation="high_score_outperforms",
+            holdout_fraction=0.2,
+            store=store,
+        )
+
+    first = research_module.factor_holdout_check_job(
+        job.id,
+        column="alpha",
+        horizon=1,
+        orientation="high_score_outperforms",
+        holdout_fraction=0.2,
+        store=store,
+    )
+    monkeypatch.setattr(
+        research_module,
+        "_precomputed_job_frames",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("tail recomputed")),
+    )
+    second = research_module.factor_holdout_check_job(
+        job.id,
+        column="alpha",
+        horizon=1,
+        orientation="high_score_outperforms",
+        holdout_fraction=0.2,
+        store=store,
+    )
+    assert first["already_spent"] is False
+    assert first["cutoff_ts"] == persisted["holdout"]["cutoff_ts"]
+    assert first["confirmation_threshold"] == {
+        "min_n": 10,
+        "one_sided_t": 1.645,
+    }
+    assert second["already_spent"] is True
+    assert second["mean_ic"] == first["mean_ic"]
+
+
+def test_factor_cli_routes_declared_family(monkeypatch: pytest.MonkeyPatch) -> None:
+    from click.testing import CliRunner
+
+    from wayfinder_paths.jobs import cli as cli_module
+
+    captured: dict[str, object] = {}
+
+    def fake_scan(job_id: str, **kwargs: object) -> dict[str, list[object]]:
+        captured.update({"job_id": job_id, **kwargs})
+        return {"passed": []}
+
+    monkeypatch.setattr(cli_module, "factor_scan_job", fake_scan)
+    result = CliRunner().invoke(
+        cli_module.job_cli,
+        [
+            "factor-scan",
+            "demo",
+            "--columns",
+            "momentum,carry",
+            "--horizons",
+            "4,24",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["job_id"] == "demo"
+    assert captured["columns"] == ["momentum", "carry"]
+    assert captured["horizons"] == [4, 24]
+
+    def fake_holdout(job_id: str, **kwargs: object) -> dict[str, str]:
+        captured.clear()
+        captured.update({"job_id": job_id, **kwargs})
+        return {"verdict": "confirm"}
+
+    monkeypatch.setattr(cli_module, "factor_holdout_check_job", fake_holdout)
+    result = CliRunner().invoke(
+        cli_module.job_cli,
+        [
+            "factor-holdout",
+            "demo",
+            "--column",
+            "momentum",
+            "--horizon",
+            "4",
+            "--orientation",
+            "high_score_outperforms",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["job_id"] == "demo"
+    assert captured["column"] == "momentum"
+    assert captured["horizon"] == 4
+    assert captured["orientation"] == "high_score_outperforms"
+
+
+@pytest.mark.asyncio
+async def test_core_jobs_routes_factor_scan(monkeypatch: pytest.MonkeyPatch) -> None:
+    from wayfinder_paths.mcp.tools import jobs as jobs_module
+
+    captured: dict[str, object] = {}
+
+    async def fake_run(
+        op: str, kwargs: dict[str, object]
+    ) -> dict[str, object]:
+        captured.update({"op": op, "kwargs": kwargs})
+        return {"ok": True, "result": {"passed": []}}
+
+    monkeypatch.setattr(jobs_module, "_run_job_op", fake_run)
+    result = await jobs_module.core_jobs(
+        action="factor_scan",
+        job_id="demo",
+        columns=["momentum", "carry"],
+        horizons=[4, 24],
+    )
+    assert result["ok"] is True
+    assert captured["op"] == "factor_scan"
+    assert captured["kwargs"] == {
+        "job_id": "demo",
+        "columns": ["momentum", "carry"],
+        "horizons": [4, 24],
+        "holdout_fraction": 0.15,
+    }
+
+    result = await jobs_module.core_jobs(
+        action="factor_holdout",
+        job_id="demo",
+        column="momentum",
+        horizon=4,
+        orientation="high_score_outperforms",
+    )
+    assert result["ok"] is True
+    assert captured["op"] == "factor_holdout"
+    assert captured["kwargs"] == {
+        "job_id": "demo",
+        "column": "momentum",
+        "horizon": 4,
+        "orientation": "high_score_outperforms",
+        "holdout_fraction": 0.15,
+    }

--- a/wayfinder_paths/tests/test_jobs_portfolio_bridge.py
+++ b/wayfinder_paths/tests/test_jobs_portfolio_bridge.py
@@ -116,6 +116,19 @@ def test_same_sign_shrink_uses_the_matching_position_side() -> None:
     assert intents[0]["size"] == pytest.approx(25.0)
 
 
+def test_scope_preserves_positions_owned_by_another_sleeve() -> None:
+    ctx = _ctx(
+        {"AAA": 10.0, "BBB": 20.0},
+        _ledger(("AAA", "long", 50.0, 10.0), ("BBB", "long", 25.0, 20.0)),
+    )
+
+    intents = target_weights_to_intents(ctx, {"AAA": 0.5}, scope=["AAA"])
+
+    assert intents == []
+    with pytest.raises(ValueError, match="outside the requested scope"):
+        target_weights_to_intents(ctx, {"BBB": 0.5}, scope=["AAA"])
+
+
 def test_same_sign_grow_opens_the_delta() -> None:
     ctx = _ctx({"AAA": 10.0}, _ledger(("AAA", "long", 50.0, 10.0)))
     intents = target_weights_to_intents(ctx, {"AAA": 0.75})

--- a/wayfinder_paths/tests/test_jobs_research_toolkit.py
+++ b/wayfinder_paths/tests/test_jobs_research_toolkit.py
@@ -314,6 +314,8 @@ def test_research_context_files_stay_small_and_versioned() -> None:
         root / ".opencode/plugins/wayfinder-compaction.ts",
     ):
         assert RESEARCH_CONTRACT_VERSION in path.read_text(encoding="utf-8")
+    assert "rules/factor-research.md" in skill.read_text(encoding="utf-8")
+    assert "factor_scan" in contract.read_text(encoding="utf-8")
 
 
 def test_worker_stable_prefix_loads_research_contract_once(tmp_path: Path) -> None:

--- a/wayfinder_paths/tests/test_jobs_starters.py
+++ b/wayfinder_paths/tests/test_jobs_starters.py
@@ -36,6 +36,7 @@ from wayfinder_paths.jobs.starters import (
     validate_starter_leverage,
 )
 from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.jobs.strategies._starter_utils import buffered_rank_weights
 from wayfinder_paths.jobs.strategies.crypto_momentum_persistence import (
     CryptoMomentumPersistenceStrategy,
 )
@@ -44,6 +45,9 @@ from wayfinder_paths.jobs.strategies.hype_passive_rsi import (
 )
 from wayfinder_paths.jobs.strategies.mixed_bollinger_pullback import (
     MixedBollingerPullbackStrategy,
+)
+from wayfinder_paths.jobs.strategies.mixed_factor_balance import (
+    MixedFactorBalanceStrategy,
 )
 from wayfinder_paths.jobs.strategies.mixed_low_vol_rank import (
     MixedLowVolRankStrategy,
@@ -212,7 +216,8 @@ def dataset_fetch_spawns(monkeypatch) -> list[dict[str, Any]]:
 
 def test_starter_catalog_has_mixed_maker_and_pair_paper_strategies() -> None:
     catalog = starter_catalog()
-    assert len(catalog) == 12
+    assert len(catalog) == 13
+    assert catalog[0]["id"] == "mixed-factor-balance-4h"
     assert {item["timeframe"] for item in catalog} == {
         "5m",
         "15m",
@@ -223,7 +228,7 @@ def test_starter_catalog_has_mixed_maker_and_pair_paper_strategies() -> None:
     assert [item["timeframe"] for item in catalog].count("5m") == 2
     assert [item["timeframe"] for item in catalog].count("15m") == 2
     assert [item["timeframe"] for item in catalog].count("1h") == 5
-    assert [item["timeframe"] for item in catalog].count("4h") == 1
+    assert [item["timeframe"] for item in catalog].count("4h") == 2
     assert [item["timeframe"] for item in catalog].count("1d") == 2
     for item in catalog:
         assert item["crypto_assets"]
@@ -237,6 +242,7 @@ def test_starter_catalog_has_mixed_maker_and_pair_paper_strategies() -> None:
             "maker_mean_reversion",
             "mean_reversion",
             "low_volatility_ranking",
+            "multi_factor",
             "relative_value_pair",
         }
         assert isinstance(item["cautions"], list)
@@ -264,17 +270,20 @@ def test_starter_catalog_has_mixed_maker_and_pair_paper_strategies() -> None:
             assert funded_return is not None and funded_return > 0
         engine = item["research_evidence"]["jobs_v1_engine"]
         assert engine["return_after_fees_and_slippage"] > 0
-        assert engine["funding_included"] is False
+        assert isinstance(engine["funding_included"], bool)
         assert engine["trace_valid"] is True
         assert engine["full_period_vs_no_stop"] in {"unchanged", "improved"}
         if item["family"] == "maker_mean_reversion":
             assert 0 <= engine["chronological_folds_non_regressing"] <= 4
+        elif item["family"] == "multi_factor":
+            assert engine["chronological_folds_non_regressing"] == 3
         else:
             assert engine["chronological_folds_non_regressing"] == 4
         assert engine["stop_count"] >= 0
         sweep = item["research_evidence"]["jobs_v1_leverage_sweep"]
         assert sweep["leverage_semantics"] == "target_exposure"
         assert sweep["account_halt_simulated"] is False
+        assert sweep["funding_included"] is engine["funding_included"]
         assert [row["leverage"] for row in sweep["results"]] == [1, 2, 3, 4, 5]
         assert all(row["liquidation_count"] == 0 for row in sweep["results"])
         assert sweep["results"][0]["return_after_fees_and_slippage"] == pytest.approx(
@@ -299,6 +308,7 @@ def test_starter_catalog_has_mixed_maker_and_pair_paper_strategies() -> None:
         ].values()
     )
     expected_stops = {
+        "mixed-factor-balance-4h": (12.0, 0.25, 0.50),
         "mixed-rsi-snapback-1h": (5.0, 0.08, 0.15),
         "mixed-momentum-rank-1h": (8.0, 0.15, 0.30),
         "crypto-momentum-persistence-4h": (12.0, 0.25, 0.50),
@@ -363,6 +373,7 @@ def test_starter_catalog_has_mixed_maker_and_pair_paper_strategies() -> None:
 # 7 of 12 entries did exactly that under the old 200-bar driver default.
 # A new/edited starter MUST update this table consciously.
 EXPECTED_STARTER_LOOKBACK_BARS = {
+    "mixed-factor-balance-4h": 66,
     "mixed-rsi-snapback-1h": 224,
     "mixed-bollinger-pullback-1h": 224,
     "mixed-volume-capitulation-1h": 224,
@@ -413,6 +424,120 @@ def test_create_starter_sets_driver_lookback_above_warmup(tmp_path) -> None:
     assert lookback == 2904
     strategy = MixedSleeveMomentumStrategy(dict(job.execution_params))
     assert lookback > strategy.warmup_bars  # 2884: momentum_bars 2880 + 4
+
+
+def test_buffered_rank_weights_keep_exact_basket_size() -> None:
+    scores = {"A": 6.0, "B": 5.0, "C": 4.0, "D": 3.0, "E": 2.0, "F": 1.0}
+
+    long_only = buffered_rank_weights(
+        scores,
+        {"C": 1.0},
+        side_count=2,
+        gross=0.60,
+        long_only=True,
+    )
+    long_short = buffered_rank_weights(
+        scores,
+        {"C": 1.0, "D": -1.0},
+        side_count=2,
+        gross=0.80,
+    )
+
+    assert {symbol for symbol, weight in long_only.items() if weight > 0} == {"A", "C"}
+    assert sum(weight > 0 for weight in long_short.values()) == 2
+    assert sum(weight < 0 for weight in long_short.values()) == 2
+    assert sum(abs(weight) for weight in long_short.values()) == pytest.approx(0.80)
+
+
+def test_factor_balance_emits_only_scoped_long_sleeves() -> None:
+    crypto = ["A", "B", "C", "D"]
+    onchain = ["E", "F", "G", "H"]
+    strategy = MixedFactorBalanceStrategy(
+        {
+            "symbols": [*crypto, *onchain],
+            "sleeves": {"crypto": crypto, "onchain": onchain},
+            "rebalance_bars": {"crypto": 1, "onchain": 1},
+            "min_trade_notional": 0.0,
+        }
+    )
+    strategy.warmup_bars = 1
+    timestamp = pd.Timestamp("2026-01-01T00:00:00Z")
+    rows = [
+        {
+            "timestamp": timestamp,
+            "symbol": symbol,
+            "open": 10.0,
+            "high": 10.1,
+            "low": 9.9,
+            "close": 10.0,
+            "volume": 1_000_000.0,
+            "starter_factor_score": float(index),
+            "starter_factor_scale": 1.0,
+            "starter_stop_atr": 0.1,
+        }
+        for index, symbol in enumerate([*crypto, *onchain])
+    ]
+    spec = ExecutionSpec()
+    spec.data_contract["bar_interval"] = "4h"
+    ctx = ExecutionContext(
+        view=CompletedBarsView.from_rows(rows),
+        ledger=PositionLedger(),
+        state_snapshot=StateSnapshot(status="valid"),
+        capacity=None,
+        params={"initial_capital": 10_000.0},
+        timestamp=timestamp.isoformat(),
+        execution_spec=spec,
+    )
+
+    intents = strategy.decide(ctx)
+
+    assert {intent["symbol"] for intent in intents} == {"C", "D", "G", "H"}
+    assert {intent["side"] for intent in intents} == {"buy"}
+    notionals = {intent["symbol"]: intent["notional"] for intent in intents}
+    assert notionals == pytest.approx(
+        {"C": 2_000.0, "D": 2_000.0, "G": 2_500.0, "H": 2_500.0}
+    )
+
+
+def test_factor_balance_precompute_is_causal() -> None:
+    symbols = ["BTC", "ETH", "SOL", "HYPE", "DOGE", "AAVE", "NEAR", "ENA"]
+    timestamps = pd.date_range("2026-01-01", periods=70, freq="4h", tz="UTC")
+    frames: dict[str, pd.DataFrame] = {}
+    for symbol_index, symbol in enumerate(symbols):
+        closes = [100.0 + symbol_index]
+        for bar in range(1, len(timestamps)):
+            change = 0.001 + 0.0002 * ((bar + symbol_index) % 5 - 2)
+            closes.append(closes[-1] * (1.0 + change))
+        frames[symbol] = pd.DataFrame(
+            {
+                "timestamp": timestamps,
+                "symbol": symbol,
+                "open": closes,
+                "high": [value * 1.001 for value in closes],
+                "low": [value * 0.999 for value in closes],
+                "close": closes,
+                "volume": 1_000_000.0,
+                "funding": 0.00001 * (symbol_index + 1),
+            }
+        )
+    strategy = MixedFactorBalanceStrategy(
+        {
+            "symbols": symbols,
+            "sleeves": {"crypto": symbols},
+            "min_assets": len(symbols),
+        }
+    )
+    baseline = strategy.precompute(frames)
+    changed = {symbol: frame.copy() for symbol, frame in frames.items()}
+    changed["HYPE"].loc[changed["HYPE"].index[-1], "close"] *= 10.0
+
+    mutated = strategy.precompute(changed)
+
+    for symbol in symbols:
+        pd.testing.assert_series_equal(
+            baseline[symbol]["starter_factor_score"].iloc[:-1],
+            mutated[symbol]["starter_factor_score"].iloc[:-1],
+        )
 
 
 def test_momentum_rank_longs_leaders_and_shorts_laggards() -> None:

--- a/wayfinder_paths/tests/test_research_and_pair_check.py
+++ b/wayfinder_paths/tests/test_research_and_pair_check.py
@@ -332,11 +332,33 @@ def test_op_runner_routes_research_ops(monkeypatch) -> None:
         "signal_check_job",
         lambda job_id, **kw: {"stub": "signal", "column": kw.get("column")},
     )
+    monkeypatch.setattr(
+        research_mod,
+        "factor_scan_job",
+        lambda job_id, **kw: {"stub": "factor", "columns": kw.get("columns")},
+    )
+    monkeypatch.setattr(
+        research_mod,
+        "factor_holdout_check_job",
+        lambda job_id, **kw: {"stub": "tail", "column": kw.get("column")},
+    )
     assert op_runner._run("pair_check", {"job_id": "j"}) == {"stub": "pair", "job": "j"}
     assert op_runner._run("signal_check", {"job_id": "j", "column": "z"}) == {
         "stub": "signal",
         "column": "z",
     }
+    assert op_runner._run_op(
+        "factor_scan", {"job_id": "j", "columns": ["mom", "carry"]}
+    ) == {"stub": "factor", "columns": ["mom", "carry"]}
+    assert op_runner._run_op(
+        "factor_holdout",
+        {
+            "job_id": "j",
+            "column": "mom",
+            "horizon": 4,
+            "orientation": "high_score_outperforms",
+        },
+    ) == {"stub": "tail", "column": "mom"}
 
 
 def _cross_section(n_bars: int, n_symbols: int, *, informative: bool, seed: int = 5):


### PR DESCRIPTION
## Summary

- add causal, vectorized factor primitives for panel alignment, ranks, robust z-scores, rolling beta, residual returns, and weighted blends
- add pooled factor admission and one-shot holdout checks with next-open outcomes, Newey-West statistics, BH correction, chronological stability, and a frozen cutoff
- expose `factor-scan` / `factor-holdout` through the jobs CLI, MCP, and background op runner, with compact research-agent guidance
- add `Mixed Factor Balance · 4h` as the first starter in the selector: a long-only crypto plus HIP-3 equity/commodity allocator using trend, relative value, low-volatility quality, and funding carry
- extend the existing buffered rank and target-weight helpers for long-only baskets and independently rebalanced sleeves

## Corrected research outcome

The initial exploratory results were discarded after finding two research-harness defects: cached 4h frames contained 1h candles, and funding buckets were labeled at their start. A rank-buffer overflow was also fixed before final selection. The promoted evidence uses validated raw 4h OHLC, right-labeled completed funding buckets, next-open execution, and 8 bps one-way costs.

Market-neutral candidates failed their frozen tails, so the final topology removes the short-book drag without turning the starter into the existing momentum strategy:

- crypto sleeve: trend quality plus low volatility and carry; frozen tail **+8.60%**, Sharpe **4.09**
- onchain sleeve: relative value plus residual strength and low volatility behind a broad trend/breadth gate; frozen tail **+0.56%**, Sharpe **2.31**

Exact jobs_v1 replay at the catalog default of 1x, including fees and funding:

- 180-day net return: **+32.45%** vs **+23.64%** buy-and-hold
- Sharpe: **2.00**
- max drawdown: **-13.80%**
- recent 7-day return: **+10.95%**
- chronological segments: **3/4 positive** (`+3.13%, +15.95%, -3.34%, +14.58%`)
- all six 4h rebalance phases positive: **+8.91% to +51.97%**
- 192 trades, $201.83 fees, -$160.73 funding, zero stop triggers, zero liquidations

The 1x-5x sweep had no liquidations, but 2x-5x exceeded the catalog -20% historical account-halt budget. The selector therefore remains defaulted to 1x and explicitly flags the higher settings as outside budget.

## Limitations

- the evidence window is 180 days and overlaps the recent crypto run-up
- one of four exact chronological segments was negative
- the long-only topology was evaluated after observing the factor-family failure, so forward paper tracking remains required
- the onchain sleeve holds cash when its broad trend-and-breadth gate is off

## Quality pass

- reused the shared factor primitives and removed the duplicate research panel builder
- extended one buffered-rank helper instead of adding a parallel allocator
- added sleeve-scoped target diffing so one sleeve cannot close positions owned by another
- added regression coverage for exact basket size, scope isolation, causal precompute, catalog ordering, leverage evidence, and the live lookback window
- replaced a brittle synthetic null fixture that deterministically admitted noise at the configured 10% FDR

## Validation

- `677 passed` across `wayfinder_paths/tests/test_jobs_*.py`
- `80 passed` in the focused factor, portfolio bridge, and starter suites after final cleanup
- Ruff format/check on every changed Python file
- `git diff --check`
- exact jobs_v1 replay completed with no validation issues and the catalog 66-bar live window

## Dependency

Stacked on #704 (`feat/jobs-research-robustness-toolkit`) so this PR contains the factor-specific delta.