### PR TITLE
jobs: evolution throughput and integrity — session nudges, pipelined authoring, bounded-window parity, finalize-aware expiry

### DIFF
--- a/wayfinder_paths/jobs/evolution_campaign.py
+++ b/wayfinder_paths/jobs/evolution_campaign.py
@@ -727,16 +727,29 @@ def campaign_prompt_block(
     candidates = state.get("candidates") or []
     prepared = [item for item in candidates if item.get("status") == "prepared"]
     policy = manifest.get("policy") or {}
+    budget = int(policy.get("generated_programs") or 0)
     deadline_elapsed = _aware(now or datetime.now(UTC)) >= _parse(state["deadline_at"])
     if deadline_elapsed:
         next_action = "Generation deadline elapsed; run evolution-finalize now."
+    elif prepared and len(candidates) < budget and len(prepared) < 3:
+        # Pipelined authoring: evaluation runs as a detached op, so the agent
+        # keeps writing the next candidate instead of idling on the result.
+        next_action = (
+            f"Edit only files inside {prepared[0]['bundle']} (workspace, job.yaml, "
+            "and optional search_space.json) if you have not already, then launch "
+            f"evolution-evaluate for {prepared[0]['candidate_id']}. It runs "
+            "detached — do not wait for its result, and an already_running "
+            "response just means the launch already happened; that is normal, "
+            "move on. Immediately prepare the next candidate with "
+            "evolution-prepare while the evaluation runs."
+        )
     elif prepared:
         next_action = (
             f"Edit only files inside {prepared[0]['bundle']} (workspace, job.yaml, "
             "and optional search_space.json), then run evolution-evaluate for "
             f"{prepared[0]['candidate_id']}."
         )
-    elif len(candidates) < int(policy.get("generated_programs") or 0):
+    elif len(candidates) < budget:
         next_action = (
             "Prepare the next candidate with evolution-prepare. At least half "
             "the campaign must change signal/exit/regime/portfolio structure."

--- a/wayfinder_paths/jobs/execution/op_runner.py
+++ b/wayfinder_paths/jobs/execution/op_runner.py
@@ -247,11 +247,35 @@ def _lower_priority() -> None:
         pass
 
 
+_NUDGE_OPS = {"evolution_start", "evolution_evaluate"}
+
+
+def _nudge_evolution(op: str, kwargs: dict[str, Any]) -> None:
+    """Poke the persistent evolution session the moment a campaign op lands,
+    so the agent resumes immediately instead of idling until the next hourly
+    wake. Best-effort: a nudge failure must never fail the op it follows."""
+    if op not in _NUDGE_OPS or not kwargs.get("job_id"):
+        return
+    try:
+        from wayfinder_paths.jobs.store import JobStore
+        from wayfinder_paths.jobs.worker import nudge_evolution_session
+
+        nudge_evolution_session(JobStore(), str(kwargs["job_id"]))
+    except Exception:  # noqa: BLE001 - observability lane only
+        pass
+
+
 def main() -> None:
     _lower_priority()
     request = json.load(sys.stdin)
-    result = _run(request["op"], dict(request.get("kwargs") or {}))
+    op = str(request["op"])
+    kwargs = dict(request.get("kwargs") or {})
+    result = _run(op, dict(kwargs))
     json.dump(result, sys.stdout, default=str)
+    # Flush before nudging: the re-prompted session's campaign block must see
+    # the completed op's result file, not a half-written one.
+    sys.stdout.flush()
+    _nudge_evolution(op, kwargs)
 
 
 if __name__ == "__main__":

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -1637,6 +1637,37 @@ def _queue_evolution_worker(store: JobStore, job_id: str) -> dict[str, Any] | No
         return {"queued": False, "error": str(exc)[:300]}
     if not campaign or campaign.get("status") == "blocked":
         return None
+    return _prompt_evolution_session(store, job_id, campaign, source="wake")
+
+
+def nudge_evolution_session(store: JobStore, job_id: str) -> dict[str, Any] | None:
+    """Re-prompt the persistent evolution session as soon as a detached
+    campaign op (start/evaluate) lands, instead of leaving the fresh state
+    idle until the next hourly wake. Best-effort: callers must tolerate None.
+    """
+    if os.environ.get("WAYFINDER_EVOLUTION_NUDGE") == "0":
+        return None
+    if not OPENCODE_CLIENT.healthy():
+        return None
+    try:
+        from wayfinder_paths.jobs.evolution_campaign import (
+            campaign_prompt_block,
+            campaign_status,
+        )
+
+        if campaign_status(store, job_id).get("status") != "active":
+            return None
+        campaign = campaign_prompt_block(store, job_id)
+    except Exception as exc:  # noqa: BLE001 - a nudge must never fail its op
+        return {"queued": False, "error": str(exc)[:300]}
+    if not campaign or campaign.get("status") == "blocked":
+        return None
+    return _prompt_evolution_session(store, job_id, campaign, source="op_completion")
+
+
+def _prompt_evolution_session(
+    store: JobStore, job_id: str, campaign: dict[str, Any], *, source: str
+) -> dict[str, Any] | None:
     controller_session_id = os.environ.get("OPENCODE_SESSION_ID") or os.environ.get(
         "OPENCODE_SESSIONID"
     )
@@ -1660,7 +1691,10 @@ def _queue_evolution_worker(store: JobStore, job_id: str) -> dict[str, Any] | No
         "active workspace. Candidate inputs are frozen at campaign start. A finalist "
         "is only staged for an immutable 24-hour forward paper proposal; it cannot "
         "authorize live trading or bypass owner promotion. Reuse the repository's "
-        "research toolkit and starter casebook instead of recreating indicators.\n\n"
+        "research toolkit and starter casebook instead of recreating indicators. "
+        "After launching an evolution-evaluate, do not wait for its result — keep "
+        "preparing candidates until the generation budget or the deadline is "
+        "reached; evaluation results arrive via follow-up prompts.\n\n"
         "Campaign:\n" + _canonical_json(campaign, max_chars=12_000)
     )
     queued = OPENCODE_CLIENT.prompt_async(
@@ -1686,6 +1720,7 @@ def _queue_evolution_worker(store: JobStore, job_id: str) -> dict[str, Any] | No
             else "Dedicated evolution wake could not be queued",
             "session_id": session_id,
             "queued": queued,
+            "source": source,
             "created_at": created_at,
         },
     )
@@ -1696,6 +1731,7 @@ def _queue_evolution_worker(store: JobStore, job_id: str) -> dict[str, Any] | No
             "campaign_id": campaign.get("campaign_id"),
             "session_id": session_id,
             "queued": queued,
+            "source": source,
         },
     )
     return {"queued": queued, "session_id": session_id}

--- a/wayfinder_paths/tests/test_jobs_evolution_campaign.py
+++ b/wayfinder_paths/tests/test_jobs_evolution_campaign.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import io
 import json
 from datetime import UTC, datetime
+from typing import Any
 
 import pytest
 
@@ -30,7 +32,7 @@ from wayfinder_paths.jobs.starter_casebook import (
     load_starter_casebook,
 )
 from wayfinder_paths.jobs.store import JobStore
-from wayfinder_paths.jobs.worker import _queue_evolution_worker
+from wayfinder_paths.jobs.worker import _queue_evolution_worker, nudge_evolution_session
 
 
 def _job(tmp_path, job_id: str) -> tuple[JobStore, str]:
@@ -442,6 +444,62 @@ def test_jsonl_features_are_frozen_at_the_campaign_cutoff(tmp_path) -> None:
     assert [row["value"] for row in rows] == [0, 1]
 
 
+def test_next_action_pipelines_authoring_against_detached_evaluation(tmp_path) -> None:
+    store, job_id = _job(tmp_path, "majors-5m-lab")
+    started = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    start_campaign(store, job_id, now=started)
+    working = started.replace(hour=13)
+    prepare_candidate(
+        store, job_id, family="breakout", summary="pipeline probe", now=working
+    )
+
+    block = campaign_prompt_block(store, job_id, now=working)
+    assert block is not None
+    assert "evolution-evaluate" in block["next_action"]
+    assert "evolution-prepare" in block["next_action"]
+    assert "do not wait" in block["next_action"]
+
+    for index in range(2):
+        prepare_candidate(
+            store, job_id, family="breakout", summary=f"queued {index}", now=working
+        )
+    drain = campaign_prompt_block(store, job_id, now=working)
+    assert "evolution-evaluate" in drain["next_action"]
+    assert "evolution-prepare" not in drain["next_action"]
+
+    state = campaign_status(store, job_id)
+    manifest = json.loads(
+        (store.job_dir(job_id) / state["manifest"]).read_text(encoding="utf-8")
+    )
+    budget = int(manifest["policy"]["generated_programs"])
+    for candidate in state["candidates"]:
+        candidate["status"] = "quick_complete"
+    while len(state["candidates"]) < budget:
+        state["candidates"].append({"status": "quick_complete"})
+    store.write_json(job_id, "state/evolution_campaign.json", state)
+    done = campaign_prompt_block(store, job_id, now=working)
+    assert (
+        done["next_action"] == "Run evolution-finalize in the isolated background "
+        "worker."
+    )
+
+    # Budget exhausted with a candidate still awaiting evaluation: drain only.
+    state["candidates"][0]["status"] = "prepared"
+    store.write_json(job_id, "state/evolution_campaign.json", state)
+    exhausted = campaign_prompt_block(store, job_id, now=working)
+    assert "evolution-evaluate" in exhausted["next_action"]
+    assert "evolution-prepare" not in exhausted["next_action"]
+
+    elapsed = campaign_prompt_block(
+        store, job_id, now=datetime(2026, 8, 25, 16, 30, tzinfo=UTC)
+    )
+    assert (
+        elapsed["next_action"] == "Generation deadline elapsed; run "
+        "evolution-finalize now."
+    )
+    assert elapsed["deadline_elapsed"] is True
+
+
 def test_evolution_uses_a_dedicated_long_lived_session(tmp_path, monkeypatch) -> None:
     store, job_id = _job(tmp_path, "majors-5m-lab")
     store.write_json(
@@ -483,5 +541,114 @@ def test_evolution_uses_a_dedicated_long_lived_session(tmp_path, monkeypatch) ->
     assert result == {"queued": True, "session_id": "evolution-session"}
     assert len(client.prompts) == 1
     assert "immutable 24-hour forward paper proposal" in client.prompts[0][1]
+    assert "do not wait for its result" in client.prompts[0][1]
     session = store.read_json(job_id, "reports/evolution/session.json")
     assert session["session_id"] == "evolution-session"
+
+
+class _FakeEvolutionClient:
+    def __init__(self, job_id: str) -> None:
+        self.job_id = job_id
+        self.prompts: list[tuple[str, str, str]] = []
+
+    def healthy(self) -> bool:
+        return True
+
+    def find_child_session(self, *, parent_id: Any, title: str) -> str:
+        assert title == f"job/{self.job_id}/evolution"
+        return "evolution-session"
+
+    def create_session(self, **kwargs: Any) -> str:
+        raise AssertionError("the stable evolution session should be reused")
+
+    def prompt_async(self, *, session_id: str, text: str, agent: str) -> bool:
+        self.prompts.append((session_id, text, agent))
+        return True
+
+
+def test_op_completion_nudge_reuses_session_and_respects_kill_switch(
+    tmp_path, monkeypatch
+) -> None:
+    store, job_id = _job(tmp_path, "majors-5m-lab")
+    store.write_json(
+        job_id,
+        "state/evolution_campaign.json",
+        {"campaign_id": "campaign-1", "status": "active"},
+    )
+    client = _FakeEvolutionClient(job_id)
+    monkeypatch.setattr("wayfinder_paths.jobs.worker.OPENCODE_CLIENT", client)
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.evolution_campaign.campaign_prompt_block",
+        lambda store, job_id: {
+            "campaign_id": "campaign-1",
+            "next_action": "prepare the next candidate",
+        },
+    )
+
+    result = nudge_evolution_session(store, job_id)
+
+    assert result == {"queued": True, "session_id": "evolution-session"}
+    assert len(client.prompts) == 1
+    session = store.read_json(job_id, "reports/evolution/session.json")
+    assert session["session_id"] == "evolution-session"
+    latest = store.read_json(job_id, "reports/evolution/latest.json")
+    assert latest["source"] == "op_completion"
+    journal = store.job_dir(job_id) / "journal.jsonl"
+    entry = json.loads(journal.read_text(encoding="utf-8").splitlines()[-1])
+    assert entry["type"] == "evolution_worker_wakeup"
+    assert entry["source"] == "op_completion"
+
+    # No nudge without an active campaign.
+    store.write_json(
+        job_id,
+        "state/evolution_campaign.json",
+        {"campaign_id": "campaign-1", "status": "complete"},
+    )
+    assert nudge_evolution_session(store, job_id) is None
+    assert len(client.prompts) == 1
+
+    # Kill-switch disables op-completion nudges entirely.
+    store.write_json(
+        job_id,
+        "state/evolution_campaign.json",
+        {"campaign_id": "campaign-1", "status": "active"},
+    )
+    monkeypatch.setenv("WAYFINDER_EVOLUTION_NUDGE", "0")
+    assert nudge_evolution_session(store, job_id) is None
+    assert len(client.prompts) == 1
+
+
+def test_op_runner_nudges_after_evolution_ops_and_contains_failures(
+    monkeypatch, capsys
+) -> None:
+    from wayfinder_paths.jobs.execution import op_runner
+
+    nudged: list[str] = []
+    monkeypatch.setattr(op_runner, "_lower_priority", lambda: None)
+    monkeypatch.setattr(op_runner, "_run", lambda op, kwargs: {"ok": True})
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.worker.nudge_evolution_session",
+        lambda store, job_id: nudged.append(job_id),
+    )
+
+    def run_main(op: str, kwargs: dict[str, Any]) -> None:
+        monkeypatch.setattr(
+            "sys.stdin", io.StringIO(json.dumps({"op": op, "kwargs": kwargs}))
+        )
+        op_runner.main()
+
+    run_main("evolution_evaluate", {"job_id": "majors-5m-lab", "candidate_id": "c1"})
+    # evolution_start completion nudges too: the first campaign prompt no
+    # longer waits out a full hourly wake interval.
+    run_main("evolution_start", {"job_id": "majors-5m-lab"})
+    run_main("backtest_job", {"job_id": "majors-5m-lab"})
+    assert nudged == ["majors-5m-lab", "majors-5m-lab"]
+
+    def boom(store: Any, job_id: str) -> None:
+        raise RuntimeError("nudge failed")
+
+    monkeypatch.setattr("wayfinder_paths.jobs.worker.nudge_evolution_session", boom)
+    run_main("evolution_evaluate", {"job_id": "majors-5m-lab", "candidate_id": "c1"})
+    # The op result was written all four times; the failed nudge stayed inside
+    # its guard instead of failing the op.
+    assert capsys.readouterr().out.count('{"ok": true}') == 4


### PR DESCRIPTION
Four workstreams that together take an evolution campaign from "idles between hourly wakes, runs quadratic backtests, and gets its finalize orphan-killed" to a pipeline that is fast, honest by construction, and self-healing.

## 1. Evolution session nudges (commit 1)

**Problem**: after a detached campaign op (start/evaluate) landed, the fresh state sat idle until the next hourly wake — dead air between every candidate.

**Fix**: `op_runner` completion nudges the persistent evolution session (`nudge_evolution_session`) the moment `evolution_start`/`evolution_evaluate` finish, reusing the same long-lived child session.

**Kill switch**: `WAYFINDER_EVOLUTION_NUDGE=0` disables op-completion nudges entirely; the hourly wake funnel is untouched.

## 2. Pipelined candidate authoring (commit 1)

**Problem**: the session launched an evaluation and then waited on it, serializing authoring behind compute.

**Fix**: `campaign_prompt_block` next_action + the session prompt now direct the agent to launch `evolution-evaluate` detached and immediately `evolution-prepare` the next candidate; `already_running` responses are normalized as "the launch already happened, move on". Budget-exhausted and deadline-elapsed states still drain/finalize as before.

## 3. Bounded-window parity — backtest ≡ forward by construction (commit 2)

**Problem — a parity inversion**: the LIVE driver was already bounded (it fetched `lookback_bars or 200` bars per tick); the BACKTEST was the dishonest path. The simulator resolved a compute window but the shadow replayer handed candidates full growing history, the driver used its own separate `or 200` default, and nothing proved a strategy actually respected its declared window. Any decide() consuming more history than the live fetch was backtesting a strategy that cannot exist in production — and full-frame recompute is the O(N²) trap that ran last night's finalize at 8–14 bars/s over 27,648 bars.

**Fix — one contract, mechanically enforced, taught to the pipeline**:
- `primitives.ComputeWindow` + `resolve_compute_window` — the single resolution (`params.warmup_bars` canonical → `lookback_bars` back-compat → `strategy.warmup_bars` attr → default 512; `full_history` opt-out) and the single slice, now shared by the simulator, the live driver, and the candidate shadow replayer. A declared `warmup_bars` sizes live view loading too; `lookback_bars`-only jobs keep their exact live depth; undeclared jobs align live to the simulator's 512 default (closing the old 200-live vs 512-backtest drift); `full_history` keeps the legacy 200-bar live fetch.
- Window-invariance probe (`execution/validation.py`): for declared windows, ~12 decision bars sampled across the canonical dataset are replayed twice — window W vs min(available, W+64) — from identical fresh state. Any intent difference means decide() consumed history beyond its declaration → validation RED naming the differing bar and embedding the bounded-window hint. This is a mechanical proof that backtest inputs ≡ forward inputs.
- Campaign admission: `prepare_candidate` seeds `warmup_bars` into every candidate bundle (inheriting the source's declared window, else 512), the frozen source is seeded identically so the identical-to-source guard still catches unedited candidates, and `evaluate`/full-dev reject undeclared windows or probe failures as `invalid` with the hint as the reason.
- Teaching, not just patching: the campaign session prompt and a new `bounded-window-parity` casebook case state the contract — declare the window covering your longest indicator lookback plus buffer; recompute from the bounded window or carry long memory as incremental state; never recompute over full history.

**Kill switches / escape hatches**: `full_history: true` keeps genuine since-genesis strategies on full-history backtests (exempt from the probe, inadmissible as campaign candidates); undeclared legacy jobs keep today's simulator behavior exactly and only gain a validation WARNING when the profiler flags heavy/growing ticks; the probe check degrades to non-blocking on probe infrastructure errors.

## 4. Finalize-aware campaign expiry + orphan reap (commit 3)

**Problem**: last night the watchdog hard-expired the campaign at the 60-minute finalize grace while a healthy finalize was mid-Optuna; the orphan ran 8+ hours holding the replication lock.

**Fix**: past the grace, `_run_evolution_campaign_pass` checks the `evolution_finalize` op first — live pid + op log written within 10 minutes ⇒ EXTEND (journal `evolution_finalize_still_running`, deduped once per campaign via a watchdog-owned marker); dead pid or stale log ⇒ expire as before AND SIGKILL the op's process group first (`killpg` on the recorded pid — pgid == pid via `start_new_session=True`, so surviving children are reaped even when the leader died), journaling `evolution_finalize_reaped` with the pid. Reaping happens before taking the campaign lock a wedged finalize may itself hold.

## Tests

- Nudges + pipelining: session reuse, kill switch, op_runner nudge containment, next_action pipelining states (commit 1).
- Declared window bounds every decide() view (≤W timestamps, ≤W symbol_frame rows); undeclared runs keep the pinned default and surface the hint warning; `resolve_compute_window` unit matrix (warmup/lookback/attr/default/full_history) feeding both simulator and driver; driver fetch-depth test via a recording feed; shadow ticks capped at the declared window.
- Probe: window-respecting strategy passes; full-frame-mean strategy REDs naming the bar with the hint; validate-level check blocking semantics; undeclared exemption.
- Campaign: seeding (default + inheritance), unedited-candidate identical-revision guard still holds, undeclared/full_history candidate → invalid with hint, seeded candidate evaluates to quick_complete; casebook loads with the new case and selection stays bounded.
- Watchdog: healthy finalize past grace extends (journal deduped), stale live finalize is reaped (killpg mocked, order asserted) then expired, dead pid expires with no reap journal; the pre-existing finalize/retry/expiry ladder test is unchanged and green.
- Full `pytest -k "jobs or runner or mcp"`: 1280 passed / 9 skipped (baseline 1272/9 + 8 new in-filter tests). Ruff clean on touched files; scoped mypy introduces no new errors (and removes one legacy simulator error).
