### PR TITLE
jobs: first venue deposit replaces declared capital

### DIFF
--- a/wayfinder_paths/jobs/sync.py
+++ b/wayfinder_paths/jobs/sync.py
@@ -551,10 +551,13 @@ async def venue_deposit(
     job_id: str, amount: float, *, store: JobStore | None = None
 ) -> dict[str, Any]:
     """Fund the strategy where it trades: bridge USDC from the job's bound
-    wallet into Hyperliquid, then grow ``initial_capital`` by the same
-    amount — one op keeps bankroll and accounting in lockstep. An
-    ``unconfirmed`` bridge credit still counts (the deposit is en route);
-    only a failed send aborts before the capital write."""
+    wallet into Hyperliquid, then record ``initial_capital`` in lockstep. The
+    FIRST venue deposit REPLACES the declared capital — the paper-mode
+    default (e.g. $10k) must not leak into live sizing over a $50 bankroll —
+    and later deposits add. The marker lives in state/ (not hashed, wiped
+    with engine state, survives capital edits). An ``unconfirmed`` bridge
+    credit still counts (the deposit is en route); only a failed send aborts
+    before the capital write."""
     from wayfinder_paths.mcp.tools.hyperliquid import hyperliquid_deposit_usdc
 
     store = store or JobStore()
@@ -563,8 +566,14 @@ async def venue_deposit(
     outcome = await hyperliquid_deposit_usdc(wallet_label=label, amount_usdc=amount)
     if outcome["status"] == "failed":
         raise ValueError(f"venue deposit failed: {outcome}")
-    current = float(job.execution_params.get("initial_capital") or 0.0)
-    capital = apply_initial_capital(job_id, current + float(amount), store=store)
+    funding = store.read_json(job_id, "state/funding.json", default=None) or {}
+    base = (
+        float(job.execution_params.get("initial_capital") or 0.0)
+        if funding.get("venue_funded")
+        else 0.0
+    )
+    capital = apply_initial_capital(job_id, base + float(amount), store=store)
+    store.write_json(job_id, "state/funding.json", {"venue_funded": True})
     return {
         "job_id": job_id,
         "deposit_status": outcome["status"],

--- a/wayfinder_paths/tests/test_jobs_funding_knobs.py
+++ b/wayfinder_paths/tests/test_jobs_funding_knobs.py
@@ -157,8 +157,12 @@ def test_venue_deposit_bridges_then_grows_capital(tmp_path, monkeypatch) -> None
     result = asyncio.run(sync_module.venue_deposit(job_id, 25.0, store=store))
     assert calls == [{"wallet_label": job_id, "amount_usdc": 25.0}]
     assert result["deposit_status"] == "confirmed"
-    assert result["initial_capital"] == 10_025.0
-    assert store.load(job_id).execution_params["initial_capital"] == 10_025.0
+    # First venue deposit REPLACES the paper-default capital...
+    assert result["initial_capital"] == 25.0
+    assert store.load(job_id).execution_params["initial_capital"] == 25.0
+    # ...and later deposits add.
+    again = asyncio.run(sync_module.venue_deposit(job_id, 10.0, store=store))
+    assert again["initial_capital"] == 35.0
 
 
 def test_venue_deposit_failed_send_never_touches_capital(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
### Summary
`venue-deposit`'s first run REPLACES `initial_capital` with the deposit amount instead of adding to the paper-mode default ($10k paper + $12 real = engine sizing a $10k account against a $12 wallet). Later deposits add. The venue-funded marker lives in `state/funding.json` — outside the revision hash, reset with engine state. Test pins replace-then-add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)