### PR TITLE
jobs: venue-withdraw takes an explicit destination

### DIFF
--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -1061,9 +1061,7 @@ def rank_check_cmd(job_id: str, column: str, horizons: str | None) -> None:
     default=None,
     help="Quote currency (default: USDC on hyperliquid, USDT elsewhere).",
 )
-def fetch_funding_cmd(
-    job_id: str, days: int, exchange: str, quote: str | None
-) -> None:
+def fetch_funding_cmd(job_id: str, days: int, exchange: str, quote: str | None) -> None:
     store = JobStore()
     result = fetch_funding_features(
         job_id, days=days, exchange=exchange, quote=quote, store=store
@@ -1493,9 +1491,14 @@ def venue_deposit_cmd(job_id: str, amount: float) -> None:
 )
 @click.argument("job_id")
 @click.argument("amount", type=float)
-def venue_withdraw_cmd(job_id: str, amount: float) -> None:
+@click.option(
+    "--destination",
+    default=None,
+    help="Arbitrum address receiving the USDC (defaults to the job's wallet).",
+)
+def venue_withdraw_cmd(job_id: str, amount: float, destination: str | None) -> None:
     try:
-        result = asyncio.run(venue_withdraw(job_id, amount))
+        result = asyncio.run(venue_withdraw(job_id, amount, destination=destination))
     except ValueError as exc:
         raise click.ClickException(str(exc)) from exc
     _echo_json({"ok": True, "result": result})
@@ -2189,9 +2192,7 @@ def resume_cmd(job_id: str) -> None:
     "never-operational jobs plus monitor-decay park. The watchdog runs this "
     "daily; --force bypasses the throttle.",
 )
-@click.option(
-    "--force", is_flag=True, default=False, help="Bypass the daily throttle."
-)
+@click.option("--force", is_flag=True, default=False, help="Bypass the daily throttle.")
 def lifecycle_sweep_cmd(force: bool) -> None:
     _echo_json({"ok": True, "result": lifecycle_sweep(JobStore(), force=force)})
 

--- a/wayfinder_paths/jobs/sync.py
+++ b/wayfinder_paths/jobs/sync.py
@@ -585,18 +585,25 @@ async def venue_deposit(
 
 
 async def venue_withdraw(
-    job_id: str, amount: float, *, store: JobStore | None = None
+    job_id: str,
+    amount: float,
+    *,
+    destination: str | None = None,
+    store: JobStore | None = None,
 ) -> dict[str, Any]:
-    """Pull bankroll off the venue: withdraw USDC from Hyperliquid to the
-    job's bound wallet (Bridge2 nets $1 off the amount) and shrink
-    ``initial_capital`` by the gross amount, floored at zero — a full
-    withdrawal honestly reads as unfunded and turns the gate red."""
+    """Pull bankroll off the venue: withdraw USDC from Hyperliquid (Bridge2
+    nets $1 off the amount) to ``destination`` — the job's bound wallet when
+    omitted — and shrink ``initial_capital`` by the gross amount, floored at
+    zero; a full withdrawal honestly reads as unfunded and turns the gate
+    red."""
     from wayfinder_paths.mcp.tools.hyperliquid import hyperliquid_withdraw_usdc
 
     store = store or JobStore()
     job = store.load(job_id)
     label = _funded_wallet_label(job)
-    envelope = await hyperliquid_withdraw_usdc(wallet_label=label, amount_usdc=amount)
+    envelope = await hyperliquid_withdraw_usdc(
+        wallet_label=label, amount_usdc=amount, destination=destination
+    )
     if not envelope["ok"]:
         raise ValueError(f"venue withdraw failed: {envelope}")
     outcome = envelope["result"]

--- a/wayfinder_paths/mcp/tools/hyperliquid.py
+++ b/wayfinder_paths/mcp/tools/hyperliquid.py
@@ -1236,6 +1236,7 @@ async def hyperliquid_withdraw_usdc(
     *,
     wallet_label: str,
     amount_usdc: float,
+    destination: str | None = None,
 ) -> dict[str, Any]:
     """Withdraw USDC from Hyperliquid back to Arbitrum.
 
@@ -1267,7 +1268,9 @@ async def hyperliquid_withdraw_usdc(
     # one withdrawable balance.
     effects.append(await _unify_split_account_effect(adapter, sender))
 
-    ok_wd, res = await adapter.withdraw(amount=amt, address=sender)
+    # withdraw3 supports an explicit destination — default to the account's
+    # own address (self-withdrawal) when none is given.
+    ok_wd, res = await adapter.withdraw(amount=amt, address=destination or sender)
     effects.append({"type": "hl", "label": "withdraw", "ok": ok_wd, "result": res})
 
     if ok_wd:

--- a/wayfinder_paths/tests/test_jobs_funding_knobs.py
+++ b/wayfinder_paths/tests/test_jobs_funding_knobs.py
@@ -199,7 +199,7 @@ def test_venue_withdraw_shrinks_capital_floored_at_zero(tmp_path, monkeypatch) -
     store.save(job)
     monkeypatch.setattr(sync_module, "sync_all_jobs", lambda **kwargs: None)
 
-    async def fake_withdraw(*, wallet_label, amount_usdc):
+    async def fake_withdraw(*, wallet_label, amount_usdc, destination=None):
         return {"ok": True, "result": {"status": "confirmed"}}
 
     import wayfinder_paths.mcp.tools.hyperliquid as hl


### PR DESCRIPTION
### Summary
`withdraw3` supports an explicit destination — plumb it through `hyperliquid_withdraw_usdc`, `venue_withdraw` and the CLI (`--destination`), defaulting to the job's bound wallet (self-withdrawal) when omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)