### PR TITLE
jobs: venue ops unwrap the MCP ok-envelope

### DIFF
--- a/wayfinder_paths/jobs/sync.py
+++ b/wayfinder_paths/jobs/sync.py
@@ -563,7 +563,10 @@ async def venue_deposit(
     store = store or JobStore()
     job = store.load(job_id)
     label = _funded_wallet_label(job)
-    outcome = await hyperliquid_deposit_usdc(wallet_label=label, amount_usdc=amount)
+    envelope = await hyperliquid_deposit_usdc(wallet_label=label, amount_usdc=amount)
+    if not envelope["ok"]:
+        raise ValueError(f"venue deposit failed: {envelope}")
+    outcome = envelope["result"]
     if outcome["status"] == "failed":
         raise ValueError(f"venue deposit failed: {outcome}")
     funding = store.read_json(job_id, "state/funding.json", default=None) or {}
@@ -593,7 +596,10 @@ async def venue_withdraw(
     store = store or JobStore()
     job = store.load(job_id)
     label = _funded_wallet_label(job)
-    outcome = await hyperliquid_withdraw_usdc(wallet_label=label, amount_usdc=amount)
+    envelope = await hyperliquid_withdraw_usdc(wallet_label=label, amount_usdc=amount)
+    if not envelope["ok"]:
+        raise ValueError(f"venue withdraw failed: {envelope}")
+    outcome = envelope["result"]
     if outcome["status"] == "failed":
         raise ValueError(f"venue withdraw failed: {outcome}")
     current = float(job.execution_params.get("initial_capital") or 0.0)

--- a/wayfinder_paths/tests/test_jobs_funding_knobs.py
+++ b/wayfinder_paths/tests/test_jobs_funding_knobs.py
@@ -148,7 +148,7 @@ def test_venue_deposit_bridges_then_grows_capital(tmp_path, monkeypatch) -> None
 
     async def fake_deposit(*, wallet_label, amount_usdc):
         calls.append({"wallet_label": wallet_label, "amount_usdc": amount_usdc})
-        return {"status": "confirmed"}
+        return {"ok": True, "result": {"status": "confirmed"}}
 
     import wayfinder_paths.mcp.tools.hyperliquid as hl
 
@@ -176,7 +176,7 @@ def test_venue_deposit_failed_send_never_touches_capital(tmp_path, monkeypatch) 
     store.save(job)
 
     async def fake_deposit(*, wallet_label, amount_usdc):
-        return {"status": "failed", "error": "no gas"}
+        return {"ok": True, "result": {"status": "failed", "error": "no gas"}}
 
     import wayfinder_paths.mcp.tools.hyperliquid as hl
 
@@ -200,7 +200,7 @@ def test_venue_withdraw_shrinks_capital_floored_at_zero(tmp_path, monkeypatch) -
     monkeypatch.setattr(sync_module, "sync_all_jobs", lambda **kwargs: None)
 
     async def fake_withdraw(*, wallet_label, amount_usdc):
-        return {"status": "confirmed"}
+        return {"ok": True, "result": {"status": "confirmed"}}
 
     import wayfinder_paths.mcp.tools.hyperliquid as hl
 


### PR DESCRIPTION
### Summary
`hyperliquid_deposit_usdc`/`withdraw_usdc` return the MCP `{ok, result}` envelope; the venue ops read `status` off the envelope and KeyErrored after the bridge send — money moved, capital write skipped. Unwrap + assert ok. Tests updated to the real shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)