### PR TITLE
Jobs - Attribute agent-built jobs to their creating conversation

### DIFF
--- a/wayfinder_paths/core/clients/OpenCodeClient.py
+++ b/wayfinder_paths/core/clients/OpenCodeClient.py
@@ -29,6 +29,14 @@ class OpenCodeClient:
         except Exception:
             return False
 
+    def session_statuses(self) -> dict[str, Any]:
+        """Live non-idle sessions: id -> {"type": "busy"|"retry"|...}.
+        Empty on any failure — status is advisory."""
+        try:
+            return self.client.get(f"{self.base_url}/session/status").json()
+        except Exception:  # noqa: BLE001 — advisory read
+            return {}
+
     def list_sessions(self) -> list[dict[str, Any]]:
         try:
             return self.client.get(f"{self.base_url}/session").json()

--- a/wayfinder_paths/mcp/tools/jobs.py
+++ b/wayfinder_paths/mcp/tools/jobs.py
@@ -7,6 +7,8 @@ import sys
 from pathlib import Path
 from typing import Any, Literal
 
+from wayfinder_paths.core.clients.OpenCodeClient import OPENCODE_CLIENT
+from wayfinder_paths.core.config import is_opencode_instance
 from wayfinder_paths.jobs.application import (
     claim_application,
     complete_application,
@@ -293,6 +295,31 @@ def _background_op_status(store: JobStore, job_id: str, op: str) -> dict[str, An
     return ok(payload)
 
 
+def _infer_initializer_session() -> str | None:
+    """Best-effort attribution of a create call to the conversation making
+    it. MCP tool calls carry no session identity, but the calling session is
+    busy RIGHT NOW (it is mid-tool-call) — ask the local opencode API. This
+    is why every agent-built job used to show "No linked conversations":
+    agents cannot know their own session id to pass explicitly. Ambiguity
+    (several busy non-wake sessions) returns None rather than guessing."""
+    if not is_opencode_instance():
+        return None
+    busy = [
+        session_id
+        for session_id, status in OPENCODE_CLIENT.session_statuses().items()
+        if status["type"] in {"busy", "retry"}
+    ]
+    if not busy:
+        return None
+    if len(busy) == 1:
+        return busy[0]
+    titles = {
+        session["id"]: session["title"] for session in OPENCODE_CLIENT.list_sessions()
+    }
+    user_busy = [sid for sid in busy if not titles.get(sid, "").startswith("job/")]
+    return user_busy[0] if len(user_busy) == 1 else None
+
+
 @catch_errors
 async def core_jobs(
     action: JobAction,
@@ -487,7 +514,8 @@ async def core_jobs(
                 job_id=job_id,
                 store=store,
                 compile_job=compile,
-                initializer_session_id=initializer_session_id,
+                initializer_session_id=initializer_session_id
+                or _infer_initializer_session(),
                 leverage=leverage,
                 agent_mode=agent_mode,
             )
@@ -541,6 +569,8 @@ async def core_jobs(
             agent_wake_seconds=agent_wake_seconds,
             auto_limits=auto_limits,
             execution_contract=execution_contract,
+            initializer_session_id=initializer_session_id
+            or _infer_initializer_session(),
         )
         job_path = store.create_job(job)
         result: dict[str, Any] = {"job": job.to_dict(), "job_yaml": str(job_path)}

--- a/wayfinder_paths/tests/test_jobs_funding_knobs.py
+++ b/wayfinder_paths/tests/test_jobs_funding_knobs.py
@@ -286,3 +286,46 @@ def test_mcp_venue_actions_share_button_code_path(tmp_path, monkeypatch) -> None
 
     missing = asyncio.run(jobs_tool.core_jobs("venue_deposit", job_id=job_id))
     assert not missing["ok"]
+
+
+def test_create_paths_infer_initializer_from_busy_session(monkeypatch) -> None:
+    """Agent-built jobs showed no conversation trail: MCP calls carry no
+    session identity and agents can't know their own id. The create paths
+    now attribute to the single busy session on the box."""
+    from wayfinder_paths.mcp.tools import jobs as jobs_tool
+
+    monkeypatch.setattr(jobs_tool, "is_opencode_instance", lambda: True)
+
+    class FakeClient:
+        def session_statuses(self):
+            return {
+                "ses_user": {"type": "busy"},
+                "ses_wake": {"type": "busy"},
+                "ses_idle": {"type": "idle"},
+            }
+
+        def list_sessions(self):
+            return [
+                {"id": "ses_user", "title": "Strategy Lab · custom idea"},
+                {"id": "ses_wake", "title": "job/other-job/intervene"},
+                {"id": "ses_idle", "title": "Strategy Lab"},
+            ]
+
+    monkeypatch.setattr(jobs_tool, "OPENCODE_CLIENT", FakeClient())
+    assert jobs_tool._infer_initializer_session() == "ses_user"
+
+    class Ambiguous(FakeClient):
+        def session_statuses(self):
+            return {"a": {"type": "busy"}, "b": {"type": "busy"}}
+
+        def list_sessions(self):
+            return [
+                {"id": "a", "title": "Strategy Lab"},
+                {"id": "b", "title": "Strategy Lab"},
+            ]
+
+    monkeypatch.setattr(jobs_tool, "OPENCODE_CLIENT", Ambiguous())
+    assert jobs_tool._infer_initializer_session() is None
+
+    monkeypatch.setattr(jobs_tool, "is_opencode_instance", lambda: False)
+    assert jobs_tool._infer_initializer_session() is None


### PR DESCRIPTION
### Summary
Every agent-built job showed "No linked conversations": the create paths accept `initializer_session_id`, but MCP tool calls carry no session identity and an agent cannot know its own session id — so only UI starter launches (where the frontend supplies the id) ever recorded a conversation trail.

Fix: when a create call arrives without an initializer, attribute it to the session that is busy on the box right now — the calling session is mid-tool-call by definition. Single busy session → use it; several → prefer the single non-wake (`job/`-titled) one; still ambiguous → record nothing rather than guess. Applied to both `create_starter` and `create` (which previously never passed an initializer at all, even when known).

Observed on a dev box: 5 of 5 agent-built jobs had no controller block; the one UI-launched starter had one.