### PR TITLE
Jobs - Self-heal loops that never got scheduled

### DIFF
--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -70,6 +70,7 @@ from wayfinder_paths.jobs.lifecycle import lifecycle_sweep
 from wayfinder_paths.jobs.models import (
     AgentMode,
     WayfinderJob,
+    default_wake_seconds,
     infer_job_kind,
     normalize_agent_mode,
 )
@@ -1703,6 +1704,14 @@ def agent_set_mode_cmd(job_id: str, mode: AgentMode, wake_seconds: int | None) -
     job.job_kind = infer_job_kind(job.script_loop.enabled, normalized_mode)
     if wake_seconds is not None:
         job.agent_loop.wake_interval_seconds = wake_seconds
+    elif (
+        job.agent_loop.enabled
+        and not job.agent_loop.wake_interval_seconds
+        and not job.agent_loop.cron_expr
+    ):
+        # Jobs created with mode off carry wake_interval_seconds=null; an
+        # enabled loop with no schedule crashes the recompile below.
+        job.agent_loop.wake_interval_seconds = default_wake_seconds(normalized_mode)
     store.save(job)
     # Journal the operator's selection so a later revert (e.g. a stale
     # candidate promotion) is diagnosable from the job dir alone.

--- a/wayfinder_paths/jobs/compiler.py
+++ b/wayfinder_paths/jobs/compiler.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Any
 
-from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.models import WayfinderJob, default_wake_seconds
 from wayfinder_paths.jobs.runner_bridge import RunnerBridge
 from wayfinder_paths.jobs.store import JobStore
 
@@ -87,7 +87,18 @@ class JobCompiler:
             resp = self.bridge.add_or_update_script_job(
                 name=job.agent_loop.runner_job_name,
                 script_path=wrappers["agent"],
-                interval_seconds=job.agent_loop.wake_interval_seconds,
+                # A mode flip can enable the loop with wake_interval_seconds
+                # still null (set-mode without --wake on a job created with
+                # mode off). Registering with no schedule raises AFTER the
+                # script loop registered but BEFORE runner_links is written —
+                # a half-compiled job the UI can't see runs for. Default here
+                # so every path (create, set-mode, watchdog repair) heals.
+                interval_seconds=job.agent_loop.wake_interval_seconds
+                or (
+                    None
+                    if job.agent_loop.cron_expr
+                    else default_wake_seconds(job.agent_loop.mode)
+                ),
                 cron_expr=job.agent_loop.cron_expr,
                 timezone=job.agent_loop.timezone,
                 timeout_seconds=job.agent_loop.timeout_seconds,

--- a/wayfinder_paths/jobs/models.py
+++ b/wayfinder_paths/jobs/models.py
@@ -65,6 +65,10 @@ def infer_job_kind(script_enabled: bool, agent_mode: AgentMode) -> JobKind:
     return "agent_only"
 
 
+def default_wake_seconds(mode: AgentMode) -> int:
+    return 900 if mode == "auto" else 3600
+
+
 def utc_now_iso() -> str:
     return datetime.now(UTC).isoformat()
 
@@ -236,7 +240,7 @@ class WayfinderJob:
             mode=normalized_mode,
             runner_job_name=f"{jid}-agent",
             wake_interval_seconds=agent_wake_seconds
-            or (900 if normalized_mode == "auto" else 3600 if agent_enabled else None),
+            or (default_wake_seconds(normalized_mode) if agent_enabled else None),
             timezone=timezone,
             triggers=[
                 "script_failure",

--- a/wayfinder_paths/jobs/watchdog.py
+++ b/wayfinder_paths/jobs/watchdog.py
@@ -27,6 +27,7 @@ from textwrap import dedent
 from typing import Any, TypedDict
 
 from wayfinder_paths.jobs.application import complete_application
+from wayfinder_paths.jobs.compiler import JobCompiler
 from wayfinder_paths.jobs.failures import cpu_steal_pct
 from wayfinder_paths.jobs.lifecycle import lifecycle_sweep
 from wayfinder_paths.jobs.models import utc_now_iso
@@ -932,6 +933,68 @@ def _check_agent_mode_drift(
     return None
 
 
+# Unlinked-loop repair: JobCompiler.compile registers the script loop, then
+# the agent loop, then writes runner_links.json + journals "compiled". A
+# crash between those steps (e.g. an enabled agent loop with a null wake
+# interval raising "provide exactly one of interval_seconds or cron_expr")
+# strands the job half-compiled forever: job.yaml promises loops, the seed
+# runner_links.json stays `{"jobs": []}`, the UI's run history keys on those
+# links and renders empty, and nothing ever retries — create/set-mode already
+# returned. The watchdog is the only recurring owner, so it recompiles any
+# job whose enabled loops are missing from its links. The grace window keeps
+# it from racing a create that is about to compile.
+_UNLINKED_REPAIR_PATH = "state/unlinked_repair.json"
+UNLINKED_REPAIR_GRACE = timedelta(minutes=15)
+
+
+def _check_unlinked_loops(
+    store: JobStore, job: Any, now: datetime
+) -> dict[str, Any] | None:
+    expected = set()
+    if job.script_loop.enabled:
+        expected.add("script")
+    if job.agent_loop.enabled and job.agent_loop.mode != "off":
+        expected.add("agent")
+    if not expected or _age(now, job.created_at) < UNLINKED_REPAIR_GRACE:
+        return None
+    links = store.read_json(job.id, "runner_links.json", default={}) or {}
+    present = {item["loop"] for item in links.get("jobs") or []}
+    missing = sorted(expected - present)
+    if not missing:
+        return None
+    scorecard = store.read_json(job.id, "scorecard.json", default={}) or {}
+    if scorecard.get("paused"):
+        return None
+    try:
+        JobCompiler(store=store).compile(job, start_daemon=False)
+    except Exception as exc:  # noqa: BLE001 — journal instead of silent retry
+        error = str(exc)
+        marker = store.read_json(job.id, _UNLINKED_REPAIR_PATH, default={}) or {}
+        if marker.get("error") == error:
+            return None  # already journaled this failure; retried silently
+        store.write_json(
+            job.id, _UNLINKED_REPAIR_PATH, {"error": error, "ts": now.isoformat()}
+        )
+        store.append_journal(
+            job.id,
+            {
+                "type": "unlinked_loops_compile_failed",
+                "missing": missing,
+                "error": error,
+            },
+        )
+        return {
+            "action": "unlinked_loops_compile_failed",
+            "missing": missing,
+            "error": error,
+        }
+    store.write_json(job.id, _UNLINKED_REPAIR_PATH, {})
+    store.append_journal(
+        job.id, {"type": "unlinked_loops_recompiled", "missing": missing}
+    )
+    return {"action": "unlinked_loops_recompiled", "missing": missing}
+
+
 # Research-impasse alerting: all three production research jobs froze the
 # same way — staleness computed correctly and the wake mandate fired every
 # wake, but the mandate's "state why research is not warranted" hatch let the
@@ -1682,6 +1745,13 @@ def recover_stalled_applications(
             drift_event = None
         if drift_event is not None:
             recovered.append({"job_id": job.id, **drift_event})
+        try:
+            unlinked_event = _check_unlinked_loops(store, job, now)
+        except Exception as exc:  # noqa: BLE001
+            errors.append({"job_id": job.id, "error": f"unlinked: {exc}"})
+            unlinked_event = None
+        if unlinked_event is not None:
+            recovered.append({"job_id": job.id, **unlinked_event})
         try:
             impasse_event = _check_research_impasse(store, job, proposals, now)
         except Exception as exc:

--- a/wayfinder_paths/mcp/tools/jobs.py
+++ b/wayfinder_paths/mcp/tools/jobs.py
@@ -21,6 +21,7 @@ from wayfinder_paths.jobs.execution.validation import validate_execution_job
 from wayfinder_paths.jobs.halt import clear_halt, request_halt
 from wayfinder_paths.jobs.models import (
     WayfinderJob,
+    default_wake_seconds,
     infer_job_kind,
     normalize_agent_mode,
     utc_now_iso,
@@ -592,6 +593,14 @@ async def core_jobs(
         job.job_kind = infer_job_kind(job.script_loop.enabled, mode)
         if agent_wake_seconds is not None:
             job.agent_loop.wake_interval_seconds = agent_wake_seconds
+        elif (
+            job.agent_loop.enabled
+            and not job.agent_loop.wake_interval_seconds
+            and not job.agent_loop.cron_expr
+        ):
+            # Jobs created with mode off carry wake_interval_seconds=null;
+            # an enabled loop with no schedule crashes the recompile below.
+            job.agent_loop.wake_interval_seconds = default_wake_seconds(mode)
         store.save(job)
         # Journal the operator's selection so a later revert (e.g. a stale
         # candidate promotion) is diagnosable from the job dir alone.

--- a/wayfinder_paths/tests/test_jobs_unlinked_repair.py
+++ b/wayfinder_paths/tests/test_jobs_unlinked_repair.py
@@ -1,0 +1,177 @@
+"""Watchdog unlinked-loop repair + compiler wake-interval default.
+
+Motivating incident: three self-built jobs sat 38-40h with hourly script
+ticks running but runner_links.json stuck at the init seed `{"jobs": []}` and
+their agent loops never scheduled. The compile that should have written the
+links crashed between registering the script loop and the agent loop — the
+agent loop was enabled by a set-mode with wake_interval_seconds still null,
+and registering a schedule-less job raises. Nothing ever retried: create and
+set-mode had already returned.
+
+Two fixes under test: the compiler defaults a null wake interval on an
+enabled agent loop (so a recompile cannot re-crash the same way), and the
+watchdog recompiles any job whose enabled loops are missing from its links.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from wayfinder_paths.jobs.compiler import JobCompiler
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.jobs.watchdog import recover_stalled_applications
+
+
+def _journal_events(store: JobStore, job_id: str, event_type: str) -> list[dict]:
+    path = store.job_dir(job_id) / "journal.jsonl"
+    if not path.exists():
+        return []
+    rows = [json.loads(line) for line in path.read_text().splitlines()]
+    return [row for row in rows if row.get("type") == event_type]
+
+
+def _make_job(
+    store: JobStore,
+    job_id: str,
+    *,
+    agent_mode: str = "monitor",
+    age: timedelta = timedelta(hours=1),
+) -> WayfinderJob:
+    job = WayfinderJob.new(
+        job_id,
+        script="workspace/src/strategy.py",
+        interval_seconds=3600,
+        agent_mode=agent_mode,
+        execution_contract="jobs_v1",
+    )
+    job.created_at = (datetime.now(UTC) - age).isoformat()
+    store.save(job)
+    store.write_json(job.id, "runner_links.json", {"jobs": []})
+    return job
+
+
+@pytest.fixture
+def compiles(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    calls: list[str] = []
+
+    class FakeCompiler:
+        def __init__(self, *, store=None):  # noqa: ANN001
+            self.store = store
+
+        def compile(self, job, *, start_daemon=True):  # noqa: ANN001
+            calls.append(job.id)
+            payload = {
+                "job_id": job.id,
+                "jobs": [{"loop": "script"}, {"loop": "agent"}],
+            }
+            self.store.write_json(job.id, "runner_links.json", payload)
+            return payload
+
+    monkeypatch.setattr("wayfinder_paths.jobs.watchdog.JobCompiler", FakeCompiler)
+    return calls
+
+
+def test_watchdog_recompiles_unlinked_loops(tmp_path: Path, compiles: list[str]):
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "half-compiled")
+
+    report = recover_stalled_applications(store=store)
+
+    assert compiles == [job.id]
+    events = [
+        event
+        for event in report["recovered"]
+        if event.get("action") == "unlinked_loops_recompiled"
+    ]
+    assert events == [
+        {
+            "job_id": job.id,
+            "action": "unlinked_loops_recompiled",
+            "missing": ["agent", "script"],
+        }
+    ]
+    assert len(_journal_events(store, job.id, "unlinked_loops_recompiled")) == 1
+
+    # Repaired links present → the next pass leaves the job alone.
+    recover_stalled_applications(store=store)
+    assert compiles == [job.id]
+
+
+def test_watchdog_unlinked_repair_skips_fresh_and_paused(
+    tmp_path: Path, compiles: list[str]
+):
+    store = JobStore(repo_root=tmp_path)
+    # Fresh job: a create may still be mid-flight and about to compile.
+    _make_job(store, "fresh", age=timedelta(minutes=1))
+    # Paused before first compile: pause wins, repair must not re-schedule.
+    paused = _make_job(store, "paused")
+    store.write_json(paused.id, "scorecard.json", {"paused": True})
+
+    recover_stalled_applications(store=store)
+
+    assert compiles == []
+
+
+def test_watchdog_unlinked_repair_journals_failure_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    calls: list[str] = []
+
+    class BrokenCompiler:
+        def __init__(self, *, store=None):  # noqa: ANN001
+            self.store = store
+
+        def compile(self, job, *, start_daemon=True):  # noqa: ANN001
+            calls.append(job.id)
+            raise RuntimeError("runner daemon unreachable")
+
+    monkeypatch.setattr("wayfinder_paths.jobs.watchdog.JobCompiler", BrokenCompiler)
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "still-broken")
+
+    recover_stalled_applications(store=store)
+    recover_stalled_applications(store=store)
+
+    # Retried every pass, but the identical failure journals only once.
+    assert calls == [job.id, job.id]
+    assert len(_journal_events(store, job.id, "unlinked_loops_compile_failed")) == 1
+
+
+def test_compiler_defaults_null_wake_interval(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    recorded: list[dict[str, Any]] = []
+
+    class FakeBridge:
+        def __init__(self, *, repo_root=None):  # noqa: ANN001
+            self.repo_root = repo_root
+
+        def add_or_update_script_job(self, **kwargs):  # noqa: ANN003
+            recorded.append(kwargs)
+            return {"ok": True}
+
+    monkeypatch.setattr("wayfinder_paths.jobs.compiler.RunnerBridge", FakeBridge)
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        "wake-null",
+        script="workspace/src/strategy.py",
+        interval_seconds=3600,
+        agent_mode="off",
+        execution_contract="jobs_v1",
+    )
+    # A set-mode without --wake used to leave exactly this shape behind.
+    job.agent_loop.enabled = True
+    job.agent_loop.mode = "monitor"
+    store.save(job)
+
+    payload = JobCompiler(store=store).compile(job, start_daemon=False)
+
+    agent = next(k for k in recorded if k["name"].endswith("-agent"))
+    assert agent["interval_seconds"] == 3600
+    assert {item["loop"] for item in payload["jobs"]} == {"script", "agent"}


### PR DESCRIPTION
### Summary

A `JobCompiler.compile` that crashes between registering the script loop and writing `runner_links.json` leaves a job half-scheduled forever: `job.yaml` promises loops, the links file stays at the init seed `{"jobs": []}`, the UI's run history keys on those links and renders empty, and nothing ever retries — create/set-mode already returned. The observed trigger: a job created with `agent_mode off` carries `wake_interval_seconds=null`; a later `agent set-mode monitor` without `--wake` enables the loop with no schedule, and registering it raises `provide exactly one of interval_seconds or cron_expr` after the script loop registered but before the links write.

Three layers:
- `JobCompiler` defaults a null wake interval on an enabled agent loop (900s auto / 3600s otherwise, matching `WayfinderJob.new`), so a recompile can't re-crash the same way — including for existing job.yamls already carrying the null.
- CLI `agent set-mode` and MCP `set_agent_mode` backfill the default into `job.yaml` when enabling a wake-less, cron-less loop, so the persisted spec stays honest.
- The application watchdog recompiles any job whose enabled loops are missing from its runner links (journaled as `unlinked_loops_recompiled`; failures journal once per distinct error and retry silently). Guarded by a 15-min creation grace window and skipped for paused jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)