### PR TITLE
Jobs - Enabled agent loops always compile with a schedule

### DIFF
--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -70,6 +70,7 @@ from wayfinder_paths.jobs.lifecycle import lifecycle_sweep
 from wayfinder_paths.jobs.models import (
     AgentMode,
     WayfinderJob,
+    default_wake_seconds,
     infer_job_kind,
     normalize_agent_mode,
 )
@@ -1703,6 +1704,14 @@ def agent_set_mode_cmd(job_id: str, mode: AgentMode, wake_seconds: int | None) -
     job.job_kind = infer_job_kind(job.script_loop.enabled, normalized_mode)
     if wake_seconds is not None:
         job.agent_loop.wake_interval_seconds = wake_seconds
+    elif (
+        job.agent_loop.enabled
+        and not job.agent_loop.wake_interval_seconds
+        and not job.agent_loop.cron_expr
+    ):
+        # Jobs created with mode off carry wake_interval_seconds=null; an
+        # enabled loop with no schedule crashes the recompile below.
+        job.agent_loop.wake_interval_seconds = default_wake_seconds(normalized_mode)
     store.save(job)
     # Journal the operator's selection so a later revert (e.g. a stale
     # candidate promotion) is diagnosable from the job dir alone.

--- a/wayfinder_paths/jobs/compiler.py
+++ b/wayfinder_paths/jobs/compiler.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Any
 
-from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.models import WayfinderJob, default_wake_seconds
 from wayfinder_paths.jobs.runner_bridge import RunnerBridge
 from wayfinder_paths.jobs.store import JobStore
 
@@ -87,7 +87,19 @@ class JobCompiler:
             resp = self.bridge.add_or_update_script_job(
                 name=job.agent_loop.runner_job_name,
                 script_path=wrappers["agent"],
-                interval_seconds=job.agent_loop.wake_interval_seconds,
+                # A mode flip can enable the loop with wake_interval_seconds
+                # still null (set-mode without --wake on a job created with
+                # mode off). Registering with no schedule raises AFTER the
+                # script loop registered but BEFORE runner_links is written —
+                # a half-compiled job the UI can't see runs for. Default
+                # here so any recompile path heals, including existing
+                # job.yamls already carrying the null.
+                interval_seconds=job.agent_loop.wake_interval_seconds
+                or (
+                    None
+                    if job.agent_loop.cron_expr
+                    else default_wake_seconds(job.agent_loop.mode)
+                ),
                 cron_expr=job.agent_loop.cron_expr,
                 timezone=job.agent_loop.timezone,
                 timeout_seconds=job.agent_loop.timeout_seconds,

--- a/wayfinder_paths/jobs/models.py
+++ b/wayfinder_paths/jobs/models.py
@@ -65,6 +65,10 @@ def infer_job_kind(script_enabled: bool, agent_mode: AgentMode) -> JobKind:
     return "agent_only"
 
 
+def default_wake_seconds(mode: AgentMode) -> int:
+    return 900 if mode == "auto" else 3600
+
+
 def utc_now_iso() -> str:
     return datetime.now(UTC).isoformat()
 
@@ -236,7 +240,7 @@ class WayfinderJob:
             mode=normalized_mode,
             runner_job_name=f"{jid}-agent",
             wake_interval_seconds=agent_wake_seconds
-            or (900 if normalized_mode == "auto" else 3600 if agent_enabled else None),
+            or (default_wake_seconds(normalized_mode) if agent_enabled else None),
             timezone=timezone,
             triggers=[
                 "script_failure",

--- a/wayfinder_paths/mcp/tools/jobs.py
+++ b/wayfinder_paths/mcp/tools/jobs.py
@@ -21,6 +21,7 @@ from wayfinder_paths.jobs.execution.validation import validate_execution_job
 from wayfinder_paths.jobs.halt import clear_halt, request_halt
 from wayfinder_paths.jobs.models import (
     WayfinderJob,
+    default_wake_seconds,
     infer_job_kind,
     normalize_agent_mode,
     utc_now_iso,
@@ -592,6 +593,14 @@ async def core_jobs(
         job.job_kind = infer_job_kind(job.script_loop.enabled, mode)
         if agent_wake_seconds is not None:
             job.agent_loop.wake_interval_seconds = agent_wake_seconds
+        elif (
+            job.agent_loop.enabled
+            and not job.agent_loop.wake_interval_seconds
+            and not job.agent_loop.cron_expr
+        ):
+            # Jobs created with mode off carry wake_interval_seconds=null;
+            # an enabled loop with no schedule crashes the recompile below.
+            job.agent_loop.wake_interval_seconds = default_wake_seconds(mode)
         store.save(job)
         # Journal the operator's selection so a later revert (e.g. a stale
         # candidate promotion) is diagnosable from the job dir alone.

--- a/wayfinder_paths/tests/test_jobs_wake_default.py
+++ b/wayfinder_paths/tests/test_jobs_wake_default.py
@@ -1,0 +1,63 @@
+"""Enabled agent loops always compile with a schedule.
+
+Motivating incident: jobs created with agent_mode off carry
+wake_interval_seconds=null; a later `agent set-mode monitor` (no --wake)
+enabled the loop with no schedule, and registering it raised "provide
+exactly one of interval_seconds or cron_expr" AFTER the script loop had
+registered but BEFORE runner_links.json was written — a half-scheduled job
+nothing ever retried. The compiler now defaults the null wake (900s auto /
+3600s otherwise, matching WayfinderJob.new), and both set-mode paths
+backfill the default into job.yaml when enabling a wake-less, cron-less
+loop.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from wayfinder_paths.jobs.compiler import JobCompiler
+from wayfinder_paths.jobs.models import WayfinderJob, default_wake_seconds
+from wayfinder_paths.jobs.store import JobStore
+
+
+def test_compiler_defaults_null_wake_interval(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    recorded: list[dict[str, Any]] = []
+
+    class FakeBridge:
+        def __init__(self, *, repo_root=None):  # noqa: ANN001
+            self.repo_root = repo_root
+
+        def add_or_update_script_job(self, **kwargs):  # noqa: ANN003
+            recorded.append(kwargs)
+            return {"ok": True}
+
+    monkeypatch.setattr("wayfinder_paths.jobs.compiler.RunnerBridge", FakeBridge)
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        "wake-null",
+        script="workspace/src/strategy.py",
+        interval_seconds=3600,
+        agent_mode="off",
+        execution_contract="jobs_v1",
+    )
+    # A set-mode without --wake used to leave exactly this shape behind.
+    job.agent_loop.enabled = True
+    job.agent_loop.mode = "monitor"
+    store.save(job)
+
+    payload = JobCompiler(store=store).compile(job, start_daemon=False)
+
+    agent = next(k for k in recorded if k["name"].endswith("-agent"))
+    assert agent["interval_seconds"] == 3600
+    assert {item["loop"] for item in payload["jobs"]} == {"script", "agent"}
+
+
+def test_default_wake_seconds_by_mode():
+    assert default_wake_seconds("auto") == 900
+    assert default_wake_seconds("monitor") == 3600
+    assert default_wake_seconds("intervene") == 3600


### PR DESCRIPTION
### Summary

The crash half of the closed #737, alone — no watchdog, no automation, 37 lines + a test file.

A job created with `agent_mode off` carries `wake_interval_seconds: null`; a later `agent set-mode monitor` without `--wake` enables the loop with no schedule, and registering it raises `provide exactly one of interval_seconds or cron_expr` after the script loop registered but before `runner_links.json` is written. The job is left half-scheduled: script ticks hourly, agent never wakes, `last_agent_check_at` never advances (the "last activity: 1 day ago" symptom), run history renders empty, and the strategy/runner lists disagree.

- `JobCompiler` defaults a null wake on an enabled agent loop (900s auto / 3600s otherwise, same defaults as `WayfinderJob.new`) — heals existing job.yamls already carrying the null on their next recompile.
- CLI `agent set-mode` and MCP `set_agent_mode` backfill the default into job.yaml when enabling a wake-less, cron-less loop.

Root-cause proof (clean-room repro on base + production signature) and a full live before/after on a dev instance are on #737: the same change was exercised there end-to-end — set-mode crashed on pre-fix code, compiled cleanly with both loops registered on post-fix code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)