### PR TITLE
Fix evolution worker permissions in baked images

### DIFF
--- a/.opencode/agents/wayfinder-evolution-worker.md
+++ b/.opencode/agents/wayfinder-evolution-worker.md
@@ -8,10 +8,14 @@ permission:
   task:
     "*": deny
   question: deny
+  # Baked images have no git metadata, so opencode authorizes file tools with
+  # paths relative to the global `/` worktree (`wf/...`, without a leading `/`).
   read:
     "*": deny
     ".wayfinder/jobs/**": allow
     "/wf/user_vault/wayfinder/jobs/**": allow
+    "wf/sdk/.wayfinder/jobs/**": allow
+    "wf/user_vault/wayfinder/jobs/**": allow
   grep: deny
   glob: deny
   list: allow
@@ -19,9 +23,13 @@ permission:
     "*": deny
     ".wayfinder/jobs/**": allow
     "/wf/user_vault/wayfinder/jobs/**": allow
+    "wf/sdk/.wayfinder/jobs/**": allow
+    "wf/user_vault/wayfinder/jobs/**": allow
   edit:
     "*": deny
     ".wayfinder/jobs/**": allow
+    "wf/sdk/.wayfinder/jobs/**": allow
+    "wf/user_vault/wayfinder/jobs/**": allow
     "governance/**": deny
     "audit/**": deny
   external_directory:

--- a/wayfinder_paths/tests/test_jobs_live_loose_ends.py
+++ b/wayfinder_paths/tests/test_jobs_live_loose_ends.py
@@ -253,11 +253,15 @@ def test_evolution_worker_has_minimal_vault_access_and_denies_audit() -> None:
         "*": "deny",
         ".wayfinder/jobs/**": "allow",
         "/wf/user_vault/wayfinder/jobs/**": "allow",
+        "wf/sdk/.wayfinder/jobs/**": "allow",
+        "wf/user_vault/wayfinder/jobs/**": "allow",
     }
     assert frontmatter["permission"]["write"] == frontmatter["permission"]["read"]
     assert list(frontmatter["permission"]["edit"].items()) == [
         ("*", "deny"),
         (".wayfinder/jobs/**", "allow"),
+        ("wf/sdk/.wayfinder/jobs/**", "allow"),
+        ("wf/user_vault/wayfinder/jobs/**", "allow"),
         ("governance/**", "deny"),
         ("audit/**", "deny"),
     ]
@@ -275,6 +279,38 @@ def test_evolution_worker_has_minimal_vault_access_and_denies_audit() -> None:
         "wayfinder_contracts_execute",
     ):
         assert _evaluate(denied, "*", ruleset)["action"] == "deny"
+
+
+def test_evolution_worker_can_mutate_candidate_from_global_project() -> None:
+    """The production image has no git metadata, so opencode's worktree is `/`.
+
+    Read and edit permissions receive paths relative to that worktree, not the
+    absolute paths passed to the tools. Cover both names the worker uses for a
+    candidate: the SDK's `.wayfinder` symlink and its canonical vault target.
+    """
+    path = ".opencode/agents/wayfinder-evolution-worker.md"
+    frontmatter = yaml.safe_load(Path(path).read_text().split("---\n")[1])
+    permission = frontmatter["permission"]
+    candidates = (
+        "wf/sdk/.wayfinder/jobs/majors-5m-lab/research/evolution/"
+        "campaigns/campaign-1/candidates/candidate-1/workspace/src/strategy.py",
+        "wf/user_vault/wayfinder/jobs/majors-5m-lab/research/evolution/"
+        "campaigns/campaign-1/candidates/candidate-1/workspace/src/strategy.py",
+    )
+
+    for operation in ("read", "edit"):
+        ruleset = _from_config({operation: permission[operation]})
+        for candidate in candidates:
+            assert _evaluate(operation, candidate, ruleset)["action"] == "allow"
+        assert _evaluate(operation, "wf/sdk/AGENTS.md", ruleset)["action"] == "deny"
+        assert (
+            _evaluate(
+                operation,
+                "wf/user_vault/audit/evolution/private.json",
+                ruleset,
+            )["action"]
+            == "deny"
+        )
 
 
 def _wildcard_match(string: str, pattern: str) -> bool:


### PR DESCRIPTION
## Summary

- allow the dedicated evolution worker to read and edit candidate bundles when OpenCode registers the baked SDK as the global `/` project
- cover both the `.wayfinder` symlink path and canonical user-vault path emitted by OpenCode's root-relative permission checks
- preserve the narrow job-only capability boundary and explicit governance/audit denials

## Production evidence

The canary campaign started and prepared a candidate, but every candidate-bundle read was denied. On that image, `GET /project` reported `worktree: "/"`; OpenCode authorizes read/edit operations with `path.relative(instance.worktree, filepath)`, producing `wf/sdk/.wayfinder/jobs/...` or `wf/user_vault/wayfinder/jobs/...`. The worker manifest only allowed repo-relative and leading-slash forms.

## Validation

- regression test failed before the manifest change and passes after it
- `pytest -q --no-cov wayfinder_paths/tests/test_mcp_profiles.py wayfinder_paths/tests/test_jobs_live_loose_ends.py` — 28 passed
- `ruff check wayfinder_paths/tests/test_jobs_live_loose_ends.py`
- `ruff format --check wayfinder_paths/tests/test_jobs_live_loose_ends.py`
- `git diff --check`
