### PR TITLE
jobs: owner attention — per-claim needs_you exhaustion items so FE adjudicate buttons work

### DIFF
--- a/wayfinder_paths/jobs/owner_attention.py
+++ b/wayfinder_paths/jobs/owner_attention.py
@@ -44,6 +44,40 @@ CLAIM_AUDIT_GRACE_SECONDS = 60 * 60
 _JOURNAL_SCAN_LIMIT = 4000
 _MECHANICAL_AUDIT_VERDICTS = frozenset({"pass", "narrow", "reject"})
 
+# owner_review_required journal markers surface as needs_you items with
+# kind = event type — but ONLY for these event types. The FE renders each
+# kind with dedicated action buttons (vault-frontend WAYFINDER_NEEDS_YOU_KINDS);
+# an unknown kind renders as a dead generic label the owner cannot act on, so
+# marker types outside this set must never pass through. Notably the batch
+# ``exhaustion_claims_pending`` marker (written by older deployed watchdogs,
+# still present in live journals) is dropped here — pending claims surface
+# per-claim via ``_unauditable_claims`` with ref_id = claim_id instead.
+_OWNER_REVIEW_MARKER_KINDS = frozenset(
+    {
+        "successor_abandoned",
+        "proposal_reject_refused",
+        "live_mode_audit",
+    }
+)
+
+# The complete needs_you kind union the deployed FE understands. Every item
+# emitted by _needs_you MUST use one of these kinds — this constant exists so
+# tests can pin the contract and future drift fails loudly. Mirror of
+# vault-frontend's WAYFINDER_NEEDS_YOU_KINDS.
+NEEDS_YOU_KINDS = _OWNER_REVIEW_MARKER_KINDS | frozenset(
+    {
+        "live_proposal_approval",
+        "exhaustion_claim_unauditable",
+        "decision_gate_tripped",
+        "halt_awaiting_owner_clear",
+    }
+)
+
+_PROBATION_OPENED_EVENTS = frozenset({"probation_leg_opened", "paper_probation_opened"})
+_PROBATION_EVENTS = _PROBATION_OPENED_EVENTS | frozenset(
+    {"probation_leg_graduated", "probation_leg_killed"}
+)
+
 
 def job_live_capital_risk(job: WayfinderJob) -> bool:
     """Live capital at stake: running live, or wallet-bound (one flip away)."""
@@ -78,7 +112,7 @@ def _build(
     proposals = store.proposals(job_id)
     return {
         "needs_you": _needs_you(store, job_id, job, proposals, journal, now),
-        "decided_autonomously": _decided_autonomously(job_id, journal, now),
+        "decided_autonomously": _decided_autonomously(store, job_id, journal, now),
     }
 
 
@@ -163,15 +197,19 @@ def _unauditable_claims(
         ):
             continue  # audit simply hasn't run yet
         claim_id = str(claim.get("claim_id"))
+        summary = (
+            f"exhaustion claim on lane {claim.get('lane')!r} has no "
+            "mechanical audit verdict — owner adjudication required"
+        )
+        evidence = " ".join(str(claim.get("evidence") or "").split())
+        if evidence:
+            summary = f"{summary}; evidence: {evidence}"
         items.append(
             _item(
                 kind="exhaustion_claim_unauditable",
                 job_id=job_id,
                 ref_id=claim_id,
-                summary=(
-                    f"exhaustion claim on lane {claim.get('lane')!r} has no "
-                    "mechanical audit verdict — owner adjudication required"
-                ),
+                summary=summary[:300],
                 evidence_ref=f"research/exhaustion_claims/{claim_id}.json",
                 since_ts=claim.get("filed_at"),
             )
@@ -189,6 +227,11 @@ def _owner_review_markers(
     latest: dict[tuple[str, str], dict[str, Any]] = {}
     for event in journal:  # append-ordered: later events overwrite
         if not event.get("owner_review_required"):
+            continue
+        if str(event.get("type")) not in _OWNER_REVIEW_MARKER_KINDS:
+            # Unknown marker types must not leak into needs_you: the FE only
+            # wires action buttons for _OWNER_REVIEW_MARKER_KINDS, so anything
+            # else would render as an item the owner cannot act on.
             continue
         ts = _parse_time(event.get("ts"))
         if ts and ts < cutoff:
@@ -253,22 +296,63 @@ def _tripped_gates(store: JobStore, job_id: str) -> list[dict[str, Any]]:
 
 
 def _decided_autonomously(
-    job_id: str, journal: list[dict[str, Any]], now: dt.datetime
+    store: JobStore, job_id: str, journal: list[dict[str, Any]], now: dt.datetime
 ) -> list[dict[str, Any]]:
     cutoff = now - dt.timedelta(days=DECIDED_WINDOW_DAYS)
+    legs_by_name = _probation_legs(store, job_id, journal)
     items: list[dict[str, Any]] = []
     for event in journal:
         ts = _parse_time(event.get("ts"))
         if ts is None or ts < cutoff:
             continue
-        decided = _decided_item(job_id, event)
+        decided = _decided_item(job_id, event, legs_by_name)
         if decided is not None:
             items.append(decided)
     items.sort(key=lambda item: str(item.get("ts") or ""), reverse=True)
     return items[:DECIDED_CAP]
 
 
-def _decided_item(job_id: str, event: dict[str, Any]) -> dict[str, Any] | None:
+def _probation_legs(
+    store: JobStore, job_id: str, journal: list[dict[str, Any]]
+) -> dict[str, dict[str, Any]]:
+    if not any(str(e.get("type")) in _PROBATION_EVENTS for e in journal):
+        return {}
+    from wayfinder_paths.jobs.probation import load_probation
+
+    return {
+        str(leg.get("name")): leg
+        for leg in load_probation(store, job_id).get("legs") or []
+        if isinstance(leg, dict)
+    }
+
+
+def _probation_evidence(
+    event: dict[str, Any],
+    decision: str,
+    legs_by_name: dict[str, dict[str, Any]],
+) -> str:
+    """Owner-readable probation evidence: ALWAYS lead with the leg name (an
+    owner read a bare 'Killed' chip as the whole JOB being killed), then the
+    registered criterion for the decision when one exists."""
+    leg_name = str(event.get("leg") or "")
+    text = f"leg {leg_name} {decision}"
+    leg = legs_by_name.get(leg_name) or {}
+    criterion_key = "kill" if decision == "killed" else "graduate"
+    criterion = str((leg.get(criterion_key) or {}).get("criterion") or "").strip()
+    if criterion:
+        prefix = "graduates when" if decision == "opened" else "criterion"
+        text = f"{text} — {prefix}: {criterion}"
+    entry = event.get("entry")
+    if decision == "opened" and entry:
+        text = f"{text} — entry: {_compact(entry)}"
+    return text[:300]
+
+
+def _decided_item(
+    job_id: str,
+    event: dict[str, Any],
+    legs_by_name: dict[str, dict[str, Any]],
+) -> dict[str, Any] | None:
     event_type = str(event.get("type") or "")
     ts = event.get("ts")
     if event_type == "proposal_auto_applied":
@@ -323,32 +407,19 @@ def _decided_item(job_id: str, event: dict[str, Any]) -> dict[str, Any] | None:
             "decision": "reject",
             "evidence": _compact(event.get("reason_codes")),
         }
-    if event_type in {"probation_leg_opened", "paper_probation_opened"}:
+    if event_type in _PROBATION_EVENTS:
+        decision = (
+            "opened"
+            if event_type in _PROBATION_OPENED_EVENTS
+            else event_type.removeprefix("probation_leg_")
+        )
         return {
             "kind": "probation",
             "job_id": job_id,
             "ref_id": event.get("leg"),
             "ts": ts,
-            "decision": "opened",
-            "evidence": _compact(event.get("entry")),
-        }
-    if event_type == "probation_leg_graduated":
-        return {
-            "kind": "probation",
-            "job_id": job_id,
-            "ref_id": event.get("leg"),
-            "ts": ts,
-            "decision": "graduated",
-            "evidence": None,
-        }
-    if event_type == "probation_leg_killed":
-        return {
-            "kind": "probation",
-            "job_id": job_id,
-            "ref_id": event.get("leg"),
-            "ts": ts,
-            "decision": "killed",
-            "evidence": None,
+            "decision": decision,
+            "evidence": _probation_evidence(event, decision, legs_by_name),
         }
     return None
 

--- a/wayfinder_paths/tests/test_jobs_owner_attention.py
+++ b/wayfinder_paths/tests/test_jobs_owner_attention.py
@@ -10,11 +10,28 @@ from wayfinder_paths.jobs import sync as sync_mod
 from wayfinder_paths.jobs.halt import request_halt
 from wayfinder_paths.jobs.models import WayfinderJob
 from wayfinder_paths.jobs.owner_attention import (
+    NEEDS_YOU_KINDS,
     build_owner_attention,
     job_live_capital_risk,
 )
 from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.jobs.sync import snapshot_job
+
+# Pinned mirror of vault-frontend's WAYFINDER_NEEDS_YOU_KINDS: the deployed FE
+# wires accept/reject/adjudicate buttons per kind and renders any OTHER kind
+# as a dead generic label. If this set and NEEDS_YOU_KINDS drift, the FE
+# contract broke — update vault-frontend first, then this pin.
+WAYFINDER_NEEDS_YOU_KINDS = frozenset(
+    {
+        "live_proposal_approval",
+        "exhaustion_claim_unauditable",
+        "successor_abandoned",
+        "proposal_reject_refused",
+        "live_mode_audit",
+        "decision_gate_tripped",
+        "halt_awaiting_owner_clear",
+    }
+)
 
 
 def _store(
@@ -155,6 +172,144 @@ def test_owner_review_markers_surface_and_resolve(tmp_path: Path) -> None:
     assert kinds == ["successor_abandoned"]
 
 
+def test_pending_claims_emit_one_item_per_claim(tmp_path: Path) -> None:
+    store, job_id = _store(tmp_path)
+    old = (dt.datetime.now(dt.UTC) - dt.timedelta(hours=3)).isoformat()
+    pending = {
+        "claim-imx": {"lane": "imx-gap", "evidence": "20 variants, all OOS-negative"},
+        "claim-sol": {"lane": "sol-momo", "evidence": "holdout refuted 3 configs"},
+        "claim-eth": {"lane": "eth-basis", "evidence": "data wall at 2024-01"},
+    }
+    for claim_id, claim in pending.items():
+        store.write_json(
+            job_id,
+            f"research/exhaustion_claims/{claim_id}.json",
+            {"claim_id": claim_id, "status": "pending", "filed_at": old, **claim},
+        )
+    # Pending but audit-decided: the mechanical path owns it, not the owner.
+    store.write_json(
+        job_id,
+        "research/exhaustion_claims/claim-audited.json",
+        {
+            "claim_id": "claim-audited",
+            "status": "pending",
+            "lane": "audited",
+            "filed_at": old,
+            "audit": {"verdict": "narrow"},
+        },
+    )
+    # The deployed watchdog's BATCH journal marker must NOT surface as an
+    # item — the FE has no buttons for it; claims surface per-claim instead.
+    _journal(
+        store,
+        job_id,
+        {
+            "type": "exhaustion_claims_pending",
+            "count": 3,
+            "owner_review_required": "3 exhaustion claims pending — use the CLI",
+        },
+    )
+
+    items = build_owner_attention(store, job_id)["needs_you"]
+
+    assert _kinds(items) == ["exhaustion_claim_unauditable"] * 3
+    by_ref = {item["ref_id"]: item for item in items}
+    assert set(by_ref) == set(pending)
+    for claim_id, claim in pending.items():
+        item = by_ref[claim_id]
+        assert claim["lane"] in item["summary"]
+        assert claim["evidence"] in item["summary"]
+        assert len(item["summary"]) <= 300
+        assert item["evidence_ref"] == f"research/exhaustion_claims/{claim_id}.json"
+        assert item["since_ts"] == old
+
+
+def test_every_emitted_needs_you_kind_is_in_the_fe_union(tmp_path: Path) -> None:
+    assert NEEDS_YOU_KINDS == WAYFINDER_NEEDS_YOU_KINDS
+
+    # Exercise every emitter at once and assert full union coverage — a new
+    # emitter with an off-union kind, or a union member no emitter can
+    # produce, both fail here.
+    store, job_id = _store(tmp_path, wallet_label="main")
+    _write_pending_proposal(store, job_id, "prop-live")
+    old = (dt.datetime.now(dt.UTC) - dt.timedelta(hours=3)).isoformat()
+    store.write_json(
+        job_id,
+        "research/exhaustion_claims/claim-stuck.json",
+        {
+            "claim_id": "claim-stuck",
+            "status": "pending",
+            "lane": "imx-gap",
+            "filed_at": old,
+        },
+    )
+    _journal(
+        store,
+        job_id,
+        {
+            "type": "successor_abandoned",
+            "proposal_id": "prop-dead",
+            "owner_review_required": "successor self-rejected 3 times",
+        },
+    )
+    store.write_proposal(
+        job_id,
+        {
+            "proposal_id": "prop-stuck",
+            "job_id": job_id,
+            "status": "approved",
+            "proposed_change": {"summary": "x"},
+            "application": {"status": "not_requested", "restage_requested": True},
+        },
+    )
+    _journal(
+        store,
+        job_id,
+        {
+            "type": "proposal_reject_refused",
+            "proposal_id": "prop-stuck",
+            "owner_review_required": "gate ESCALATED",
+        },
+    )
+    _journal(
+        store,
+        job_id,
+        {
+            "type": "live_mode_audit",
+            "flags": [],
+            "cleared": True,
+            "owner_review_required": "stamp created after the flag was raised",
+        },
+    )
+    store.write_json(
+        job_id,
+        "research/decision_gates.json",
+        {
+            "gates": [
+                {
+                    "gate_id": "gate-1",
+                    "status": "tripped_needs_owner",
+                    "on_met": "retire_and_pivot",
+                }
+            ]
+        },
+    )
+    request_halt(store, job_id, reason="dd breach", source="risk_limits")
+    # An off-union marker type must be dropped, not passed through.
+    _journal(
+        store,
+        job_id,
+        {
+            "type": "some_future_marker",
+            "owner_review_required": "unknown escalation",
+        },
+    )
+
+    kinds = set(_kinds(build_owner_attention(store, job_id)["needs_you"]))
+
+    assert kinds == WAYFINDER_NEEDS_YOU_KINDS
+
+
 def test_unauditable_pending_claim_needs_owner(tmp_path: Path) -> None:
     store, job_id = _store(tmp_path)
     old = (dt.datetime.now(dt.UTC) - dt.timedelta(hours=3)).isoformat()
@@ -275,6 +430,63 @@ def test_decided_feed_carries_undo_refs(tmp_path: Path) -> None:
     # Feed is newest-first.
     timestamps = [item["ts"] for item in decided]
     assert timestamps == sorted(timestamps, reverse=True)
+
+
+def test_probation_items_lead_with_leg_name_and_criterion(tmp_path: Path) -> None:
+    # An owner read a bare "Killed" probation chip as the whole JOB being
+    # killed — the evidence must lead with the leg name and carry the
+    # registered criterion when one exists.
+    store, job_id = _store(tmp_path)
+    store.write_json(
+        job_id,
+        "probation.json",
+        {
+            "legs": [
+                {
+                    "name": "SOL_holdout_pair_5m15m_paper",
+                    "graduate": {"criterion": "20 trades, net_pnl > 0"},
+                    "kill": {"criterion": "net_pnl < -2% over 30 trades"},
+                },
+                {
+                    "name": "HYPE_leg",
+                    "graduate": {"criterion": "sharpe > 1 over 14d"},
+                    "kill": {"criterion": None},
+                },
+            ]
+        },
+    )
+    _journal(
+        store,
+        job_id,
+        {"type": "probation_leg_opened", "leg": "SOL_holdout_pair_5m15m_paper"},
+    )
+    _journal(
+        store,
+        job_id,
+        {"type": "probation_leg_killed", "leg": "SOL_holdout_pair_5m15m_paper"},
+    )
+    _journal(store, job_id, {"type": "probation_leg_graduated", "leg": "HYPE_leg"})
+
+    decided = build_owner_attention(store, job_id)["decided_autonomously"]
+
+    by_decision = {item["decision"]: item for item in decided}
+    assert set(by_decision) == {"opened", "killed", "graduated"}
+    for item in decided:
+        assert item["kind"] == "probation"
+        assert item["evidence"].startswith(f"leg {item['ref_id']} ")
+    killed = by_decision["killed"]
+    assert killed["ref_id"] == "SOL_holdout_pair_5m15m_paper"
+    assert "net_pnl < -2% over 30 trades" in killed["evidence"]
+    opened = by_decision["opened"]
+    assert "20 trades, net_pnl > 0" in opened["evidence"]
+    graduated = by_decision["graduated"]
+    assert graduated["ref_id"] == "HYPE_leg"
+    assert "sharpe > 1 over 14d" in graduated["evidence"]
+    # A leg unknown to probation.json still renders leg-first, criterion-free.
+    _journal(store, job_id, {"type": "probation_leg_killed", "leg": "ghost-leg"})
+    decided = build_owner_attention(store, job_id)["decided_autonomously"]
+    ghost = next(item for item in decided if item["ref_id"] == "ghost-leg")
+    assert ghost["evidence"] == "leg ghost-leg killed"
 
 
 def test_decided_feed_is_windowed_and_capped(tmp_path: Path) -> None:


### PR DESCRIPTION
## Production bug

The deployed FE (vault-frontend) wires its Adjudicate accept/reject buttons (backend `adjudicate_claim {claim_id, status, note}`) against needs_you kind `exhaustion_claim_unauditable` with `ref_id = claim_id`. Unknown kinds render as a generic label with NO buttons.

`_owner_review_markers` passed through ANY journal event carrying `owner_review_required` as a needs_you item with `kind = event type`. Live journals still contain the older watchdog's BATCH `exhaustion_claims_pending` marker (30-day marker window), so owners clicked a notification and landed on an unknown-kind item with no per-claim ref and a summary telling them to use the CLI.

## Fix

- `_owner_review_markers` now passes through ONLY `_OWNER_REVIEW_MARKER_KINDS` (`successor_abandoned`, `proposal_reject_refused`, `live_mode_audit`) — the batch claims marker and any future off-union marker type are dropped. Pending claims surface per-claim via `_unauditable_claims` (kind `exhaustion_claim_unauditable`, `ref_id = claim_id`, `evidence_ref` = claim file path, `since_ts = filed_at`), keeping the #713 semantics: pending + no mechanical audit verdict + 1h filing grace; audit-decided claims never enter needs_you.
- Per-claim summary now carries the lane + the claim's 1-line evidence, capped at 300 chars.
- Added module constant `NEEDS_YOU_KINDS` pinning the FE union (mirror of vault-frontend `WAYFINDER_NEEDS_YOU_KINDS`).
- `decided_autonomously` probation items (scoped exception): evidence now leads with the leg name and appends the registered kill/graduate criterion from `probation.json` when present (an owner read a bare "Killed" chip as the whole JOB being killed — it was leg `SOL_holdout_pair_5m15m_paper` with an empty reason). `ref_id` stays the leg name. No structural/shape changes; `decided_autonomously` routing otherwise untouched.

## Kind/ref audit (every needs_you emitter vs the FE union)

| Kind emitted | Source | ref_id | In union | Verdict |
|---|---|---|---|---|
| `live_proposal_approval` | pending proposals on live-capable jobs | proposal_id | yes | OK |
| `exhaustion_claim_unauditable` | `_unauditable_claims` (per claim) | claim_id | yes | OK (summary enriched) |
| `successor_abandoned` | journal marker | proposal_id | yes | OK |
| `proposal_reject_refused` | journal marker | proposal_id | yes | OK |
| `live_mode_audit` | journal marker | "" (event carries no id; laundered-stamp review is job-level) | yes | OK — noted: no actionable id exists on the event |
| `decision_gate_tripped` | `_tripped_gates` | gate_id | yes | OK |
| `halt_awaiting_owner_clear` | risk-latched halt | halt source | yes | OK (resume-from-halt is job-level; source names the latch) |
| `exhaustion_claims_pending` | batch journal marker (older deployed watchdogs) | — | NO | removed — dropped by the marker whitelist, replaced by per-claim items |

Structural guarantee: the marker pass-through is now whitelist-only, so no future `owner_review_required` event type can leak an off-union kind.

## Tests

- `test_pending_claims_emit_one_item_per_claim`: 3 pending claims -> 3 items with correct kind/ref/summary (lane + evidence, <=300); audit-decided pending claim excluded; the batch `exhaustion_claims_pending` journal marker no longer surfaces.
- `test_every_emitted_needs_you_kind_is_in_the_fe_union`: pins the exact FE list (`WAYFINDER_NEEDS_YOU_KINDS` mirrored in the test with a comment citing vault-frontend) against `NEEDS_YOU_KINDS`, exercises every emitter at once, asserts emitted kinds == the full union, and that an off-union marker type is dropped.
- `test_probation_items_lead_with_leg_name_and_criterion`: opened/graduated/killed evidence leads with the leg name; killed carries the kill criterion; unknown leg renders leg-first, criterion-free.

`pytest -k "jobs or runner or mcp"`: baseline 1188 passed / 9 skipped -> after 1191 passed / 9 skipped. ruff lint + format clean; mypy scoped to `owner_attention.py` introduces no errors (all reported errors are pre-existing in other files).