### PR TITLE
Jobs - Incremental dataset refresh survives venue history caps

### DIFF
--- a/wayfinder_paths/jobs/execution/preflight.py
+++ b/wayfinder_paths/jobs/execution/preflight.py
@@ -733,9 +733,17 @@ def _incremental_plan(
     oldest = pd.Timestamp(stamps[0])
     newest = pd.Timestamp(stamps[-1])
     # The kept file must reach back far enough for the requested window —
-    # incremental fetching can only extend the tail, never backfill.
+    # incremental fetching can only extend the tail, never backfill. One
+    # exception: when the previous fetch made the SAME days request and this
+    # depth is all the source returned (venue history caps — HL serves only
+    # ~5000 bars), a full refetch cannot reach further back either. Falling
+    # back to full here made every refresh re-download the whole window
+    # forever: hundreds of paginated candle calls per job per hour, 429
+    # storms on the shared proxy throttle, and the stale-features
+    # degraded/recovered flapping that followed.
     if oldest > now - pd.Timedelta(days=days) + pd.Timedelta(seconds=2 * bar_seconds):
-        return [], float(days)
+        if int(float(meta.get("days") or 0)) != int(days):
+            return [], float(days)
     gap_seconds = max((now - newest).total_seconds(), 0.0) + 2 * bar_seconds
     fetch_days = min(float(days), gap_seconds / 86_400)
     return list(rows), max(fetch_days, 2 * bar_seconds / 86_400)

--- a/wayfinder_paths/tests/test_jobs_evidence_window.py
+++ b/wayfinder_paths/tests/test_jobs_evidence_window.py
@@ -392,3 +392,44 @@ def test_replication_window_change_repins_not_decays(tmp_path, monkeypatch) -> N
     second = replication_job(job.id, store=store, force=True)
     assert second["decayed"] is False  # window change, not edge decay
     assert second["baseline"]["dataset_days"] == 40.0  # re-pinned
+
+
+class _CappedFeed(_CountingFeed):
+    """Venue with a history cap: serves at most `cap` bars regardless of the
+    requested lookback (Hyperliquid serves ~5000)."""
+
+    def __init__(self, cap: int):
+        super().__init__()
+        self.cap = cap
+
+    async def get_completed_bars(self, symbols, interval, *, lookback_bars, as_of=None):
+        view = await super().get_completed_bars(
+            symbols, interval, lookback_bars=min(int(lookback_bars), self.cap)
+        )
+        # Record what was REQUESTED (super recorded the capped value).
+        self.lookbacks[-1] = lookback_bars
+        return view
+
+
+def test_incremental_survives_venue_history_cap(tmp_path) -> None:
+    """When the source can't serve the full requested window, the on-disk
+    dataset never reaches back far enough — treating that as a provenance
+    miss re-downloaded the whole window on EVERY refresh (hundreds of
+    paginated candle calls per job per hour → 429 storms → stale features).
+    Same days request + matching provenance must stay tail-only."""
+    from wayfinder_paths.jobs.execution.preflight import build_live_dataset
+
+    store, job_id, root = _mk_dataset_job(tmp_path)
+    feed = _CappedFeed(cap=100)
+
+    build_live_dataset(job_id, days=10, store=store, source="ccxt", feed=feed)
+    assert feed.lookbacks[0] == 240  # asked for the window...
+    # ...but the capped venue returned only ~100 bars of history.
+
+    second = build_live_dataset(job_id, days=10, store=store, source="ccxt", feed=feed)
+    assert feed.lookbacks[1] <= 4, "capped history must not force a full refetch"
+    assert second["metadata"]["incremental"] is True
+
+    # A genuinely longer request still goes full — that's a real backfill ask.
+    build_live_dataset(job_id, days=20, store=store, source="ccxt", feed=feed)
+    assert feed.lookbacks[2] == 480


### PR DESCRIPTION
### Summary
Root cause of the fleet-wide `data_feed_degraded`/`recovered` flapping: `_incremental_plan` required the on-disk dataset to reach back the full requested window, but venues cap history (Hyperliquid serves ~5000 bars) — so long-window jobs could NEVER satisfy the check and every hourly refresh silently fell back to a full multi-hundred-request window fetch. Several jobs doing this concurrently blew through the shared proxy throttle (observed: paginated 2-year candle fetches answering 429), refreshes partially failed, features went stale past the 6h alarm, and the degraded/recovered pairs took over the activity log.

Fix: when provenance matches AND the previous fetch made the same `days` request, stay tail-only — a full refetch cannot reach further back than the source serves. A genuinely longer request still goes full (that's a real backfill ask; existing test unchanged). Regression test simulates a history-capped venue.