### PR TITLE
Evolution Campaigns - Burst Recovery

### DIFF
--- a/wayfinder_paths/jobs/background.py
+++ b/wayfinder_paths/jobs/background.py
@@ -9,21 +9,20 @@ parseable result file = done)."""
 from __future__ import annotations
 
 import json
+import os
 import subprocess
-import sys
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 from wayfinder_paths.jobs.compute_lock import job_state_lock
+from wayfinder_paths.jobs.execution.op_process import op_runner_command
 from wayfinder_paths.jobs.models import utc_now_iso
 from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.runner.monitor_state import atomic_write_json
 
 
 def _pid_alive(pid: Any) -> bool:
-    import os
-
     if not isinstance(pid, int) or pid <= 0:
         return False
     try:
@@ -120,7 +119,7 @@ def _spawn_detached_op(
     result_path.unlink(missing_ok=True)
     with log_path.open("wb") as log_handle, result_path.open("wb") as result_handle:
         proc = subprocess.Popen(
-            [sys.executable, "-m", "wayfinder_paths.jobs.execution.op_runner"],
+            op_runner_command(op),
             stdin=subprocess.PIPE,
             stdout=result_handle,
             stderr=log_handle,

--- a/wayfinder_paths/jobs/evolution_campaign.py
+++ b/wayfinder_paths/jobs/evolution_campaign.py
@@ -72,6 +72,7 @@ from wayfinder_paths.jobs.models import utc_now_iso
 from wayfinder_paths.jobs.resource_envelope import (
     evolution_resource_phase,
     require_evolution_headroom,
+    require_evolution_launch_headroom,
 )
 from wayfinder_paths.jobs.robustness import _strategy_warmup_bars
 from wayfinder_paths.jobs.starter_casebook import select_starter_cases
@@ -249,6 +250,13 @@ def _start_campaign(
         store, job_id, now=current, reserve_campaign=True
     ):
         raise ValueError("evolution campaign does not fit outside peak pricing")
+    require_evolution_launch_headroom()
+    from wayfinder_paths.jobs.worker import job_worker_session_busy
+
+    if job_worker_session_busy(job_id, "intervene"):
+        raise TransientInfrastructureError(
+            "evolution campaign deferred while the intervention worker is active"
+        )
 
     root = store.job_dir(job_id)
     dataset_path = root / "results" / "backtest" / "input_bars.json"
@@ -1110,7 +1118,7 @@ def campaign_prompt_block(
     """Bounded dynamic context; the full casebook is never reloaded into prompts."""
     try:
         state = maybe_start_campaign(store, job_id, now=now)
-    except (FileNotFoundError, ValueError) as exc:
+    except (FileNotFoundError, TransientInfrastructureError, ValueError) as exc:
         return {"status": "blocked", "reason": str(exc)}
     if not state or state.get("status") != "active":
         return None

--- a/wayfinder_paths/jobs/execution/op_process.py
+++ b/wayfinder_paths/jobs/execution/op_process.py
@@ -1,0 +1,185 @@
+"""Process contract shared by isolated job-operation launchers and reapers."""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from wayfinder_paths.jobs.models import utc_now_iso
+from wayfinder_paths.runner.monitor_state import atomic_write_json
+
+if TYPE_CHECKING:
+    from wayfinder_paths.jobs.store import JobStore
+
+_RUNNER_MODULE = "wayfinder_paths.jobs.execution.op_runner"
+_CONTROL_PLANE_OPS = frozenset({"evolution_start", "evolution_prepare"})
+_CAMPAIGN_OWNED_OPS = frozenset(
+    {"evolution_prepare", "evolution_evaluate", "evolution_finalize"}
+)
+
+
+def operation_resource_tier(op: str) -> str:
+    """Classify runner work for the image-level CPU burst governor."""
+    return "control" if op in _CONTROL_PLANE_OPS else "heavy"
+
+
+def op_runner_command(op: str) -> list[str]:
+    """Return the canonical, process-visible command for an isolated op."""
+    return [
+        sys.executable,
+        "-m",
+        _RUNNER_MODULE,
+        f"--op-name={op}",
+        f"--resource-tier={operation_resource_tier(op)}",
+    ]
+
+
+def _proc_start_ticks(pid: int) -> int | None:
+    try:
+        fields = (
+            Path(f"/proc/{pid}/stat").read_text(encoding="utf-8").rsplit(") ", 1)[1]
+        )
+        return int(fields.split()[19])
+    except (OSError, IndexError, ValueError):
+        return None
+
+
+def _pid_alive(pid: Any) -> bool:
+    if not isinstance(pid, int) or pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def _pid_matches_runner(pid: int, op: str, start_ticks: int) -> bool:
+    try:
+        parts = Path(f"/proc/{pid}/cmdline").read_bytes().rstrip(b"\0").split(b"\0")
+    except OSError:
+        return False
+    return (
+        _proc_start_ticks(pid) == start_ticks
+        and b"wayfinder_paths.jobs.execution.op_runner" in parts
+        and f"--op-name={op}".encode() in parts
+    )
+
+
+@contextmanager
+def track_evolution_process(op: str, kwargs: dict[str, Any]) -> Iterator[None]:
+    """Register campaign-owned children so expiry can reap them exactly."""
+    job_id = str(kwargs.get("job_id") or "").strip()
+    if not job_id or op not in _CAMPAIGN_OWNED_OPS:
+        yield
+        return
+
+    from wayfinder_paths.jobs.evolution_campaign import campaign_status
+    from wayfinder_paths.jobs.store import JobStore
+
+    store = JobStore()
+    campaign_id = str(campaign_status(store, job_id).get("campaign_id") or "").strip()
+    process_start_ticks = _proc_start_ticks(os.getpid())
+    if not campaign_id or process_start_ticks is None:
+        yield
+        return
+
+    registry_dir = store.job_dir(job_id) / "state" / "running_ops"
+    registry_dir.mkdir(parents=True, exist_ok=True)
+    path = registry_dir / f"{os.getpid()}.json"
+    record = {
+        "schema_version": "1.0",
+        "pid": os.getpid(),
+        "process_group": os.getpgrp(),
+        "process_start_ticks": process_start_ticks,
+        "op": op,
+        "job_id": job_id,
+        "campaign_id": campaign_id,
+        "resource_tier": operation_resource_tier(op),
+        "started_at": utc_now_iso(),
+    }
+    atomic_write_json(path, record)
+    try:
+        yield
+    finally:
+        try:
+            current = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            current = None
+        if isinstance(current, dict) and current.get("pid") == os.getpid():
+            path.unlink(missing_ok=True)
+
+
+def terminate_campaign_ops(
+    store: JobStore, job_id: str, campaign_id: str
+) -> list[dict[str, Any]]:
+    """SIGKILL only registered children owned by the closing campaign."""
+    registry_dir = store.job_dir(job_id) / "state" / "running_ops"
+    reaped: list[dict[str, Any]] = []
+    for path in sorted(registry_dir.glob("*.json")):
+        try:
+            record = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(record, dict) or str(record.get("campaign_id")) != str(
+            campaign_id
+        ):
+            continue
+        pid = record.get("pid")
+        op = str(record.get("op") or "")
+        process_start_ticks = record.get("process_start_ticks")
+        if (
+            not isinstance(pid, int)
+            or not _pid_alive(pid)
+            or not op
+            or not isinstance(process_start_ticks, int)
+            or not _pid_matches_runner(pid, op, process_start_ticks)
+        ):
+            path.unlink(missing_ok=True)
+            continue
+        process_group = record.get("process_group")
+        try:
+            if (
+                isinstance(process_group, int)
+                and process_group == pid
+                and os.getpgid(pid) == process_group
+            ):
+                os.killpg(process_group, signal.SIGKILL)
+            else:
+                os.kill(pid, signal.SIGKILL)
+        except OSError:
+            continue
+        reaped.append(
+            {
+                "pid": pid,
+                "op": op,
+                "resource_tier": record.get("resource_tier"),
+            }
+        )
+        path.unlink(missing_ok=True)
+        status_path = registry_dir.parent / "background_ops" / f"{op}.json"
+        try:
+            status = json.loads(status_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            status = None
+        if (
+            isinstance(status, dict)
+            and status.get("state") == "running"
+            and status.get("pid") == pid
+        ):
+            status.update(
+                {
+                    "state": "killed",
+                    "exit_code": -signal.SIGKILL,
+                    "finished_at": utc_now_iso(),
+                    "reason": "owning evolution campaign closed",
+                }
+            )
+            atomic_write_json(status_path, status)
+    return reaped

--- a/wayfinder_paths/jobs/execution/op_runner.py
+++ b/wayfinder_paths/jobs/execution/op_runner.py
@@ -27,6 +27,8 @@ import subprocess
 import sys
 from typing import Any
 
+from wayfinder_paths.jobs.execution.op_process import track_evolution_process
+
 _EVIDENCE_OPS = {
     "backtest_job",
     "experiments",
@@ -270,7 +272,8 @@ def main() -> None:
     request = json.load(sys.stdin)
     op = str(request["op"])
     kwargs = dict(request.get("kwargs") or {})
-    result = _run(op, dict(kwargs))
+    with track_evolution_process(op, kwargs):
+        result = _run(op, dict(kwargs))
     json.dump(result, sys.stdout, default=str)
     # Flush before nudging: the re-prompted session's campaign block must see
     # the completed op's result file, not a half-written one.

--- a/wayfinder_paths/jobs/resource_envelope.py
+++ b/wayfinder_paths/jobs/resource_envelope.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import resource
 from collections.abc import Iterator
@@ -15,6 +16,8 @@ from wayfinder_paths.jobs.failures import TransientInfrastructureError, cpu_stea
 from wayfinder_paths.jobs.store import JobStore
 
 RESOURCE_REPORT_PATH = "reports/evolution/resources.json"
+BURST_STATE_PATH = "/tmp/wayfinder-burst-governor.json"
+BURST_STATE_MAX_AGE_SECONDS = 10.0
 
 
 def resource_snapshot(*, sample_cpu: bool = False) -> dict[str, Any]:
@@ -53,6 +56,48 @@ def require_evolution_headroom() -> dict[str, Any]:
             "evolution resource guard deferred heavy compute: " + "; ".join(reasons)
         )
     return snapshot
+
+
+def evolution_launch_readiness(*, now: datetime | None = None) -> dict[str, Any]:
+    """Read the image governor's bounded handoff without requiring Fly APIs."""
+    path = Path(os.environ.get("WAYFINDER_BURST_STATE_PATH", BURST_STATE_PATH))
+    if not path.exists():
+        return {"ready": True, "source": "governor_unavailable"}
+    try:
+        state = json.loads(path.read_text(encoding="utf-8"))
+        updated_at = datetime.fromtimestamp(float(state["updated_at"]), tz=UTC)
+    except (OSError, TypeError, ValueError, KeyError) as exc:
+        return {
+            "ready": False,
+            "source": "governor_invalid",
+            "reason": f"burst governor state is unreadable: {str(exc)[:160]}",
+        }
+    age = max(0.0, ((now or datetime.now(UTC)) - updated_at).total_seconds())
+    if age > BURST_STATE_MAX_AGE_SECONDS:
+        return {
+            "ready": False,
+            "source": "governor_stale",
+            "age_seconds": round(age, 1),
+            "reason": f"burst governor state is stale ({age:.1f}s)",
+        }
+    ready = bool(state.get("allow_new_heavy")) and not bool(state.get("paused"))
+    result = {
+        "ready": ready,
+        "source": "governor",
+        "balance_pct": state.get("balance_pct"),
+        "paused": bool(state.get("paused")),
+        "age_seconds": round(age, 1),
+    }
+    if not ready:
+        result["reason"] = "CPU burst reserve is below the campaign launch threshold"
+    return result
+
+
+def require_evolution_launch_headroom() -> dict[str, Any]:
+    readiness = evolution_launch_readiness()
+    if not readiness["ready"]:
+        raise TransientInfrastructureError(str(readiness["reason"]))
+    return readiness
 
 
 @contextmanager

--- a/wayfinder_paths/jobs/watchdog.py
+++ b/wayfinder_paths/jobs/watchdog.py
@@ -1330,12 +1330,14 @@ def _run_evolution_campaign_pass(
         CAMPAIGN_DRAIN,
         CAMPAIGN_STATE_PATH,
     )
+    from wayfinder_paths.jobs.execution.op_process import terminate_campaign_ops
     from wayfinder_paths.jobs.worker import retire_evolution_session
 
     state = store.read_json(job_id, CAMPAIGN_STATE_PATH, default={}) or {}
     campaign_id = str(state.get("campaign_id") or "")
     if state.get("status") not in {"active", "finalizing"}:
         if state.get("status") in {"complete", "expired"} and state.get("campaign_id"):
+            terminate_campaign_ops(store, job_id, str(state["campaign_id"]))
             retired = retire_evolution_session(store, job_id, str(state["campaign_id"]))
             if (
                 retired
@@ -1393,6 +1395,18 @@ def _run_evolution_campaign_pass(
                 )
                 expired_bootstrap = True
         if expired_bootstrap:
+            reaped = terminate_campaign_ops(
+                store, job_id, str(state.get("campaign_id") or "")
+            )
+            if reaped:
+                store.append_journal(
+                    job_id,
+                    {
+                        "type": "evolution_campaign_ops_reaped",
+                        "campaign_id": state.get("campaign_id"),
+                        "ops": reaped,
+                    },
+                )
             retirement = retire_evolution_session(
                 store, job_id, str(state.get("campaign_id") or "")
             )
@@ -1401,6 +1415,8 @@ def _run_evolution_campaign_pass(
                 "campaign_id": state.get("campaign_id"),
                 "session_retired": bool(retirement and retirement.get("retired")),
             }
+            if reaped:
+                result["reaped_ops"] = reaped
             if retirement and retirement.get("error"):
                 result["retirement_error"] = retirement["error"]
             return result
@@ -1523,10 +1539,16 @@ def _run_evolution_campaign_pass(
                     "finalize_attempts": attempts,
                 },
             )
-            return {
+            reaped = terminate_campaign_ops(
+                store, job_id, str(state.get("campaign_id") or "")
+            )
+            result = {
                 "action": "evolution_campaign_expired",
                 "campaign_id": state.get("campaign_id"),
             }
+            if reaped:
+                result["reaped_ops"] = reaped
+            return result
         if attempts >= len(_CAMPAIGN_FINALIZE_RETRY_S):
             return None
         last_attempt = state.get("finalize_last_attempt_at")

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -10,6 +10,7 @@ from typing import Any
 from loguru import logger
 
 from wayfinder_paths.core.clients.OpenCodeClient import OPENCODE_CLIENT
+from wayfinder_paths.core.config import is_opencode_instance
 from wayfinder_paths.jobs.derived_features import refresh_derived_features_if_stale
 from wayfinder_paths.jobs.failures import disk_used_pct
 from wayfinder_paths.jobs.forward import is_forward_empty
@@ -568,9 +569,7 @@ def _compute_status_block(root: Path) -> dict[str, Any]:
 
     resources = resource_snapshot(sample_cpu=True)
     available = resources.get("mem_available_mb")
-    mem_available_mb = (
-        int(available) if isinstance(available, (int, float)) else None
-    )
+    mem_available_mb = int(available) if isinstance(available, (int, float)) else None
     last_experiment_at: str | None = None
     experiments_path = root / "results" / "backtest" / "experiments.jsonl"
     try:
@@ -1549,10 +1548,35 @@ def run_job_worker(
         return report
 
     # Open-ended evolution has its own long-lived session. It is intentionally
-    # queued independently from the hourly funnel so a four-hour campaign can
-    # keep coherent context without pinning the normal island rotation.
+    # kept separate from the hourly funnel so a four-hour campaign can keep
+    # coherent context without running two LLM sessions against one CPU pool.
+    evolution_wake: dict[str, Any] | None = None
     if mode_typed == "intervene" and apply_proposal_id is None:
-        _queue_evolution_worker(store, job.id)
+        evolution_wake = _queue_evolution_worker(store, job.id)
+        from wayfinder_paths.jobs.evolution_campaign import campaign_status
+
+        evolution_status = campaign_status(store, job.id).get("status")
+        evolution_claimed_lane = bool(
+            evolution_wake is not None and not evolution_wake.get("error")
+        )
+        if evolution_claimed_lane or evolution_status in {"active", "finalizing"}:
+            session_id = str((evolution_wake or {}).get("session_id") or "") or None
+            reason = str((evolution_wake or {}).get("reason") or "").strip()
+            return _write_report(
+                store=store,
+                job_id=job.id,
+                mode=mode_typed,
+                status="green",
+                summary=(
+                    f"Intervention LLM wake deferred to evolution: {reason}"
+                    if reason
+                    else "Intervention LLM wake deferred while evolution owns the lane"
+                ),
+                session_id=session_id,
+                queued=False,
+                error=None,
+                wake_context=wake_context,
+            )
 
     # Wake economy cheap-skip (same tier as the auto-limits guard above): a
     # saturated paper job whose evidence watermark has not moved since the
@@ -1662,6 +1686,24 @@ def _ensure_worker_session(job_id: str, mode: str) -> str | None:
         return None
 
 
+def job_worker_session_busy(job_id: str, mode: str) -> bool:
+    """Whether the ordinary job worker currently owns the shared LLM lane."""
+    if not is_opencode_instance() or not OPENCODE_CLIENT.healthy():
+        return False
+    controller_session_id = os.environ.get("OPENCODE_SESSION_ID") or os.environ.get(
+        "OPENCODE_SESSIONID"
+    )
+    try:
+        session_id = OPENCODE_CLIENT.find_child_session(
+            parent_id=controller_session_id,
+            title=f"job/{job_id}/{mode}",
+        )
+        return bool(session_id and OPENCODE_CLIENT.session_statuses().get(session_id))
+    except Exception:
+        logger.opt(exception=True).debug("Failed to inspect OpenCode job worker")
+        return False
+
+
 def _queue_evolution_worker(store: JobStore, job_id: str) -> dict[str, Any] | None:
     from wayfinder_paths.jobs.improver.spec import ImproverSpec
 
@@ -1676,8 +1718,31 @@ def _queue_evolution_worker(store: JobStore, job_id: str) -> dict[str, Any] | No
             campaign_prompt_block,
             campaign_status,
         )
+        from wayfinder_paths.jobs.resource_envelope import evolution_launch_readiness
 
         if campaign_due(store, job_id):
+            readiness = evolution_launch_readiness()
+            if not readiness["ready"]:
+                deferred = {
+                    "queued": False,
+                    "starting": False,
+                    "reason": str(readiness.get("reason") or "resource guard"),
+                }
+                if readiness.get("source") == "governor":
+                    # A healthy governor with low credit needs the ordinary
+                    # LLM lane quiet so the reserve can actually recover.
+                    deferred["deferred"] = True
+                else:
+                    # A stale/invalid governor must not wedge both lanes.
+                    deferred["error"] = deferred["reason"]
+                return deferred
+            if job_worker_session_busy(job_id, "intervene"):
+                return {
+                    "queued": False,
+                    "starting": False,
+                    "deferred": True,
+                    "reason": "the intervention worker is already active",
+                }
             started = spawn_detached_op(
                 store, job_id, "evolution_start", {"job_id": job_id}
             )

--- a/wayfinder_paths/mcp/tools/jobs.py
+++ b/wayfinder_paths/mcp/tools/jobs.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import json
 import os
-import sys
 from pathlib import Path
 from typing import Any, Literal
 
@@ -19,6 +18,7 @@ from wayfinder_paths.jobs.apply_launcher import launch_application
 from wayfinder_paths.jobs.backtest_artifacts import diagnose_backtest
 from wayfinder_paths.jobs.compiler import JobCompiler
 from wayfinder_paths.jobs.execution.experiments import list_experiments
+from wayfinder_paths.jobs.execution.op_process import op_runner_command
 from wayfinder_paths.jobs.execution.validation import validate_execution_job
 from wayfinder_paths.jobs.halt import clear_halt, request_halt
 from wayfinder_paths.jobs.models import (
@@ -112,12 +112,11 @@ async def _run_job_op(op: str, kwargs: dict[str, Any]) -> dict[str, Any]:
     clean tool error. See op_runner for the protocol.
     """
     proc = await asyncio.create_subprocess_exec(
-        sys.executable,
-        "-m",
-        "wayfinder_paths.jobs.execution.op_runner",
+        *op_runner_command(op),
         stdin=asyncio.subprocess.PIPE,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
+        start_new_session=True,
     )
     stdout, stderr = await proc.communicate(
         json.dumps({"op": op, "kwargs": kwargs}).encode()
@@ -203,9 +202,7 @@ async def _start_background_op(
     result_path.unlink(missing_ok=True)
     with log_path.open("wb") as log_handle, result_path.open("wb") as result_handle:
         proc = await asyncio.create_subprocess_exec(
-            sys.executable,
-            "-m",
-            "wayfinder_paths.jobs.execution.op_runner",
+            *op_runner_command(op),
             stdin=asyncio.subprocess.PIPE,
             stdout=result_handle,
             stderr=log_handle,
@@ -940,7 +937,9 @@ async def core_jobs(
             return err("invalid_request", "forward_experience requires job_id")
         kwargs = {"job_id": job_id}
         if background is not False:
-            return await _start_background_op(store, job_id, "forward_experience", kwargs)
+            return await _start_background_op(
+                store, job_id, "forward_experience", kwargs
+            )
         return await _run_job_op("forward_experience", kwargs)
 
     if action == "promote_params":

--- a/wayfinder_paths/tests/test_jobs_apply_watchdog.py
+++ b/wayfinder_paths/tests/test_jobs_apply_watchdog.py
@@ -1086,7 +1086,6 @@ def test_watchdog_drains_and_retires_session_before_finalize(
             retired.append(campaign_id) or {"retired": True}
         ),
     )
-
     result = _run_evolution_campaign_pass(
         store, job.id, deadline - timedelta(minutes=20)
     )
@@ -1127,6 +1126,16 @@ def test_watchdog_expires_campaign_that_never_generates_a_candidate(
             retired.append(campaign_id) or {"retired": True}
         ),
     )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.execution.op_process.terminate_campaign_ops",
+        lambda store, job_id, campaign_id: [
+            {
+                "pid": 4242,
+                "op": "evolution_prepare",
+                "resource_tier": "control",
+            }
+        ],
+    )
 
     assert (
         _run_evolution_campaign_pass(
@@ -1142,6 +1151,13 @@ def test_watchdog_expires_campaign_that_never_generates_a_candidate(
         "action": "evolution_campaign_bootstrap_failed",
         "campaign_id": "campaign-1",
         "session_retired": True,
+        "reaped_ops": [
+            {
+                "pid": 4242,
+                "op": "evolution_prepare",
+                "resource_tier": "control",
+            }
+        ],
     }
     assert retired == ["campaign-1"]
     state = store.read_json(job.id, "state/evolution_campaign.json")
@@ -1149,6 +1165,7 @@ def test_watchdog_expires_campaign_that_never_generates_a_candidate(
     assert state["stage"] == "expired"
     assert state["expiry_reason"] == "no_candidates_generated"
     assert "evolution_campaign_bootstrap_failed" in _journal_types(store, job.id)
+    assert "evolution_campaign_ops_reaped" in _journal_types(store, job.id)
 
 
 def test_watchdog_keeps_campaign_after_first_candidate(tmp_path: Path) -> None:

--- a/wayfinder_paths/tests/test_jobs_evolution_campaign.py
+++ b/wayfinder_paths/tests/test_jobs_evolution_campaign.py
@@ -31,7 +31,9 @@ from wayfinder_paths.jobs.evolution_campaign import (
     resolve_candidate_bundle,
     start_campaign,
 )
+from wayfinder_paths.jobs.execution.op_process import op_runner_command
 from wayfinder_paths.jobs.execution.primitives import DEFAULT_WARMUP_BARS
+from wayfinder_paths.jobs.failures import TransientInfrastructureError
 from wayfinder_paths.jobs.gating import compute_workspace_revision
 from wayfinder_paths.jobs.models import WayfinderJob
 from wayfinder_paths.jobs.starter_casebook import (
@@ -44,6 +46,7 @@ from wayfinder_paths.jobs.worker import (
     _queue_evolution_worker,
     nudge_evolution_session,
     retire_evolution_session,
+    run_job_worker,
 )
 
 
@@ -108,6 +111,102 @@ def test_rollout_is_gated_and_campaign_context_is_bounded(tmp_path) -> None:
         "finalist_requires_24h_forward_proposal": True,
     }
     assert len(load_starter_casebook()) > len(block["cases"])
+
+
+def test_campaign_start_defers_while_intervention_worker_is_busy(
+    tmp_path, monkeypatch
+) -> None:
+    store, job_id = _job(tmp_path, "majors-5m-lab")
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.evolution_campaign.require_evolution_launch_headroom",
+        lambda: {"ready": True},
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.worker.job_worker_session_busy", lambda *args: True
+    )
+
+    with pytest.raises(TransientInfrastructureError, match="intervention worker"):
+        start_campaign(store, job_id)
+
+    assert campaign_status(store, job_id) == {}
+
+
+def test_runner_command_declares_control_and_heavy_resource_tiers() -> None:
+    assert "--resource-tier=control" in op_runner_command("evolution_prepare")
+    assert "--resource-tier=control" in op_runner_command("evolution_start")
+    assert "--resource-tier=heavy" in op_runner_command("evolution_evaluate")
+    assert "--resource-tier=heavy" in op_runner_command("backtest_job")
+
+
+def test_due_campaign_defers_without_spawning_when_burst_credit_is_low(
+    tmp_path, monkeypatch
+) -> None:
+    store, job_id = _job(tmp_path, "majors-5m-lab")
+
+    class FakeClient:
+        def healthy(self) -> bool:
+            return True
+
+    monkeypatch.setattr("wayfinder_paths.jobs.worker.OPENCODE_CLIENT", FakeClient())
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.evolution_campaign.campaign_due", lambda *args: True
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.resource_envelope.evolution_launch_readiness",
+        lambda: {
+            "ready": False,
+            "source": "governor",
+            "reason": "burst reserve is low",
+        },
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.background.spawn_detached_op",
+        lambda *args, **kwargs: pytest.fail("campaign start should not spawn"),
+    )
+
+    result = _queue_evolution_worker(store, job_id)
+
+    assert result == {
+        "queued": False,
+        "starting": False,
+        "deferred": True,
+        "reason": "burst reserve is low",
+    }
+
+
+def test_active_evolution_suppresses_the_parallel_intervention_llm(
+    tmp_path, monkeypatch
+) -> None:
+    store, job_id = _job(tmp_path, "majors-5m-lab")
+    monkeypatch.setattr("wayfinder_paths.jobs.worker.JobStore", lambda: store)
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.worker._queue_evolution_worker",
+        lambda *args: {"queued": True, "session_id": "evolution-session"},
+    )
+
+    report = run_job_worker(job_id, mode="intervene")
+
+    assert report["queued"] is False
+    assert report["session_id"] == "evolution-session"
+    assert "deferred while evolution owns the lane" in report["summary"]
+
+
+def test_governor_diagnostic_error_does_not_wedge_the_intervention_lane(
+    tmp_path, monkeypatch
+) -> None:
+    store, job_id = _job(tmp_path, "majors-5m-lab")
+    normal_report = {"status": "green", "summary": "normal lane reached"}
+    monkeypatch.setattr("wayfinder_paths.jobs.worker.JobStore", lambda: store)
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.worker._queue_evolution_worker",
+        lambda *args: {"queued": False, "error": "governor state is stale"},
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.worker.maybe_skip_wake",
+        lambda *args, **kwargs: normal_report,
+    )
+
+    assert run_job_worker(job_id, mode="intervene") is normal_report
 
 
 @pytest.mark.parametrize(

--- a/wayfinder_paths/tests/test_jobs_resource_envelope.py
+++ b/wayfinder_paths/tests/test_jobs_resource_envelope.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from wayfinder_paths.jobs.failures import TransientInfrastructureError
+from wayfinder_paths.jobs.resource_envelope import (
+    evolution_launch_readiness,
+    require_evolution_launch_headroom,
+)
+
+
+def _write_state(path, *, now: datetime, **overrides) -> None:
+    state = {
+        "updated_at": now.timestamp(),
+        "balance_pct": 80.0,
+        "paused": False,
+        "allow_new_heavy": True,
+        **overrides,
+    }
+    path.write_text(json.dumps(state), encoding="utf-8")
+
+
+def test_launch_readiness_uses_fresh_governor_state(tmp_path, monkeypatch) -> None:
+    now = datetime.now(UTC)
+    path = tmp_path / "burst.json"
+    monkeypatch.setenv("WAYFINDER_BURST_STATE_PATH", str(path))
+    _write_state(
+        path,
+        now=now,
+        balance_pct=12.0,
+        paused=True,
+        allow_new_heavy=False,
+    )
+
+    readiness = evolution_launch_readiness(now=now)
+
+    assert readiness["ready"] is False
+    assert readiness["balance_pct"] == 12.0
+    with pytest.raises(TransientInfrastructureError, match="burst reserve"):
+        require_evolution_launch_headroom()
+
+
+def test_launch_readiness_fails_closed_on_stale_governor_state(
+    tmp_path, monkeypatch
+) -> None:
+    now = datetime.now(UTC)
+    path = tmp_path / "burst.json"
+    monkeypatch.setenv("WAYFINDER_BURST_STATE_PATH", str(path))
+    _write_state(path, now=now - timedelta(minutes=1))
+
+    readiness = evolution_launch_readiness(now=now)
+
+    assert readiness["ready"] is False
+    assert readiness["source"] == "governor_stale"
+
+
+def test_launch_readiness_is_portable_without_a_governor(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("WAYFINDER_BURST_STATE_PATH", str(tmp_path / "missing.json"))
+
+    assert evolution_launch_readiness()["ready"] is True

--- a/wayfinder_paths/tests/test_mcp_jobs_background_ops.py
+++ b/wayfinder_paths/tests/test_mcp_jobs_background_ops.py
@@ -12,6 +12,7 @@ import pytest
 
 import wayfinder_paths.mcp.tools.jobs as jobs_module
 from wayfinder_paths.jobs.background import op_status_summary
+from wayfinder_paths.jobs.execution.op_process import terminate_campaign_ops
 from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.mcp.tools.jobs import (
     _background_op_status,
@@ -107,6 +108,56 @@ def test_sync_status_reconciles_dead_detached_operation(tmp_path) -> None:
     assert reconciled["state"] == "failed"
     assert reconciled["reconciled_at"]
     assert "without a result" in reconciled["error"]
+
+
+def test_campaign_close_reaps_registered_runner_group(tmp_path, monkeypatch) -> None:
+    store, job_id = _store(tmp_path)
+    registry = store.job_dir(job_id) / "state" / "running_ops"
+    registry.mkdir(parents=True)
+    (registry / "4242.json").write_text(
+        json.dumps(
+            {
+                "pid": 4242,
+                "process_group": 4242,
+                "op": "evolution_prepare",
+                "campaign_id": "campaign-1",
+                "resource_tier": "control",
+                "process_start_ticks": 1234,
+            }
+        )
+    )
+    ops_dir = _background_ops_dir(store, job_id)
+    ops_dir.mkdir(parents=True, exist_ok=True)
+    status_path = ops_dir / "evolution_prepare.json"
+    status_path.write_text(
+        json.dumps({"pid": 4242, "op": "evolution_prepare", "state": "running"})
+    )
+    killed = []
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.execution.op_process._pid_alive", lambda pid: True
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.execution.op_process._pid_matches_runner",
+        lambda pid, op, start_ticks: True,
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.execution.op_process.os.getpgid", lambda pid: pid
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.execution.op_process.os.killpg",
+        lambda process_group, sig: killed.append((process_group, sig)),
+    )
+
+    reaped = terminate_campaign_ops(store, job_id, "campaign-1")
+
+    assert reaped == [
+        {"pid": 4242, "op": "evolution_prepare", "resource_tier": "control"}
+    ]
+    assert killed and killed[0][0] == 4242
+    assert not (registry / "4242.json").exists()
+    status = json.loads(status_path.read_text())
+    assert status["state"] == "killed"
+    assert status["reason"] == "owning evolution campaign closed"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

- Gate campaign launch on fresh CPU burst headroom and serialize evolution with the intervention LLM lane.
- Tag isolated operations as control or heavy and register campaign-owned process groups with PID-reuse-safe identity.
- Reap orphaned operations when campaigns expire while preserving the normal intervention lane if governor telemetry is stale.