### PR TITLE
Jobs - Owner halt-clear resets the loss-streak counter

### DIFF
--- a/wayfinder_paths/jobs/halt.py
+++ b/wayfinder_paths/jobs/halt.py
@@ -18,7 +18,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from wayfinder_paths.jobs.models import utc_now_iso
+from wayfinder_paths.jobs.models import DEFAULT_FORWARD_SUMMARY, utc_now_iso
 from wayfinder_paths.jobs.store import JobStore
 
 HALT_PATH = "state/halt.json"
@@ -128,8 +128,6 @@ def clear_halt(store: JobStore, job_id: str, *, by: str) -> dict[str, Any]:
 
 
 def _reset_loss_streak(store: JobStore, job_id: str, *, by: str) -> None:
-    from wayfinder_paths.jobs.models import DEFAULT_FORWARD_SUMMARY
-
     summary = store.read_json(job_id, DEFAULT_FORWARD_SUMMARY, default=None)
     trades = (summary or {}).get("trades")
     if not isinstance(trades, dict):

--- a/wayfinder_paths/jobs/halt.py
+++ b/wayfinder_paths/jobs/halt.py
@@ -113,8 +113,33 @@ def clear_halt(store: JobStore, job_id: str, *, by: str) -> dict[str, Any]:
         path.unlink()
     if existing is not None:
         store.append_journal(job_id, {"type": "halt_cleared", "by": by})
+        if "pause_after_consecutive_losses" in str(existing.get("reason") or ""):
+            # Clearing a loss-streak halt must reset the streak counter, or
+            # the clear is a no-op treadmill: the very next tick re-reads the
+            # stale count, re-latches before any trade can run, and a win
+            # (the only organic reset) can never happen under reduce-only.
+            # The owner's clear IS the acknowledgement of those losses.
+            _reset_loss_streak(store, job_id, by=by)
         store.refresh_scorecard(
             job_id,
             {"live_execution_status": existing.get("prior_live_execution_status")},
         )
     return {"cleared": existing is not None, "previous": existing}
+
+
+def _reset_loss_streak(store: JobStore, job_id: str, *, by: str) -> None:
+    from wayfinder_paths.jobs.models import DEFAULT_FORWARD_SUMMARY
+
+    summary = store.read_json(job_id, DEFAULT_FORWARD_SUMMARY, default=None)
+    trades = (summary or {}).get("trades")
+    if not isinstance(trades, dict):
+        return
+    previous = int(trades.get("current_loss_streak") or 0)
+    if previous == 0:
+        return
+    trades["current_loss_streak"] = 0
+    store.write_json(job_id, DEFAULT_FORWARD_SUMMARY, summary)
+    store.append_journal(
+        job_id,
+        {"type": "loss_streak_reset", "by": by, "from": previous},
+    )

--- a/wayfinder_paths/tests/test_jobs_halt.py
+++ b/wayfinder_paths/tests/test_jobs_halt.py
@@ -15,6 +15,7 @@ from wayfinder_paths.jobs.execution.driver import tick_job
 from wayfinder_paths.jobs.execution.engine import EngineState
 from wayfinder_paths.jobs.execution.paper import PaperBroker
 from wayfinder_paths.jobs.halt import clear_halt, read_halt, request_halt
+from wayfinder_paths.jobs.models import DEFAULT_FORWARD_SUMMARY
 from wayfinder_paths.tests.test_jobs_live_driver import (
     PERP_CAPS,
     FakeAdapter,
@@ -217,8 +218,6 @@ def test_clearing_loss_streak_halt_resets_the_streak(tmp_path: Path) -> None:
     """Without the reset, clearing is a treadmill: the next tick re-reads the
     stale streak, re-latches before any trade runs, and the only organic
     reset (a winning close) can never happen under reduce-only."""
-    from wayfinder_paths.jobs.models import DEFAULT_FORWARD_SUMMARY
-
     store, job, root = _make_job(tmp_path)
     store.write_json(
         job.id,
@@ -243,8 +242,6 @@ def test_clearing_loss_streak_halt_resets_the_streak(tmp_path: Path) -> None:
 
 
 def test_clearing_other_halts_leaves_streak_alone(tmp_path: Path) -> None:
-    from wayfinder_paths.jobs.models import DEFAULT_FORWARD_SUMMARY
-
     store, job, root = _make_job(tmp_path)
     store.write_json(
         job.id,

--- a/wayfinder_paths/tests/test_jobs_halt.py
+++ b/wayfinder_paths/tests/test_jobs_halt.py
@@ -211,3 +211,47 @@ def test_halt_snapshot_key_in_sync(tmp_path: Path) -> None:
 
     clear_halt(store, job.id, by="owner")
     assert snapshot_job(job.id, store=store)["halt"] is None
+
+
+def test_clearing_loss_streak_halt_resets_the_streak(tmp_path: Path) -> None:
+    """Without the reset, clearing is a treadmill: the next tick re-reads the
+    stale streak, re-latches before any trade runs, and the only organic
+    reset (a winning close) can never happen under reduce-only."""
+    from wayfinder_paths.jobs.models import DEFAULT_FORWARD_SUMMARY
+
+    store, job, root = _make_job(tmp_path)
+    store.write_json(
+        job.id,
+        DEFAULT_FORWARD_SUMMARY,
+        {"trades": {"current_loss_streak": 7, "losses": 7, "wins": 0}},
+    )
+    request_halt(
+        store,
+        job.id,
+        reason="pause_after_consecutive_losses breached: 7 >= 5",
+        source="risk_limits",
+    )
+
+    cleared = clear_halt(store, job.id, by="owner")
+    assert cleared["cleared"] is True
+    summary = store.read_json(job.id, DEFAULT_FORWARD_SUMMARY, default={})
+    assert summary["trades"]["current_loss_streak"] == 0
+    # Other tallies are history, not state — they stay.
+    assert summary["trades"]["losses"] == 7
+    journal = (root / "journal.jsonl").read_text(encoding="utf-8")
+    assert "loss_streak_reset" in journal
+
+
+def test_clearing_other_halts_leaves_streak_alone(tmp_path: Path) -> None:
+    from wayfinder_paths.jobs.models import DEFAULT_FORWARD_SUMMARY
+
+    store, job, root = _make_job(tmp_path)
+    store.write_json(
+        job.id,
+        DEFAULT_FORWARD_SUMMARY,
+        {"trades": {"current_loss_streak": 3}},
+    )
+    request_halt(store, job.id, reason="manual", source="manual")
+    clear_halt(store, job.id, by="owner")
+    summary = store.read_json(job.id, DEFAULT_FORWARD_SUMMARY, default={})
+    assert summary["trades"]["current_loss_streak"] == 3


### PR DESCRIPTION
### Summary
Clearing a `pause_after_consecutive_losses` halt was a no-op treadmill: the streak counter only resets on a winning close, but a halted job is reduce-only — so the next tick re-read the stale count (e.g. 7 >= 5) and re-latched before any trade could run. Owner clear now zeroes `current_loss_streak` (journaled as `loss_streak_reset`; loss/win tallies untouched — they're history, not state). Other halt kinds leave the streak alone.