### PR TITLE
Jobs - Pause stamps a synced flag; refuses funded live jobs

### DIFF
--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -2351,13 +2351,30 @@ def _pause_resume_loops(job_id: str, action: Literal["pause", "resume"]) -> None
         for loop in (job.script_loop, job.agent_loop)
         if loop.enabled
     ]
+    # The synced flag is what buckets the job into the UI's paused section —
+    # runner-link state alone never reaches the frontend.
+    store.refresh_scorecard(job_id, {"paused": action == "pause"})
     sync_all_jobs(store=store)
     _echo_json({"ok": True, "result": responses})
 
 
-@job_cli.command(name="pause", help="Pause a job's runner loops.")
+@job_cli.command(
+    name="pause",
+    help="Pause a job's runner loops (script + agent). Refuses while the job "
+    "is LIVE with declared capital — a paused live job leaves venue money "
+    "with nothing managing it; withdraw first (or --force).",
+)
 @click.argument("job_id")
-def pause_cmd(job_id: str) -> None:
+@click.option("--force", is_flag=True, default=False)
+def pause_cmd(job_id: str, force: bool) -> None:
+    store = JobStore()
+    job = store.load(job_id)
+    capital = float(job.execution_params.get("initial_capital") or 0.0)
+    if not force and job.script_loop.mode == "live" and capital > 0:
+        raise click.ClickException(
+            f"job is live with declared capital ${capital:g} — withdraw the "
+            "bankroll first so no venue money sits unmanaged, or pass --force"
+        )
     _pause_resume_loops(job_id, "pause")
 
 

--- a/wayfinder_paths/tests/test_jobs_halt.py
+++ b/wayfinder_paths/tests/test_jobs_halt.py
@@ -252,3 +252,36 @@ def test_clearing_other_halts_leaves_streak_alone(tmp_path: Path) -> None:
     clear_halt(store, job.id, by="owner")
     summary = store.read_json(job.id, DEFAULT_FORWARD_SUMMARY, default={})
     assert summary["trades"]["current_loss_streak"] == 3
+
+
+def test_pause_refuses_live_funded_job(tmp_path: Path, monkeypatch) -> None:
+    """A paused live job leaves venue money unmanaged — pause must refuse
+    until the bankroll is withdrawn (capital 0), unless forced."""
+    from click.testing import CliRunner
+
+    from wayfinder_paths.jobs import cli as cli_module
+
+    store, job, root = _make_job(tmp_path)
+    job.script_loop.mode = "live"
+    job.execution_params["initial_capital"] = 52.8
+    store.save(job)
+    monkeypatch.setattr(cli_module, "JobStore", lambda: store)
+
+    runner = CliRunner()
+    refused = runner.invoke(cli_module.job_cli, ["pause", job.id])
+    assert refused.exit_code != 0
+    assert "withdraw" in refused.output
+
+    # Unfunded (capital 0) pauses freely and stamps the synced flag.
+    job.execution_params["initial_capital"] = 0.0
+    store.save(job)
+    monkeypatch.setattr(cli_module, "sync_all_jobs", lambda **kwargs: None)
+    allowed = runner.invoke(cli_module.job_cli, ["pause", job.id])
+    assert allowed.exit_code == 0, allowed.output
+    scorecard = store.read_json(job.id, "scorecard.json", default={})
+    assert scorecard["paused"] is True
+
+    resumed = runner.invoke(cli_module.job_cli, ["resume", job.id])
+    assert resumed.exit_code == 0, resumed.output
+    scorecard = store.read_json(job.id, "scorecard.json", default={})
+    assert scorecard["paused"] is False


### PR DESCRIPTION
### Summary
Groundwork for a UI pause-strategy control:
- `wayfinder job pause/resume` now stamp `scorecard.paused` (synced) — runner-link state alone never reaches the frontend, and this flag is what buckets a job into a paused section.
- `pause` refuses while the job is LIVE with declared capital: all loops stopping would leave venue money unmanaged. Withdraw first, or `--force`.

Backend already routes `pause`/`resume` actions to these commands; no backend change needed.