### PR TITLE
Jobs - Top-level workload caps at add_job

### DIFF
--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -47,6 +47,9 @@ JOB_RESULT_MARKER = "WAYFINDER_JOB_RESULT "
 # the worst-case cost of a single in-flight job so one already-running job can't
 # overshoot the budget to zero (validated in the docker burst-lab); max-postpone
 # bounds starvation so a due job can't be held behind a permanent backlog.
+MAX_ACTIVE_STRATEGIES = 2
+MAX_ACTIVE_LEGACY_JOBS = 3
+
 BURST_CAP_CPU_S = 500.0
 BURST_LOW_WATER_CPU_S = 120.0
 BURST_MAX_POSTPONE_S = 600.0
@@ -1283,6 +1286,43 @@ class RunnerDaemon:
             )
         payload_norm["notify_session_id"] = session_id
 
+        # Top-level workload caps: reject NEW registrations over the limit.
+        # Existing names fall through (the bridge retries them as updates —
+        # recompiles must always work) and running jobs are never touched, so
+        # over-cap fleets are grandfathered until their owner pauses down.
+        if self._db.get_job(name=name) is None:
+            active = [
+                job["payload"].get("env") or {}
+                for job in self._db.list_jobs()
+                if job["status"] == JobStatus.ACTIVE
+            ]
+            ids = {
+                e["WAYFINDER_HIGH_LEVEL_JOB_ID"]
+                for e in active
+                if e.get("WAYFINDER_HIGH_LEVEL_JOB_ID")
+            }
+            env = payload_norm.get("env") or {}
+            hl = env.get("WAYFINDER_HIGH_LEVEL_JOB_ID")
+            if hl and hl not in ids and len(ids) >= MAX_ACTIVE_STRATEGIES:
+                return {
+                    "ok": False,
+                    "error": f"active strategy limit ({MAX_ACTIVE_STRATEGIES}) "
+                    "reached — pause or delete a strategy first",
+                }
+            if not hl and not env.get("WAYFINDER_WATCHDOG"):
+                legacy = sum(
+                    1
+                    for e in active
+                    if not e.get("WAYFINDER_HIGH_LEVEL_JOB_ID")
+                    and not e.get("WAYFINDER_WATCHDOG")
+                )
+                if legacy >= MAX_ACTIVE_LEGACY_JOBS:
+                    return {
+                        "ok": False,
+                        "error": f"active runner-job limit "
+                        f"({MAX_ACTIVE_LEGACY_JOBS}) reached — pause or "
+                        "delete a runner job first",
+                    }
         try:
             now = int(time.time())
             job_id = self._db.add_job(

--- a/wayfinder_paths/tests/test_runner_workload_caps.py
+++ b/wayfinder_paths/tests/test_runner_workload_caps.py
@@ -1,0 +1,77 @@
+"""Daemon workload caps: new registrations over the limit are rejected at
+ctl_add_job. Strategies = distinct WAYFINDER_HIGH_LEVEL_JOB_ID in wrapper
+env; anything else is a legacy runner job (watchdog exempt). Existing names
+and running jobs are untouched — over-cap fleets are grandfathered."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from wayfinder_paths.runner import daemon as daemon_mod
+from wayfinder_paths.runner.db import RunnerDB
+from wayfinder_paths.runner.paths import get_runner_paths
+
+
+def _daemon(tmp_path: Path) -> daemon_mod.RunnerDaemon:
+    daemon = daemon_mod.RunnerDaemon.__new__(daemon_mod.RunnerDaemon)
+    daemon._paths = get_runner_paths(repo_root=tmp_path)
+    daemon._db = RunnerDB(daemon._paths.db_path)
+    daemon._sync_to_backend_async = lambda: None
+    daemon._bind_runner_session_async = lambda name: None
+    return daemon
+
+
+def _add(daemon, name: str, env: dict[str, str]) -> dict[str, Any]:
+    runs = daemon._paths.repo_root / ".wayfinder_runs"
+    runs.mkdir(exist_ok=True)
+    (runs / f"{name}.py").write_text("print()\n")
+    return daemon.ctl_add_job(
+        name=name,
+        job_type="script",
+        payload={"script_path": f".wayfinder_runs/{name}.py", "env": env},
+        interval_seconds=3600,
+    )
+
+
+def _strategy_env(job_id: str) -> dict[str, str]:
+    return {"WAYFINDER_HIGH_LEVEL_JOB_ID": job_id}
+
+
+def test_strategy_cap_blocks_third_strategy(tmp_path: Path):
+    daemon = _daemon(tmp_path)
+    assert _add(daemon, "a-script", _strategy_env("a"))["ok"]
+    assert _add(daemon, "a-agent", _strategy_env("a"))["ok"]  # same strategy
+    assert _add(daemon, "b-script", _strategy_env("b"))["ok"]
+
+    refused = _add(daemon, "c-script", _strategy_env("c"))
+    assert not refused["ok"]
+    assert "active strategy limit" in refused["error"]
+
+    # A second loop of an already-active strategy is never a new slot.
+    assert _add(daemon, "b-agent", _strategy_env("b"))["ok"]
+
+
+def test_pause_frees_a_slot(tmp_path: Path):
+    daemon = _daemon(tmp_path)
+    assert _add(daemon, "a-script", _strategy_env("a"))["ok"]
+    assert _add(daemon, "b-script", _strategy_env("b"))["ok"]
+    daemon.ctl_pause_job(name="b-script")
+    assert _add(daemon, "c-script", _strategy_env("c"))["ok"]
+
+
+def test_legacy_cap_and_watchdog_exemption(tmp_path: Path):
+    daemon = _daemon(tmp_path)
+    for i in range(3):
+        assert _add(daemon, f"user-job-{i}", {})["ok"]
+
+    refused = _add(daemon, "user-job-3", {})
+    assert not refused["ok"]
+    assert "active runner-job limit" in refused["error"]
+
+    # The watchdog and strategy wrappers don't consume legacy slots.
+    assert _add(daemon, "watchdog", {"WAYFINDER_WATCHDOG": "1"})["ok"]
+    assert _add(daemon, "s-script", _strategy_env("s"))["ok"]
+
+    # Existing names are never capped (recompiles must keep working).
+    assert daemon.ctl_update_job(name="user-job-0", payload=None)["ok"]


### PR DESCRIPTION
### Summary

Two `if count >= cap: reject` checks in the daemon's `ctl_add_job`, nothing else. New registrations only:

- **At most 2 distinct active strategies** — counted by the `WAYFINDER_HIGH_LEVEL_JOB_ID` the compiler already bakes into wrapper-job env; a second loop of an already-active strategy is free.
- **At most 3 other active runner jobs** — anything without that env key; the watchdog self-identifies via `WAYFINDER_WATCHDOG` and is exempt.

Existing names fall through untouched (the bridge retries them as updates — recompiles must always work), `PAUSED` rows don't hold slots (pause is the self-serve way under the cap), and running jobs are never touched — over-cap fleets are grandfathered and simply can't add more until they pause/delete down.

One file + tests. Known-accepted gaps kept out deliberately: resume isn't capped (pause→resume can slip over), and a capped strategy create surfaces the refusal inside the compile response rather than as a hard error — both can be follow-ups if they matter in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)