### PR TITLE
jobs: CLI evolution-start nudges the session after an inline start

### DIFF
--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -104,7 +104,7 @@ from wayfinder_paths.jobs.sync import (
     venue_withdraw,
 )
 from wayfinder_paths.jobs.universe import universe_scan_job
-from wayfinder_paths.jobs.worker import run_job_worker
+from wayfinder_paths.jobs.worker import nudge_evolution_session, run_job_worker
 
 
 def _echo_json(data: Any) -> None:
@@ -1145,11 +1145,15 @@ def robustness_check_cmd(
 @click.argument("job_id")
 @click.option("--force", is_flag=True, help="Replace cooldown/completed state.")
 def evolution_start_cmd(job_id: str, force: bool) -> None:
+    store = JobStore()
     try:
-        result = start_campaign(JobStore(), job_id, force=force)
+        result = start_campaign(store, job_id, force=force)
     except (FileNotFoundError, ValueError) as exc:
         raise click.ClickException(str(exc)) from exc
-    _echo_json({"ok": True, "result": result})
+    # The op-runner path nudges on op completion; an inline CLI start must
+    # nudge itself or the fresh campaign idles until the next hourly wake.
+    nudge = nudge_evolution_session(store, job_id)
+    _echo_json({"ok": True, "result": result, "nudge": nudge})
 
 
 @job_cli.command(name="evolution-status", help="Show the current evolution campaign.")

--- a/wayfinder_paths/tests/test_jobs_evolution_campaign.py
+++ b/wayfinder_paths/tests/test_jobs_evolution_campaign.py
@@ -826,3 +826,27 @@ def test_op_runner_nudges_after_evolution_ops_and_contains_failures(
     # The op result was written all four times; the failed nudge stayed inside
     # its guard instead of failing the op.
     assert capsys.readouterr().out.count('{"ok": true}') == 4
+
+
+def test_cli_evolution_start_nudges_the_session(monkeypatch, tmp_path) -> None:
+    """An inline CLI force-start must nudge the evolution session itself —
+    it never passes through the op runner whose completion hook nudges."""
+    from click.testing import CliRunner
+
+    from wayfinder_paths.jobs import cli as cli_module
+
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        cli_module, "start_campaign", lambda store, job_id, force: {"status": "active"}
+    )
+    monkeypatch.setattr(
+        cli_module,
+        "nudge_evolution_session",
+        lambda store, job_id: calls.append(("nudge", job_id)) or {"queued": True},
+    )
+    outcome = CliRunner().invoke(
+        cli_module.job_cli, ["evolution-start", "job-nudge-demo", "--force"]
+    )
+    assert outcome.exit_code == 0, outcome.output
+    assert calls == [("nudge", "job-nudge-demo")]
+    assert '"queued": true' in outcome.output


### PR DESCRIPTION
Follow-up to #726/#731, found live: the op-completion nudge only fires for detached op-runner starts, but `wayfinder job evolution-start` calls `start_campaign()` inline — a manual force-start leaves the fresh campaign idle until the next hourly wake (observed on campaign 2 today; bridged manually with a run-once). The CLI now nudges the evolution session itself after a successful inline start and reports the nudge outcome in its JSON output.

One test pins the behavior (CliRunner, fake start/nudge). Targeted suites green; touched files ruff-clean.