### PR TITLE
jobs: bounded-window parity contract + finalize-aware campaign expiry

### DIFF
--- a/wayfinder_paths/jobs/candidate_shadow.py
+++ b/wayfinder_paths/jobs/candidate_shadow.py
@@ -17,6 +17,7 @@ from wayfinder_paths.jobs.execution.primitives import (
     CompletedBarsView,
     ExecutionSpec,
     StateSnapshot,
+    resolve_compute_window,
 )
 from wayfinder_paths.jobs.execution.simulator import (
     _load_strategy,
@@ -196,6 +197,11 @@ async def _run_target(
         raise FileNotFoundError("candidate execution script missing")
     params = dict(job_data.get("execution_params") or {})
     strategy = _load_strategy(script, params)
+    # Same bounded window the simulator replays with and the live driver
+    # fetches — the shadow lane must not hand candidates deeper history than
+    # production would.
+    window = resolve_compute_window(params, strategy)
+    view = window.slice_view(view, len(view.timestamps) - 1)
     candidate_view = apply_precompute(strategy, view)
     shadow_root = _shadow_state_root(
         root,

--- a/wayfinder_paths/jobs/evolution_campaign.py
+++ b/wayfinder_paths/jobs/evolution_campaign.py
@@ -33,16 +33,21 @@ from wayfinder_paths.jobs.execution.features import parse_feature_specs
 from wayfinder_paths.jobs.execution.job import _load_dataset, _load_job_yaml
 from wayfinder_paths.jobs.execution.optimize import is_search_space, run_optuna_search
 from wayfinder_paths.jobs.execution.primitives import (
+    DEFAULT_WARMUP_BARS,
     ExecutionSpec,
     bar_interval_seconds,
+    resolve_compute_window,
 )
 from wayfinder_paths.jobs.execution.simulator import (
     PreparedExecutionDataset,
+    _load_strategy,
     simulate_execution,
 )
 from wayfinder_paths.jobs.execution.validation import (
+    BOUNDED_WINDOW_HINT,
     resolve_execution_spec,
     validate_execution_job,
+    window_invariance_probe,
 )
 from wayfinder_paths.jobs.execution.walk_forward import _slice, _test_window_stats
 from wayfinder_paths.jobs.forward_experience import (
@@ -268,6 +273,15 @@ def _start_campaign(
             experience=experience,
             development_fraction=1.0,
         )
+    # Seed the frozen source's compute window BEFORE any candidate copies it:
+    # candidates inherit the declaration without their bundle diverging from
+    # the baseline, so the identical-to-source guard still catches unedited
+    # candidates. Behavior-neutral — the seeded value is exactly what
+    # resolve_compute_window already produced for the source.
+    _seed_bundle_window(store, job_id, campaign_root / "source")
+    snapshots["source_bundle"]["revision"] = compute_workspace_revision(
+        campaign_root / "source"
+    )
     campaign_policy = {
         **spec.evolution,
         "same_family_non_wins": spec.stuck_same_family_non_wins,
@@ -393,6 +407,7 @@ def _prepare_candidate(
         store.job_dir(job_id) / CAMPAIGN_ROOT / str(state["campaign_id"]) / "source"
     )
     _copy_active_bundle(frozen_source, candidate_root)
+    seeded_window = _seed_bundle_window(store, job_id, candidate_root)
     candidate = {
         "candidate_id": candidate_id,
         "campaign_id": state["campaign_id"],
@@ -405,6 +420,7 @@ def _prepare_candidate(
         "mutation_kind": chosen_mutation,
         "forced_jump": forced_jump,
         "bundle": relative,
+        "warmup_bars": seeded_window,
         "prepared_at": utc_now_iso(),
     }
     atomic_write_json(candidate_root / "candidate.json", candidate)
@@ -428,6 +444,57 @@ def _prepare_candidate(
         },
     )
     return candidate
+
+
+def _source_baseline_revision(manifest: dict[str, Any]) -> str:
+    """Revision an UNEDITED candidate carries: the frozen (window-seeded)
+    source bundle. Falls back to the active-root revision for campaigns
+    started before window seeding existed — the two were identical then."""
+    return str(
+        (manifest.get("source_bundle") or {}).get("revision")
+        or manifest.get("source_revision")
+        or ""
+    )
+
+
+def _seed_bundle_window(store: JobStore, job_id: str, bundle_root: Path) -> int:
+    """Campaign candidates must declare their compute window up front —
+    backtest and live hand decide() the same bounded view only when
+    warmup_bars is explicit in params. Inherit the source bundle's declared
+    window; otherwise seed the simulator's default cap."""
+    job_data = _load_job_yaml(bundle_root)
+    params = dict(job_data.get("execution_params") or {})
+    if params.get("warmup_bars"):
+        return int(params["warmup_bars"])
+    script = store.resolve_script_entrypoint(
+        job_id, job_data, candidate_dir=bundle_root
+    )
+    strategy = (
+        _load_strategy(script, dict(params))
+        if script is not None and script.exists()
+        else None
+    )
+    window = resolve_compute_window(params, strategy)
+    seeded = window.size if window.declared and window.size else DEFAULT_WARMUP_BARS
+    params["warmup_bars"] = seeded
+    job_data["execution_params"] = params
+    atomic_write_text(
+        bundle_root / "job.yaml", yaml.safe_dump(job_data, sort_keys=False)
+    )
+    return seeded
+
+
+def _require_declared_window(subject: dict[str, Any], params: dict[str, Any]) -> None:
+    """Undeclared (or full_history) candidates are inadmissible: the campaign
+    contract is that whatever the backtest measured is what live would run."""
+    window = resolve_compute_window(
+        params, _load_strategy(subject["script"], dict(params))
+    )
+    if not window.declared:
+        raise ValueError(
+            "candidate does not declare a bounded compute window "
+            f"(execution_params.warmup_bars) — {BOUNDED_WINDOW_HINT}"
+        )
 
 
 def evaluate_candidate(
@@ -457,7 +524,7 @@ def _evaluate_candidate(
     revision = compute_workspace_revision(candidate_root)
     manifest = store.read_json(job_id, str(state["manifest"]), default={}) or {}
     if (
-        revision == manifest.get("source_revision")
+        revision == _source_baseline_revision(manifest)
         and not (candidate_root / "search_space.json").exists()
     ):
         return _reject_candidate(
@@ -480,6 +547,30 @@ def _evaluate_candidate(
         )
         quick = _tail(train, 10_000)
         params, _, calibration = _calibrated_params(store, job_id, subject)
+        _require_declared_window(subject, params)
+        probe = window_invariance_probe(
+            subject["script"], quick.bars, subject["spec"], params
+        )
+        if probe["status"] == "failed":
+            return _reject_candidate(
+                store,
+                job_id,
+                state,
+                candidate,
+                "invalid",
+                {
+                    "error": (
+                        f"window-invariance probe failed at bar {probe['bar']}: "
+                        "decide() consumed history beyond its declared window "
+                        f"of {probe['window']} bars — {BOUNDED_WINDOW_HINT}"
+                    ),
+                    "probe": {
+                        key: value
+                        for key, value in probe.items()
+                        if not key.endswith("_intents")
+                    },
+                },
+            )
         result = simulate_execution(subject["script"], quick, subject["spec"], params)
     except Exception as exc:  # noqa: BLE001 - candidate failure is evidence
         return _reject_candidate(
@@ -788,6 +879,7 @@ def _full_dev(
         subject["dataset"], train_end=train_end, validation_end=validation_end
     )
     params, stress_params, calibration = _calibrated_params(store, job_id, subject)
+    _require_declared_window(subject, params)
     tuning: dict[str, Any] | None = None
     search_path = root / "search_space.json"
     if tune and search_path.exists():
@@ -826,6 +918,17 @@ def _full_dev(
                 root / "job.yaml", yaml.safe_dump(job_data, sort_keys=False)
             )
         tuning = {"trials": len(grid.runs), "selected_params": params}
+    # Post-tune probe: optuna may have moved the window params, so prove the
+    # FINAL configuration is window-invariant before spending dev backtests.
+    probe = window_invariance_probe(
+        subject["script"], train.bars, subject["spec"], params
+    )
+    if probe["status"] == "failed":
+        raise ValueError(
+            f"window-invariance probe failed at bar {probe['bar']}: decide() "
+            "consumed history beyond its declared window of "
+            f"{probe['window']} bars — {BOUNDED_WINDOW_HINT}"
+        )
     revision = compute_workspace_revision(root)
     manifest = (
         store.read_json(
@@ -833,7 +936,7 @@ def _full_dev(
         )
         or {}
     )
-    if revision == manifest.get("source_revision"):
+    if revision == _source_baseline_revision(manifest):
         raise ValueError("candidate has no effective mutation after tuning")
     train_result, train_stats = _window_result(subject, 0.0, train_end, params)
     validation_result, validation_stats = _window_result(

--- a/wayfinder_paths/jobs/execution/driver.py
+++ b/wayfinder_paths/jobs/execution/driver.py
@@ -31,6 +31,7 @@ from wayfinder_paths.jobs.execution.primitives import (
     ExecutionTrace,
     StateSnapshot,
     bar_interval_seconds,
+    resolve_compute_window,
 )
 from wayfinder_paths.jobs.execution.protection import monitor_native_protection
 from wayfinder_paths.jobs.execution.risk import RISK_STATE_PATH, check_risk_halt
@@ -306,7 +307,10 @@ async def tick_job(
         }
     brokers = {name: adapter.broker for name, adapter in adapters.items()}
 
-    lookback_bars = int(params.get("lookback_bars") or 200)
+    # One window contract with the backtest simulator: a declared warmup_bars
+    # (or legacy lookback_bars) sizes the live fetch exactly like the replay
+    # slice, so decide() sees the same bounded history in both.
+    lookback_bars = resolve_compute_window(params, strategy).live_depth
     rows: list[dict[str, Any]] = []
     for adapter in adapters.values():
         view = await adapter.feed.get_completed_bars(

--- a/wayfinder_paths/jobs/execution/primitives.py
+++ b/wayfinder_paths/jobs/execution/primitives.py
@@ -347,6 +347,91 @@ class CompletedBarsView:
         return self._bars.to_dict(orient="records")
 
 
+# Default per-bar compute window. Bounding the view handed to each decide()
+# keeps the DEFAULT backtest O(N·k) instead of O(N²): a strategy that
+# recomputes indicators over the whole handed frame goes quadratic when that
+# frame grows with the replay index (the classic "simple backtest pegs the
+# CPU" trap). 512 bars covers the lookback of essentially every standard
+# indicator (SMA200, ATR/ADX, long EMAs) with margin. Strategies tune it via
+# `warmup_bars`; genuine since-genesis strategies opt out with
+# `full_history: true`.
+DEFAULT_WARMUP_BARS = 512
+
+# A full_history strategy still needs a concrete live fetch depth (no feed
+# pages "everything since genesis" each tick); 200 bars is the legacy driver
+# default, so pre-contract live jobs keep their exact fetch size.
+FULL_HISTORY_LIVE_DEPTH_BARS = 200
+
+_DECLARED_WINDOW_SOURCES = frozenset(
+    {"warmup_bars", "lookback_bars", "strategy.warmup_bars"}
+)
+
+
+@dataclass(frozen=True)
+class ComputeWindow:
+    """The single decide() history contract shared by the backtest simulator,
+    the live driver, and the candidate shadow replayer.
+
+    One resolution + one slice makes backtest inputs ≡ forward inputs by
+    construction: whatever window a strategy declares is exactly the history
+    every execution path hands it."""
+
+    size: int | None  # None ⇒ full history (explicit `full_history` opt-out)
+    source: str
+    live_depth: int  # completed bars a live/shadow fetch loads each tick
+
+    @property
+    def full_history(self) -> bool:
+        return self.size is None
+
+    @property
+    def declared(self) -> bool:
+        """True when the window was declared (params or strategy attribute)
+        rather than defaulted — the precondition for the window-invariance
+        probe and for evolution-campaign admission."""
+        return self.source in _DECLARED_WINDOW_SOURCES
+
+    def slice_view(self, bars: CompletedBarsView, index: int) -> CompletedBarsView:
+        """Causal view for a decision at timestamp `index`: at most `size`
+        trailing timestamps, or everything through `index` for full history."""
+        if self.size is None:
+            return bars.through(index)
+        return bars.window(index, self.size)
+
+
+def resolve_compute_window(
+    params: Mapping[str, Any], strategy: Any = None
+) -> ComputeWindow:
+    """Size of the trailing view handed to decide() each tick.
+
+    Resolution (first hit wins):
+      1. ``params['warmup_bars']``   — explicit, canonical name.
+      2. ``params['lookback_bars']`` — back-compat with the old windowing lever.
+      3. ``strategy.warmup_bars``    — strategy-declared attribute.
+      4. ``DEFAULT_WARMUP_BARS``.
+    ``params['full_history']`` truthy opts backtests into full-history views;
+    live fetches then fall back to the legacy driver depth (``lookback_bars``
+    or ``FULL_HISTORY_LIVE_DEPTH_BARS``).
+    """
+    if params.get("full_history"):
+        live_depth = max(
+            int(params.get("lookback_bars") or FULL_HISTORY_LIVE_DEPTH_BARS), 1
+        )
+        return ComputeWindow(size=None, source="full_history", live_depth=live_depth)
+    for key in ("warmup_bars", "lookback_bars"):
+        raw = params.get(key)
+        if raw:
+            size = max(int(raw), 1)
+            return ComputeWindow(size=size, source=key, live_depth=size)
+    attr = getattr(strategy, "warmup_bars", None)
+    if attr:
+        size = max(int(attr), 1)
+        return ComputeWindow(size=size, source="strategy.warmup_bars", live_depth=size)
+    return ComputeWindow(
+        size=DEFAULT_WARMUP_BARS, source="default", live_depth=DEFAULT_WARMUP_BARS
+    )
+
+
 # Actions that only ever shrink an existing position — never sized up by
 # engine-level leverage, never blocked as fresh exposure.
 REDUCE_ONLY_ACTIONS = frozenset({"CLOSE", "STOP_LOSS", "TAKE_PROFIT"})

--- a/wayfinder_paths/jobs/execution/simulator.py
+++ b/wayfinder_paths/jobs/execution/simulator.py
@@ -24,10 +24,16 @@ from wayfinder_paths.jobs.execution.engine import (
 )
 from wayfinder_paths.jobs.execution.features import apply_precompute
 from wayfinder_paths.jobs.execution.gates import summarize_gate_diagnostics
+
+# DEFAULT_WARMUP_BARS is re-exported under its own name: the compute-window
+# contract moved to primitives (ONE resolution shared by this simulator, the
+# live driver, and the candidate shadow replayer) but existing callers import
+# it from here.
 from wayfinder_paths.jobs.execution.primitives import (
     DEFAULT_INITIAL_CAPITAL,
     REDUCE_ONLY_ACTIONS,
     CompletedBarsView,
+    ComputeWindow,
     ExecutionSpec,
     ExecutionTrace,
     FillEvent,
@@ -37,6 +43,10 @@ from wayfinder_paths.jobs.execution.primitives import (
     TradeCapacity,
     _load_module_from_path,
     bar_interval_seconds,
+    resolve_compute_window,
+)
+from wayfinder_paths.jobs.execution.primitives import (
+    DEFAULT_WARMUP_BARS as DEFAULT_WARMUP_BARS,
 )
 from wayfinder_paths.jobs.execution.validation import validate_execution_trace
 from wayfinder_paths.jobs.execution.venues import (
@@ -290,44 +300,6 @@ def _resolve_maker_fee_bps(
     return _DEFAULT_MAKER_FEE_BPS.get(venue, 0.0)
 
 
-# Default per-bar compute window. Bounding the view the simulator hands each
-# tick keeps the DEFAULT backtest O(N·k) instead of O(N²): a strategy that
-# recomputes indicators over the whole handed frame goes quadratic when that
-# frame grows with the replay index (the classic "simple backtest pegs the
-# CPU" trap). 512 bars covers the lookback of essentially every standard
-# indicator (SMA200, ATR/ADX, long EMAs) with margin. Strategies tune it via
-# `warmup_bars`; genuine since-genesis strategies opt out with
-# `full_history: true`.
-DEFAULT_WARMUP_BARS = 512
-
-
-def _resolve_compute_window(
-    params_data: Mapping[str, Any], strategy: Any
-) -> tuple[int | None, str, bool]:
-    """Size of the trailing view handed to `decide()` each bar.
-
-    Resolution (first hit wins):
-      1. ``params['warmup_bars']``  — explicit, canonical name.
-      2. ``params['lookback_bars']`` — back-compat with the old windowing lever.
-      3. ``strategy.warmup_bars``   — strategy-declared attribute.
-      4. ``DEFAULT_WARMUP_BARS``.
-    ``params['full_history']`` truthy opts back into full-history views.
-
-    Returns ``(window_size | None, source, full_history)``; ``None`` window ⇒
-    full history (``through(index)``).
-    """
-    if params_data.get("full_history"):
-        return None, "full_history", True
-    for key in ("warmup_bars", "lookback_bars"):
-        raw = params_data.get(key)
-        if raw:
-            return max(int(raw), 1), key, False
-    attr = getattr(strategy, "warmup_bars", None)
-    if attr:
-        return max(int(attr), 1), "strategy.warmup_bars", False
-    return DEFAULT_WARMUP_BARS, "default", False
-
-
 def _percentile(values: list[float], pct: float) -> float:
     if not values:
         return 0.0
@@ -378,9 +350,7 @@ def _build_profile(
     tick_ms: list[float],
     wall_start: float,
     total_bars: int,
-    window_size: int | None,
-    window_source: str,
-    full_history: bool,
+    window: ComputeWindow,
 ) -> dict[str, Any]:
     wall_s = time.perf_counter() - wall_start
     timed = len(tick_ms)
@@ -398,8 +368,8 @@ def _build_profile(
             "max": round(max(tick_ms), 2) if tick_ms else 0.0,
             "last": round(tick_ms[-1], 2) if tick_ms else 0.0,
         },
-        "compute_window": "full_history" if full_history else window_size,
-        "compute_window_source": window_source,
+        "compute_window": "full_history" if window.full_history else window.size,
+        "compute_window_source": window.source,
         "tick_time_growing": growing,
     }
     # Most "why is this backtest so slow" cases are a heavy full recompute in
@@ -473,12 +443,11 @@ def simulate_execution(
     )
     # None unless params["enable_liquidation"] is truthy — default-off parity.
     liquidation = LiquidationConfig.from_params(params_data)
-    # Each tick sees a bounded trailing window (the same the live driver
-    # fetches) so per-tick strategy recompute stays O(k), not O(index). This
-    # is now the DEFAULT — full history is opt-in via `full_history: true`.
-    window_size, window_source, full_history = _resolve_compute_window(
-        params_data, strategy
-    )
+    # Each tick sees a bounded trailing window — resolved by the SAME
+    # function that sizes the live driver's fetch and the shadow replayer's
+    # slice, so backtest inputs ≡ forward inputs by construction. Full
+    # history is opt-in via `full_history: true`.
+    window = resolve_compute_window(params_data, strategy)
 
     total_bars = len(dataset.bars.timestamps)
     progress_every = max(1, total_bars // 20)
@@ -521,11 +490,7 @@ def simulate_execution(
             tick_start = time.perf_counter()
             tick = await run_tick(
                 strategy,
-                view=(
-                    dataset.bars.through(index)
-                    if full_history
-                    else dataset.bars.window(index, window_size)
-                ),
+                view=window.slice_view(dataset.bars, index),
                 brokers={"*": broker},
                 state=state,
                 spec=spec,
@@ -569,7 +534,21 @@ def simulate_execution(
         )
     asyncio.run(_run_simulation())
 
+    profile = _build_profile(
+        tick_ms=tick_ms,
+        wall_start=wall_start,
+        total_bars=total_bars,
+        window=window,
+    )
     validation = validate_execution_trace(trace.to_dict(), spec)
+    if window.source == "default" and profile.get("hint"):
+        # The default cap already bounds the run, but the strategy never told
+        # backtest and live what history it needs — surface the profiler's
+        # diagnosis where agents actually look (validation warnings).
+        validation["warnings"].append(
+            "no declared compute window (set execution_params.warmup_bars): "
+            + str(profile["hint"])
+        )
     stats = _stats(
         equity_curve,
         trades,
@@ -605,14 +584,6 @@ def simulate_execution(
         "params": params_data,
         "validation": validation,
     }
-    profile = _build_profile(
-        tick_ms=tick_ms,
-        wall_start=wall_start,
-        total_bars=total_bars,
-        window_size=window_size,
-        window_source=window_source,
-        full_history=full_history,
-    )
     return ExecutionBacktestResult(
         run_id=uuid.uuid4().hex[:12],
         params=params_data,

--- a/wayfinder_paths/jobs/execution/validation.py
+++ b/wayfinder_paths/jobs/execution/validation.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import asyncio
 import io
 import json
+import math
 import py_compile
 import re
 import tokenize
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -14,13 +16,18 @@ import yaml
 from croniter import croniter
 
 from wayfinder_paths.jobs.execution.features import (
+    apply_precompute,
     load_feature_rows,
     parse_feature_specs,
 )
 from wayfinder_paths.jobs.execution.primitives import (
+    CompletedBarsView,
     ExecutionSpec,
+    ExecutionTrace,
+    StateSnapshot,
     _load_module_from_path,
     bar_interval_seconds,
+    resolve_compute_window,
 )
 from wayfinder_paths.jobs.gating import compute_workspace_revision
 from wayfinder_paths.jobs.store import JobStore
@@ -237,6 +244,7 @@ def validate_execution_job(
                 {"name": "strategy_module_loads", "passed": False, "error": str(exc)}
             )
         checks.extend(_execution_scenario_checks(script_path, job_data, spec))
+        checks.extend(_window_invariance_checks(root, script_path, job_data, spec))
 
     trace_report = _latest_trace_validation(root, spec)
     if trace_report is not None:
@@ -404,6 +412,187 @@ def _evidence_window_check(root: Path) -> list[dict[str, Any]]:
     ]
 
 
+# Window-invariance probe: a mechanical backtest ≡ forward-input proof for
+# declared compute windows. Bars beyond the declared window must be invisible
+# to decide(), so replaying a bar with W and with W+extra bars from identical
+# fresh state must produce identical intents.
+WINDOW_PROBE_SAMPLES = 12
+WINDOW_PROBE_EXTRA_BARS = 64
+BOUNDED_WINDOW_HINT = (
+    "live decide() sees at most the declared window of completed bars; any "
+    "logic that consumes more history than warmup_bars is testing a strategy "
+    "that cannot exist in production. Declare warmup_bars covering your "
+    "longest indicator lookback plus buffer, compute within that window, and "
+    "carry long memory as incremental state."
+)
+
+
+def _probe_values_match(left: Any, right: Any) -> bool:
+    """Structural equality with float tolerance: sizing arithmetic may carry
+    float noise between the two slices (e.g. an EMA seeded 64 rows earlier)
+    without any real dependence beyond the window."""
+    match left, right:
+        case dict(), dict():
+            return left.keys() == right.keys() and all(
+                _probe_values_match(left[key], right[key]) for key in left
+            )
+        case ((list() | tuple()), (list() | tuple())):
+            return len(left) == len(right) and all(
+                _probe_values_match(a, b) for a, b in zip(left, right, strict=True)
+            )
+        case bool(), _:
+            return left == right
+        case ((int() | float()), (int() | float())):
+            return math.isclose(float(left), float(right), rel_tol=1e-6, abs_tol=1e-9)
+        case _:
+            return left == right
+
+
+def window_invariance_probe(
+    script_entrypoint: str | Path | Callable[..., Any],
+    bars: CompletedBarsView,
+    execution_spec: ExecutionSpec | Mapping[str, Any] | None,
+    params: Mapping[str, Any],
+    *,
+    samples: int = WINDOW_PROBE_SAMPLES,
+) -> dict[str, Any]:
+    """Replay sampled decision bars twice — declared window W versus
+    min(available, W + WINDOW_PROBE_EXTRA_BARS) — from identical fresh state
+    and require identical intents. A mismatch means decide() consumed history
+    beyond its declared window: its backtest inputs are not its live inputs."""
+    from wayfinder_paths.jobs.execution.engine import (  # circular import
+        EngineState,
+        run_tick,
+    )
+    from wayfinder_paths.jobs.execution.simulator import (  # circular import
+        BacktestBroker,
+        _load_strategy,
+    )
+
+    params_data = dict(params)
+    spec = ExecutionSpec.coerce(execution_spec)
+    window = resolve_compute_window(
+        params_data, _load_strategy(script_entrypoint, dict(params_data))
+    )
+    if not window.declared or window.size is None:
+        return {
+            "status": "skipped",
+            "reason": f"compute window is {window.source}, not declared",
+        }
+    size = window.size
+    timestamps = bars.timestamps
+    first = size  # earliest index where the wide slice adds bars
+    if len(timestamps) - 1 < first:
+        return {
+            "status": "skipped",
+            "reason": "dataset does not extend beyond the declared window",
+        }
+    span = len(timestamps) - 1 - first
+    count = max(1, min(samples, span + 1))
+    step = span / max(count - 1, 1)
+    indices = sorted({first + round(k * step) for k in range(count)})
+
+    async def decided_intents(index: int, lookback: int) -> list[dict[str, Any]]:
+        # Fresh strategy + fresh engine state per replay: the two runs differ
+        # ONLY in view depth, so any intent difference is window dependence.
+        strategy = _load_strategy(script_entrypoint, dict(params_data))
+        view = apply_precompute(strategy, bars.window(index, lookback))
+        trace = ExecutionTrace(execution_spec=spec.to_dict())
+        await run_tick(
+            strategy,
+            view=view,
+            brokers={"*": BacktestBroker()},
+            state=EngineState(),
+            spec=spec,
+            params=params_data,
+            timestamp=timestamps[index],
+            snapshot=StateSnapshot(status="valid"),
+            trace=trace,
+        )
+        return trace.intents
+
+    async def probe() -> dict[str, Any]:
+        for index in indices:
+            base = await decided_intents(index, size)
+            wide = await decided_intents(index, size + WINDOW_PROBE_EXTRA_BARS)
+            if not _probe_values_match(base, wide):
+                return {
+                    "status": "failed",
+                    "bar": timestamps[index].isoformat(),
+                    "window": size,
+                    "window_source": window.source,
+                    "base_intents": base,
+                    "wide_intents": wide,
+                }
+        return {
+            "status": "passed",
+            "window": size,
+            "window_source": window.source,
+            "bars_probed": len(indices),
+        }
+
+    return asyncio.run(probe())
+
+
+def _window_invariance_checks(
+    root: Path, script_path: Path, job_data: Mapping[str, Any], spec: ExecutionSpec
+) -> list[dict[str, Any]]:
+    """Bounded-window parity gate: for jobs that DECLARE a compute window,
+    prove backtest inputs ≡ forward inputs on the canonical dataset. Jobs
+    without a declared window are exempt — the simulator surfaces the
+    profiler hint as a backtest validation warning instead."""
+    from wayfinder_paths.jobs.execution.simulator import (  # circular import
+        _load_strategy,
+    )
+
+    params = dict(job_data.get("execution_params") or {})
+    try:
+        window = resolve_compute_window(params, _load_strategy(script_path, params))
+    except Exception:  # noqa: BLE001 — strategy_module_loads reports this already
+        return []
+    if not window.declared:
+        return []
+    from wayfinder_paths.jobs.execution.job import _load_dataset  # circular import
+
+    try:
+        dataset = _load_dataset(root, spec, dict(job_data))
+        probe = window_invariance_probe(script_path, dataset.bars, spec, params)
+    except FileNotFoundError:
+        return []  # fixture/scenario-driven validation contexts have no dataset
+    except Exception as exc:  # noqa: BLE001 — a broken probe must not block jobs
+        return [
+            {
+                "name": "window_invariance",
+                "passed": False,
+                "blocking": False,
+                "error": str(exc)[:300],
+            }
+        ]
+    if probe["status"] == "skipped":
+        return [
+            {
+                "name": "window_invariance",
+                "passed": True,
+                "blocking": False,
+                "note": probe["reason"],
+            }
+        ]
+    check: dict[str, Any] = {
+        "name": "window_invariance",
+        "passed": probe["status"] == "passed",
+        "details": {
+            key: value for key, value in probe.items() if not key.endswith("_intents")
+        },
+    }
+    if probe["status"] != "passed":
+        check["error"] = (
+            f"decide() at bar {probe['bar']} changed its intents when handed "
+            f"{WINDOW_PROBE_EXTRA_BARS} bars beyond the declared window of "
+            f"{probe['window']} ({probe['window_source']}) — {BOUNDED_WINDOW_HINT}"
+        )
+    return [check]
+
+
 def _feature_checks(root: Path, spec: ExecutionSpec) -> list[dict[str, Any]]:
     try:
         specs = parse_feature_specs(spec)
@@ -559,16 +748,17 @@ def _timing_checks(
             "blocking": False,
         },
         {
-            # The live driver always fetches a bounded window (default 200
-            # bars); an undeclared lookback means backtests see full history
-            # while live sees 200 — path-dependent indicators (Wilder ATR,
-            # SuperTrend) will diverge. Declaring it aligns both AND bounds
-            # per-tick backtest cost. Blocking for starter jobs: most catalog
-            # starters have warmup_bars > 200, so an undeclared lookback caps
-            # ctx.bar_index below warmup and the job silently never trades.
+            # The live driver and the backtest simulator hand decide() the
+            # SAME declared window (warmup_bars canonical, lookback_bars
+            # back-compat); undeclared jobs ride the default cap without ever
+            # stating what history the strategy needs. Blocking for starter
+            # jobs: most catalog starters have warmup_bars above the old live
+            # default, so an undeclared window caps ctx.bar_index below
+            # warmup and the job silently never trades.
             "name": "lookback_bars_declared",
-            "passed": bool(params.get("lookback_bars")) or not is_jobs_v1,
-            "value": params.get("lookback_bars"),
+            "passed": bool(params.get("warmup_bars") or params.get("lookback_bars"))
+            or not is_jobs_v1,
+            "value": params.get("warmup_bars") or params.get("lookback_bars"),
             "blocking": is_jobs_v1 and is_starter,
         },
     ]

--- a/wayfinder_paths/jobs/prompts/starter_research_cases.json
+++ b/wayfinder_paths/jobs/prompts/starter_research_cases.json
@@ -48,6 +48,12 @@
       "tags": ["costs", "funding", "execution", "validity"],
       "lesson": "Candidates are comparable only when fees, funding, next-open execution, interval labels, and feature availability match between incumbent, candidate, and forward paths.",
       "source": "starter research synthesis"
+    },
+    {
+      "id": "bounded-window-parity",
+      "tags": ["warmup", "data-contract", "performance", "validity"],
+      "lesson": "Live decide() sees a bounded window of completed bars; any backtest logic consuming more history than the declared warmup_bars is testing a strategy that cannot exist in production, and recomputing over full history turns replays quadratic. Declare the window, compute within it, carry long memory as incremental state.",
+      "source": "majors evolution campaign 1 post-mortem (2026-08-26)"
     }
   ]
 }

--- a/wayfinder_paths/jobs/watchdog.py
+++ b/wayfinder_paths/jobs/watchdog.py
@@ -1273,6 +1273,49 @@ _LIFECYCLE_MARKER = "state/lifecycle_pass.json"
 _LIFECYCLE_INTERVAL_S = 6 * 3600
 _CAMPAIGN_FINALIZE_RETRY_S = (0, 5 * 60, 15 * 60, 30 * 60)
 _CAMPAIGN_FINALIZE_GRACE = timedelta(minutes=60)
+# A finalize op still writing output past the grace is extended, not expired:
+# expiry once fired mid-Optuna at exactly the grace boundary and the orphaned
+# finalize ran 8+ hours holding the replication lock. Freshness = op log
+# mtime — the simulator's per-bar progress lines land there continuously
+# during finalize backtests.
+_FINALIZE_LOG_FRESH = timedelta(minutes=10)
+_FINALIZE_EXTEND_MARKER = "state/evolution_finalize_extend.json"
+
+
+def _finalize_op_health(job_dir: Path, now: datetime) -> tuple[int | None, bool]:
+    """(pid, healthy) for the evolution_finalize detached op: healthy means
+    the recorded pid is alive AND the op log was written recently."""
+    ops_dir = job_dir / "state" / "background_ops"
+    try:
+        status = json.loads(
+            (ops_dir / "evolution_finalize.json").read_text(encoding="utf-8")
+        )
+    except (OSError, ValueError):
+        return None, False
+    pid = status.get("pid") if isinstance(status, dict) else None
+    if not isinstance(pid, int) or not _pid_alive(pid):
+        return pid if isinstance(pid, int) else None, False
+    try:
+        log_age = now.timestamp() - (ops_dir / "evolution_finalize.log").stat().st_mtime
+    except OSError:
+        return pid, False
+    return pid, log_age < _FINALIZE_LOG_FRESH.total_seconds()
+
+
+def _reap_finalize_group(pid: int | None) -> bool:
+    """SIGKILL the finalize op's process group; pgid == pid because
+    spawn_detached_op starts the op with start_new_session=True. Signaling
+    the recorded pid AS a pgid also reaps surviving children when the session
+    leader already exited (os.getpgid would fail there). True when a live
+    group was killed."""
+    if not pid or pid <= 0:
+        return False
+    try:
+        os.killpg(pid, 0)
+        os.killpg(pid, signal.SIGKILL)
+    except OSError:
+        return False
+    return True
 
 
 def _run_evolution_campaign_pass(
@@ -1296,7 +1339,49 @@ def _run_evolution_campaign_pass(
         return None
 
     op = op_status_summary(store.job_dir(job_id), "evolution_finalize")
-    if state.get("status") == "finalizing" and (op or {}).get("status") == "running":
+    past_grace = now - deadline >= _CAMPAIGN_FINALIZE_GRACE
+    if past_grace:
+        # Finalize-aware expiry: a live finalize still writing output past
+        # the grace extends the campaign (journaled once per campaign); a
+        # dead or wedged one is reaped BEFORE the expiry takes the campaign
+        # lock the wedged process itself may be holding.
+        pid, healthy = _finalize_op_health(store.job_dir(job_id), now)
+        if healthy:
+            marker = store.read_json(job_id, _FINALIZE_EXTEND_MARKER) or {}
+            if marker.get("campaign_id") == state.get("campaign_id"):
+                return None
+            store.write_json(
+                job_id,
+                _FINALIZE_EXTEND_MARKER,
+                {
+                    "campaign_id": state.get("campaign_id"),
+                    "pid": pid,
+                    "noted_at": now.isoformat(),
+                },
+            )
+            store.append_journal(
+                job_id,
+                {
+                    "type": "evolution_finalize_still_running",
+                    "campaign_id": state.get("campaign_id"),
+                    "pid": pid,
+                },
+            )
+            return {
+                "action": "evolution_finalize_still_running",
+                "campaign_id": state.get("campaign_id"),
+                "pid": pid,
+            }
+        if _reap_finalize_group(pid):
+            store.append_journal(
+                job_id,
+                {
+                    "type": "evolution_finalize_reaped",
+                    "campaign_id": state.get("campaign_id"),
+                    "pid": pid,
+                },
+            )
+    elif state.get("status") == "finalizing" and (op or {}).get("status") == "running":
         return None
 
     with job_state_lock(store.repo_root, job_id, name="evolution_campaign"):

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -1694,7 +1694,10 @@ def _prompt_evolution_session(
         "research toolkit and starter casebook instead of recreating indicators. "
         "After launching an evolution-evaluate, do not wait for its result — keep "
         "preparing candidates until the generation budget or the deadline is "
-        "reached; evaluation results arrive via follow-up prompts.\n\n"
+        "reached; evaluation results arrive via follow-up prompts. Declare "
+        "execution_params.warmup_bars covering your longest indicator lookback "
+        "plus buffer; recompute from that bounded window or carry state "
+        "incrementally — never recompute over full history.\n\n"
         "Campaign:\n" + _canonical_json(campaign, max_chars=12_000)
     )
     queued = OPENCODE_CLIENT.prompt_async(

--- a/wayfinder_paths/tests/test_backtest_profile_and_summary.py
+++ b/wayfinder_paths/tests/test_backtest_profile_and_summary.py
@@ -136,6 +136,95 @@ def test_lookback_bars_still_windows_for_back_compat() -> None:
     assert res.profile["compute_window_source"] == "lookback_bars"
 
 
+def test_declared_window_bounds_every_decide_view() -> None:
+    """warmup_bars=W ⇒ decide() never sees more than W timestamps (and
+    symbol_frame() never more than W rows) — the same bounded view the live
+    driver fetches, so backtest inputs ≡ forward inputs by construction."""
+    seen: list[int] = []
+
+    def build(params=None):
+        def decide(ctx: ExecutionContext):
+            seen.append(len(ctx.view.timestamps))
+            assert len(ctx.view.symbol_frame("IMX")) <= 40
+            return []
+
+        return types.SimpleNamespace(decide=decide)
+
+    res = simulate_execution(build, _dataset(300), SPEC, {"warmup_bars": 40})
+    assert res.profile["compute_window"] == 40
+    assert max(seen) == 40  # ramps up to W, never beyond
+
+
+def test_undeclared_window_surfaces_hint_as_validation_warning(monkeypatch) -> None:
+    """An undeclared window still runs bounded at the default cap, but the
+    profiler's O(N²)/heavy-tick hint must land in validation warnings so the
+    agent is told to declare warmup_bars; declared runs stay clean."""
+    from wayfinder_paths.jobs.execution import simulator as sim
+
+    monkeypatch.setattr(sim, "_tick_time_growing", lambda tick_ms: True)
+    marker = "no declared compute window"
+    undeclared = simulate_execution(_build_strategy, _dataset(120), SPEC, {})
+    assert any(marker in warning for warning in undeclared.validation["warnings"])
+    declared = simulate_execution(
+        _build_strategy, _dataset(120), SPEC, {"warmup_bars": 40}
+    )
+    assert not any(marker in warning for warning in declared.validation["warnings"])
+
+
+def test_resolve_compute_window_is_the_single_view_depth_contract() -> None:
+    """One resolution feeds the simulator slice AND the driver's live fetch
+    depth: params warmup_bars > params lookback_bars > strategy attribute >
+    default; full_history opts backtests out but keeps a legacy live depth."""
+    from wayfinder_paths.jobs.execution.primitives import (
+        DEFAULT_WARMUP_BARS as DEFAULT,
+    )
+    from wayfinder_paths.jobs.execution.primitives import (
+        FULL_HISTORY_LIVE_DEPTH_BARS,
+        resolve_compute_window,
+    )
+
+    strategy = types.SimpleNamespace(warmup_bars=77)
+    window = resolve_compute_window({"warmup_bars": 96, "lookback_bars": 250}, strategy)
+    assert (window.size, window.source, window.live_depth, window.declared) == (
+        96,
+        "warmup_bars",
+        96,
+        True,
+    )
+    window = resolve_compute_window({"lookback_bars": 250}, strategy)
+    assert (window.size, window.source, window.live_depth) == (
+        250,
+        "lookback_bars",
+        250,
+    )
+    window = resolve_compute_window({}, strategy)
+    assert (window.size, window.source, window.live_depth) == (
+        77,
+        "strategy.warmup_bars",
+        77,
+    )
+    window = resolve_compute_window({}, None)
+    assert (window.size, window.source, window.live_depth, window.declared) == (
+        DEFAULT,
+        "default",
+        DEFAULT,
+        False,
+    )
+    window = resolve_compute_window(
+        {"full_history": True, "lookback_bars": 300}, strategy
+    )
+    assert (window.size, window.full_history, window.live_depth, window.declared) == (
+        None,
+        True,
+        300,
+        False,
+    )
+    assert (
+        resolve_compute_window({"full_history": True}, None).live_depth
+        == FULL_HISTORY_LIVE_DEPTH_BARS
+    )
+
+
 def test_summarize_backtest_payload_drops_heavy_arrays() -> None:
     res = simulate_execution(_build_strategy, _dataset(120), SPEC, {})
     payload = {

--- a/wayfinder_paths/tests/test_execution_timing_validation.py
+++ b/wayfinder_paths/tests/test_execution_timing_validation.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+import json
+import types
 from pathlib import Path
 from typing import Any
 
 import pytest
 import yaml
 
-from wayfinder_paths.jobs.execution import ExecutionSpec
+from wayfinder_paths.jobs.execution import ExecutionSpec, OrderIntent
 from wayfinder_paths.jobs.execution.simulator import (
     PreparedExecutionDataset,
     run_execution_grid,
@@ -469,3 +471,136 @@ def test_live_mode_blocks_without_wallet_label() -> None:
     assert _live_wallet_checks(paper) == []
     legacy = {"execution_contract": "legacy", "script_loop": {"mode": "live"}}
     assert _live_wallet_checks(legacy) == []
+
+
+def _build_windowed_strategy(params: dict[str, Any]) -> Any:
+    """Reads only the trailing 10 closes — window-invariant by construction."""
+
+    def decide(ctx: Any) -> list[OrderIntent]:
+        closes = ctx.view.symbol_frame("SNX")["close"].astype(float)
+        if len(closes) < 10:
+            return []
+        last = float(closes.iloc[-1])
+        if last > float(closes.iloc[-10:].mean()):
+            return [
+                OrderIntent(
+                    action="OPEN",
+                    venue="hyperliquid",
+                    symbol="SNX",
+                    side="long",
+                    size=1.0,
+                    bracket={"stop_loss": last * 0.95, "take_profit": last * 1.05},
+                )
+            ]
+        return []
+
+    return types.SimpleNamespace(decide=decide)
+
+
+def _build_full_frame_strategy(params: dict[str, Any]) -> Any:
+    """Sizes off the mean of EVERYTHING handed — the parity trap: its
+    decisions depend on how deep the harness's view happens to be."""
+
+    def decide(ctx: Any) -> list[OrderIntent]:
+        closes = ctx.view.symbol_frame("SNX")["close"].astype(float)
+        return [
+            OrderIntent(
+                action="OPEN",
+                venue="hyperliquid",
+                symbol="SNX",
+                side="long",
+                notional=float(closes.mean()),
+            )
+        ]
+
+    return types.SimpleNamespace(decide=decide)
+
+
+_PROBE_SPEC = {
+    "market_kind": "perp",
+    "data_contract": {"bar_interval": "5m", "symbols": ["SNX"]},
+}
+
+
+def test_window_invariance_probe_passes_window_respecting_strategy() -> None:
+    from wayfinder_paths.jobs.execution.primitives import CompletedBarsView
+    from wayfinder_paths.jobs.execution.validation import window_invariance_probe
+
+    bars = CompletedBarsView.from_rows(_bars(140))
+    result = window_invariance_probe(
+        _build_windowed_strategy, bars, _PROBE_SPEC, {"warmup_bars": 30}
+    )
+    assert result["status"] == "passed"
+    assert result["window"] == 30
+    assert result["bars_probed"] >= 2
+
+    # Undeclared windows have nothing to prove — the probe skips.
+    skipped = window_invariance_probe(_build_windowed_strategy, bars, _PROBE_SPEC, {})
+    assert skipped["status"] == "skipped"
+
+
+def test_window_invariance_probe_reds_full_frame_recompute() -> None:
+    from wayfinder_paths.jobs.execution.primitives import CompletedBarsView
+    from wayfinder_paths.jobs.execution.validation import window_invariance_probe
+
+    bars = CompletedBarsView.from_rows(_bars(140))
+    result = window_invariance_probe(
+        _build_full_frame_strategy, bars, _PROBE_SPEC, {"warmup_bars": 30}
+    )
+    assert result["status"] == "failed"
+    assert result["window"] == 30
+    assert result["bar"]  # the differing bar is named
+    assert result["base_intents"] != result["wide_intents"]
+
+
+def test_window_invariance_check_reds_validation_with_hint(tmp_path: Path) -> None:
+    """The validate_execution_job check: a declared-window job whose decide()
+    reads beyond the window goes RED (blocking) with the differing bar and the
+    bounded-window hint; a window-respecting job passes; undeclared jobs are
+    exempt."""
+    from wayfinder_paths.jobs.execution.validation import (
+        BOUNDED_WINDOW_HINT,
+        _window_invariance_checks,
+    )
+
+    root = tmp_path / "job"
+    bars_path = root / "results" / "backtest" / "input_bars.json"
+    bars_path.parent.mkdir(parents=True, exist_ok=True)
+    bars_path.write_text(json.dumps({"bars": _bars(140)}), encoding="utf-8")
+    script = root / "workspace" / "src" / "strategy.py"
+    script.parent.mkdir(parents=True, exist_ok=True)
+    script.write_text(
+        "def decide(ctx):\n"
+        "    closes = ctx.view.symbol_frame('SNX')['close'].astype(float)\n"
+        "    return [{'action': 'OPEN', 'venue': 'hyperliquid', 'symbol': 'SNX',\n"
+        "             'side': 'long', 'notional': float(closes.mean())}]\n",
+        encoding="utf-8",
+    )
+    spec = ExecutionSpec.coerce(_PROBE_SPEC)
+    job_data = {"execution_params": {"warmup_bars": 30, "symbols": ["SNX"]}}
+
+    checks = _window_invariance_checks(root, script, job_data, spec)
+    assert len(checks) == 1
+    check = checks[0]
+    assert check["name"] == "window_invariance"
+    assert check["passed"] is False
+    assert check.get("blocking") is not False  # RED, not advisory
+    assert check["details"]["bar"] in check["error"]
+    assert BOUNDED_WINDOW_HINT in check["error"]
+
+    script.write_text(
+        "def decide(ctx):\n"
+        "    closes = ctx.view.symbol_frame('SNX')['close'].astype(float)\n"
+        "    if len(closes) < 10:\n"
+        "        return []\n"
+        "    if float(closes.iloc[-1]) > float(closes.iloc[-10:].mean()):\n"
+        "        return [{'action': 'OPEN', 'venue': 'hyperliquid',\n"
+        "                 'symbol': 'SNX', 'side': 'long', 'size': 1.0}]\n"
+        "    return []\n",
+        encoding="utf-8",
+    )
+    passing = _window_invariance_checks(root, script, job_data, spec)
+    assert len(passing) == 1 and passing[0]["passed"] is True
+
+    # No declared window ⇒ no check (the simulator warns instead).
+    assert _window_invariance_checks(root, script, {"execution_params": {}}, spec) == []

--- a/wayfinder_paths/tests/test_jobs_apply_watchdog.py
+++ b/wayfinder_paths/tests/test_jobs_apply_watchdog.py
@@ -1061,3 +1061,132 @@ def test_watchdog_mechanically_finalizes_then_expires_campaign(
     assert store.read_json(job.id, "state/evolution_campaign.json")["status"] == (
         "expired"
     )
+
+
+def _journal_types(store: JobStore, job_id: str) -> list[str]:
+    path = store.job_dir(job_id) / "journal.jsonl"
+    if not path.exists():
+        return []
+    return [
+        str(json.loads(line).get("type"))
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _finalizing_campaign(
+    store: JobStore, job_id: str, deadline: datetime, *, pid: int
+) -> Path:
+    store.write_json(
+        job_id,
+        "state/evolution_campaign.json",
+        {
+            "campaign_id": "campaign-1",
+            "status": "finalizing",
+            "stage": "finalizing",
+            "deadline_at": deadline.isoformat(),
+            "finalize_attempts": 1,
+            "finalize_last_attempt_at": deadline.isoformat(),
+        },
+    )
+    ops = store.job_dir(job_id) / "state" / "background_ops"
+    ops.mkdir(parents=True, exist_ok=True)
+    (ops / "evolution_finalize.json").write_text(
+        json.dumps(
+            {
+                "op": "evolution_finalize",
+                "job_id": job_id,
+                "state": "running",
+                "pid": pid,
+            }
+        ),
+        encoding="utf-8",
+    )
+    log = ops / "evolution_finalize.log"
+    log.write_text("[backtest] bar 100/27648 · 12 bars/s\n", encoding="utf-8")
+    return log
+
+
+def test_watchdog_extends_grace_while_finalize_is_healthy(tmp_path: Path) -> None:
+    """A live finalize with a fresh log past the grace is EXTENDED, not
+    expired — expiry once fired mid-Optuna and the orphan ran 8+ hours
+    holding the replication lock. The still-running journal is deduped to
+    once per campaign."""
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "campaign-healthy")
+    deadline = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    log = _finalizing_campaign(store, job.id, deadline, pid=os.getpid())
+    now = deadline + timedelta(minutes=61)
+    os.utime(log, (now.timestamp() - 60, now.timestamp() - 60))
+
+    first = _run_evolution_campaign_pass(store, job.id, now)
+
+    assert first == {
+        "action": "evolution_finalize_still_running",
+        "campaign_id": "campaign-1",
+        "pid": os.getpid(),
+    }
+    state = store.read_json(job.id, "state/evolution_campaign.json")
+    assert state["status"] == "finalizing"  # extended, not expired
+
+    later = now + timedelta(minutes=5)
+    os.utime(log, (later.timestamp() - 60, later.timestamp() - 60))
+    assert _run_evolution_campaign_pass(store, job.id, later) is None
+    assert _journal_types(store, job.id).count("evolution_finalize_still_running") == 1
+
+
+def test_watchdog_reaps_stale_live_finalize_on_expiry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A live pid whose log went stale is wedged: the watchdog SIGKILLs the
+    op's process group (pgid == pid via start_new_session) BEFORE expiring,
+    and journals the reap with the pid."""
+    import signal
+
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "campaign-wedged")
+    deadline = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    log = _finalizing_campaign(store, job.id, deadline, pid=os.getpid())
+    now = deadline + timedelta(minutes=61)
+    stale = now.timestamp() - 20 * 60
+    os.utime(log, (stale, stale))
+    killed: list[tuple[int, int]] = []
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.watchdog.os.killpg",
+        lambda pid, sig: killed.append((pid, sig)),
+    )
+
+    expired = _run_evolution_campaign_pass(store, job.id, now)
+
+    assert expired["action"] == "evolution_campaign_expired"
+    assert killed == [(os.getpid(), 0), (os.getpid(), signal.SIGKILL)]
+    assert store.read_json(job.id, "state/evolution_campaign.json")["status"] == (
+        "expired"
+    )
+    types = _journal_types(store, job.id)
+    assert "evolution_finalize_reaped" in types
+    assert "evolution_campaign_expired" in types
+
+
+def test_watchdog_expires_dead_finalize_without_reap(tmp_path: Path) -> None:
+    """A dead finalize pid past the grace expires exactly as before — no
+    process group to reap, no reap journal."""
+    import subprocess
+    import sys
+
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "campaign-dead")
+    deadline = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    proc.wait()
+    _finalizing_campaign(store, job.id, deadline, pid=proc.pid)
+
+    expired = _run_evolution_campaign_pass(
+        store, job.id, deadline + timedelta(minutes=61)
+    )
+
+    assert expired["action"] == "evolution_campaign_expired"
+    assert store.read_json(job.id, "state/evolution_campaign.json")["status"] == (
+        "expired"
+    )
+    assert "evolution_finalize_reaped" not in _journal_types(store, job.id)

--- a/wayfinder_paths/tests/test_jobs_candidate_shadow.py
+++ b/wayfinder_paths/tests/test_jobs_candidate_shadow.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 
 import pandas as pd
 import yaml
@@ -117,7 +118,19 @@ def test_candidate_shadow_uses_separate_paper_state_and_stream(tmp_path) -> None
             / revision
             / "engine_state.json"
         ).exists()
-    assert any(
-        (root / "results" / "forward" / "experiment" / "proposals").rglob("ticks.jsonl")
+    ticks_paths = list(
+        (root / "results" / "forward" / "experiment" / "proposals").rglob(
+            "ticks.jsonl"
+        )
     )
+    assert ticks_paths
+    # Shadow replays hand candidates the SAME bounded window the simulator and
+    # live driver resolve (lookback_bars=20 here) — never the full growing
+    # replay history.
+    for ticks_path in ticks_paths:
+        rows = [
+            json.loads(line)
+            for line in ticks_path.read_text(encoding="utf-8").splitlines()
+        ]
+        assert rows and max(row["view_window"]["rows"] for row in rows) <= 20
     assert asyncio.run(run_candidate_shadows(store, job.id)) == []

--- a/wayfinder_paths/tests/test_jobs_evolution_campaign.py
+++ b/wayfinder_paths/tests/test_jobs_evolution_campaign.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import io
 import json
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import pytest
+import yaml
 
 from wayfinder_paths.jobs.archive import (
     behavior_cell,
@@ -19,6 +20,7 @@ from wayfinder_paths.jobs.evolution_campaign import (
     campaign_due,
     campaign_prompt_block,
     campaign_status,
+    evaluate_candidate,
     evolution_compute_window_open,
     finalize_campaign,
     maybe_start_campaign,
@@ -26,10 +28,13 @@ from wayfinder_paths.jobs.evolution_campaign import (
     resolve_candidate_bundle,
     start_campaign,
 )
+from wayfinder_paths.jobs.execution.primitives import DEFAULT_WARMUP_BARS
+from wayfinder_paths.jobs.gating import compute_workspace_revision
 from wayfinder_paths.jobs.models import WayfinderJob
 from wayfinder_paths.jobs.starter_casebook import (
     MAX_PROMPT_CASES,
     load_starter_casebook,
+    select_starter_cases,
 )
 from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.jobs.worker import _queue_evolution_worker, nudge_evolution_session
@@ -616,6 +621,175 @@ def test_op_completion_nudge_reuses_session_and_respects_kill_switch(
     monkeypatch.setenv("WAYFINDER_EVOLUTION_NUDGE", "0")
     assert nudge_evolution_session(store, job_id) is None
     assert len(client.prompts) == 1
+
+
+_EVAL_SPEC = {
+    "market_kind": "perp",
+    "data_contract": {"bar_interval": "1h", "symbols": ["IMX"]},
+}
+
+
+def _hourly_bars(count: int) -> list[dict[str, Any]]:
+    rows = []
+    for index in range(count):
+        price = 10.0 + index * 0.05
+        stamp = datetime(2026, 8, 1, tzinfo=UTC) + timedelta(hours=index)
+        rows.append(
+            {
+                "timestamp": stamp.isoformat(),
+                "symbol": "IMX",
+                "open": price,
+                "high": price * 1.01,
+                "low": price * 0.99,
+                "close": price,
+                "volume": 100.0,
+            }
+        )
+    return rows
+
+
+def _evaluatable_job(
+    tmp_path: Any, *, source_params: dict[str, Any] | None = None
+) -> tuple[JobStore, str]:
+    """Like _job but with a real spec, runnable strategy, and enough bars for
+    the low-fidelity screen — so evaluate_candidate runs end to end."""
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        "majors-5m-lab",
+        name="Majors momentum lab",
+        goal="find robust momentum and factor strategies",
+        script="workspace/src/strategy.py",
+        agent_mode="intervene",
+        execution_contract="jobs_v1",
+        interval_seconds=3600,
+    )
+    job.execution_spec = dict(_EVAL_SPEC)
+    job.execution_params = {
+        "symbols": ["IMX"],
+        "initial_capital": 1_000.0,
+        **(source_params or {}),
+    }
+    store.save(job)
+    root = store.job_dir(job.id)
+    script = root / "workspace" / "src" / "strategy.py"
+    script.parent.mkdir(parents=True, exist_ok=True)
+    script.write_text("def decide(ctx):\n    return []\n", encoding="utf-8")
+    bars = root / "results" / "backtest" / "input_bars.json"
+    bars.parent.mkdir(parents=True, exist_ok=True)
+    bars.write_text(
+        json.dumps({"metadata": {"days": 120}, "bars": _hourly_bars(60)}),
+        encoding="utf-8",
+    )
+    return store, job.id
+
+
+def _read_bundle_params(store: JobStore, job_id: str, bundle: str) -> dict[str, Any]:
+    data = yaml.safe_load(
+        (store.job_dir(job_id) / bundle / "job.yaml").read_text(encoding="utf-8")
+    )
+    return dict(data["execution_params"])
+
+
+def test_prepare_candidate_seeds_declared_window(tmp_path) -> None:
+    store, job_id = _evaluatable_job(tmp_path / "default")
+    start_campaign(store, job_id, now=datetime(2026, 8, 25, 12, tzinfo=UTC))
+    candidate = prepare_candidate(
+        store,
+        job_id,
+        family="breakout",
+        summary="seed default",
+        now=datetime(2026, 8, 25, 13, tzinfo=UTC),
+    )
+    params = _read_bundle_params(store, job_id, candidate["bundle"])
+    assert params["warmup_bars"] == DEFAULT_WARMUP_BARS
+    assert candidate["warmup_bars"] == DEFAULT_WARMUP_BARS
+    # The frozen source was seeded identically, so an UNEDITED candidate still
+    # matches the baseline revision (the identical-to-source guard holds).
+    state = campaign_status(store, job_id)
+    manifest = json.loads(
+        (store.job_dir(job_id) / state["manifest"]).read_text(encoding="utf-8")
+    )
+    bundle_root = store.job_dir(job_id) / candidate["bundle"]
+    assert (
+        compute_workspace_revision(bundle_root)
+        == manifest["source_bundle"]["revision"]
+    )
+
+    # A source that already declared a window (legacy lookback_bars) is
+    # inherited, never overwritten with the default.
+    inherit_store, inherit_id = _evaluatable_job(
+        tmp_path / "inherit", source_params={"lookback_bars": 48}
+    )
+    start_campaign(inherit_store, inherit_id, now=datetime(2026, 8, 25, 12, tzinfo=UTC))
+    inherited = prepare_candidate(
+        inherit_store,
+        inherit_id,
+        family="breakout",
+        summary="seed inherited",
+        now=datetime(2026, 8, 25, 13, tzinfo=UTC),
+    )
+    params = _read_bundle_params(inherit_store, inherit_id, inherited["bundle"])
+    assert params["warmup_bars"] == 48
+
+
+def test_evaluate_rejects_undeclared_window_candidate(tmp_path) -> None:
+    """A candidate that dodges the bounded-window contract (full_history)
+    is invalid with the bounded-window hint as the reason."""
+    store, job_id = _evaluatable_job(tmp_path)
+    start_campaign(store, job_id, now=datetime(2026, 8, 25, 12, tzinfo=UTC))
+    candidate = prepare_candidate(
+        store,
+        job_id,
+        family="breakout",
+        summary="undeclared window",
+        now=datetime(2026, 8, 25, 13, tzinfo=UTC),
+    )
+    bundle = store.job_dir(job_id) / candidate["bundle"]
+    data = yaml.safe_load((bundle / "job.yaml").read_text(encoding="utf-8"))
+    data["execution_params"].pop("warmup_bars")
+    data["execution_params"]["full_history"] = True
+    data["execution_params"]["lookback_bars"] = 20
+    (bundle / "job.yaml").write_text(
+        yaml.safe_dump(data, sort_keys=False), encoding="utf-8"
+    )
+
+    result = evaluate_candidate(store, job_id, candidate["candidate_id"])
+
+    assert result["status"] == "invalid"
+    evidence = json.dumps(result["evidence"])
+    assert "warmup_bars" in evidence
+    assert "cannot exist in production" in evidence
+
+
+def test_evaluate_accepts_seeded_candidate(tmp_path) -> None:
+    store, job_id = _evaluatable_job(tmp_path)
+    start_campaign(store, job_id, now=datetime(2026, 8, 25, 12, tzinfo=UTC))
+    candidate = prepare_candidate(
+        store,
+        job_id,
+        family="breakout",
+        summary="seeded and edited",
+        now=datetime(2026, 8, 25, 13, tzinfo=UTC),
+    )
+    script = (
+        store.job_dir(job_id) / candidate["bundle"] / "workspace" / "src" / "strategy.py"
+    )
+    script.write_text(
+        script.read_text(encoding="utf-8") + "\nSTRUCTURAL_PROBE = True\n",
+        encoding="utf-8",
+    )
+
+    result = evaluate_candidate(store, job_id, candidate["candidate_id"])
+
+    assert result["status"] == "quick_complete", result.get("evidence")
+
+
+def test_casebook_includes_bounded_window_parity_case() -> None:
+    cases = {case["id"] for case in load_starter_casebook()}
+    assert "bounded-window-parity" in cases
+    selected = select_starter_cases({"warmup", "performance"})
+    assert len(selected) <= MAX_PROMPT_CASES
+    assert any(case["id"] == "bounded-window-parity" for case in selected)
 
 
 def test_op_runner_nudges_after_evolution_ops_and_contains_failures(

--- a/wayfinder_paths/tests/test_jobs_live_driver.py
+++ b/wayfinder_paths/tests/test_jobs_live_driver.py
@@ -497,6 +497,51 @@ async def test_happy_paper_ticks_fill_at_next_bar_open(tmp_path: Path) -> None:
     assert json.loads(ticks[0])["view_hash"]
 
 
+class RecordingFeed(FakeFeed):
+    def __init__(self, view: CompletedBarsView) -> None:
+        super().__init__(view)
+        self.lookbacks: list[int] = []
+
+    async def get_completed_bars(
+        self, symbols: Any, interval: str, *, lookback_bars: int, as_of: Any = None
+    ) -> CompletedBarsView:
+        self.lookbacks.append(lookback_bars)
+        return await super().get_completed_bars(
+            symbols, interval, lookback_bars=lookback_bars, as_of=as_of
+        )
+
+
+async def test_driver_view_depth_uses_shared_window_resolution(
+    tmp_path: Path,
+) -> None:
+    """A declared warmup_bars sizes the live fetch through the SAME resolution
+    the simulator slices with — one window contract, so a strategy backtested
+    on W bars is handed W bars live. lookback_bars-only jobs keep their exact
+    depth; undeclared jobs get the simulator default."""
+    from wayfinder_paths.jobs.execution.primitives import DEFAULT_WARMUP_BARS
+
+    for params, expected in (
+        ({"warmup_bars": 96}, 96),
+        ({"lookback_bars": 250}, 250),
+        ({}, DEFAULT_WARMUP_BARS),
+    ):
+        store, job, root = _make_job(tmp_path / f"depth-{expected}", params=params)
+        broker = PaperBroker(capabilities=PERP_CAPS)
+        view = _view(2)
+        adapter = FakeAdapter(view, broker)
+        feed = RecordingFeed(view)
+        adapter.feed = feed
+        await tick_job(
+            job,
+            root,
+            "paper",
+            store=store,
+            adapters={"hyperliquid": adapter},
+            now=_now(view),
+        )
+        assert feed.lookbacks == [expected], params
+
+
 async def test_duplicate_bar_tick_is_skipped_and_idempotent(tmp_path: Path) -> None:
     store, job, root = _make_job(tmp_path)
     broker = PaperBroker(capabilities=PERP_CAPS)


### PR DESCRIPTION
Re-lands the two commits stranded when #726 merged before their push (same class as the #709/#712 orphaning; clean cherry-pick, zero conflicts).

## Commit 1 — bounded-window contract
One shared view slice (`execution/primitives.py: resolve_compute_window` + `slice_view`) feeds the backtest simulator, the shadow replayer, and the live driver, keyed to declared `warmup_bars` (`lookback_bars` back-compat, `full_history` opt-out). The live path was already bounded — the backtest's unbounded `symbol_frame()` was the dishonest side, the O(N²) finalize slowness its symptom. Now backtest == forward-ahead by construction, verified mechanically by a **window-invariance probe** in validation (sampled bars replayed at W vs W+64 must produce identical intents; red-blocking with the profiler's bounded-window hint). Campaign candidates must declare `warmup_bars` (seeded by `prepare_candidate`, undeclared/full_history → invalid); `bounded-window-parity` casebook case teaches the pattern. Legacy behavior for declared `lookback_bars` jobs preserved exactly; undeclared jobs' live depth aligns 200→512 to match the simulator default (fixes indicators that computed in backtest but NaN'd live). Starters unaffected: all 18 declare warmup_bars and use only finite-memory transforms (pinned-reference tests unchanged).

## Commit 2 — finalize-aware expiry + orphan reap
The watchdog no longer hard-expires a campaign whose finalize child is alive with a fresh log (last incident: a healthy finalize was expired at the 60-min grace, then ran 8+ hours as an orphan holding the replication lock). On true expiry (dead pid or stale log) the finalize process group is SIGKILLed and journaled (`evolution_finalize_reaped`).

## Validation
Full `pytest -k "jobs or runner or mcp"`: **1,280 passed, 9 skipped, 2 failed — both failures are pre-existing on the base tip** (verified by running them at de0354ff without these commits: `test_runner_burst_gate.py::test_agent_wake_gets_short_floor_even_when_live`, `test_runner_e2e.py::test_detached_daemon_survives_parent_process_group_termination` — they came in with #728/#729 and need a separate fix). Ruff + scoped mypy clean.