### PR TITLE
Jobs: make research wakes evidence driven

### DIFF
--- a/wayfinder_paths/jobs/execution/driver.py
+++ b/wayfinder_paths/jobs/execution/driver.py
@@ -130,7 +130,7 @@ def run_scheduled_tick(job_dir: str | Path | None = None) -> dict[str, Any]:
 
 def _tick_trigger_events(payload: dict[str, Any]) -> list[str]:
     events: list[str] = []
-    if payload.get("ok") is not True:
+    if payload.get("ok") is not True and not _is_retryable_data_failure(payload):
         events.append("script_failure")
     snapshot = payload.get("snapshot") or {}
     if snapshot.get("status") == "ambiguous":
@@ -158,6 +158,27 @@ def _tick_trigger_events(payload: dict[str, Any]) -> list[str]:
         # Compatibility with reports produced before durable remediation cases.
         events.append("regime_shift")
     return events
+
+
+def _is_retryable_data_failure(payload: Mapping[str, Any]) -> bool:
+    """Keep transient public-data throttling on the mechanical retry path.
+
+    Derived-feature refresh already journals persistent feed degradation and
+    recovery. Waking an LLM for each 429 cannot repair the provider and was a
+    major source of duplicate canary sessions; non-rate-limit failures retain
+    the existing immediate ``script_failure`` trigger.
+    """
+    error = str(payload.get("error") or "").lower()
+    return any(
+        marker in error
+        for marker in (
+            "rate_limited",
+            "rate limited",
+            "too many requests",
+            "http 429",
+            "status code 429",
+        )
+    )
 
 
 async def tick_job(

--- a/wayfinder_paths/jobs/remediation.py
+++ b/wayfinder_paths/jobs/remediation.py
@@ -191,18 +191,19 @@ def sync_remediation_with_health(
         # not-yet-due path, so the reset re-derives every tick until it fires.
         next_retry = REMEDIATION_BACKOFF_BASE_SECONDS
     # Progress-only ticks must not re-wake: a bounded evaluation/blocker note
-    # recorded since the last wake is the agent already working the case.
+    # is an accountable terminal result until the evidence watermark moves.
     last_wake = _parse_time(current.get("last_wake_requested_at"))
     progress_at = _parse_time((current.get("progress") or {}).get("recorded_at"))
-    anchors = [ts for ts in (last_wake, progress_at) if ts is not None]
+    last_check = _parse_time(recheck.get("last_checked_at"))
+    anchors = [ts for ts in (last_wake, progress_at, last_check) if ts is not None]
     wait = min(next_retry, REMEDIATION_MAX_QUIET_SECONDS)
     if anchors and (now - max(anchors)).total_seconds() < wait:
         return None
 
     current["updated_at"] = now_iso
-    current["last_wake_requested_at"] = now_iso
-    current["attempts"] = int(current.get("attempts") or 0) + 1
     current["health"] = evidence
+    progress_watermark = (current.get("progress") or {}).get("watermark")
+    accountable_progress = isinstance(progress_watermark, Mapping)
     current["recheck"] = {
         "watermark": watermark,
         "last_checked_at": now_iso,
@@ -213,6 +214,12 @@ def sync_remediation_with_health(
             _backoff_cap_seconds(),
         ),
     }
+    wake_required = bool(evidence_reasons) or not accountable_progress
+    if wake_required:
+        current["last_wake_requested_at"] = now_iso
+        current["attempts"] = int(current.get("attempts") or 0) + 1
+    else:
+        current["quiet_checks"] = int(current.get("quiet_checks") or 0) + 1
     store.write_json(job_id, REMEDIATION_PATH, current)
     if evidence_reasons:
         store.append_journal(
@@ -235,10 +242,13 @@ def sync_remediation_with_health(
                 "case_id": current.get("case_id"),
                 "state": state,
                 "attempts": current["attempts"],
+                "llm_wake_requested": wake_required,
                 "last_checked_at": now_iso,
                 "next_retry_seconds": current["recheck"]["next_retry_seconds"],
             },
         )
+    if not wake_required:
+        return None
     return {
         "event": "regime_remediation_due",
         "case_id": current.get("case_id"),

--- a/wayfinder_paths/jobs/triggers.py
+++ b/wayfinder_paths/jobs/triggers.py
@@ -156,7 +156,15 @@ def _fire_triggers(
     # → execution.driver → triggers
     from wayfinder_paths.jobs.worker import run_job_worker
 
-    wakeup = run_job_worker(job.id, mode=loop.mode)
+    wakeup = run_job_worker(
+        job.id,
+        mode=loop.mode,
+        wake_source=source,
+        wake_triggers=due,
+        # A trigger wake represents named actionable work. It must not be
+        # mistaken for an unchanged scheduled heartbeat by wake economy.
+        force_llm=True,
+    )
     return {"triggers": due, "source": source, "ts": utc_now_iso(), **wakeup}
 
 

--- a/wayfinder_paths/jobs/wake_economy.py
+++ b/wayfinder_paths/jobs/wake_economy.py
@@ -1,15 +1,11 @@
-"""Wake economy: saturated paper jobs skip LLM wakes until evidence moves.
+"""Evidence-driven LLM wakes for paper research jobs.
 
-Generalizes the remediation module's evidence-anchored watermark doctrine to
-the wake loop itself: when every research obligation is settled and the
-forward book is still below its evidence gate, a full LLM wake re-verifies
-identical facts. Those wakes are skipped mechanically — a quiet report plus
-a deduped heartbeat — until the saturation watermark moves or the max-quiet
-window expires. Anything mid-flight (an active lane, an outstanding impasse
-mandate, a pending exhaustion claim or proposal, a non-quiet remediation
-case) defeats saturation: the claim machinery always plays first. Live jobs
-never skip, and a quiet remediation case never satisfies a wake — the prompt
-says so explicitly and routes the session to research obligations.
+Scheduled wakes skip mechanically when the compact decision watermark has
+not changed since the last delivered LLM wake. A bounded heartbeat still
+runs periodically, while actionable workflow state (an impasse mandate,
+pending claim/proposal, or remediation without an accountable outcome)
+always defeats the skip. Event-triggered, apply, auto, and live wakes keep
+their existing immediate behavior.
 """
 
 from __future__ import annotations
@@ -32,6 +28,7 @@ from wayfinder_paths.jobs.probation import load_probation
 from wayfinder_paths.jobs.remediation import (
     REMEDIATION_MAX_QUIET_SECONDS,
     _evidence_watermark,
+    _fingerprint,
     _watermark_reasons,
     compact_remediation,
     load_remediation,
@@ -42,9 +39,8 @@ WAKE_ECONOMY_PATH = "state/wake_economy.json"
 # Kill-switch: "0" disables the skip path entirely.
 WAKE_ECONOMY_ENV = "WAYFINDER_WAKE_ECONOMY"
 WAKE_QUIET_MAX_HOURS_ENV = "WAYFINDER_WAKE_QUIET_MAX_HOURS"
-DEFAULT_WAKE_QUIET_MAX_HOURS = 24.0
+DEFAULT_WAKE_QUIET_MAX_HOURS = 12.0
 SKIP_REASON = "saturation_watermark_unchanged"
-_DEFAULT_FORWARD_GATE_MIN_TRADES = 20
 
 REMEDIATION_QUIET_LINE = (
     "Remediation is evidence-blocked and backed off — it does NOT satisfy "
@@ -57,20 +53,17 @@ def wake_economy_enabled() -> bool:
     return os.environ.get(WAKE_ECONOMY_ENV) != "0"
 
 
-def research_saturation_posture(
-    store: JobStore, job_id: str, *, job: WayfinderJob | None = None
-) -> dict[str, Any]:
-    """Return "saturated" only when every research obligation is settled and the
-    forward book is still below its evidence gate. Anything mid-flight
-    defeats saturation — let the claim machinery play first."""
-    job = job or store.load(job_id)
+def research_saturation_posture(store: JobStore, job_id: str) -> dict[str, Any]:
+    """Return ``saturated`` when no actionable intervention is outstanding.
+
+    Stable research-lane labels, mature forward samples, and a parallel
+    evolution campaign are evidence context, not reasons to wake an LLM on
+    every timer tick. Their material transitions remain in the watermark.
+    """
     blockers: list[str] = []
     if not is_operational(store, job_id):
         # Bootstrap owns a never-operational job; the economy never starves it.
         blockers.append("not_operational")
-    lane = store.read_json(job_id, RESEARCH_LANE_PATH, default={}) or {}
-    if str(lane.get("active_lane") or "").strip():
-        blockers.append("research_lane_active")
     impasse = store.read_json(job_id, RESEARCH_IMPASSE_PATH, default={}) or {}
     if impasse.get("alerted_at") or impasse.get("status"):
         blockers.append("impasse_mandate_outstanding")
@@ -91,13 +84,6 @@ def research_saturation_posture(
         and not remediation_backed_off(store, job_id, case)
     ):
         blockers.append("remediation_case_active")
-    if _closed_trades(store, job_id) >= _forward_gate_minimum(job):
-        blockers.append("forward_sample_adequate")
-    campaign = (
-        store.read_json(job_id, "state/evolution_campaign.json", default={}) or {}
-    )
-    if campaign.get("status") in {"active", "finalizing"}:
-        blockers.append("evolution_campaign_open")
     return {"posture": "in_flight" if blockers else "saturated", "blockers": blockers}
 
 
@@ -120,6 +106,22 @@ def saturation_watermark(
     )
     experiment_arms = experiment.get("arms") or {}
     experiment_proposals = experiment.get("proposals") or {}
+    lane = store.read_json(job_id, RESEARCH_LANE_PATH, default={}) or {}
+    claims = sorted(
+        [
+            (str(claim.get("claim_id")), str(claim.get("status") or ""))
+            for claim in list_exhaustion_claims(store, job_id)
+        ]
+    )
+    probation_legs = sorted(
+        [
+            (str(leg.get("name")), str(leg.get("status") or ""))
+            for leg in load_probation(store, job_id).get("legs") or []
+            if isinstance(leg, Mapping)
+        ]
+    )
+    remediation = load_remediation(store, job_id) or {}
+    remediation_progress = (remediation.get("progress") or {}).get("watermark")
     experiment_watermark = None
     if experiment:
         proposal_watermarks = {}
@@ -155,10 +157,19 @@ def saturation_watermark(
         }
     return {
         "claims": {
-            str(claim.get("claim_id")): str(claim.get("status") or "")
-            for claim in list_exhaustion_claims(store, job_id)
+            "count": len(claims),
+            "fingerprint": _fingerprint({"claims": claims}),
         },
-        "lane": store.read_json(job_id, RESEARCH_LANE_PATH, default={}) or {},
+        "lane": {
+            key: lane.get(key)
+            for key in (
+                "active_lane",
+                "opened_from_claim",
+                "settled_lane",
+                "reopened_claim",
+            )
+            if lane.get(key) is not None
+        },
         "mandate": {
             "status": impasse.get("status"),
             "alerted_at": impasse.get("alerted_at"),
@@ -166,9 +177,8 @@ def saturation_watermark(
         "closed_trades": int(trades.get("closed_count") or 0),
         "last_trade_at": trades.get("last_trade_at"),
         "probation_legs": {
-            str(leg.get("name")): str(leg.get("status") or "")
-            for leg in load_probation(store, job_id).get("legs") or []
-            if isinstance(leg, Mapping)
+            "count": len(probation_legs),
+            "fingerprint": _fingerprint({"legs": probation_legs}),
         },
         "pending_proposals": sorted(
             str(proposal.get("proposal_id"))
@@ -176,6 +186,19 @@ def saturation_watermark(
             if proposal.get("status") == "pending"
         ),
         "incumbent_revision": job.versioning.get("active_revision"),
+        "remediation": {
+            "case_id": remediation.get("case_id"),
+            "state": remediation.get("state"),
+            "proposal_id": remediation.get("proposal_id"),
+            "health_fingerprint": (remediation.get("health") or {}).get("fingerprint"),
+            "evidence_fingerprint": _fingerprint(
+                {"watermark": dict(remediation_progress)}
+            )
+            if isinstance(remediation_progress, Mapping)
+            else None,
+        }
+        if remediation
+        else None,
         "evolution_campaign": {
             key: campaign.get(key)
             for key in (
@@ -247,6 +270,9 @@ def maybe_skip_wake(
     *,
     mode: str,
     apply_proposal_id: str | None,
+    force: bool = False,
+    wake_source: str = "scheduled_timer",
+    wake_triggers: list[str] | None = None,
     now: dt.datetime | None = None,
 ) -> dict[str, Any] | None:
     """Pre-spawn skip decision, called BEFORE any OpenCode session work.
@@ -254,7 +280,7 @@ def maybe_skip_wake(
     Returns the quiet report (already written to reports/{mode}/latest.json)
     when this wake should be skipped, else None for a normal full wake.
     """
-    if not wake_economy_enabled():
+    if not wake_economy_enabled() or force:
         return None
     if apply_proposal_id is not None or mode == "auto":
         # Apply wakes always run; auto wakes can act on markets — the
@@ -267,7 +293,7 @@ def maybe_skip_wake(
     last_full = _parse_time(state.get("last_full_wake_at"))
     if last_full is None or (now - last_full).total_seconds() >= _quiet_max_seconds():
         return None  # max-quiet floor: a full wake is due regardless
-    if research_saturation_posture(store, job.id, job=job)["posture"] != "saturated":
+    if research_saturation_posture(store, job.id)["posture"] != "saturated":
         return None
     watermark = saturation_watermark(store, job.id, job=job)
     if watermark != state.get("watermark"):
@@ -286,7 +312,12 @@ def maybe_skip_wake(
         "job_id": job.id,
         "mode": mode,
         "status": "quiet",
+        "outcome": "no_change",
+        "material_change": False,
         "skip_reason": SKIP_REASON,
+        "wake_source": wake_source,
+        "wake_triggers": sorted(set(wake_triggers or [])),
+        "decision_watermark_hash": _fingerprint({"watermark": watermark}),
         "summary": (
             "wake skipped: research saturated and the evidence watermark is "
             f"unchanged since the last full wake; next full wake by "
@@ -312,6 +343,7 @@ def maybe_skip_wake(
             {
                 "type": "wake_skipped_saturated",
                 "mode": mode,
+                "wake_source": wake_source,
                 "next_full_wake_by": next_full_wake_by,
             },
         )
@@ -319,30 +351,25 @@ def maybe_skip_wake(
 
 
 def record_full_wake(
-    store: JobStore, job: WayfinderJob, *, now: dt.datetime | None = None
+    store: JobStore,
+    job: WayfinderJob,
+    *,
+    wake_source: str = "scheduled_timer",
+    now: dt.datetime | None = None,
 ) -> None:
     """Stamp the wake-economy state after a full wake is queued: the next
     skip window anchors here and the skip episode counter resets."""
     now = now or dt.datetime.now(dt.UTC)
+    watermark = saturation_watermark(store, job.id, job=job)
     store.write_json(
         job.id,
         WAKE_ECONOMY_PATH,
         {
             "last_full_wake_at": now.isoformat(),
-            "watermark": saturation_watermark(store, job.id, job=job),
+            "last_full_wake_source": wake_source,
+            "decision_watermark_hash": _fingerprint({"watermark": watermark}),
+            "watermark": watermark,
         },
-    )
-
-
-def _closed_trades(store: JobStore, job_id: str) -> int:
-    summary = store.read_json(job_id, "results/forward/summary.json", default={}) or {}
-    return int(((summary.get("trades") or {}).get("closed_count")) or 0)
-
-
-def _forward_gate_minimum(job: WayfinderJob) -> int:
-    drift_policy = (job.performance or {}).get("drift_policy") or {}
-    return int(
-        drift_policy.get("min_forward_trades") or _DEFAULT_FORWARD_GATE_MIN_TRADES
     )
 
 

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -28,6 +28,7 @@ from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.jobs.sync import snapshot_job, sync_all_jobs
 from wayfinder_paths.jobs.wake_economy import (
     REMEDIATION_QUIET_LINE,
+    WAKE_ECONOMY_PATH,
     maybe_skip_wake,
     record_full_wake,
     remediation_backed_off,
@@ -670,6 +671,8 @@ def _build_worker_prompt_sections(
     mode: str,
     snapshot: dict[str, Any],
     apply_proposal_id: str | None = None,
+    wake_source: str = "scheduled_timer",
+    wake_triggers: list[str] | None = None,
 ) -> dict[str, str]:
     root = store.job_dir(job_id)
     from wayfinder_paths.jobs.improver.spec import ImproverSpec
@@ -758,6 +761,7 @@ def _build_worker_prompt_sections(
     if (
         mode == "intervene"
         and apply_proposal_id is None
+        and not wake_triggers
         and not restage_tasks
         and not remediation_overrides
     ):
@@ -794,6 +798,10 @@ def _build_worker_prompt_sections(
         "archive": _archive_block(store, job_id),
         "restage_tasks": restage_tasks,
         "search_assignment": search_assignment,
+        "wake": {
+            "source": wake_source,
+            "triggers": sorted(set(wake_triggers or [])),
+        },
         "portfolio": _portfolio_context(store, job_id),
     }
 
@@ -1358,6 +1366,17 @@ def _build_worker_prompt_sections(
             "the new base, reject it (agent housekeeping) and only then "
             "propose fresh.\n\n"
         )
+    report_outcome_directive = ""
+    if apply_proposal_id is None:
+        report_outcome_directive = (
+            "- REPORT OUTCOME: include `outcome` as exactly one of "
+            "no_change | deferred | experiment_completed | candidate_proposed | "
+            "remediation_advanced | blocked, plus `material_change` as a boolean. "
+            "For a scheduled wake with no material delta, use no_change and update "
+            "only the compact latest report; do not append candidate/decision "
+            "ledgers, memory, the research agenda/island agenda, or remediation "
+            "reaffirmations.\n"
+        )
     dynamic_context = (
         f"{DYNAMIC_CONTEXT_MARKER}\n"
         f"{gate_alert}"
@@ -1378,6 +1397,7 @@ def _build_worker_prompt_sections(
         f"{ideation_task_line}"
         f"{task_line}"
         "- Write the appropriate monitor/intervene/auto/apply report.\n"
+        f"{report_outcome_directive}"
         "- Emit a user-visible result only for meaningful state transitions, "
         "warnings, proposals, or blocked auto decisions.\n"
     )
@@ -1396,6 +1416,8 @@ def prepare_job_worker_prompt(
     job_id: str,
     mode: str,
     apply_proposal_id: str | None = None,
+    wake_source: str = "scheduled_timer",
+    wake_triggers: list[str] | None = None,
 ) -> dict[str, Any]:
     """Prepare the exact prompt payload used for a job worker wakeup.
 
@@ -1454,6 +1476,8 @@ def prepare_job_worker_prompt(
         mode=mode_typed,
         snapshot=snapshot,
         apply_proposal_id=apply_proposal_id,
+        wake_source=wake_source,
+        wake_triggers=wake_triggers,
     )
     return {
         **prompt_sections,
@@ -1483,7 +1507,13 @@ def _emit_job_result(
 
 
 def run_job_worker(
-    job_id: str, mode: str = "monitor", *, apply_proposal_id: str | None = None
+    job_id: str,
+    mode: str = "monitor",
+    *,
+    apply_proposal_id: str | None = None,
+    wake_source: str = "scheduled_timer",
+    wake_triggers: list[str] | None = None,
+    force_llm: bool = False,
 ) -> dict[str, Any]:
     store = JobStore()
     job = store.load(job_id)
@@ -1491,6 +1521,12 @@ def run_job_worker(
     if mode == "off":
         mode = "monitor"
     mode_typed: AgentMode = mode
+    if apply_proposal_id is not None and wake_source == "scheduled_timer":
+        wake_source = "proposal_apply"
+    wake_context: dict[str, Any] = {
+        "wake_source": wake_source,
+        "wake_triggers": sorted(set(wake_triggers or [])),
+    }
 
     blocked_reason = (
         _auto_limits_error(job.agent_loop.auto_limits) if mode_typed == "auto" else None
@@ -1505,6 +1541,7 @@ def run_job_worker(
             session_id=None,
             queued=False,
             error=blocked_reason,
+            wake_context=wake_context,
         )
         _emit_job_result(report["summary"], job.id)
         return report
@@ -1519,7 +1556,13 @@ def run_job_worker(
     # saturated paper job whose evidence watermark has not moved since the
     # last full wake skips the LLM session entirely.
     quiet_report = maybe_skip_wake(
-        store, job, mode=mode_typed, apply_proposal_id=apply_proposal_id
+        store,
+        job,
+        mode=mode_typed,
+        apply_proposal_id=apply_proposal_id,
+        force=force_llm,
+        wake_source=wake_source,
+        wake_triggers=wake_triggers,
     )
     if quiet_report is not None:
         return quiet_report
@@ -1532,6 +1575,8 @@ def run_job_worker(
         job_id=job.id,
         mode=mode_typed,
         apply_proposal_id=apply_proposal_id,
+        wake_source=wake_source,
+        wake_triggers=wake_triggers,
     )
     prompt = prompt_sections["prompt"]
 
@@ -1553,7 +1598,11 @@ def run_job_worker(
     if queued:
         # Anchor the wake-economy skip window on delivered wakes only: a
         # failed queue leaves the state untouched so the retry runs in full.
-        record_full_wake(store, job)
+        record_full_wake(store, job, wake_source=wake_source)
+        wake_state = store.read_json(job.id, WAKE_ECONOMY_PATH, default={}) or {}
+        wake_context["decision_watermark_hash"] = wake_state.get(
+            "decision_watermark_hash"
+        )
 
     report = _write_report(
         store=store,
@@ -1576,6 +1625,7 @@ def run_job_worker(
             "dynamic_context_hash": prompt_sections["dynamic_context_hash"],
             "metrics": "not_available",
         },
+        wake_context=wake_context,
     )
 
     if report["status"] != "green":
@@ -1713,12 +1763,13 @@ def _write_report(
     error: str | None,
     apply_proposal_id: str | None = None,
     cache: dict[str, Any] | None = None,
+    wake_context: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     report_dir = (
         store.job_dir(job_id) / "reports" / ("apply" if apply_proposal_id else mode)
     )
     report_dir.mkdir(parents=True, exist_ok=True)
-    report = {
+    report: dict[str, Any] = {
         "job_id": job_id,
         "mode": mode,
         "status": status,
@@ -1732,6 +1783,8 @@ def _write_report(
         report["apply_proposal_id"] = apply_proposal_id
     if cache is not None:
         report["cache"] = cache
+    if wake_context is not None:
+        report.update(wake_context)
     (report_dir / "latest.json").write_text(
         json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
     )
@@ -1767,7 +1820,14 @@ def _write_report(
         scorecard_updates,
     )
     store.append_journal(
-        job_id, {"type": "agent_wakeup", "mode": mode, "report": report}
+        job_id,
+        {
+            "type": "agent_wakeup",
+            "mode": mode,
+            "wake_source": report.get("wake_source"),
+            "wake_triggers": report.get("wake_triggers") or [],
+            "report": report,
+        },
     )
 
     try:

--- a/wayfinder_paths/tests/test_jobs_remediation.py
+++ b/wayfinder_paths/tests/test_jobs_remediation.py
@@ -91,9 +91,8 @@ def test_case_opens_once_and_retries_until_accountable_outcome(
     assert load_remediation(store, job_id)["attempts"] == 2  # type: ignore[index]
 
 
-def test_recorded_progress_defers_the_retry_wake(tmp_path: Path) -> None:
-    """A bounded progress note is the agent already working the case — the
-    next quiet retry anchors on the note, not the original wake."""
+def test_recorded_progress_makes_unchanged_rechecks_mechanical(tmp_path: Path) -> None:
+    """An accountable outcome remains quiet until its evidence moves."""
     store, job_id = _store(tmp_path)
     now = dt.datetime(2026, 8, 21, 12, tzinfo=dt.UTC)
     sync_remediation_with_health(store, job_id, _health(), now=now)
@@ -114,14 +113,20 @@ def test_recorded_progress_defers_the_retry_wake(tmp_path: Path) -> None:
         is None
     )
 
-    # 6h+ after the progress note: the quiet retry fires again.
+    # 6h+ after the progress note: the deterministic recheck advances its
+    # backoff but does not emit another LLM event.
     retry = sync_remediation_with_health(
         store,
         job_id,
         _health(),
         now=dt.datetime.now(dt.UTC) + dt.timedelta(hours=6, minutes=1),
     )
-    assert retry and retry["event"] == "regime_remediation_due"
+    assert retry is None
+    case = load_remediation(store, job_id)
+    assert case and case["quiet_checks"] == 1
+    assert case["attempts"] == 1
+    assert case["recheck"]["next_retry_seconds"] == 12 * 3600
+    assert _journal_types(store, job_id).count("remediation_recheck_quiet") == 1
 
 
 def test_material_evidence_still_wakes_through_the_debounce(tmp_path: Path) -> None:

--- a/wayfinder_paths/tests/test_jobs_triggers.py
+++ b/wayfinder_paths/tests/test_jobs_triggers.py
@@ -50,6 +50,9 @@ def test_matching_trigger_fires_once_and_debounces(
     assert first["triggers"] == ["risk_halt"]
     assert len(wakes) == 1
     assert wakes[0]["mode"] == "intervene"
+    assert wakes[0]["wake_source"] == "test"
+    assert wakes[0]["wake_triggers"] == ["risk_halt"]
+    assert wakes[0]["force_llm"] is True
     journal = (store.job_dir(job.id) / "journal.jsonl").read_text(encoding="utf-8")
     assert "agent_triggered_wake" in journal
 
@@ -137,6 +140,15 @@ def test_default_triggers_include_risk_halt() -> None:
 
 def test_tick_trigger_event_derivation() -> None:
     assert _tick_trigger_events({"ok": False}) == ["script_failure"]
+    assert (
+        _tick_trigger_events(
+            {
+                "ok": False,
+                "error": "rate_limited: Client error '429 Too Many Requests'",
+            }
+        )
+        == []
+    )
     assert _tick_trigger_events({"ok": True, "snapshot": {"status": "ambiguous"}}) == [
         "reconcile_mismatch"
     ]

--- a/wayfinder_paths/tests/test_jobs_wake_economy.py
+++ b/wayfinder_paths/tests/test_jobs_wake_economy.py
@@ -111,18 +111,12 @@ def test_posture_saturated_when_nothing_is_mid_flight(tmp_path: Path) -> None:
     assert posture == {"posture": "saturated", "blockers": []}
 
 
-def test_each_mid_flight_condition_defeats_saturation(tmp_path: Path) -> None:
+def test_each_actionable_condition_defeats_saturation(tmp_path: Path) -> None:
     cases = [
         (
             "not_operational",
             lambda store, job: store.refresh_scorecard(
                 job.id, {"last_script_run_at": None}
-            ),
-        ),
-        (
-            "research_lane_active",
-            lambda store, job: store.write_json(
-                job.id, "state/research_lane.json", {"active_lane": "vol-regimes"}
             ),
         ),
         (
@@ -155,10 +149,6 @@ def test_each_mid_flight_condition_defeats_saturation(tmp_path: Path) -> None:
             "remediation_case_active",
             lambda store, job: sync_remediation_with_health(store, job.id, _health()),
         ),
-        (
-            "forward_sample_adequate",
-            lambda store, job: _record_closed_trades(store, job.id, 20),
-        ),
     ]
     for index, (blocker, arrange) in enumerate(cases):
         store, job = _saturated_job(tmp_path / f"case-{index}", f"posture-{index}")
@@ -168,6 +158,31 @@ def test_each_mid_flight_condition_defeats_saturation(tmp_path: Path) -> None:
 
         assert posture["posture"] == "in_flight", blocker
         assert posture["blockers"] == [blocker]
+
+
+def test_stable_lane_mature_sample_and_parallel_campaign_can_skip(
+    tmp_path: Path,
+) -> None:
+    store, job = _saturated_job(tmp_path)
+    store.write_json(
+        job.id,
+        "state/research_lane.json",
+        {"active_lane": "vol-regimes", "notes": "x" * 100_000},
+    )
+    _record_closed_trades(store, job.id, 40)
+    store.write_json(
+        job.id,
+        "state/evolution_campaign.json",
+        {"campaign_id": "campaign-1", "status": "active", "stage": "generate"},
+    )
+
+    assert research_saturation_posture(store, job.id) == {
+        "posture": "saturated",
+        "blockers": [],
+    }
+    watermark = saturation_watermark(store, job.id)
+    assert watermark["lane"] == {"active_lane": "vol-regimes"}
+    assert len(json.dumps(watermark)) < 5_000
 
 
 def test_backed_off_remediation_case_does_not_defeat_saturation(
@@ -190,6 +205,17 @@ def test_skip_path_writes_quiet_report_without_touching_llm(
 ) -> None:
     store, job = _saturated_job(tmp_path)
     record_full_wake(store, job)
+    root = store.job_dir(job.id)
+    protected = {
+        "memory.md": "durable memory\n",
+        "research/agenda.md": "research agenda\n",
+        "research/islands/exploit.md": "island agenda\n",
+        "ledgers/candidates.jsonl": '{"status":"no_edge"}\n',
+    }
+    for relative, content in protected.items():
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
     monkeypatch.setattr("wayfinder_paths.jobs.worker.JobStore", lambda: store)
     monkeypatch.setattr(
         "wayfinder_paths.jobs.worker.OPENCODE_CLIENT", ForbiddenOpenCodeClient()
@@ -198,9 +224,15 @@ def test_skip_path_writes_quiet_report_without_touching_llm(
     report = run_job_worker(job.id, mode="intervene")
 
     assert report["status"] == "quiet"
+    assert report["outcome"] == "no_change"
+    assert report["material_change"] is False
+    assert report["wake_source"] == "scheduled_timer"
+    assert report["decision_watermark_hash"]
     assert report["skip_reason"] == "saturation_watermark_unchanged"
     assert report["watermark"]["closed_trades"] == 0
     assert report["next_full_wake_by"]
+    for relative, content in protected.items():
+        assert (root / relative).read_text(encoding="utf-8") == content
     latest = json.loads(
         (store.job_dir(job.id) / "reports" / "intervene" / "latest.json").read_text(
             encoding="utf-8"
@@ -225,8 +257,8 @@ def test_watermark_movement_forces_full_wake(
     monkeypatch.setattr("wayfinder_paths.jobs.worker.JobStore", lambda: store)
     monkeypatch.setattr("wayfinder_paths.jobs.worker.OPENCODE_CLIENT", client)
 
-    # One closed trade (still below the gate minimum → still saturated) moves
-    # the watermark: the next wake must run in full and re-anchor the state.
+    # One closed trade moves the watermark: the next wake must run in full and
+    # re-anchor the state.
     _record_closed_trades(store, job.id, 1)
     report = run_job_worker(job.id, mode="intervene")
 
@@ -246,7 +278,7 @@ def test_quiet_max_floor_forces_full_wake(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     store, job = _saturated_job(tmp_path)
-    record_full_wake(store, job, now=datetime.now(UTC) - timedelta(hours=25))
+    record_full_wake(store, job, now=datetime.now(UTC) - timedelta(hours=13))
 
     assert maybe_skip_wake(store, job, mode="intervene", apply_proposal_id=None) is None
 
@@ -264,6 +296,24 @@ def test_live_apply_and_auto_wakes_never_skip(tmp_path: Path) -> None:
     job.script_loop.mode = "live"
     store.save(job)
     assert maybe_skip_wake(store, job, mode="intervene", apply_proposal_id=None) is None
+
+
+def test_forced_trigger_wake_never_skips(tmp_path: Path) -> None:
+    store, job = _saturated_job(tmp_path)
+    record_full_wake(store, job)
+
+    assert (
+        maybe_skip_wake(
+            store,
+            job,
+            mode="intervene",
+            apply_proposal_id=None,
+            force=True,
+            wake_source="scheduled_tick",
+            wake_triggers=["risk_halt"],
+        )
+        is None
+    )
 
 
 def test_kill_switch_disables_the_skip_path(
@@ -355,8 +405,7 @@ def test_saturation_watermark_components_move_independently(tmp_path: Path) -> N
     )
     assert saturation_watermark(store3, job3.id) != base3
     posture = research_saturation_posture(store3, job3.id)
-    assert posture["posture"] == "in_flight"
-    assert "evolution_campaign_open" in posture["blockers"]
+    assert posture == {"posture": "saturated", "blockers": []}
 
     store4, job4 = _saturated_job(tmp_path / "experiment", "experiment-demo")
     base4 = saturation_watermark(store4, job4.id)
@@ -404,3 +453,23 @@ def test_saturation_watermark_components_move_independently(tmp_path: Path) -> N
     }
     store4.write_json(job4.id, "state/evolution_experiment.json", experiment)
     assert saturation_watermark(store4, job4.id) != active
+
+
+def test_prompt_carries_wake_provenance_and_compact_outcome_contract(
+    tmp_path: Path,
+) -> None:
+    store, job = _saturated_job(tmp_path)
+
+    prompt = _build_worker_prompt_sections(
+        store=store,
+        job_id=job.id,
+        mode="intervene",
+        snapshot=_worker_snapshot(job),
+        wake_source="scheduled_tick",
+        wake_triggers=["risk_halt"],
+    )["prompt"]
+
+    assert '"source": "scheduled_tick"' in prompt
+    assert '"triggers": [' in prompt and '"risk_halt"' in prompt
+    assert "no_change | deferred | experiment_completed" in prompt
+    assert "do not append candidate/decision ledgers" in prompt


### PR DESCRIPTION
## Why

A six-day canary audit found that routine monitor/intervene sessions dominated LLM spend while most candidate outcomes were no-change, deferred, or no-edge. The largest avoidable sources were 30-minute timer wakes, transient public-data 429s escalating as script failures, and remediation retries that re-adjudicated an unchanged evidence fingerprint.

## What changed

- Make scheduled paper-research wakes evidence-driven with a compact decision watermark and a 12-hour maximum quiet heartbeat.
- Treat stable research lanes, mature forward samples, and parallel evolution campaigns as context instead of permanent skip blockers; their transitions still move the watermark.
- Preserve immediate behavior for live, auto, apply, and all named event-triggered wakes. Trigger source and event names now cross the worker boundary and are recorded in reports/journal rows.
- Keep transient rate-limit failures on the existing mechanical retry/degradation path instead of spawning an LLM.
- Stop emitting `regime_remediation_due` after an accountable bounded outcome when its evidence fingerprint is unchanged; retain mechanical bounded rechecks and wake immediately when evidence moves.
- Require compact wake outcomes (`no_change`, `deferred`, `experiment_completed`, `candidate_proposed`, `remediation_advanced`, `blocked`) and prevent no-change heartbeats from appending candidate/decision ledgers, memory, agendas, or remediation reaffirmations.
- Bound wake state growth by fingerprinting claim/probation collections and selecting only decision-relevant lane fields.

## Safety invariants

- Script execution cadence and deterministic risk/reconciliation logic are unchanged.
- Live jobs never use the scheduled skip path.
- Auto and proposal-apply wakes never skip.
- Named triggers explicitly force an LLM wake after the existing per-event debounce.
- The economy kill switch remains `WAYFINDER_WAKE_ECONOMY=0`.
- A paper job receives a full scheduled heartbeat at least every 12 hours by default.

## Verification

- `pytest -q --no-cov wayfinder_paths/tests/test_jobs*.py` — 816 passed
- Focused campaign/live-risk/watchdog regression set — 108 passed
- `ruff check` on all changed source and test files — clean
- Isolated mypy on the five changed source modules with skipped third-party imports — clean
- `git diff --check` — clean

## Canary rollout after merge

Bake from `cloud-harness-poc` `main` with the merged SDK SHA as the dev-only SDK override, then roll only canary machine `4d8955e1f0d738` in app `oc-871046544b704b0f916c7a09716cc8ec`.

After the image is healthy, set all three active intervention timers to four hours:

```bash
poetry run wayfinder job agent set-mode majors-5m-lab intervene --wake 14400
poetry run wayfinder job agent set-mode xyz-scalp-lab intervene --wake 14400
poetry run wayfinder job agent set-mode imx-short intervene --wake 14400
```

Run a 72-hour canary before any wider rollout. Acceptance criteria:

- at least 75% fewer token-bearing intervention sessions versus the audited baseline;
- zero LLM wakes caused solely by retryable 429 failures;
- zero repeated remediation wakes with an unchanged accountable evidence fingerprint;
- every risk/reconcile/proposal/adjudication trigger still produces a forced wake after debounce;
- no change in script-loop tick cadence, live-risk halts, or reconciliation coverage;
- quiet reports remain compact and expose `wake_source`, `wake_triggers`, `outcome`, `material_change`, and the decision-watermark hash.
