### PR TITLE
jobs: lifecycle resilience — remediation backoff, bootstrap-or-park, wake economy, ccxt quote fix

### DIFF
--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -662,7 +662,11 @@ def reconcile_cmd(job_id: str, limit: int) -> None:
     default="swap",
     show_default=True,
 )
-@click.option("--quote", default="USDT", show_default=True)
+@click.option(
+    "--quote",
+    default=None,
+    help="Quote currency (default: USDC on hyperliquid, USDT elsewhere).",
+)
 @click.option(
     "--full",
     is_flag=True,
@@ -675,7 +679,7 @@ def fetch_dataset_cmd(
     source: str,
     exchange: str,
     market_type: str,
-    quote: str,
+    quote: str | None,
     full: bool,
 ) -> None:
     store = JobStore()
@@ -1051,8 +1055,14 @@ def rank_check_cmd(job_id: str, column: str, horizons: str | None) -> None:
 @click.argument("job_id")
 @click.option("--days", type=int, default=30, show_default=True)
 @click.option("--exchange", default="binance", show_default=True)
-@click.option("--quote", default="USDT", show_default=True)
-def fetch_funding_cmd(job_id: str, days: int, exchange: str, quote: str) -> None:
+@click.option(
+    "--quote",
+    default=None,
+    help="Quote currency (default: USDC on hyperliquid, USDT elsewhere).",
+)
+def fetch_funding_cmd(
+    job_id: str, days: int, exchange: str, quote: str | None
+) -> None:
     store = JobStore()
     result = fetch_funding_features(
         job_id, days=days, exchange=exchange, quote=quote, store=store

--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -60,6 +60,7 @@ from wayfinder_paths.jobs.forward_artifacts import load_forward_view
 from wayfinder_paths.jobs.gating import evaluate_live_gate
 from wayfinder_paths.jobs.halt import clear_halt, request_halt
 from wayfinder_paths.jobs.ledger import append_ledger_row, tail_ledger
+from wayfinder_paths.jobs.lifecycle import lifecycle_sweep
 from wayfinder_paths.jobs.models import (
     AgentMode,
     WayfinderJob,
@@ -2180,6 +2181,19 @@ def pause_cmd(job_id: str) -> None:
 @click.argument("job_id")
 def resume_cmd(job_id: str) -> None:
     _pause_resume_loops(job_id, "resume")
+
+
+@job_cli.command(
+    name="lifecycle-sweep",
+    help="Run the fleet lifecycle sweep now: bootstrap nudge/park for "
+    "never-operational jobs plus monitor-decay park. The watchdog runs this "
+    "daily; --force bypasses the throttle.",
+)
+@click.option(
+    "--force", is_flag=True, default=False, help="Bypass the daily throttle."
+)
+def lifecycle_sweep_cmd(force: bool) -> None:
+    _echo_json({"ok": True, "result": lifecycle_sweep(JobStore(), force=force)})
 
 
 @job_cli.group(

--- a/wayfinder_paths/jobs/execution/ccxt_feed.py
+++ b/wayfinder_paths/jobs/execution/ccxt_feed.py
@@ -26,6 +26,14 @@ RETRYABLE_ERRORS = {
 }
 
 
+def default_quote(exchange_id: str) -> str:
+    """Hyperliquid's ccxt markets settle in USDC ("BTC/USDC:USDC"; HIP-3 keeps
+    the dex prefix in the base: "xyz:TSLA/USDC:USDC"). A baked USDT default
+    built symbols no hyperliquid market has, which surfaced as an opaque
+    failure deep in the fetch path."""
+    return "USDC" if exchange_id == "hyperliquid" else "USDT"
+
+
 class CcxtMarketFeed:
     """Dataset-building MarketDataFeed over ccxt.async_support.
 
@@ -45,14 +53,14 @@ class CcxtMarketFeed:
         self,
         *,
         exchange_id: str = "binance",
-        market_type: str = "swap",  # "swap" -> COIN/USDT:USDT, "spot" -> COIN/USDT
-        quote: str = "USDT",
+        market_type: str = "swap",  # "swap" -> COIN/<q>:<q>, "spot" -> COIN/<q>
+        quote: str | None = None,  # None -> exchange default (see default_quote)
         exchange: Any | None = None,  # injectable fake for tests
         retries: int = 3,
     ) -> None:
         self.exchange_id = exchange_id
         self.market_type = market_type
-        self.quote = quote
+        self.quote = quote or default_quote(exchange_id)
         self.retries = retries
         self.symbol_map: dict[str, str] = {}
         self._exchange = exchange
@@ -187,7 +195,7 @@ async def fetch_ccxt_dataset_rows(
     days: int,
     exchange_id: str = "binance",
     market_type: str = "swap",
-    quote: str = "USDT",
+    quote: str | None = None,
     exchange: Any | None = None,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     """Fetch OHLCV rows for a backtest dataset, plus a metadata fragment
@@ -212,7 +220,7 @@ async def fetch_ccxt_dataset_rows(
     metadata = {
         "exchange": exchange_id,
         "market_type": market_type,
-        "quote": quote,
+        "quote": feed.quote,
         "symbol_map": dict(feed.symbol_map),
         "label_convention": "close_time",
     }
@@ -224,7 +232,7 @@ async def fetch_ccxt_funding_rows(
     *,
     days: int,
     exchange_id: str = "binance",
-    quote: str = "USDT",
+    quote: str | None = None,
     exchange: Any | None = None,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     """Historical funding rates as canonical feature rows.
@@ -280,7 +288,7 @@ async def fetch_ccxt_funding_rows(
         await feed.close()
     metadata = {
         "exchange": exchange_id,
-        "quote": quote,
+        "quote": feed.quote,
         "symbol_map": dict(feed.symbol_map),
         "feature": "funding",
         "days": int(days),

--- a/wayfinder_paths/jobs/execution/preflight.py
+++ b/wayfinder_paths/jobs/execution/preflight.py
@@ -11,6 +11,7 @@ from typing import Any
 import pandas as pd
 
 from wayfinder_paths.jobs.execution.ccxt_feed import (
+    default_quote,
     fetch_ccxt_dataset_rows,
     fetch_ccxt_funding_rows,
 )
@@ -56,7 +57,7 @@ def build_live_dataset(
     source: str = "venues",
     exchange: str = "binance",
     market_type: str = "swap",
-    quote: str = "USDT",
+    quote: str | None = None,
     feed: Any | None = None,
     incremental: bool = True,
 ) -> dict[str, Any]:
@@ -117,7 +118,9 @@ def build_live_dataset(
             source_metadata = {
                 "exchange": exchange,
                 "market_type": market_type,
-                "quote": quote,
+                "quote": getattr(feed, "quote", None)
+                or quote
+                or default_quote(exchange),
                 "symbol_map": dict(feed.symbol_map),
                 "label_convention": "close_time",
             }
@@ -669,11 +672,12 @@ def _write_report(
 
 
 def _ccxt_missing_markets(
-    symbols: list[str], *, exchange: str, quote: str
+    symbols: list[str], *, exchange: str, quote: str | None
 ) -> list[str] | None:
     """Symbols with no swap OR spot market on the long-history exchange.
     None = probe failed (network etc.) — record nothing so the evidence gate
     stays conservative."""
+    quote = quote or default_quote(exchange)
     try:
         import ccxt
 
@@ -767,7 +771,7 @@ def fetch_funding_features(
     *,
     days: int = 30,
     exchange: str = "binance",
-    quote: str = "USDT",
+    quote: str | None = None,
     store: JobStore | None = None,
     exchange_client: Any | None = None,
 ) -> dict[str, Any]:

--- a/wayfinder_paths/jobs/lifecycle.py
+++ b/wayfinder_paths/jobs/lifecycle.py
@@ -1,0 +1,345 @@
+"""Bootstrap contract and monitor-decay parking for rotting jobs.
+
+A job that never reaches operational state consumes wakes, disk, and owner
+attention forever — nothing in the pipeline ever concluded "this job failed
+to bootstrap".  This module owns that conclusion in the mechanical zone
+(paper-mode, wallet-unbound jobs ONLY — anything live or one operator flip
+from live is never auto-touched): past half the bootstrap deadline the job is
+nudged once and every wake prompt leads with a bootstrap directive; past the
+full deadline it is parked — runner loops paused with the same machinery as
+the ``wayfinder job pause`` verb, a durable failure record written, and the
+decision journaled with a bounded undo.  Monitor-mode jobs whose deploy
+evidence stopped replicating rot the same way and share the park path.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from wayfinder_paths.jobs.models import WayfinderJob, utc_now_iso
+from wayfinder_paths.jobs.owner_attention import job_live_capital_risk
+from wayfinder_paths.jobs.replication import load_replication
+from wayfinder_paths.jobs.runner_bridge import RunnerBridge
+from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.jobs.sync import sync_all_jobs
+
+LIFECYCLE_PATH = "state/lifecycle.json"
+BOOTSTRAP_FAILURE_PATH = "state/bootstrap_failure.json"
+FORWARD_TRADES_PATH = "results/forward/trades.jsonl"
+BASELINE_BACKTEST_PATH = "results/backtest/baseline.json"
+BOOTSTRAP_DEADLINE_HOURS_ENV = "WAYFINDER_BOOTSTRAP_DEADLINE_HOURS"
+DEFAULT_BOOTSTRAP_DEADLINE_HOURS = 72.0
+MONITOR_DECAY_PARK_DAYS_ENV = "WAYFINDER_MONITOR_DECAY_PARK_DAYS"
+DEFAULT_MONITOR_DECAY_PARK_DAYS = 7.0
+# Kill-switch: "0" disables both park paths. The nudge journal and the wake
+# prompt directive stay — visibility is never switched off.
+LIFECYCLE_REAPER_ENV = "WAYFINDER_LIFECYCLE_REAPER"
+_DECAYED_REPLICATION_STATUSES = frozenset({"decayed", "invalid"})
+# Fleet-level sweep throttle (fleet artifact convention, like the portfolio
+# report): the watchdog calls the sweep every pass, the throttle makes it a
+# daily decision cadence.
+SWEEP_STATE_RELPATH = Path(".wayfinder") / "lifecycle" / "sweep.json"
+SWEEP_INTERVAL_SECONDS = 24 * 3600
+
+BOOTSTRAP_DIRECTIVE = (
+    "BOOTSTRAP CONTRACT — this job has never reached operational state. "
+    "FIRST priority this wake: complete bootstrap (compile, dataset, "
+    "baseline backtest, first tick) or journal a concrete blocker.\n\n"
+)
+
+
+def is_operational(store: JobStore, job_id: str) -> bool:
+    """Has this job EVER produced a sign of life? Any completed script run or
+    agent wake, a baseline backtest, or a closed forward trade counts."""
+    scorecard = store.read_json(job_id, "scorecard.json", default={}) or {}
+    if scorecard.get("last_script_run_at") or scorecard.get("last_agent_check_at"):
+        return True
+    if (store.job_dir(job_id) / BASELINE_BACKTEST_PATH).exists():
+        return True
+    return closed_forward_trades(store, job_id) > 0
+
+
+def closed_forward_trades(store: JobStore, job_id: str) -> int:
+    """Same source of truth as the wake prompt's standing-checks block: the
+    forward trades ledger, not the summary (which can lag a recorder bug)."""
+    return len(store.read_jsonl(job_id, FORWARD_TRADES_PATH))
+
+
+def bootstrap_directive(store: JobStore, job_id: str) -> str:
+    """Wake prompt directive for a never-operational job past half its
+    deadline. Rendered regardless of the reaper kill-switch."""
+    job = store.load(job_id)
+    now = dt.datetime.now(dt.UTC)
+    if _job_age_hours(job, now) <= _deadline_hours() / 2:
+        return ""
+    if is_operational(store, job_id):
+        return ""
+    return BOOTSTRAP_DIRECTIVE
+
+
+def lifecycle_sweep(
+    store: JobStore,
+    *,
+    now: dt.datetime | None = None,
+    force: bool = False,
+) -> dict[str, Any]:
+    """Apply the bootstrap contract and monitor-decay policy to every job.
+
+    Throttled to at most one pass per day (the watchdog calls it every 5
+    minutes); ``force`` bypasses the throttle. Never raises per-job — one
+    broken job record must not stop the sweep.
+    """
+    now = now or dt.datetime.now(dt.UTC)
+    state_path = store.repo_root / SWEEP_STATE_RELPATH
+    if not force and _sweep_ran_recently(state_path, now):
+        return {"throttled": True, "scanned": 0, "actions": [], "errors": []}
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps({"ran_at": now.isoformat()}, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    actions: list[dict[str, Any]] = []
+    errors: list[dict[str, Any]] = []
+    scanned = 0
+    for job in store.list_jobs():
+        scanned += 1
+        try:
+            actions.extend(_sweep_job(store, job, now))
+        except Exception as exc:  # noqa: BLE001 — sweep the remaining jobs
+            errors.append({"job_id": job.id, "error": str(exc)[:300]})
+    if any(str(action.get("action") or "").startswith("job_parked") for action in actions):
+        try:
+            sync_all_jobs(store=store)
+        except Exception:  # noqa: BLE001 — the park stands; next sync reflects it
+            pass
+    return {"throttled": False, "scanned": scanned, "actions": actions, "errors": errors}
+
+
+def reaper_enabled() -> bool:
+    return os.environ.get(LIFECYCLE_REAPER_ENV) != "0"
+
+
+def _sweep_job(
+    store: JobStore, job: WayfinderJob, now: dt.datetime
+) -> list[dict[str, Any]]:
+    actions: list[dict[str, Any]] = []
+    marker = store.read_json(job.id, LIFECYCLE_PATH, default={}) or {}
+    operational = is_operational(store, job.id)
+    age_hours = _job_age_hours(job, now)
+    deadline = _deadline_hours()
+    parked = bool(store.read_json(job.id, BOOTSTRAP_FAILURE_PATH))
+    exempt = job_live_capital_risk(job)
+
+    if (
+        not operational
+        and age_hours > deadline / 2
+        and not marker.get("bootstrap_nudged_at")
+    ):
+        marker["bootstrap_nudged_at"] = now.isoformat()
+        store.write_json(job.id, LIFECYCLE_PATH, marker)
+        store.append_journal(
+            job.id,
+            {
+                "type": "bootstrap_lagging",
+                "age_hours": round(age_hours, 1),
+                "deadline_hours": deadline,
+                "predicates_failed": _operational_predicates_failed(store, job.id),
+            },
+        )
+        actions.append({"job_id": job.id, "action": "bootstrap_lagging"})
+
+    if (
+        not operational
+        and age_hours > deadline
+        and not exempt
+        and not parked
+        and reaper_enabled()
+    ):
+        actions.append(
+            _park(
+                store,
+                job,
+                reason=(
+                    f"never operational within the {deadline:g}h bootstrap deadline"
+                ),
+                journal_type="job_parked_unbootstrapped",
+                predicates_failed=_operational_predicates_failed(store, job.id),
+            )
+        )
+        return actions  # parked — nothing further to evaluate this pass
+
+    decay_action = _monitor_decay(
+        store, job, marker, now, exempt=exempt, parked=parked
+    )
+    if decay_action is not None:
+        actions.append(decay_action)
+    return actions
+
+
+def _monitor_decay(
+    store: JobStore,
+    job: WayfinderJob,
+    marker: dict[str, Any],
+    now: dt.datetime,
+    *,
+    exempt: bool,
+    parked: bool,
+) -> dict[str, Any] | None:
+    """Park a monitor-mode job whose deploy evidence stopped replicating and
+    that shows no forward trades and no journal activity for the window."""
+    if str(job.agent_loop.mode or "off") != "monitor":
+        return None
+    replication = load_replication(store, job.id) or {}
+    status = str(replication.get("status") or "")
+    if (
+        not replication.get("available")
+        or status not in _DECAYED_REPLICATION_STATUSES
+    ):
+        if marker.pop("monitor_decay", None) is not None:
+            store.write_json(job.id, LIFECYCLE_PATH, marker)
+        return None
+    decay = dict(marker.get("monitor_decay") or {})
+    if not decay.get("first_seen_at"):
+        marker["monitor_decay"] = {"status": status, "first_seen_at": now.isoformat()}
+        store.write_json(job.id, LIFECYCLE_PATH, marker)
+        return None
+    if decay.get("status") != status:
+        # decayed<->invalid flips stay inside the bad set — keep the clock.
+        marker["monitor_decay"] = {**decay, "status": status}
+        store.write_json(job.id, LIFECYCLE_PATH, marker)
+    first_seen = _parse_time(decay.get("first_seen_at"))
+    park_days = _decay_park_days()
+    if first_seen is None or now - first_seen < dt.timedelta(days=park_days):
+        return None
+    if closed_forward_trades(store, job.id) > 0:
+        return None
+    if _journal_activity_since(store, job.id, str(decay.get("first_seen_at"))):
+        return None
+    if exempt or parked or not reaper_enabled():
+        return None
+    return _park(
+        store,
+        job,
+        reason=(
+            f"monitor-mode job with backtest replication {status} for more "
+            f"than {park_days:g} days, zero forward trades, and no journal "
+            "activity in the window"
+        ),
+        journal_type="job_parked_monitor_decay",
+        predicates_failed=[
+            f"replication_{status}",
+            "no_forward_trades",
+            "no_journal_activity",
+        ],
+    )
+
+
+def _park(
+    store: JobStore,
+    job: WayfinderJob,
+    *,
+    reason: str,
+    journal_type: str,
+    predicates_failed: list[str],
+) -> dict[str, Any]:
+    # Same machinery as the `wayfinder job pause` CLI verb: RunnerBridge
+    # pause per enabled loop. The undo is the matching `resume` verb.
+    bridge = RunnerBridge(repo_root=store.repo_root)
+    responses = [
+        {
+            "runner_job_name": loop.runner_job_name,
+            "response": bridge.pause(loop.runner_job_name),
+        }
+        for loop in (job.script_loop, job.agent_loop)
+        if loop.enabled
+    ]
+    store.write_json(
+        job.id,
+        BOOTSTRAP_FAILURE_PATH,
+        {
+            "reason": reason,
+            "parked_at": utc_now_iso(),
+            "predicates_failed": predicates_failed,
+        },
+    )
+    undo = {"command": f"wayfinder job resume {job.id}"}
+    store.append_journal(
+        job.id,
+        {
+            "type": journal_type,
+            "reason": reason,
+            "predicates_failed": predicates_failed,
+            "undo": undo,
+            "runner_responses": responses,
+        },
+    )
+    return {"job_id": job.id, "action": journal_type, "reason": reason}
+
+
+def _operational_predicates_failed(store: JobStore, job_id: str) -> list[str]:
+    scorecard = store.read_json(job_id, "scorecard.json", default={}) or {}
+    failed: list[str] = []
+    if not scorecard.get("last_script_run_at"):
+        failed.append("no_script_run")
+    if not scorecard.get("last_agent_check_at"):
+        failed.append("no_agent_check")
+    if not (store.job_dir(job_id) / BASELINE_BACKTEST_PATH).exists():
+        failed.append("no_baseline_backtest")
+    if closed_forward_trades(store, job_id) == 0:
+        failed.append("no_forward_trades")
+    return failed
+
+
+def _journal_activity_since(store: JobStore, job_id: str, since_ts: str) -> bool:
+    # Rows are append-ordered, so the tail bounds the newest timestamps.
+    return any(
+        str(row.get("ts") or "") > since_ts
+        for row in store.read_jsonl(job_id, "journal.jsonl", limit=200)
+    )
+
+
+def _sweep_ran_recently(state_path: Path, now: dt.datetime) -> bool:
+    if not state_path.exists():
+        return False
+    try:
+        doc = json.loads(state_path.read_text(encoding="utf-8"))
+    except ValueError:
+        return False
+    ran_at = _parse_time(doc.get("ran_at")) if isinstance(doc, dict) else None
+    return (
+        ran_at is not None
+        and (now - ran_at).total_seconds() < SWEEP_INTERVAL_SECONDS
+    )
+
+
+def _job_age_hours(job: WayfinderJob, now: dt.datetime) -> float:
+    created = _parse_time(job.created_at)
+    if created is None:
+        return 0.0  # unparseable creation stamp — treat as new, never park
+    return (now - created).total_seconds() / 3600
+
+
+def _deadline_hours() -> float:
+    return float(
+        os.environ.get(BOOTSTRAP_DEADLINE_HOURS_ENV)
+        or DEFAULT_BOOTSTRAP_DEADLINE_HOURS
+    )
+
+
+def _decay_park_days() -> float:
+    return float(
+        os.environ.get(MONITOR_DECAY_PARK_DAYS_ENV)
+        or DEFAULT_MONITOR_DECAY_PARK_DAYS
+    )
+
+
+def _parse_time(value: Any) -> dt.datetime | None:
+    try:
+        parsed = dt.datetime.fromisoformat(str(value))
+    except (TypeError, ValueError):
+        return None
+    return parsed.replace(tzinfo=dt.UTC) if parsed.tzinfo is None else parsed

--- a/wayfinder_paths/jobs/lifecycle.py
+++ b/wayfinder_paths/jobs/lifecycle.py
@@ -51,6 +51,38 @@ BOOTSTRAP_DIRECTIVE = (
     "baseline backtest, first tick) or journal a concrete blocker.\n\n"
 )
 
+# Journal types the harness emits on a timer with no decision content. The
+# monitor-decay "no journal activity" predicate means "no meaningful owner/
+# agent decisions" — an hourly agent loop journals agent_wakeup on EVERY
+# delivered wake (plus per-wake monitor-failure heartbeats), which made the
+# park unreachable for exactly the jobs it targets. Script ticks never
+# journal (they record to results/forward/*), so no tick type appears here.
+# Unknown types still COUNT as activity — conservative, blocks the park.
+_MECHANICAL_JOURNAL_TYPES = frozenset(
+    {
+        "agent_wakeup",
+        "agent_mode_drift",
+        "agent_mode_drift_recovered",
+        "bootstrap_lagging",
+        "claim_sync_failed",
+        "counterfactual_failed",
+        "data_feed_degraded",
+        "data_feed_recovered",
+        "derived_features_refresh_failed",
+        "disk_pressure",
+        "disk_pressure_recovered",
+        "ideation_incomplete",
+        "memory_quarantined",
+        "regime_health_failed",
+        "remediation_recheck_quiet",
+        "replication_failed",
+        "restamp_deferred_load",
+        "runner_loop_gap",
+        "runner_loop_recovered",
+        "wake_skipped_saturated",
+    }
+)
+
 
 def is_operational(store: JobStore, job_id: str) -> bool:
     """Has this job EVER produced a sign of life? Any completed script run or
@@ -295,10 +327,13 @@ def _operational_predicates_failed(store: JobStore, job_id: str) -> list[str]:
 
 
 def _journal_activity_since(store: JobStore, job_id: str, since_ts: str) -> bool:
-    # Rows are append-ordered, so the tail bounds the newest timestamps.
+    # Rows are append-ordered, so the tail bounds the newest timestamps. The
+    # tail must be deep enough that a week of hourly mechanical heartbeats
+    # (~a few hundred rows) cannot bury a real decision row inside the window.
     return any(
         str(row.get("ts") or "") > since_ts
-        for row in store.read_jsonl(job_id, "journal.jsonl", limit=200)
+        and str(row.get("type") or "") not in _MECHANICAL_JOURNAL_TYPES
+        for row in store.read_jsonl(job_id, "journal.jsonl", limit=2000)
     )
 
 

--- a/wayfinder_paths/jobs/owner_attention.py
+++ b/wayfinder_paths/jobs/owner_attention.py
@@ -77,6 +77,12 @@ _PROBATION_OPENED_EVENTS = frozenset({"probation_leg_opened", "paper_probation_o
 _PROBATION_EVENTS = _PROBATION_OPENED_EVENTS | frozenset(
     {"probation_leg_graduated", "probation_leg_killed"}
 )
+# Lifecycle parks are mechanical-with-visibility: the sweep already paused
+# the loops; the owner sees the decision plus the bounded undo here, never
+# an approval queue item.
+_LIFECYCLE_PARK_EVENTS = frozenset(
+    {"job_parked_unbootstrapped", "job_parked_monitor_decay"}
+)
 
 
 def job_live_capital_risk(job: WayfinderJob) -> bool:
@@ -406,6 +412,21 @@ def _decided_item(
             "ts": ts,
             "decision": "reject",
             "evidence": _compact(event.get("reason_codes")),
+        }
+    if event_type in _LIFECYCLE_PARK_EVENTS:
+        return {
+            "kind": "lifecycle_park",
+            "job_id": job_id,
+            "ref_id": job_id,
+            "ts": ts,
+            "decision": event_type.removeprefix("job_parked_"),
+            "evidence": _compact(
+                {
+                    "reason": event.get("reason"),
+                    "predicates_failed": event.get("predicates_failed"),
+                }
+            ),
+            "undo": event.get("undo"),
         }
     if event_type in _PROBATION_EVENTS:
         decision = (

--- a/wayfinder_paths/jobs/remediation.py
+++ b/wayfinder_paths/jobs/remediation.py
@@ -12,10 +12,12 @@ from __future__ import annotations
 import datetime as dt
 import hashlib
 import json
+import os
 from collections.abc import Mapping
 from pathlib import PurePosixPath
 from typing import Any
 
+from wayfinder_paths.jobs.gating import evaluate_live_gate
 from wayfinder_paths.jobs.models import utc_now_iso
 from wayfinder_paths.jobs.store import JobStore
 
@@ -27,8 +29,21 @@ REMEDIATION_SCHEMA_VERSION = "1.0"
 # evidence updates), and each wake produced another bounded progress note
 # that changed nothing before the next retry. Material evidence still wakes
 # immediately (the branch above the retry path), a recorded progress/blocker
-# note now counts as activity, and quiet retries wait 6 hours.
+# note now counts as activity, and quiet retries wait 6 hours before the
+# evidence-anchored backoff below takes over.
 REMEDIATION_RETRY_SECONDS = 6 * 60 * 60
+# Evidence-anchored re-check pacing. A blocked case re-affirming every
+# scheduled tick spammed the owner feed (rem-7b84af1: attempts 9→14 overnight,
+# each wake re-verifying identical facts — book flat, closed count unchanged).
+# Quiet re-checks now DOUBLE toward the cap; the moment material forward
+# evidence lands (new closed trades, counterfactual/promotion-verdict update,
+# gate flip, treatment/config change) the wait resets to the prompt interval
+# so adjudication is never starved. A hard max-quiet bound guarantees a case
+# can never go fully silent even with a mis-tuned cap.
+REMEDIATION_BACKOFF_BASE_SECONDS = 30 * 60
+REMEDIATION_BACKOFF_CAP_ENV = "WAYFINDER_REMEDIATION_BACKOFF_CAP_SECONDS"
+REMEDIATION_BACKOFF_CAP_SECONDS = 12 * 60 * 60
+REMEDIATION_MAX_QUIET_SECONDS = 24 * 60 * 60
 
 _ALERT_STATUSES = frozenset({"warning", "critical"})
 _STATUS_RANK = {
@@ -125,6 +140,18 @@ def sync_remediation_with_health(
             .get("fingerprint")
             if current
             else None,
+            # Seed the forward-evidence watermark at open so trades/verdicts
+            # landing before the first quiet retry reset it to a prompt
+            # re-check instead of waiting out the full interval.
+            "recheck": {
+                "watermark": _evidence_watermark(
+                    store,
+                    job_id,
+                    incumbent_revision=evidence.get("incumbent_revision"),
+                ),
+                "last_checked_at": now_iso,
+                "next_retry_seconds": REMEDIATION_RETRY_SECONDS,
+            },
         }
         store.write_json(job_id, REMEDIATION_PATH, case)
         store.append_journal(
@@ -150,24 +177,73 @@ def sync_remediation_with_health(
     state = str(current.get("state") or "open")
     if state not in _ACTIONABLE_STATES:
         return None
+    raw_recheck = current.get("recheck")
+    recheck: Mapping[str, Any] = raw_recheck if isinstance(raw_recheck, Mapping) else {}
+    watermark = _evidence_watermark(
+        store, job_id, incumbent_revision=evidence.get("incumbent_revision")
+    )
+    evidence_reasons = _watermark_reasons(recheck.get("watermark"), watermark)
+    next_retry = int(recheck.get("next_retry_seconds") or REMEDIATION_RETRY_SECONDS)
+    if evidence_reasons:
+        # Material forward evidence (trades closed, verdict landed, gate
+        # flipped, treatment changed): reset to a prompt re-check no matter
+        # how far the quiet backoff had grown. Nothing is persisted on the
+        # not-yet-due path, so the reset re-derives every tick until it fires.
+        next_retry = REMEDIATION_BACKOFF_BASE_SECONDS
     # Progress-only ticks must not re-wake: a bounded evaluation/blocker note
     # recorded since the last wake is the agent already working the case.
     last_wake = _parse_time(current.get("last_wake_requested_at"))
     progress_at = _parse_time((current.get("progress") or {}).get("recorded_at"))
     anchors = [ts for ts in (last_wake, progress_at) if ts is not None]
-    if anchors and (now - max(anchors)).total_seconds() < REMEDIATION_RETRY_SECONDS:
+    wait = min(next_retry, REMEDIATION_MAX_QUIET_SECONDS)
+    if anchors and (now - max(anchors)).total_seconds() < wait:
         return None
 
     current["updated_at"] = now_iso
     current["last_wake_requested_at"] = now_iso
     current["attempts"] = int(current.get("attempts") or 0) + 1
     current["health"] = evidence
+    current["recheck"] = {
+        "watermark": watermark,
+        "last_checked_at": now_iso,
+        # Quiet re-check → double toward the cap. Material → restart the
+        # ladder one doubling above the prompt interval (30m→1h→2h→4h→…).
+        "next_retry_seconds": min(
+            (REMEDIATION_BACKOFF_BASE_SECONDS if evidence_reasons else next_retry) * 2,
+            _backoff_cap_seconds(),
+        ),
+    }
     store.write_json(job_id, REMEDIATION_PATH, current)
+    if evidence_reasons:
+        store.append_journal(
+            job_id,
+            {
+                "type": "regime_remediation_evidence_updated",
+                "case_id": current.get("case_id"),
+                "state": state,
+                "material_reasons": evidence_reasons,
+                "source": "forward_evidence",
+            },
+        )
+    else:
+        # Heartbeat, not a transition: keep the owner feed to one compact
+        # line per quiet re-check instead of a full re-affirmation entry.
+        store.append_journal(
+            job_id,
+            {
+                "type": "remediation_recheck_quiet",
+                "case_id": current.get("case_id"),
+                "state": state,
+                "attempts": current["attempts"],
+                "last_checked_at": now_iso,
+                "next_retry_seconds": current["recheck"]["next_retry_seconds"],
+            },
+        )
     return {
         "event": "regime_remediation_due",
         "case_id": current.get("case_id"),
         "evidence_fingerprint": evidence["fingerprint"],
-        "material_reasons": ["open_case_without_proposal"],
+        "material_reasons": evidence_reasons or ["open_case_without_proposal"],
     }
 
 
@@ -255,14 +331,58 @@ def update_remediation_progress(
     case = load_remediation(store, job_id)
     if not case or str(case.get("state")) not in _ACTIONABLE_STATES:
         raise ValueError(f"job {job_id} has no actionable remediation case")
+    now_iso = utc_now_iso()
+    prior_state = str(case.get("state"))
+    prior_progress = case.get("progress") or {}
+    watermark = _evidence_watermark(
+        store,
+        job_id,
+        incumbent_revision=(case.get("health") or {}).get("incumbent_revision"),
+    )
+    # Consecutive no-change re-affirmations (same state, no new forward
+    # evidence since the last recorded note) roll into ONE note plus a compact
+    # journal heartbeat — the owner feed shows transitions, not heartbeats.
+    reaffirmation = (
+        state == prior_state
+        and isinstance(prior_progress.get("watermark"), Mapping)
+        and not _watermark_reasons(prior_progress.get("watermark"), watermark)
+    )
+    if reaffirmation:
+        progress = dict(prior_progress)
+        progress.update(
+            {
+                "note": note.strip()[:2_000],
+                "artifact_path": artifact_path or progress.get("artifact_path"),
+                "recorded_at": now_iso,
+                "first_recorded_at": progress.get("first_recorded_at")
+                or prior_progress.get("recorded_at"),
+                "reaffirmations": int(progress.get("reaffirmations") or 0) + 1,
+                "watermark": watermark,
+            }
+        )
+        case.update({"state": state, "updated_at": now_iso, "progress": progress})
+        store.write_json(job_id, REMEDIATION_PATH, case)
+        store.append_journal(
+            job_id,
+            {
+                "type": "remediation_recheck_quiet",
+                "case_id": case.get("case_id"),
+                "state": state,
+                "attempts": int(case.get("attempts") or 0),
+                "reaffirmations": progress["reaffirmations"],
+                "last_checked_at": now_iso,
+            },
+        )
+        return case
     case.update(
         {
             "state": state,
-            "updated_at": utc_now_iso(),
+            "updated_at": now_iso,
             "progress": {
                 "note": note.strip()[:2_000],
                 "artifact_path": artifact_path,
-                "recorded_at": utc_now_iso(),
+                "recorded_at": now_iso,
+                "watermark": watermark,
             },
         }
     )
@@ -350,6 +470,7 @@ def compact_remediation(case: Mapping[str, Any] | None) -> dict[str, Any] | None
             "candidate_gate",
             "rejection",
             "progress",
+            "recheck",
             "application_status",
             "applied_at",
             "resolved_at",
@@ -416,6 +537,79 @@ def _material_reasons(
         and evidence.get("incumbent_revision") != prior.get("incumbent_revision")
     ):
         reasons.append("incumbent_revision_changed")
+    return reasons
+
+
+def _backoff_cap_seconds() -> int:
+    raw = os.environ.get(REMEDIATION_BACKOFF_CAP_ENV)
+    if raw is None:
+        return REMEDIATION_BACKOFF_CAP_SECONDS
+    return max(int(raw), REMEDIATION_BACKOFF_BASE_SECONDS)
+
+
+def _evidence_watermark(
+    store: JobStore, job_id: str, *, incumbent_revision: Any
+) -> dict[str, Any]:
+    """Deterministic snapshot of the forward evidence a re-check adjudicates.
+
+    A change in ANY component is material: the case wakes promptly and the
+    quiet backoff resets. Everything here is a cheap file read — no network.
+    """
+    summary = store.read_json(job_id, "results/forward/summary.json", default={}) or {}
+    trades = summary.get("trades") or {}
+    counterfactual = (
+        store.read_json(job_id, "results/forward/counterfactual.json", default={}) or {}
+    )
+    # The counterfactual fingerprint (revision + closed-trade total) only moves
+    # when the shadow comparison actually has new inputs — computed_at churns
+    # on every ~6h recompute and must NOT count as evidence.
+    counterfactual_fp = counterfactual.get("fingerprint")
+    verdicts = (
+        store.read_json(job_id, "state/promotion_verdicts.json", default={}) or {}
+    )
+    try:
+        gate = evaluate_live_gate(job_id, store=store)
+        gate_mark: dict[str, Any] = {
+            "live_ready": bool(gate.get("live_ready")),
+            "reasons": sorted(str(reason) for reason in gate.get("reasons") or []),
+        }
+    except Exception as exc:  # noqa: BLE001 — a broken gate eval must not
+        # silence re-check scheduling (the case would starve); the error text
+        # itself watermarks, so flipping in/out of failure still counts.
+        gate_mark = {"error": str(exc)[:200]}
+    return {
+        "closed_trades": int(trades.get("closed_count") or 0),
+        "last_trade_at": trades.get("last_trade_at"),
+        "counterfactual": dict(counterfactual_fp)
+        if isinstance(counterfactual_fp, Mapping)
+        else None,
+        "verdicts": {
+            str(proposal_id): str((entry or {}).get("verdict") or "")
+            for proposal_id, entry in verdicts.items()
+            if isinstance(entry, Mapping)
+        },
+        "gate": gate_mark,
+        "incumbent_revision": incumbent_revision,
+    }
+
+
+def _watermark_reasons(prior: Any, current: Mapping[str, Any]) -> list[str]:
+    """Which evidence classes moved since the last check. Empty = quiet."""
+    if not isinstance(prior, Mapping):
+        return []
+    reasons: list[str] = []
+    if current.get("closed_trades") != prior.get("closed_trades") or current.get(
+        "last_trade_at"
+    ) != prior.get("last_trade_at"):
+        reasons.append("forward_trades_advanced")
+    if current.get("counterfactual") != prior.get("counterfactual"):
+        reasons.append("counterfactual_updated")
+    if current.get("verdicts") != prior.get("verdicts"):
+        reasons.append("promotion_verdict_updated")
+    if current.get("gate") != prior.get("gate"):
+        reasons.append("gate_state_changed")
+    if current.get("incumbent_revision") != prior.get("incumbent_revision"):
+        reasons.append("treatment_changed")
     return reasons
 
 

--- a/wayfinder_paths/jobs/wake_economy.py
+++ b/wayfinder_paths/jobs/wake_economy.py
@@ -1,0 +1,311 @@
+"""Wake economy: saturated paper jobs skip LLM wakes until evidence moves.
+
+Generalizes the remediation module's evidence-anchored watermark doctrine to
+the wake loop itself: when every research obligation is settled and the
+forward book is still below its evidence gate, a full LLM wake re-verifies
+identical facts. Those wakes are skipped mechanically — a quiet report plus
+a deduped heartbeat — until the saturation watermark moves or the max-quiet
+window expires. Anything mid-flight (an active lane, an outstanding impasse
+mandate, a pending exhaustion claim or proposal, a non-quiet remediation
+case) defeats saturation: the claim machinery always plays first. Live jobs
+never skip, and a quiet remediation case never satisfies a wake — the prompt
+says so explicitly and routes the session to research obligations.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+from collections.abc import Mapping
+from typing import Any
+
+from wayfinder_paths.jobs.exhaustion import (
+    RESEARCH_IMPASSE_PATH,
+    RESEARCH_LANE_PATH,
+    list_exhaustion_claims,
+)
+from wayfinder_paths.jobs.halt import read_halt
+from wayfinder_paths.jobs.lifecycle import is_operational
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.probation import load_probation
+from wayfinder_paths.jobs.remediation import (
+    REMEDIATION_MAX_QUIET_SECONDS,
+    _evidence_watermark,
+    _watermark_reasons,
+    compact_remediation,
+    load_remediation,
+)
+from wayfinder_paths.jobs.store import JobStore
+
+WAKE_ECONOMY_PATH = "state/wake_economy.json"
+# Kill-switch: "0" disables the skip path entirely.
+WAKE_ECONOMY_ENV = "WAYFINDER_WAKE_ECONOMY"
+WAKE_QUIET_MAX_HOURS_ENV = "WAYFINDER_WAKE_QUIET_MAX_HOURS"
+DEFAULT_WAKE_QUIET_MAX_HOURS = 24.0
+SKIP_REASON = "saturation_watermark_unchanged"
+_DEFAULT_FORWARD_GATE_MIN_TRADES = 20
+
+REMEDIATION_QUIET_LINE = (
+    "Remediation is evidence-blocked and backed off — it does NOT satisfy "
+    "this wake. Proceed to research obligations: experiment | probation leg "
+    "| exhaustion claim.\n\n"
+)
+
+
+def wake_economy_enabled() -> bool:
+    return os.environ.get(WAKE_ECONOMY_ENV) != "0"
+
+
+def research_saturation_posture(
+    store: JobStore, job_id: str, *, job: WayfinderJob | None = None
+) -> dict[str, Any]:
+    """"saturated" ONLY when every research obligation is settled AND the
+    forward book is still below its evidence gate. Anything mid-flight
+    defeats saturation — let the claim machinery play first."""
+    job = job or store.load(job_id)
+    blockers: list[str] = []
+    if not is_operational(store, job_id):
+        # Bootstrap owns a never-operational job; the economy never starves it.
+        blockers.append("not_operational")
+    lane = store.read_json(job_id, RESEARCH_LANE_PATH, default={}) or {}
+    if str(lane.get("active_lane") or "").strip():
+        blockers.append("research_lane_active")
+    impasse = store.read_json(job_id, RESEARCH_IMPASSE_PATH, default={}) or {}
+    if impasse.get("alerted_at") or impasse.get("status"):
+        blockers.append("impasse_mandate_outstanding")
+    if list_exhaustion_claims(store, job_id, status="pending"):
+        blockers.append("exhaustion_claim_pending")
+    scorecard = store.read_json(job_id, "scorecard.json", default={}) or {}
+    if (
+        int(scorecard.get("pending_proposals") or 0) > 0
+        or int(scorecard.get("queued_proposal_applications") or 0) > 0
+        or int(scorecard.get("applying_proposal_applications") or 0) > 0
+    ):
+        blockers.append("proposals_in_flight")
+    case = load_remediation(store, job_id)
+    if (
+        case
+        and str(case.get("state"))
+        in {"open", "evaluating", "blocked", "proposal_pending"}
+        and not remediation_backed_off(store, job_id, case)
+    ):
+        blockers.append("remediation_case_active")
+    if _closed_trades(store, job_id) >= _forward_gate_minimum(job):
+        blockers.append("forward_sample_adequate")
+    return {"posture": "in_flight" if blockers else "saturated", "blockers": blockers}
+
+
+def saturation_watermark(
+    store: JobStore, job_id: str, *, job: WayfinderJob | None = None
+) -> dict[str, Any]:
+    """Deterministic snapshot of everything a full wake adjudicates — same
+    construction as remediation's evidence watermark. A change in ANY
+    component means the next wake runs in full. Cheap file reads only."""
+    job = job or store.load(job_id)
+    summary = store.read_json(job_id, "results/forward/summary.json", default={}) or {}
+    trades = summary.get("trades") or {}
+    impasse = store.read_json(job_id, RESEARCH_IMPASSE_PATH, default={}) or {}
+    halt = read_halt(store.job_dir(job_id)) or {}
+    return {
+        "claims": {
+            str(claim.get("claim_id")): str(claim.get("status") or "")
+            for claim in list_exhaustion_claims(store, job_id)
+        },
+        "lane": store.read_json(job_id, RESEARCH_LANE_PATH, default={}) or {},
+        "mandate": {
+            "status": impasse.get("status"),
+            "alerted_at": impasse.get("alerted_at"),
+        },
+        "closed_trades": int(trades.get("closed_count") or 0),
+        "last_trade_at": trades.get("last_trade_at"),
+        "probation_legs": {
+            str(leg.get("name")): str(leg.get("status") or "")
+            for leg in load_probation(store, job_id).get("legs") or []
+            if isinstance(leg, Mapping)
+        },
+        "pending_proposals": sorted(
+            str(proposal.get("proposal_id"))
+            for proposal in store.proposals(job_id)
+            if proposal.get("status") == "pending"
+        ),
+        "incumbent_revision": job.versioning.get("active_revision"),
+        "halt": {"source": halt.get("source"), "ts": halt.get("ts")}
+        if halt
+        else None,
+    }
+
+
+def remediation_backed_off(
+    store: JobStore, job_id: str, case: Mapping[str, Any] | None
+) -> bool:
+    """Quiet = the agent already recorded its bounded evaluation/blocker and
+    no forward evidence has moved since the note — the exact evidence-blocked
+    state the remediation backoff was built for. Open and proposal_pending
+    cases (and any evidence movement) are mid-flight, never quiet."""
+    if not case or str(case.get("state")) not in {"evaluating", "blocked"}:
+        return False
+    progress = case.get("progress") or {}
+    prior = progress.get("watermark")
+    if not isinstance(prior, Mapping):
+        return False  # no accountable outcome recorded yet
+    current = _evidence_watermark(
+        store,
+        job_id,
+        incumbent_revision=(case.get("health") or {}).get("incumbent_revision"),
+    )
+    return not _watermark_reasons(prior, current)
+
+
+def remediation_wake_block(case: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    """Compact remediation view for the standing-checks block: current state,
+    the recheck ladder, and when the next evidence recheck is due."""
+    compact = compact_remediation(case)
+    if not compact or case is None:
+        return None
+    recheck_raw = compact.get("recheck")
+    recheck: Mapping[str, Any] = (
+        recheck_raw if isinstance(recheck_raw, Mapping) else {}
+    )
+    next_recheck_at = None
+    anchors = [
+        _parse_time(case.get("last_wake_requested_at")),
+        _parse_time((case.get("progress") or {}).get("recorded_at")),
+    ]
+    anchored = [anchor for anchor in anchors if anchor is not None]
+    if anchored and recheck:
+        wait = min(
+            int(recheck.get("next_retry_seconds") or 0),
+            REMEDIATION_MAX_QUIET_SECONDS,
+        )
+        next_recheck_at = (max(anchored) + dt.timedelta(seconds=wait)).isoformat()
+    return {
+        "state": compact.get("state"),
+        "recheck": dict(recheck) if recheck else None,
+        "next_recheck_at": next_recheck_at,
+    }
+
+
+def maybe_skip_wake(
+    store: JobStore,
+    job: WayfinderJob,
+    *,
+    mode: str,
+    apply_proposal_id: str | None,
+    now: dt.datetime | None = None,
+) -> dict[str, Any] | None:
+    """Pre-spawn skip decision, called BEFORE any OpenCode session work.
+
+    Returns the quiet report (already written to reports/{mode}/latest.json)
+    when this wake should be skipped, else None for a normal full wake.
+    """
+    if not wake_economy_enabled():
+        return None
+    if apply_proposal_id is not None or mode == "auto":
+        # Apply wakes always run; auto wakes can act on markets — the
+        # economy meters research wakes only.
+        return None
+    if str(job.script_loop.mode or "paper") == "live":
+        return None  # live jobs NEVER skip
+    now = now or dt.datetime.now(dt.UTC)
+    state = store.read_json(job.id, WAKE_ECONOMY_PATH, default={}) or {}
+    last_full = _parse_time(state.get("last_full_wake_at"))
+    if (
+        last_full is None
+        or (now - last_full).total_seconds() >= _quiet_max_seconds()
+    ):
+        return None  # max-quiet floor: a full wake is due regardless
+    if research_saturation_posture(store, job.id, job=job)["posture"] != "saturated":
+        return None
+    watermark = saturation_watermark(store, job.id, job=job)
+    if watermark != state.get("watermark"):
+        return None  # evidence moved — the full wake adjudicates it
+    next_full_wake_by = (
+        last_full + dt.timedelta(seconds=_quiet_max_seconds())
+    ).isoformat()
+    prior_skips = dict(state.get("skips") or {})
+    skips = {
+        "count": int(prior_skips.get("count") or 0) + 1,
+        "first_skipped_at": prior_skips.get("first_skipped_at") or now.isoformat(),
+        "last_skipped_at": now.isoformat(),
+    }
+    store.write_json(job.id, WAKE_ECONOMY_PATH, {**state, "skips": skips})
+    report = {
+        "job_id": job.id,
+        "mode": mode,
+        "status": "quiet",
+        "skip_reason": SKIP_REASON,
+        "summary": (
+            "wake skipped: research saturated and the evidence watermark is "
+            f"unchanged since the last full wake; next full wake by "
+            f"{next_full_wake_by}"
+        ),
+        "watermark": watermark,
+        "next_full_wake_by": next_full_wake_by,
+        "skips": skips,
+        "queued": False,
+        "session_id": None,
+        "created_at": now.isoformat(),
+    }
+    report_dir = store.job_dir(job.id) / "reports" / mode
+    report_dir.mkdir(parents=True, exist_ok=True)
+    (report_dir / "latest.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    # Deduped heartbeat (the remediation note-dedupe pattern): one journal
+    # entry per saturation episode; repeat skips roll into the state counter.
+    if not prior_skips:
+        store.append_journal(
+            job.id,
+            {
+                "type": "wake_skipped_saturated",
+                "mode": mode,
+                "next_full_wake_by": next_full_wake_by,
+            },
+        )
+    return report
+
+
+def record_full_wake(
+    store: JobStore, job: WayfinderJob, *, now: dt.datetime | None = None
+) -> None:
+    """Stamp the wake-economy state after a full wake is queued: the next
+    skip window anchors here and the skip episode counter resets."""
+    now = now or dt.datetime.now(dt.UTC)
+    store.write_json(
+        job.id,
+        WAKE_ECONOMY_PATH,
+        {
+            "last_full_wake_at": now.isoformat(),
+            "watermark": saturation_watermark(store, job.id, job=job),
+        },
+    )
+
+
+def _closed_trades(store: JobStore, job_id: str) -> int:
+    summary = store.read_json(job_id, "results/forward/summary.json", default={}) or {}
+    return int(((summary.get("trades") or {}).get("closed_count")) or 0)
+
+
+def _forward_gate_minimum(job: WayfinderJob) -> int:
+    drift_policy = (job.performance or {}).get("drift_policy") or {}
+    return int(
+        drift_policy.get("min_forward_trades") or _DEFAULT_FORWARD_GATE_MIN_TRADES
+    )
+
+
+def _quiet_max_seconds() -> float:
+    return (
+        float(
+            os.environ.get(WAKE_QUIET_MAX_HOURS_ENV) or DEFAULT_WAKE_QUIET_MAX_HOURS
+        )
+        * 3600
+    )
+
+
+def _parse_time(value: Any) -> dt.datetime | None:
+    try:
+        parsed = dt.datetime.fromisoformat(str(value))
+    except (TypeError, ValueError):
+        return None
+    return parsed.replace(tzinfo=dt.UTC) if parsed.tzinfo is None else parsed

--- a/wayfinder_paths/jobs/watchdog.py
+++ b/wayfinder_paths/jobs/watchdog.py
@@ -28,6 +28,7 @@ from typing import Any, TypedDict
 
 from wayfinder_paths.jobs.application import complete_application
 from wayfinder_paths.jobs.failures import cpu_steal_pct
+from wayfinder_paths.jobs.lifecycle import lifecycle_sweep
 from wayfinder_paths.jobs.models import utc_now_iso
 from wayfinder_paths.jobs.runner_bridge import RunnerBridge
 from wayfinder_paths.jobs.store import JobStore
@@ -1520,6 +1521,15 @@ def recover_stalled_applications(
             audit_event = None
         if audit_event is not None:
             recovered.append({"job_id": job.id, **audit_event})
+    # Fleet lifecycle sweep rides the watchdog tick so bootstrap/park policy
+    # fires even when a rotting job's own loops never run. Internally daily-
+    # throttled; the 5-minute cadence just keeps the clock honest.
+    try:
+        sweep = lifecycle_sweep(store, now=now)
+        recovered.extend(dict(action) for action in sweep.get("actions") or [])
+        errors.extend(sweep.get("errors") or [])
+    except Exception as exc:  # noqa: BLE001 — lifecycle never blocks recovery
+        errors.append({"job_id": "_lifecycle", "error": str(exc)})
     try:
         _refresh_portfolio_report(store, now)
     except Exception as exc:  # noqa: BLE001 — fleet telemetry never blocks recovery

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -25,6 +25,13 @@ from wayfinder_paths.jobs.models import (
 )
 from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.jobs.sync import snapshot_job, sync_all_jobs
+from wayfinder_paths.jobs.wake_economy import (
+    REMEDIATION_QUIET_LINE,
+    maybe_skip_wake,
+    record_full_wake,
+    remediation_backed_off,
+    remediation_wake_block,
+)
 
 JOB_RESULT_MARKER = "WAYFINDER_JOB_RESULT "
 STABLE_PREFIX_END_MARKER = "## End Stable Cache Prefix"
@@ -515,13 +522,15 @@ def _standing_checks_block(
             block["portfolio_regime_health"] = compact_regime_health(regime)
     from wayfinder_paths.jobs.remediation import compact_remediation, load_remediation
 
-    remediation = (
-        compact_remediation(load_remediation(store, job_id))
+    case = (
+        load_remediation(store, job_id)
         if store is not None and job_id is not None
         else None
     )
+    remediation = compact_remediation(case)
     if remediation:
         block["regime_remediation"] = remediation
+        block["remediation"] = remediation_wake_block(case)
     if block:
         block["_basis"] = (
             "Routine numbers computed mechanically THIS wake — never re-fetch "
@@ -733,12 +742,19 @@ def _build_worker_prompt_sections(
         "evaluating",
         "blocked",
     }
+    # A backed-off case (bounded blocker recorded, no forward evidence moved
+    # since) never satisfies a wake: it must not consume the search
+    # assignment or override research obligations.
+    remediation_quiet = remediation_actionable and remediation_backed_off(
+        store, job_id, remediation_case
+    )
+    remediation_overrides = remediation_actionable and not remediation_quiet
     search_assignment = None
     if (
         mode == "intervene"
         and apply_proposal_id is None
         and not restage_tasks
-        and not remediation_actionable
+        and not remediation_overrides
     ):
         try:
             from wayfinder_paths.jobs.improver.scheduler import assign_island
@@ -1190,7 +1206,9 @@ def _build_worker_prompt_sections(
         bootstrap_directive(store, job_id) if apply_proposal_id is None else ""
     )
     remediation_directive = ""
-    if remediation_actionable and apply_proposal_id is None:
+    if remediation_quiet and apply_proposal_id is None:
+        remediation_directive = REMEDIATION_QUIET_LINE
+    elif remediation_overrides and apply_proposal_id is None:
         remediation_directive = (
             "REGIME REMEDIATION REQUIRED — this durable case remains open:\n"
             f"{_canonical_json(remediation_case, max_chars=3000)}\n"
@@ -1477,6 +1495,15 @@ def run_job_worker(
         _emit_job_result(report["summary"], job.id)
         return report
 
+    # Wake economy cheap-skip (same tier as the auto-limits guard above): a
+    # saturated paper job whose evidence watermark has not moved since the
+    # last full wake skips the LLM session entirely.
+    quiet_report = maybe_skip_wake(
+        store, job, mode=mode_typed, apply_proposal_id=apply_proposal_id
+    )
+    if quiet_report is not None:
+        return quiet_report
+
     session_id = _ensure_worker_session(job.id, mode_typed)
     queued = False
     error: str | None = None
@@ -1502,6 +1529,11 @@ def run_job_worker(
             error = "OpenCode prompt_async failed"
     else:
         error = "OpenCode server unavailable"
+
+    if queued:
+        # Anchor the wake-economy skip window on delivered wakes only: a
+        # failed queue leaves the state untouched so the retry runs in full.
+        record_full_wake(store, job)
 
     report = _write_report(
         store=store,

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -14,6 +14,7 @@ from wayfinder_paths.jobs.derived_features import refresh_derived_features_if_st
 from wayfinder_paths.jobs.failures import cpu_steal_pct, disk_used_pct
 from wayfinder_paths.jobs.forward import is_forward_empty
 from wayfinder_paths.jobs.ledger import tail_ledger
+from wayfinder_paths.jobs.lifecycle import bootstrap_directive
 from wayfinder_paths.jobs.memory_hygiene import sanitize_job_memory
 from wayfinder_paths.jobs.models import (
     JOB_AUTO_WORKER_AGENT_NAME,
@@ -1182,6 +1183,12 @@ def _build_worker_prompt_sections(
             "it as a strategy failure, but DO NOT report the gate as green. "
             "For any other reason, fixing the gate is a priority this wake.\n\n"
         )
+    # Bootstrap contract: a never-operational job past half its deadline gets
+    # the bootstrap-first directive on every wake until it bootstraps or is
+    # parked. Rendered as prompt text — never only snapshot JSON.
+    bootstrap_alert = (
+        bootstrap_directive(store, job_id) if apply_proposal_id is None else ""
+    )
     remediation_directive = ""
     if remediation_actionable and apply_proposal_id is None:
         remediation_directive = (
@@ -1322,6 +1329,7 @@ def _build_worker_prompt_sections(
     dynamic_context = (
         f"{DYNAMIC_CONTEXT_MARKER}\n"
         f"{gate_alert}"
+        f"{bootstrap_alert}"
         f"{remediation_directive}"
         f"{restage_priority}"
         f"{impasse_directive}"

--- a/wayfinder_paths/tests/test_execution_ccxt_feed.py
+++ b/wayfinder_paths/tests/test_execution_ccxt_feed.py
@@ -11,6 +11,7 @@ from wayfinder_paths.jobs.execution import ExecutionSpec
 from wayfinder_paths.jobs.execution.ccxt_feed import (
     CcxtMarketFeed,
     fetch_ccxt_dataset_rows,
+    fetch_ccxt_funding_rows,
 )
 from wayfinder_paths.jobs.execution.preflight import build_live_dataset
 from wayfinder_paths.jobs.models import WayfinderJob
@@ -53,6 +54,11 @@ class FakeCcxtExchange:
         rows = self.candles.get(pair, [])
         return [row for row in rows if row[0] >= (since or 0)][:limit]
 
+    async def fetch_funding_rate_history(
+        self, pair: str, since: int | None = None, limit: int = 500
+    ) -> list[dict[str, Any]]:
+        return []
+
     async def close(self) -> None:
         self.closed = True
 
@@ -83,6 +89,64 @@ async def test_symbol_resolution_missing_market_raises() -> None:
 
     with pytest.raises(ValueError, match="DOGE"):
         await feed.resolve_market_symbol("DOGE")
+
+
+async def test_hyperliquid_quote_defaults_to_usdc() -> None:
+    """Hyperliquid ccxt markets are /USDC:USDC; HIP-3 keeps the dex prefix in
+    the base (xyz:TSLA/USDC:USDC). The old baked USDT default built symbols
+    no hyperliquid market has."""
+    exchange = FakeCcxtExchange(
+        markets={
+            "xyz:TSLA/USDC:USDC": {"active": True},
+            "BTC/USDC:USDC": {"active": True},
+        }
+    )
+    feed = CcxtMarketFeed(exchange_id="hyperliquid", exchange=exchange)
+
+    assert feed.quote == "USDC"
+    assert await feed.resolve_market_symbol("xyz:TSLA") == "xyz:TSLA/USDC:USDC"
+    assert await feed.resolve_market_symbol("BTC") == "BTC/USDC:USDC"
+
+
+async def test_binance_quote_defaults_to_usdt() -> None:
+    exchange = FakeCcxtExchange(markets={"BTC/USDT:USDT": {"active": True}})
+    feed = CcxtMarketFeed(exchange=exchange)
+
+    assert feed.quote == "USDT"
+    assert await feed.resolve_market_symbol("BTC") == "BTC/USDT:USDT"
+
+
+async def test_explicit_quote_overrides_exchange_default() -> None:
+    exchange = FakeCcxtExchange(markets={"BTC/USDT:USDT": {"active": True}})
+    feed = CcxtMarketFeed(exchange_id="hyperliquid", quote="USDT", exchange=exchange)
+
+    assert feed.quote == "USDT"
+    assert await feed.resolve_market_symbol("BTC") == "BTC/USDT:USDT"
+
+
+async def test_missing_market_error_names_symbol_and_exchange() -> None:
+    feed = CcxtMarketFeed(
+        exchange_id="hyperliquid", exchange=FakeCcxtExchange(markets={})
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        await feed.resolve_market_symbol("xyz:TSLA")
+
+    message = str(excinfo.value)
+    assert "hyperliquid" in message
+    assert "xyz:TSLA/USDC:USDC" in message
+
+
+async def test_funding_rows_metadata_records_resolved_quote() -> None:
+    exchange = FakeCcxtExchange(markets={"BTC/USDC:USDC": {"active": True}})
+
+    rows, metadata = await fetch_ccxt_funding_rows(
+        ["BTC"], days=1, exchange_id="hyperliquid", exchange=exchange
+    )
+
+    assert rows == []
+    assert metadata["quote"] == "USDC"
+    assert metadata["symbol_map"] == {"BTC": "BTC/USDC:USDC"}
 
 
 async def test_pagination_stitches_and_dedupes() -> None:

--- a/wayfinder_paths/tests/test_jobs_bootstrap_contract.py
+++ b/wayfinder_paths/tests/test_jobs_bootstrap_contract.py
@@ -234,6 +234,41 @@ def test_monitor_decay_parks_after_window(
     assert events[0]["undo"] == {"command": f"wayfinder job resume {job.id}"}
 
 
+def test_monitor_decay_parks_through_mechanical_heartbeats(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An hourly agent loop journals agent_wakeup on EVERY delivered wake —
+    mechanical heartbeats must not read as activity, or the park is
+    unreachable for exactly the jobs it targets."""
+    calls = _patch_bridge(monkeypatch)
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "decay-heartbeat-demo", agent_mode="monitor")
+    store.refresh_scorecard(job.id, {"last_script_run_at": utc_now_iso()})
+    store.write_json(
+        job.id,
+        "results/backtest/replication.json",
+        {"available": True, "status": "decayed"},
+    )
+    now = dt.datetime.now(dt.UTC)
+    lifecycle_sweep(store, now=now, force=True)
+
+    # Periodic mechanical rows throughout the window: wake heartbeats plus
+    # the per-wake monitor-failure types.
+    for _ in range(30):
+        store.append_journal(job.id, {"type": "agent_wakeup", "mode": "monitor"})
+        store.append_journal(
+            job.id, {"type": "replication_failed", "error": "compute failed"}
+        )
+        store.append_journal(
+            job.id, {"type": "regime_health_failed", "error": "no dataset"}
+        )
+
+    result = lifecycle_sweep(store, now=now + dt.timedelta(days=8), force=True)
+
+    assert any(a["action"] == "job_parked_monitor_decay" for a in result["actions"])
+    assert ("pause", job.agent_loop.runner_job_name) in calls
+
+
 def test_monitor_decay_deferred_by_activity_and_cleared_on_recovery(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -249,8 +284,9 @@ def test_monitor_decay_deferred_by_activity_and_cleared_on_recovery(
     now = dt.datetime.now(dt.UTC)
     lifecycle_sweep(store, now=now, force=True)
 
-    # Journal activity inside the window defers the park.
-    store.append_journal(job.id, {"type": "agent_wakeup", "mode": "monitor"})
+    # A meaningful (non-mechanical) journal row inside the window defers the
+    # park — the agent/owner is actually doing something with this job.
+    store.append_journal(job.id, {"type": "proposal_created", "proposal_id": "p-1"})
     deferred = lifecycle_sweep(store, now=now + dt.timedelta(days=8), force=True)
     assert not any(a["action"].startswith("job_parked") for a in deferred["actions"])
 

--- a/wayfinder_paths/tests/test_jobs_bootstrap_contract.py
+++ b/wayfinder_paths/tests/test_jobs_bootstrap_contract.py
@@ -1,0 +1,331 @@
+"""Bootstrap contract: never-operational jobs nudge, then park with an undo;
+monitor-mode jobs whose deploy evidence stopped replicating share the park
+path. Mechanical zone only — live and wallet-bound jobs are never parked."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+from pathlib import Path
+
+import pytest
+
+from wayfinder_paths.jobs.lifecycle import (
+    BOOTSTRAP_FAILURE_PATH,
+    LIFECYCLE_PATH,
+    bootstrap_directive,
+    closed_forward_trades,
+    is_operational,
+    lifecycle_sweep,
+)
+from wayfinder_paths.jobs.models import WayfinderJob, utc_now_iso
+from wayfinder_paths.jobs.owner_attention import build_owner_attention
+from wayfinder_paths.jobs.store import JobStore
+
+
+def _patch_bridge(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, str]]:
+    calls: list[tuple[str, str]] = []
+
+    class FakeBridge:
+        def __init__(self, *, repo_root=None):  # noqa: ANN001
+            self.repo_root = repo_root
+
+        def pause(self, name: str) -> dict:
+            calls.append(("pause", name))
+            return {"ok": True}
+
+        def resume(self, name: str) -> dict:
+            calls.append(("resume", name))
+            return {"ok": True}
+
+    monkeypatch.setattr("wayfinder_paths.jobs.lifecycle.RunnerBridge", FakeBridge)
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.lifecycle.sync_all_jobs", lambda *, store: None
+    )
+    return calls
+
+
+def _make_job(
+    store: JobStore,
+    job_id: str,
+    *,
+    age_hours: float = 0.0,
+    agent_mode: str = "intervene",
+) -> WayfinderJob:
+    job = WayfinderJob.new(
+        job_id,
+        script="workspace/src/loop.py",
+        interval_seconds=60,
+        agent_mode=agent_mode,
+    )
+    job.created_at = (
+        dt.datetime.now(dt.UTC) - dt.timedelta(hours=age_hours)
+    ).isoformat()
+    store.save(job)
+    return job
+
+
+def _journal_events(store: JobStore, job_id: str) -> list[dict]:
+    path = store.job_dir(job_id) / "journal.jsonl"
+    if not path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _journal_types(store: JobStore, job_id: str) -> list[str]:
+    return [str(event.get("type")) for event in _journal_events(store, job_id)]
+
+
+def test_operational_predicate_truth_table(tmp_path: Path) -> None:
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "op-demo")
+    assert is_operational(store, job.id) is False
+
+    store.refresh_scorecard(job.id, {"last_script_run_at": utc_now_iso()})
+    assert is_operational(store, job.id) is True
+    store.refresh_scorecard(job.id, {"last_script_run_at": None})
+    assert is_operational(store, job.id) is False
+
+    store.refresh_scorecard(job.id, {"last_agent_check_at": utc_now_iso()})
+    assert is_operational(store, job.id) is True
+    store.refresh_scorecard(job.id, {"last_agent_check_at": None})
+    assert is_operational(store, job.id) is False
+
+    baseline = store.job_dir(job.id) / "results" / "backtest" / "baseline.json"
+    baseline.write_text("{}\n", encoding="utf-8")
+    assert is_operational(store, job.id) is True
+    baseline.unlink()
+    assert is_operational(store, job.id) is False
+
+    trades = store.job_dir(job.id) / "results" / "forward" / "trades.jsonl"
+    trades.write_text('{"symbol": "BTC", "net_pnl": 1.0}\n', encoding="utf-8")
+    assert closed_forward_trades(store, job.id) == 1
+    assert is_operational(store, job.id) is True
+
+
+def test_nudge_journals_once_and_prompt_directive_renders(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_bridge(monkeypatch)
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "nudge-demo", age_hours=40)  # past 72/2, before 72
+
+    first = lifecycle_sweep(store, force=True)
+    second = lifecycle_sweep(store, force=True)
+
+    assert any(a["action"] == "bootstrap_lagging" for a in first["actions"])
+    assert not any(a["action"] == "bootstrap_lagging" for a in second["actions"])
+    assert _journal_types(store, job.id).count("bootstrap_lagging") == 1
+    assert "never reached operational state" in bootstrap_directive(store, job.id)
+
+    # An operational job renders no directive even past the nudge threshold.
+    store.refresh_scorecard(job.id, {"last_script_run_at": utc_now_iso()})
+    assert bootstrap_directive(store, job.id) == ""
+
+
+def test_park_pauses_loops_writes_state_and_journals_undo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls = _patch_bridge(monkeypatch)
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "park-demo", age_hours=80)
+
+    result = lifecycle_sweep(store, force=True)
+
+    assert any(a["action"] == "job_parked_unbootstrapped" for a in result["actions"])
+    assert ("pause", job.script_loop.runner_job_name) in calls
+    assert ("pause", job.agent_loop.runner_job_name) in calls
+    failure = store.read_json(job.id, BOOTSTRAP_FAILURE_PATH)
+    assert failure["reason"].startswith("never operational")
+    assert failure["parked_at"]
+    assert "no_forward_trades" in failure["predicates_failed"]
+    parked = [
+        e
+        for e in _journal_events(store, job.id)
+        if e.get("type") == "job_parked_unbootstrapped"
+    ]
+    assert len(parked) == 1
+    assert parked[0]["undo"] == {"command": f"wayfinder job resume {job.id}"}
+
+    # Once parked, the sweep never re-parks (an owner resume is deliberate).
+    calls.clear()
+    again = lifecycle_sweep(store, force=True)
+    assert not any(a["action"].startswith("job_parked") for a in again["actions"])
+    assert calls == []
+
+
+def test_live_and_wallet_bound_jobs_are_never_parked(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls = _patch_bridge(monkeypatch)
+    store = JobStore(repo_root=tmp_path)
+    live = _make_job(store, "live-demo", age_hours=80)
+    live.script_loop.mode = "live"
+    store.save(live)
+    bound = _make_job(store, "bound-demo", age_hours=80)
+    bound.execution_params = {"wallet_label": "main"}
+    store.save(bound)
+
+    result = lifecycle_sweep(store, force=True)
+
+    assert not any(a["action"].startswith("job_parked") for a in result["actions"])
+    assert calls == []
+    assert store.read_json(live.id, BOOTSTRAP_FAILURE_PATH) is None
+    assert store.read_json(bound.id, BOOTSTRAP_FAILURE_PATH) is None
+    # The nudge (visibility) still lands — only the park is exempt.
+    assert "bootstrap_lagging" in _journal_types(store, live.id)
+
+
+def test_reaper_kill_switch_disables_park_but_keeps_nudge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls = _patch_bridge(monkeypatch)
+    monkeypatch.setenv("WAYFINDER_LIFECYCLE_REAPER", "0")
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "killswitch-demo", age_hours=80)
+
+    result = lifecycle_sweep(store, force=True)
+
+    assert not any(a["action"].startswith("job_parked") for a in result["actions"])
+    assert calls == []
+    assert "bootstrap_lagging" in _journal_types(store, job.id)
+    assert "never reached operational state" in bootstrap_directive(store, job.id)
+
+
+def test_monitor_decay_parks_after_window(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls = _patch_bridge(monkeypatch)
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "decay-demo", agent_mode="monitor")
+    store.refresh_scorecard(job.id, {"last_script_run_at": utc_now_iso()})
+    store.write_json(
+        job.id,
+        "results/backtest/replication.json",
+        {"available": True, "status": "decayed"},
+    )
+    now = dt.datetime.now(dt.UTC)
+
+    # First sighting stamps the clock — no park yet.
+    first = lifecycle_sweep(store, now=now, force=True)
+    assert not any(a["action"].startswith("job_parked") for a in first["actions"])
+    marker = store.read_json(job.id, LIFECYCLE_PATH)
+    assert marker["monitor_decay"]["status"] == "decayed"
+
+    # Inside the 7-day window: still no park.
+    mid = lifecycle_sweep(store, now=now + dt.timedelta(days=3), force=True)
+    assert not any(a["action"].startswith("job_parked") for a in mid["actions"])
+
+    later = now + dt.timedelta(days=8)
+    result = lifecycle_sweep(store, now=later, force=True)
+
+    parked = [a for a in result["actions"] if a["action"] == "job_parked_monitor_decay"]
+    assert parked and "replication decayed" in parked[0]["reason"]
+    assert ("pause", job.script_loop.runner_job_name) in calls
+    events = [
+        e
+        for e in _journal_events(store, job.id)
+        if e.get("type") == "job_parked_monitor_decay"
+    ]
+    assert events[0]["undo"] == {"command": f"wayfinder job resume {job.id}"}
+
+
+def test_monitor_decay_deferred_by_activity_and_cleared_on_recovery(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_bridge(monkeypatch)
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "decay-active-demo", agent_mode="monitor")
+    store.refresh_scorecard(job.id, {"last_script_run_at": utc_now_iso()})
+    store.write_json(
+        job.id,
+        "results/backtest/replication.json",
+        {"available": True, "status": "invalid"},
+    )
+    now = dt.datetime.now(dt.UTC)
+    lifecycle_sweep(store, now=now, force=True)
+
+    # Journal activity inside the window defers the park.
+    store.append_journal(job.id, {"type": "agent_wakeup", "mode": "monitor"})
+    deferred = lifecycle_sweep(store, now=now + dt.timedelta(days=8), force=True)
+    assert not any(a["action"].startswith("job_parked") for a in deferred["actions"])
+
+    # Replication recovery clears the decay clock entirely.
+    store.write_json(
+        job.id,
+        "results/backtest/replication.json",
+        {"available": True, "status": "valid"},
+    )
+    lifecycle_sweep(store, now=now + dt.timedelta(days=9), force=True)
+    assert "monitor_decay" not in (store.read_json(job.id, LIFECYCLE_PATH) or {})
+
+
+def test_sweep_daily_throttle_and_force(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_bridge(monkeypatch)
+    store = JobStore(repo_root=tmp_path)
+    _make_job(store, "throttle-demo")
+
+    first = lifecycle_sweep(store)
+    throttled = lifecycle_sweep(store)
+    forced = lifecycle_sweep(store, force=True)
+    next_day = lifecycle_sweep(
+        store, now=dt.datetime.now(dt.UTC) + dt.timedelta(hours=25)
+    )
+
+    assert first["throttled"] is False and first["scanned"] == 1
+    assert throttled["throttled"] is True and throttled["scanned"] == 0
+    assert forced["throttled"] is False
+    assert next_day["throttled"] is False
+
+
+def test_worker_prompt_carries_bootstrap_directive(tmp_path: Path) -> None:
+    from wayfinder_paths.jobs.worker import _build_worker_prompt_sections
+    from wayfinder_paths.tests.test_wayfinder_jobs import _worker_snapshot
+
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "prompt-demo", age_hours=40)
+
+    prompt = _build_worker_prompt_sections(
+        store=store,
+        job_id=job.id,
+        mode="intervene",
+        snapshot=_worker_snapshot(job),
+    )["prompt"]
+    assert "never reached operational state" in prompt
+
+    store.refresh_scorecard(job.id, {"last_script_run_at": utc_now_iso()})
+    operational_prompt = _build_worker_prompt_sections(
+        store=store,
+        job_id=job.id,
+        mode="intervene",
+        snapshot=_worker_snapshot(job),
+    )["prompt"]
+    assert "never reached operational state" not in operational_prompt
+
+
+def test_owner_attention_surfaces_parks_with_undo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_bridge(monkeypatch)
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "attention-demo", age_hours=80)
+    lifecycle_sweep(store, force=True)
+
+    feed = build_owner_attention(store, job.id)
+
+    parks = [
+        item
+        for item in feed["decided_autonomously"]
+        if item["kind"] == "lifecycle_park"
+    ]
+    assert len(parks) == 1
+    assert parks[0]["decision"] == "unbootstrapped"
+    assert parks[0]["undo"] == {"command": f"wayfinder job resume {job.id}"}
+    # The closed needs_you kind union is untouched.
+    assert all(item["kind"] != "lifecycle_park" for item in feed["needs_you"])

--- a/wayfinder_paths/tests/test_jobs_remediation.py
+++ b/wayfinder_paths/tests/test_jobs_remediation.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import datetime as dt
+import json
 from pathlib import Path
+
+import pytest
 
 from wayfinder_paths.jobs.models import WayfinderJob
 from wayfinder_paths.jobs.remediation import (
@@ -23,6 +26,26 @@ def _store(tmp_path: Path) -> tuple[JobStore, str]:
     job = WayfinderJob.new("remediation-demo", agent_mode="intervene")
     store.save(job)
     return store, job.id
+
+
+def _journal_types(store: JobStore, job_id: str) -> list[str]:
+    path = store.job_dir(job_id) / "journal.jsonl"
+    if not path.exists():
+        return []
+    return [
+        str(json.loads(line).get("type"))
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _record_closed_trades(store: JobStore, job_id: str, count: int) -> None:
+    summary = store.read_json(job_id, "results/forward/summary.json", default={}) or {}
+    trades = dict(summary.get("trades") or {})
+    trades["closed_count"] = count
+    trades["last_trade_at"] = f"2026-08-21T12:00:{count:02d}+00:00"
+    summary["trades"] = trades
+    store.write_json(job_id, "results/forward/summary.json", summary)
 
 
 def _health(*, score: int = 4, fingerprint: str = "health-a") -> dict:
@@ -193,6 +216,159 @@ def test_red_candidate_and_bounded_evaluation_keep_case_open(tmp_path: Path) -> 
     case = load_remediation(store, job_id)
     assert case and case["state"] == "evaluating"
     assert case["progress"]["artifact_path"].endswith("hype_ablation.json")
+
+
+def test_quiet_recheck_backs_off_and_journals_compact_heartbeat(
+    tmp_path: Path,
+) -> None:
+    """A no-change re-check doubles the next due time toward the cap and
+    leaves a compact heartbeat in the journal, not a full feed entry."""
+    store, job_id = _store(tmp_path)
+    now = dt.datetime(2026, 8, 21, 12, tzinfo=dt.UTC)
+    sync_remediation_with_health(store, job_id, _health(), now=now)
+
+    wake = now + dt.timedelta(hours=6, minutes=1)
+    retry = sync_remediation_with_health(store, job_id, _health(), now=wake)
+    assert retry and retry["event"] == "regime_remediation_due"
+    assert retry["material_reasons"] == ["open_case_without_proposal"]
+    case = load_remediation(store, job_id)
+    assert case and case["recheck"]["next_retry_seconds"] == 12 * 3600
+    assert _journal_types(store, job_id).count("remediation_recheck_quiet") == 1
+
+    # Backed off: the old flat 6h cadence no longer fires…
+    assert (
+        sync_remediation_with_health(
+            store, job_id, _health(), now=wake + dt.timedelta(hours=6, minutes=1)
+        )
+        is None
+    )
+    # …but the doubled interval does, and stays pinned at the 12h cap.
+    third = sync_remediation_with_health(
+        store, job_id, _health(), now=wake + dt.timedelta(hours=12, minutes=1)
+    )
+    assert third and third["event"] == "regime_remediation_due"
+    case = load_remediation(store, job_id)
+    assert case and case["attempts"] == 3
+    assert case["recheck"]["next_retry_seconds"] == 12 * 3600
+
+
+def test_new_closed_trades_reset_backoff_to_prompt_recheck(tmp_path: Path) -> None:
+    """Material forward evidence wakes the case promptly (30m base) through
+    any accumulated backoff, with a full evidence-updated journal entry."""
+    store, job_id = _store(tmp_path)
+    now = dt.datetime(2026, 8, 21, 12, tzinfo=dt.UTC)
+    sync_remediation_with_health(store, job_id, _health(), now=now)
+
+    _record_closed_trades(store, job_id, 1)
+    # Well inside the 6h quiet window — the evidence reset fires anyway.
+    woke = sync_remediation_with_health(
+        store, job_id, _health(), now=now + dt.timedelta(minutes=31)
+    )
+    assert woke and woke["event"] == "regime_remediation_due"
+    assert "forward_trades_advanced" in woke["material_reasons"]
+    assert "regime_remediation_evidence_updated" in _journal_types(store, job_id)
+    case = load_remediation(store, job_id)
+    assert case and case["recheck"]["next_retry_seconds"] == 3600
+
+    # The ladder restarts from the prompt interval: quiet at +30m, due at +1h.
+    wake = now + dt.timedelta(minutes=31)
+    assert (
+        sync_remediation_with_health(
+            store, job_id, _health(), now=wake + dt.timedelta(minutes=31)
+        )
+        is None
+    )
+    quiet = sync_remediation_with_health(
+        store, job_id, _health(), now=wake + dt.timedelta(hours=1, minutes=1)
+    )
+    assert quiet and quiet["material_reasons"] == ["open_case_without_proposal"]
+    case = load_remediation(store, job_id)
+    assert case and case["recheck"]["next_retry_seconds"] == 2 * 3600
+
+
+def test_backoff_cap_env_and_max_quiet_bound(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The cap is env-tunable, and even a mis-tuned cap can never silence a
+    case past the 24h max-quiet bound."""
+    monkeypatch.setenv("WAYFINDER_REMEDIATION_BACKOFF_CAP_SECONDS", str(48 * 3600))
+    store, job_id = _store(tmp_path)
+    now = dt.datetime(2026, 8, 21, 12, tzinfo=dt.UTC)
+    sync_remediation_with_health(store, job_id, _health(), now=now)
+
+    wake = now + dt.timedelta(hours=6, minutes=1)
+    assert sync_remediation_with_health(store, job_id, _health(), now=wake)
+    wake += dt.timedelta(hours=12, minutes=1)
+    assert sync_remediation_with_health(store, job_id, _health(), now=wake)
+    wake += dt.timedelta(hours=24, minutes=1)
+    assert sync_remediation_with_health(store, job_id, _health(), now=wake)
+    case = load_remediation(store, job_id)
+    assert case and case["recheck"]["next_retry_seconds"] == 48 * 3600
+
+    # next_retry says 48h, but the hard bound wakes the case at 24h.
+    assert (
+        sync_remediation_with_health(
+            store, job_id, _health(), now=wake + dt.timedelta(hours=23)
+        )
+        is None
+    )
+    bounded = sync_remediation_with_health(
+        store, job_id, _health(), now=wake + dt.timedelta(hours=24, minutes=1)
+    )
+    assert bounded and bounded["event"] == "regime_remediation_due"
+
+
+def test_reaffirmation_notes_roll_into_single_note(tmp_path: Path) -> None:
+    """Consecutive no-change re-affirmations update one rolling note and a
+    compact heartbeat — they do not append full feed entries."""
+    store, job_id = _store(tmp_path)
+    sync_remediation_with_health(store, job_id, _health())
+
+    update_remediation_progress(
+        store, job_id, state="blocked", note="Waiting for forward evidence"
+    )
+    update_remediation_progress(
+        store, job_id, state="blocked", note="Still waiting: book flat"
+    )
+    update_remediation_progress(
+        store, job_id, state="blocked", note="Still waiting: book flat, no closes"
+    )
+
+    case = load_remediation(store, job_id)
+    assert case and case["progress"]["reaffirmations"] == 2
+    assert case["progress"]["note"].endswith("no closes")
+    assert case["progress"]["first_recorded_at"]
+    types = _journal_types(store, job_id)
+    assert types.count("regime_remediation_progress") == 1
+    assert types.count("remediation_recheck_quiet") == 2
+
+
+def test_state_transition_or_new_evidence_writes_full_note(tmp_path: Path) -> None:
+    store, job_id = _store(tmp_path)
+    sync_remediation_with_health(store, job_id, _health())
+
+    update_remediation_progress(
+        store, job_id, state="evaluating", note="Running ablation"
+    )
+    # evaluating → blocked is a transition: full entry.
+    update_remediation_progress(
+        store, job_id, state="blocked", note="Ablation blocked on evidence"
+    )
+    # New closed trades between notes: full entry even with the state unchanged.
+    _record_closed_trades(store, job_id, 1)
+    update_remediation_progress(
+        store, job_id, state="blocked", note="One close landed; still short"
+    )
+    # No further change: compact.
+    update_remediation_progress(
+        store, job_id, state="blocked", note="No additional closes"
+    )
+
+    types = _journal_types(store, job_id)
+    assert types.count("regime_remediation_progress") == 3
+    assert types.count("remediation_recheck_quiet") == 1
+    case = load_remediation(store, job_id)
+    assert case and case["progress"]["reaffirmations"] == 1
 
 
 def test_applied_treatment_monitors_until_health_recovers(tmp_path: Path) -> None:

--- a/wayfinder_paths/tests/test_jobs_wake_economy.py
+++ b/wayfinder_paths/tests/test_jobs_wake_economy.py
@@ -1,0 +1,353 @@
+"""Wake economy: saturated paper jobs skip LLM wakes until evidence moves,
+and a backed-off remediation case never satisfies a wake."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from wayfinder_paths.jobs.exhaustion import file_exhaustion_claim
+from wayfinder_paths.jobs.models import WayfinderJob, utc_now_iso
+from wayfinder_paths.jobs.remediation import (
+    sync_remediation_with_health,
+    update_remediation_progress,
+)
+from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.jobs.wake_economy import (
+    REMEDIATION_QUIET_LINE,
+    WAKE_ECONOMY_PATH,
+    maybe_skip_wake,
+    record_full_wake,
+    research_saturation_posture,
+    saturation_watermark,
+)
+from wayfinder_paths.jobs.worker import (
+    _build_worker_prompt_sections,
+    _standing_checks_block,
+    run_job_worker,
+)
+from wayfinder_paths.tests.test_jobs_remediation import _health
+from wayfinder_paths.tests.test_wayfinder_jobs import _worker_snapshot
+
+
+class ForbiddenOpenCodeClient:
+    """A skipped wake must never touch the OpenCode client."""
+
+    def healthy(self) -> bool:
+        raise AssertionError("OpenCode client touched on a skipped wake")
+
+    def find_child_session(self, **kwargs) -> str | None:  # noqa: ANN003
+        raise AssertionError("OpenCode client touched on a skipped wake")
+
+    def create_session(self, **kwargs) -> str:  # noqa: ANN003
+        raise AssertionError("OpenCode client touched on a skipped wake")
+
+    def prompt_async(self, *args, **kwargs) -> bool:  # noqa: ANN002, ANN003
+        raise AssertionError("OpenCode client touched on a skipped wake")
+
+
+class FakeOpenCodeClient:
+    def __init__(self) -> None:
+        self.prompts: list[str] = []
+
+    def healthy(self) -> bool:
+        return True
+
+    def find_child_session(self, *, parent_id, title):  # noqa: ANN001
+        return None
+
+    def create_session(self, *, parent_id=None, title=None, agent=None):  # noqa: ANN001
+        return "session-wake-economy"
+
+    def prompt_async(self, session_id: str, text: str, *, agent=None) -> bool:  # noqa: ANN001
+        self.prompts.append(text)
+        return True
+
+
+def _saturated_job(tmp_path: Path, job_id: str = "quiet-demo") -> tuple[JobStore, WayfinderJob]:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        job_id,
+        script="workspace/src/loop.py",
+        interval_seconds=60,
+        agent_mode="intervene",
+    )
+    store.save(job)
+    # Operational (bootstrap owns never-operational jobs, not the economy).
+    store.refresh_scorecard(job.id, {"last_script_run_at": utc_now_iso()})
+    return store, job
+
+
+def _record_closed_trades(store: JobStore, job_id: str, count: int) -> None:
+    summary = store.read_json(job_id, "results/forward/summary.json", default={}) or {}
+    trades = dict(summary.get("trades") or {})
+    trades["closed_count"] = count
+    trades["last_trade_at"] = f"2026-08-25T12:00:{count % 60:02d}+00:00"
+    summary["trades"] = trades
+    store.write_json(job_id, "results/forward/summary.json", summary)
+
+
+def _journal_types(store: JobStore, job_id: str) -> list[str]:
+    path = store.job_dir(job_id) / "journal.jsonl"
+    if not path.exists():
+        return []
+    return [
+        str(json.loads(line).get("type"))
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def test_posture_saturated_when_nothing_is_mid_flight(tmp_path: Path) -> None:
+    store, job = _saturated_job(tmp_path)
+
+    posture = research_saturation_posture(store, job.id)
+
+    assert posture == {"posture": "saturated", "blockers": []}
+
+
+def test_each_mid_flight_condition_defeats_saturation(tmp_path: Path) -> None:
+    cases = [
+        (
+            "not_operational",
+            lambda store, job: store.refresh_scorecard(
+                job.id, {"last_script_run_at": None}
+            ),
+        ),
+        (
+            "research_lane_active",
+            lambda store, job: store.write_json(
+                job.id, "state/research_lane.json", {"active_lane": "vol-regimes"}
+            ),
+        ),
+        (
+            "impasse_mandate_outstanding",
+            lambda store, job: store.write_json(
+                job.id, "state/research_impasse.json", {"alerted_at": utc_now_iso()}
+            ),
+        ),
+        (
+            "exhaustion_claim_pending",
+            lambda store, job: file_exhaustion_claim(
+                store,
+                job.id,
+                lane="funding-lane",
+                evidence="all cells negative",
+                provenance="data-wall",
+                next_region="session-effects",
+            ),
+        ),
+        (
+            "proposals_in_flight",
+            lambda store, job: (
+                store.write_proposal(
+                    job.id, {"proposal_id": "prop-a", "status": "pending"}
+                ),
+                store.refresh_scorecard(job.id),
+            ),
+        ),
+        (
+            "remediation_case_active",
+            lambda store, job: sync_remediation_with_health(store, job.id, _health()),
+        ),
+        (
+            "forward_sample_adequate",
+            lambda store, job: _record_closed_trades(store, job.id, 20),
+        ),
+    ]
+    for index, (blocker, arrange) in enumerate(cases):
+        store, job = _saturated_job(tmp_path / f"case-{index}", f"posture-{index}")
+        arrange(store, job)
+
+        posture = research_saturation_posture(store, job.id)
+
+        assert posture["posture"] == "in_flight", blocker
+        assert posture["blockers"] == [blocker]
+
+
+def test_backed_off_remediation_case_does_not_defeat_saturation(
+    tmp_path: Path,
+) -> None:
+    store, job = _saturated_job(tmp_path)
+    sync_remediation_with_health(store, job.id, _health())
+    update_remediation_progress(
+        store, job.id, state="blocked", note="Waiting for forward evidence"
+    )
+
+    assert research_saturation_posture(store, job.id) == {
+        "posture": "saturated",
+        "blockers": [],
+    }
+
+
+def test_skip_path_writes_quiet_report_without_touching_llm(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job = _saturated_job(tmp_path)
+    record_full_wake(store, job)
+    monkeypatch.setattr("wayfinder_paths.jobs.worker.JobStore", lambda: store)
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.worker.OPENCODE_CLIENT", ForbiddenOpenCodeClient()
+    )
+
+    report = run_job_worker(job.id, mode="intervene")
+
+    assert report["status"] == "quiet"
+    assert report["skip_reason"] == "saturation_watermark_unchanged"
+    assert report["watermark"]["closed_trades"] == 0
+    assert report["next_full_wake_by"]
+    latest = json.loads(
+        (store.job_dir(job.id) / "reports" / "intervene" / "latest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert latest["status"] == "quiet"
+    assert _journal_types(store, job.id).count("wake_skipped_saturated") == 1
+
+    # Repeat skips roll into the state counter — no second heartbeat entry.
+    second = run_job_worker(job.id, mode="intervene")
+    assert second["status"] == "quiet"
+    assert second["skips"]["count"] == 2
+    assert _journal_types(store, job.id).count("wake_skipped_saturated") == 1
+
+
+def test_watermark_movement_forces_full_wake(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job = _saturated_job(tmp_path)
+    record_full_wake(store, job)
+    client = FakeOpenCodeClient()
+    monkeypatch.setattr("wayfinder_paths.jobs.worker.JobStore", lambda: store)
+    monkeypatch.setattr("wayfinder_paths.jobs.worker.OPENCODE_CLIENT", client)
+
+    # One closed trade (still below the gate minimum → still saturated) moves
+    # the watermark: the next wake must run in full and re-anchor the state.
+    _record_closed_trades(store, job.id, 1)
+    report = run_job_worker(job.id, mode="intervene")
+
+    assert report["status"] == "green"
+    assert len(client.prompts) == 1
+    state = store.read_json(job.id, WAKE_ECONOMY_PATH)
+    assert state["watermark"]["closed_trades"] == 1
+    assert "skips" not in state
+
+    # Watermark unchanged after the re-anchor: the follow-up wake skips.
+    followup = run_job_worker(job.id, mode="intervene")
+    assert followup["status"] == "quiet"
+    assert len(client.prompts) == 1
+
+
+def test_quiet_max_floor_forces_full_wake(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job = _saturated_job(tmp_path)
+    record_full_wake(store, job, now=datetime.now(UTC) - timedelta(hours=25))
+
+    assert (
+        maybe_skip_wake(store, job, mode="intervene", apply_proposal_id=None) is None
+    )
+
+
+def test_live_apply_and_auto_wakes_never_skip(tmp_path: Path) -> None:
+    store, job = _saturated_job(tmp_path)
+    record_full_wake(store, job)
+
+    assert (
+        maybe_skip_wake(store, job, mode="intervene", apply_proposal_id="prop-1")
+        is None
+    )
+    assert maybe_skip_wake(store, job, mode="auto", apply_proposal_id=None) is None
+
+    job.script_loop.mode = "live"
+    store.save(job)
+    assert (
+        maybe_skip_wake(store, job, mode="intervene", apply_proposal_id=None) is None
+    )
+
+
+def test_kill_switch_disables_the_skip_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYFINDER_WAKE_ECONOMY", "0")
+    store, job = _saturated_job(tmp_path)
+    record_full_wake(store, job)
+
+    assert (
+        maybe_skip_wake(store, job, mode="intervene", apply_proposal_id=None) is None
+    )
+
+
+def test_prompt_quiet_line_present_exactly_when_remediation_quiet(
+    tmp_path: Path,
+) -> None:
+    store, job = _saturated_job(tmp_path)
+
+    def prompt() -> str:
+        return _build_worker_prompt_sections(
+            store=store,
+            job_id=job.id,
+            mode="intervene",
+            snapshot=_worker_snapshot(job),
+        )["prompt"]
+
+    # No case: neither the override directive nor the quiet line.
+    baseline = prompt()
+    assert "REGIME REMEDIATION REQUIRED" not in baseline
+    assert REMEDIATION_QUIET_LINE not in baseline
+
+    # Open case without an accountable outcome: the override directive.
+    sync_remediation_with_health(store, job.id, _health())
+    open_prompt = prompt()
+    assert "REGIME REMEDIATION REQUIRED" in open_prompt
+    assert REMEDIATION_QUIET_LINE not in open_prompt
+
+    # Blocked with a recorded note and unmoved evidence: quiet line only.
+    update_remediation_progress(
+        store, job.id, state="blocked", note="Waiting for forward evidence"
+    )
+    quiet_prompt = prompt()
+    assert REMEDIATION_QUIET_LINE in quiet_prompt
+    assert "REGIME REMEDIATION REQUIRED" not in quiet_prompt
+
+    # Forward evidence moved since the note: the case is due again.
+    _record_closed_trades(store, job.id, 1)
+    due_prompt = prompt()
+    assert "REGIME REMEDIATION REQUIRED" in due_prompt
+    assert REMEDIATION_QUIET_LINE not in due_prompt
+
+
+def test_standing_checks_carry_remediation_recheck_block(tmp_path: Path) -> None:
+    store, job = _saturated_job(tmp_path)
+    sync_remediation_with_health(store, job.id, _health())
+    update_remediation_progress(
+        store, job.id, state="blocked", note="Waiting for forward evidence"
+    )
+
+    block = _standing_checks_block(
+        store.job_dir(job.id), store=store, job_id=job.id
+    )
+
+    remediation = block["remediation"]
+    assert remediation["state"] == "blocked"
+    assert remediation["recheck"]["next_retry_seconds"] > 0
+    assert remediation["next_recheck_at"] > utc_now_iso()
+
+
+def test_saturation_watermark_components_move_independently(tmp_path: Path) -> None:
+    store, job = _saturated_job(tmp_path)
+    base = saturation_watermark(store, job.id)
+
+    _record_closed_trades(store, job.id, 1)
+    assert saturation_watermark(store, job.id) != base
+
+    store2, job2 = _saturated_job(tmp_path / "legs", "legs-demo")
+    base2 = saturation_watermark(store2, job2.id)
+    store2.write_json(
+        job2.id,
+        "probation.json",
+        {"legs": [{"name": "leg-a", "status": "active"}]},
+    )
+    assert saturation_watermark(store2, job2.id) != base2


### PR DESCRIPTION
Four workstreams hardening the jobs_v1 lifecycle: wakes stop re-verifying unchanged facts, rotting jobs get a mechanical conclusion, and a symbol bug that masqueraded as a research blocker is fixed.

## 1. Remediation evidence-anchored backoff (`391e4225`)

Blocked remediation cases stop re-affirming on a timer. Quiet re-checks double toward a cap (`WAYFINDER_REMEDIATION_BACKOFF_CAP_SECONDS`, default 12h; hard 24h max-quiet bound); the moment material forward evidence lands (new closed trades, counterfactual/verdict update, gate flip, treatment change) the wait resets to a prompt re-check. Consecutive no-change re-affirmations roll into one note plus a compact journal heartbeat instead of full owner-feed entries.

## 2. ccxt exchange-aware quote (`cec351e8`)

`CcxtMarketFeed` hardcoded `quote="USDT"`, so hyperliquid fetches built symbols like `xyz:TSLA/USDT:USDT` that no hyperliquid market has — ccxt's hyperliquid markets are `/USDC:USDC` (HIP-3 keeps the dex prefix in the base). A research lane reported itself "mechanically blocked" on what was a symbol bug.

- `quote` now defaults per exchange (USDC on hyperliquid, USDT elsewhere); an explicit quote always wins
- None-default threads through `fetch_ccxt_dataset_rows`, `fetch_ccxt_funding_rows`, `build_live_dataset`, `fetch_funding_features`, and both CLI verbs; metadata records the resolved quote
- missing-market resolution raises a clear `ValueError` naming the attempted symbols and exchange

## 3. Bootstrap contract: nudge → park (`5b5580b5`)

New `jobs/lifecycle.py`. A job that never reaches operational state (no script run, no agent check, no baseline backtest, no forward trade) previously consumed wakes forever. Mechanical zone is paper-mode, wallet-unbound jobs ONLY — live or wallet-bound jobs are never auto-parked.

- **Nudge** — past `WAYFINDER_BOOTSTRAP_DEADLINE_HOURS`/2 (default 72h): one `bootstrap_lagging` journal entry (deduped via `state/lifecycle.json`) and a bootstrap-first directive leading every wake prompt
- **Park** — past the full deadline: runner loops paused with the same `RunnerBridge` machinery as `wayfinder job pause`, `state/bootstrap_failure.json` written {reason, parked_at, predicates_failed}, `job_parked_unbootstrapped` journaled with an undo (`wayfinder job resume <job_id>`); fires once — an owner resume is never fought
- **Monitor-decay park** — monitor-mode jobs whose backtest replication stays decayed/invalid past `WAYFINDER_MONITOR_DECAY_PARK_DAYS` (default 7d) with zero forward trades and no journal activity share the park path (`job_parked_monitor_decay`)
- `lifecycle_sweep` rides the application watchdog tick (daily-throttled fleet state file) so policy fires even when a rotting job's own loops never run; `wayfinder job lifecycle-sweep --force` bypasses the throttle
- Parks surface in owner attention `decided_autonomously` with the undo command; the closed `needs_you` kind union is untouched
- Kill-switch: `WAYFINDER_LIFECYCLE_REAPER=0` disables both park paths (nudge + directive stay)

## 4. Wake economy (`0551a213`)

New `jobs/wake_economy.py`, generalizing the remediation watermark doctrine to the wake loop.

- **Saturation posture** — "saturated" ONLY when nothing is mid-flight: no active research lane, no outstanding impasse mandate, no pending exhaustion claim, no pending/queued/applying proposal, no non-quiet remediation case, and the forward book below its evidence gate (`drift_policy.min_forward_trades`). Anything mid-flight defeats saturation — the claim machinery plays first.
- **Pre-spawn cheap-skip** — before any OpenCode session work: a saturated paper job whose saturation watermark (claims, lane, mandate, closed trades, probation legs, pending proposals, incumbent revision, halt state) is unchanged within `WAYFINDER_WAKE_QUIET_MAX_HOURS` (default 24h) of the last full wake skips the LLM session entirely: quiet report (`status: quiet`, `skip_reason: saturation_watermark_unchanged`, watermark, `next_full_wake_by`) plus a per-episode deduped `wake_skipped_saturated` heartbeat with a rolling skip counter. Watermark movement or the 24h floor forces a full wake. Live jobs, apply wakes, and auto wakes never skip.
- **Remediation never satisfies the wake** — standing checks gain a `remediation` sub-block {state, recheck, next_recheck_at}; when a case is blocked/evaluating with a recorded note and no forward-evidence movement since, the prompt swaps the remediation override for an explicit line routing the session to research obligations (experiment | probation leg | exhaustion claim) and restores the island search assignment.
- Kill-switch: `WAYFINDER_WAKE_ECONOMY=0` disables the skip path.

## Tests

`pytest -k "jobs or runner or mcp"`: **1217 passed, 9 skipped** (all skips are env-gated live tests requiring API keys). 27 new tests: exchange-aware quote resolution + missing-market errors; operational-predicate truth table, nudge-once, park with bridge spy + undo, live/wallet-bound exemption, monitor-decay window, reaper kill-switch, sweep throttle; posture table (each mid-flight condition individually defeats saturation), skip path never touches the OpenCode client, watermark movement / 24h floor force full wakes, live/apply/auto never skip, wake-economy kill-switch, quiet-line-exactly-when-quiet prompt matrix. Ruff clean; no new mypy errors on touched modules.
