### PR TITLE
Hyperliquid - Engine aligns stop prices to the grid; agent tool stays strict

### DIFF
--- a/wayfinder_paths/jobs/execution/hyperliquid.py
+++ b/wayfinder_paths/jobs/execution/hyperliquid.py
@@ -398,10 +398,24 @@ class HyperliquidPerpBroker:
         client_order_id: str,
     ) -> NativeProtectionResult:
         from wayfinder_paths.mcp.tools.hyperliquid import (
+            _make_hl_adapter,
+            _resolve_asset,
             hyperliquid_place_trigger_order,
         )
 
         try:
+            # Engine stop prices are entry × stop-multiple products — never
+            # on the venue tick grid. The tool is agent-facing and strictly
+            # rejects off-grid prices (rounding direction is the agent's
+            # decision there), so this deterministic caller aligns its own
+            # price first with the same adapter flooring. Sub-tick movement
+            # is risk-neutral for protection; an unplaced stop force-closes
+            # the position and halts the job.
+            adapter, _sender = await _make_hl_adapter(self.wallet_label)
+            asset_id, _market_type = await _resolve_asset(adapter, symbol)
+            trigger_price = adapter.get_valid_order_price(
+                asset_id, float(trigger_price)
+            )
             outcome = await hyperliquid_place_trigger_order(
                 wallet_label=self.wallet_label,
                 asset_name=symbol,
@@ -412,10 +426,6 @@ class HyperliquidPerpBroker:
                 is_market_trigger=True,
                 reduce_only=True,
                 cloid=client_order_id,
-                # Engine stops are entry × stop-multiple products — never
-                # tick-aligned. Alignment is this caller's explicit choice;
-                # sub-tick flooring is risk-neutral for protection.
-                align_price_to_grid=True,
             )
         except Exception as exc:
             return await self._resolve_stop_after_error(

--- a/wayfinder_paths/jobs/execution/hyperliquid.py
+++ b/wayfinder_paths/jobs/execution/hyperliquid.py
@@ -412,6 +412,10 @@ class HyperliquidPerpBroker:
                 is_market_trigger=True,
                 reduce_only=True,
                 cloid=client_order_id,
+                # Engine stops are entry × stop-multiple products — never
+                # tick-aligned. Alignment is this caller's explicit choice;
+                # sub-tick flooring is risk-neutral for protection.
+                align_price_to_grid=True,
             )
         except Exception as exc:
             return await self._resolve_stop_after_error(

--- a/wayfinder_paths/mcp/tools/hyperliquid.py
+++ b/wayfinder_paths/mcp/tools/hyperliquid.py
@@ -1548,9 +1548,15 @@ async def hyperliquid_place_trigger_order(
             f"(lot size = {min_tick}). Try size={min_tick}."
         )
 
+    # Trigger prices arrive machine-computed (entry × stop multiple) and are
+    # almost never on HL's tick grid — round to the grid like the adapter
+    # itself does, instead of rejecting. Rejecting here left positions
+    # unprotected: the stop never reached the adapter's own rounding, and
+    # the framework halted on the unconfirmed protection. Plain order paths
+    # keep the strict validator (they're fed clean prices).
     if limit_px is not None:
-        _validate_price(adapter=adapter, asset_id=resolved_asset_id, price=limit_px)
-    _validate_price(adapter=adapter, asset_id=resolved_asset_id, price=tpx)
+        limit_px = adapter.get_valid_order_price(resolved_asset_id, float(limit_px))
+    tpx = adapter.get_valid_order_price(resolved_asset_id, float(tpx))
 
     ok_order, res = await adapter.place_trigger_order(
         resolved_asset_id,

--- a/wayfinder_paths/mcp/tools/hyperliquid.py
+++ b/wayfinder_paths/mcp/tools/hyperliquid.py
@@ -1470,7 +1470,6 @@ async def hyperliquid_place_trigger_order(
     price: float | None = None,
     reduce_only: bool = True,
     cloid: str | None = None,
-    align_price_to_grid: bool = False,
 ) -> dict[str, Any]:
     """Place a perp take-profit / stop-loss trigger order.
 
@@ -1549,24 +1548,9 @@ async def hyperliquid_place_trigger_order(
             f"(lot size = {min_tick}). Try size={min_tick}."
         )
 
-    # Off-grid prices are the CALLER's decision to resolve. Interactive
-    # agents get the strict reject (the error names the floored price) so
-    # rounding direction stays their choice; deterministic engine callers
-    # opt into grid alignment explicitly with align_price_to_grid=True —
-    # their prices are machine-computed (entry × stop multiple) and almost
-    # never land on the tick grid.
-    if align_price_to_grid:
-        if limit_px is not None:
-            limit_px = adapter.get_valid_order_price(
-                resolved_asset_id, float(limit_px)
-            )
-        tpx = adapter.get_valid_order_price(resolved_asset_id, float(tpx))
-    else:
-        if limit_px is not None:
-            _validate_price(
-                adapter=adapter, asset_id=resolved_asset_id, price=limit_px
-            )
-        _validate_price(adapter=adapter, asset_id=resolved_asset_id, price=tpx)
+    if limit_px is not None:
+        _validate_price(adapter=adapter, asset_id=resolved_asset_id, price=limit_px)
+    _validate_price(adapter=adapter, asset_id=resolved_asset_id, price=tpx)
 
     ok_order, res = await adapter.place_trigger_order(
         resolved_asset_id,

--- a/wayfinder_paths/mcp/tools/hyperliquid.py
+++ b/wayfinder_paths/mcp/tools/hyperliquid.py
@@ -1470,6 +1470,7 @@ async def hyperliquid_place_trigger_order(
     price: float | None = None,
     reduce_only: bool = True,
     cloid: str | None = None,
+    align_price_to_grid: bool = False,
 ) -> dict[str, Any]:
     """Place a perp take-profit / stop-loss trigger order.
 
@@ -1548,15 +1549,24 @@ async def hyperliquid_place_trigger_order(
             f"(lot size = {min_tick}). Try size={min_tick}."
         )
 
-    # Trigger prices arrive machine-computed (entry × stop multiple) and are
-    # almost never on HL's tick grid — round to the grid like the adapter
-    # itself does, instead of rejecting. Rejecting here left positions
-    # unprotected: the stop never reached the adapter's own rounding, and
-    # the framework halted on the unconfirmed protection. Plain order paths
-    # keep the strict validator (they're fed clean prices).
-    if limit_px is not None:
-        limit_px = adapter.get_valid_order_price(resolved_asset_id, float(limit_px))
-    tpx = adapter.get_valid_order_price(resolved_asset_id, float(tpx))
+    # Off-grid prices are the CALLER's decision to resolve. Interactive
+    # agents get the strict reject (the error names the floored price) so
+    # rounding direction stays their choice; deterministic engine callers
+    # opt into grid alignment explicitly with align_price_to_grid=True —
+    # their prices are machine-computed (entry × stop multiple) and almost
+    # never land on the tick grid.
+    if align_price_to_grid:
+        if limit_px is not None:
+            limit_px = adapter.get_valid_order_price(
+                resolved_asset_id, float(limit_px)
+            )
+        tpx = adapter.get_valid_order_price(resolved_asset_id, float(tpx))
+    else:
+        if limit_px is not None:
+            _validate_price(
+                adapter=adapter, asset_id=resolved_asset_id, price=limit_px
+            )
+        _validate_price(adapter=adapter, asset_id=resolved_asset_id, price=tpx)
 
     ok_order, res = await adapter.place_trigger_order(
         resolved_asset_id,

--- a/wayfinder_paths/tests/test_execution_contract.py
+++ b/wayfinder_paths/tests/test_execution_contract.py
@@ -417,6 +417,29 @@ async def test_trade_capacity_accepts_mcp_result_shape(monkeypatch) -> None:
     assert capacity.max_notional == 25
 
 
+class _GridAdapter:
+    """Floors 67258.8 to the 5-sig-fig grid; passes aligned prices through."""
+
+    def get_valid_order_price(self, _asset_id: int, price: float) -> float:
+        return 67258.0 if abs(float(price) - 67258.8) < 1e-9 else float(price)
+
+
+def _patch_engine_price_alignment(monkeypatch) -> None:
+    async def fake_make(_label):
+        return _GridAdapter(), "0xfeed"
+
+    async def fake_resolve(_adapter, _symbol):
+        return 0, "perp"
+
+    monkeypatch.setattr(
+        "wayfinder_paths.mcp.tools.hyperliquid._make_hl_adapter", fake_make
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.mcp.tools.hyperliquid._resolve_asset", fake_resolve
+    )
+
+
+
 @pytest.mark.asyncio
 async def test_hyperliquid_trigger_order_passes_cloid(monkeypatch) -> None:
     adapter = HyperliquidAdapter()
@@ -479,6 +502,7 @@ async def test_live_broker_installs_stop_with_exact_cloid(monkeypatch) -> None:
         "wayfinder_paths.mcp.tools.hyperliquid.hyperliquid_place_trigger_order",
         fake_trigger,
     )
+    _patch_engine_price_alignment(monkeypatch)
     broker = HyperliquidPerpBroker(wallet_label="risk-wallet")
 
     result = await broker.place_stop_loss(
@@ -493,3 +517,35 @@ async def test_live_broker_installs_stop_with_exact_cloid(monkeypatch) -> None:
     assert result.order_id == "42"
     assert captured["cloid"] == "0x00000000000000000000000000000001"
     assert captured["reduce_only"] is True
+    assert captured["trigger_price"] == 90_000.0
+
+
+@pytest.mark.asyncio
+async def test_live_broker_aligns_off_grid_stop_before_the_tool(monkeypatch) -> None:
+    """Engine stop prices are entry × stop-multiple products — never on the
+    tick grid. The engine must align them itself (the agent-facing tool
+    strictly rejects off-grid prices); the old pass-through meant every stop
+    was refused, the position force-closed, and the job halted."""
+    captured: dict[str, object] = {}
+
+    async def fake_trigger(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+        return {"ok": True, "result": {"status": "confirmed", "effects": []}}
+
+    monkeypatch.setattr(
+        "wayfinder_paths.mcp.tools.hyperliquid.hyperliquid_place_trigger_order",
+        fake_trigger,
+    )
+    _patch_engine_price_alignment(monkeypatch)
+    broker = HyperliquidPerpBroker(wallet_label="risk-wallet")
+
+    result = await broker.place_stop_loss(
+        symbol="BTC",
+        side="sell",
+        size=0.1,
+        trigger_price=67258.8,
+        client_order_id="0x00000000000000000000000000000002",
+    )
+
+    assert result.confirmed is True
+    assert captured["trigger_price"] == 67258.0

--- a/wayfinder_paths/tests/test_mcp_hyperliquid_execute.py
+++ b/wayfinder_paths/tests/test_mcp_hyperliquid_execute.py
@@ -15,6 +15,7 @@ from wayfinder_paths.mcp.tools.hyperliquid import (
     hyperliquid_get_trade_asset,
     hyperliquid_place_limit_order,
     hyperliquid_place_market_order,
+    hyperliquid_place_trigger_order,
     hyperliquid_withdraw_usdc,
 )
 
@@ -1065,3 +1066,43 @@ async def test_hyperliquid_reduce_only_rejects_size_above_live_position():
     assert out["ok"] is False
     assert out["error"]["code"] == "reduce_only_size_exceeds_position"
     assert out["error"]["details"]["closeable_size"] == 0.25
+
+
+@pytest.mark.asyncio
+async def test_trigger_order_rounds_off_grid_stop_instead_of_rejecting():
+    """Machine-computed stop prices (entry × stop multiple) are almost never
+    on HL's tick grid (67258.8 is 6 sig figs). The trigger path must round to
+    the grid like the adapter does — the old reject-first validator meant the
+    stop never got placed, positions sat unprotected, and live jobs halted on
+    unconfirmed protection."""
+    seen: dict[str, Any] = {}
+
+    class _TriggerFake(_FakeExecutionAdapter):
+        def get_valid_order_price(self, _asset_id: int, price: float) -> float:
+            # Mirror HL's 5-sig-fig floor for the regression value.
+            return 67258.0 if abs(float(price) - 67258.8) < 1e-9 else float(price)
+
+        async def place_trigger_order(self, asset_id, is_buy, tpx, sz, sender, **kwargs):
+            seen["tpx"] = tpx
+            seen["limit_price"] = kwargs.get("limit_price")
+            return True, {"status": "ok"}
+
+    fake = _TriggerFake()
+    with (
+        patch(
+            "wayfinder_paths.mcp.tools.hyperliquid._make_hl_adapter",
+            new=AsyncMock(return_value=(fake, "0x1234")),
+        ),
+        patch("wayfinder_paths.mcp.tools.hyperliquid._annotate_hl_profile"),
+    ):
+        out = await hyperliquid_place_trigger_order(
+            wallet_label="main",
+            asset_name="BTC-USDC",
+            tpsl="sl",
+            trigger_price=67258.8,
+            is_buy=False,
+            size=0.01,
+        )
+
+    assert out["ok"] is True, out
+    assert seen["tpx"] == 67258.0

--- a/wayfinder_paths/tests/test_mcp_hyperliquid_execute.py
+++ b/wayfinder_paths/tests/test_mcp_hyperliquid_execute.py
@@ -1068,33 +1068,41 @@ async def test_hyperliquid_reduce_only_rejects_size_above_live_position():
     assert out["error"]["details"]["closeable_size"] == 0.25
 
 
-@pytest.mark.asyncio
-async def test_trigger_order_rounds_off_grid_stop_instead_of_rejecting():
-    """Machine-computed stop prices (entry × stop multiple) are almost never
-    on HL's tick grid (67258.8 is 6 sig figs). The trigger path must round to
-    the grid like the adapter does — the old reject-first validator meant the
-    stop never got placed, positions sat unprotected, and live jobs halted on
-    unconfirmed protection."""
-    seen: dict[str, Any] = {}
+class _OffGridTriggerFake(_FakeExecutionAdapter):
+    """Floors the regression value the way HL's 5-sig-fig rule would."""
 
-    class _TriggerFake(_FakeExecutionAdapter):
-        def get_valid_order_price(self, _asset_id: int, price: float) -> float:
-            # Mirror HL's 5-sig-fig floor for the regression value.
-            return 67258.0 if abs(float(price) - 67258.8) < 1e-9 else float(price)
+    def __init__(self):
+        super().__init__()
+        self.seen: dict[str, Any] = {}
 
-        async def place_trigger_order(self, asset_id, is_buy, tpx, sz, sender, **kwargs):
-            seen["tpx"] = tpx
-            seen["limit_price"] = kwargs.get("limit_price")
-            return True, {"status": "ok"}
+    def get_valid_order_price(self, _asset_id: int, price: float) -> float:
+        return 67258.0 if abs(float(price) - 67258.8) < 1e-9 else float(price)
 
-    fake = _TriggerFake()
-    with (
+    def get_price_decimals(self, _asset_id: int) -> int:
+        return 1
+
+    async def place_trigger_order(self, asset_id, is_buy, tpx, sz, sender, **kwargs):
+        self.seen["tpx"] = tpx
+        return True, {"status": "ok"}
+
+
+def _patched_trigger_adapter(fake):
+    return (
         patch(
             "wayfinder_paths.mcp.tools.hyperliquid._make_hl_adapter",
             new=AsyncMock(return_value=(fake, "0x1234")),
         ),
         patch("wayfinder_paths.mcp.tools.hyperliquid._annotate_hl_profile"),
-    ):
+    )
+
+
+@pytest.mark.asyncio
+async def test_trigger_order_rejects_off_grid_price_by_default():
+    """Interactive callers keep the strict validator: rounding direction is
+    the agent's decision, and the error names the floored candidate."""
+    fake = _OffGridTriggerFake()
+    p1, p2 = _patched_trigger_adapter(fake)
+    with p1, p2:
         out = await hyperliquid_place_trigger_order(
             wallet_label="main",
             asset_name="BTC-USDC",
@@ -1103,6 +1111,29 @@ async def test_trigger_order_rounds_off_grid_stop_instead_of_rejecting():
             is_buy=False,
             size=0.01,
         )
+    assert out["ok"] is False
+    # The refusal hands the agent the floored candidate to decide on.
+    assert "67258.0" in out["error"]["message"]
+    assert "tpx" not in fake.seen
+
+
+@pytest.mark.asyncio
+async def test_trigger_order_aligns_to_grid_when_caller_opts_in():
+    """Engine stops are entry × stop-multiple products (never tick-aligned);
+    with align_price_to_grid=True the stop is floored and PLACED — the old
+    reject left positions unprotected and halted live jobs."""
+    fake = _OffGridTriggerFake()
+    p1, p2 = _patched_trigger_adapter(fake)
+    with p1, p2:
+        out = await hyperliquid_place_trigger_order(
+            wallet_label="main",
+            asset_name="BTC-USDC",
+            tpsl="sl",
+            trigger_price=67258.8,
+            is_buy=False,
+            size=0.01,
+            align_price_to_grid=True,
+        )
 
     assert out["ok"] is True, out
-    assert seen["tpx"] == 67258.0
+    assert fake.seen["tpx"] == 67258.0

--- a/wayfinder_paths/tests/test_mcp_hyperliquid_execute.py
+++ b/wayfinder_paths/tests/test_mcp_hyperliquid_execute.py
@@ -1118,10 +1118,9 @@ async def test_trigger_order_rejects_off_grid_price_by_default():
 
 
 @pytest.mark.asyncio
-async def test_trigger_order_aligns_to_grid_when_caller_opts_in():
-    """Engine stops are entry × stop-multiple products (never tick-aligned);
-    with align_price_to_grid=True the stop is floored and PLACED — the old
-    reject left positions unprotected and halted live jobs."""
+async def test_trigger_order_places_grid_aligned_price():
+    """A grid-aligned resubmission (what the strict error asks for) goes
+    straight through."""
     fake = _OffGridTriggerFake()
     p1, p2 = _patched_trigger_adapter(fake)
     with p1, p2:
@@ -1129,10 +1128,9 @@ async def test_trigger_order_aligns_to_grid_when_caller_opts_in():
             wallet_label="main",
             asset_name="BTC-USDC",
             tpsl="sl",
-            trigger_price=67258.8,
+            trigger_price=67258.0,
             is_buy=False,
             size=0.01,
-            align_price_to_grid=True,
         )
 
     assert out["ok"] is True, out


### PR DESCRIPTION
### Summary
Live jobs halted on unconfirmed stop protection: the engine's `place_stop_loss` fed raw entry × stop-multiple prices (never tick-aligned) into `hyperliquid_place_trigger_order`, whose strict validator rejects off-grid prices — correct for agent callers (the error names the floored candidate and the rounding direction stays the agent's decision), wrong as an inherited behavior for a deterministic engine that treats any submission error as unconfirmed protection → force-close + halt, every rebalance.

Fix keeps each layer's contract clean:
- The agent-facing tool is UNCHANGED: strict validation, no new parameters in the schema.
- The engine aligns its own price before calling the tool, using the same adapter flooring (`get_valid_order_price`) via the tool module's adapter helpers. Sub-tick flooring is risk-neutral for protection.

Regression tests: engine-level (off-grid 67258.8 → tool receives 67258.0, stop confirmed), tool-level strict reject with the floored suggestion, and the grid-aligned resubmission path.