### PR TITLE
fix(jobs): enforce close-time dataset labels

### DIFF
--- a/wayfinder_paths/jobs/derived_features.py
+++ b/wayfinder_paths/jobs/derived_features.py
@@ -61,8 +61,12 @@ def _native_hl_closes(coin: str, start_ms: int, end_ms: int) -> pd.Series:
     rows = asyncio.run(_fetch())
     if not rows:
         return pd.Series(dtype=float)
-    stamps = [pd.Timestamp(int(r["t"]), unit="ms", tz="UTC") for r in rows]
-    return pd.Series([float(r["c"]) for r in rows], index=pd.Index(stamps)).sort_index()
+    from wayfinder_paths.jobs.execution.hyperliquid import (
+        hyperliquid_candles_to_completed_view,
+    )
+
+    frame = hyperliquid_candles_to_completed_view(coin, rows).to_frame()
+    return frame.set_index("timestamp")["close"].astype(float).sort_index()
 
 
 def derive_features_job(

--- a/wayfinder_paths/jobs/execution/ccxt_feed.py
+++ b/wayfinder_paths/jobs/execution/ccxt_feed.py
@@ -10,6 +10,7 @@ from typing import Any
 import pandas as pd
 
 from wayfinder_paths.jobs.execution.primitives import (
+    BAR_CLOSE_LABEL,
     CompletedBarsView,
     bar_interval_seconds,
 )
@@ -222,7 +223,7 @@ async def fetch_ccxt_dataset_rows(
         "market_type": market_type,
         "quote": feed.quote,
         "symbol_map": dict(feed.symbol_map),
-        "label_convention": "close_time",
+        "label_convention": BAR_CLOSE_LABEL,
     }
     return view.to_rows(), metadata
 

--- a/wayfinder_paths/jobs/execution/hyperliquid.py
+++ b/wayfinder_paths/jobs/execution/hyperliquid.py
@@ -66,7 +66,7 @@ class SafeHyperliquidMarketClient:
                     interval=interval,
                     lookback_hours=lookback_hours,
                 )
-                return _candles_to_completed_view(asset_name, rows)
+                return hyperliquid_candles_to_completed_view(asset_name, rows)
             except Exception as exc:
                 last_error = exc
                 if "429" not in str(exc) or attempt >= retries - 1:
@@ -765,7 +765,7 @@ def _lookback_hours(lookback_bars: int, interval: str) -> int:
     return max(1, math.ceil(lookback_bars * bar_seconds / 3600))
 
 
-def _candles_to_completed_view(
+def hyperliquid_candles_to_completed_view(
     asset_name: str, rows: list[CandleEntry]
 ) -> CompletedBarsView:
     now_ms = int(time.time() * 1000)

--- a/wayfinder_paths/jobs/execution/hyperliquid_prediction.py
+++ b/wayfinder_paths/jobs/execution/hyperliquid_prediction.py
@@ -10,11 +10,11 @@ import httpx
 from wayfinder_paths.jobs.execution.hyperliquid import (
     SafeHyperliquidMarketClient,
     _cancel_needs_asset_context,
-    _candles_to_completed_view,
     _hl_state_result,
     _lookback_hours,
     _paper_broker,
     _submit_market_order,
+    hyperliquid_candles_to_completed_view,
 )
 from wayfinder_paths.jobs.execution.primitives import (
     CompletedBarsView,
@@ -147,7 +147,7 @@ class HyperliquidPredictionFeed:
         raw = await self._fallback.get_candles(
             symbol, interval=interval, lookback_hours=lookback_hours
         )
-        return _candles_to_completed_view(symbol, raw)
+        return hyperliquid_candles_to_completed_view(symbol, raw)
 
     async def get_events(
         self, symbols: Sequence[str], *, since: datetime | None = None

--- a/wayfinder_paths/jobs/execution/preflight.py
+++ b/wayfinder_paths/jobs/execution/preflight.py
@@ -19,6 +19,7 @@ from wayfinder_paths.jobs.execution.driver import tick_job
 from wayfinder_paths.jobs.execution.job import _load_dataset, _load_job_yaml
 from wayfinder_paths.jobs.execution.paper import PaperBroker
 from wayfinder_paths.jobs.execution.primitives import (
+    BAR_CLOSE_LABEL,
     CompletedBarsView,
     ExecutionSpec,
     FillEvent,
@@ -122,7 +123,7 @@ def build_live_dataset(
                 or quote
                 or default_quote(exchange),
                 "symbol_map": dict(feed.symbol_map),
-                "label_convention": "close_time",
+                "label_convention": BAR_CLOSE_LABEL,
             }
         else:
             rows, source_metadata = asyncio.run(
@@ -163,6 +164,7 @@ def build_live_dataset(
         asyncio.run(_fetch())
         metadata = {
             "source": "live_fetch",
+            "label_convention": BAR_CLOSE_LABEL,
             "venues": sorted(adapters),
             "symbols": symbols,
             "interval": str(bar_interval),

--- a/wayfinder_paths/jobs/execution/primitives.py
+++ b/wayfinder_paths/jobs/execution/primitives.py
@@ -18,6 +18,7 @@ FillStatus = Literal["filled", "partial", "resting", "rejected", "ambiguous"]
 SnapshotStatus = Literal["valid", "ambiguous", "rate_limited", "stale", "risk_halt"]
 
 DEFAULT_INITIAL_CAPITAL = 10_000.0
+BAR_CLOSE_LABEL = "close_time"
 
 
 @dataclass

--- a/wayfinder_paths/jobs/execution/simulator.py
+++ b/wayfinder_paths/jobs/execution/simulator.py
@@ -30,6 +30,7 @@ from wayfinder_paths.jobs.execution.gates import summarize_gate_diagnostics
 # live driver, and the candidate shadow replayer) but existing callers import
 # it from here.
 from wayfinder_paths.jobs.execution.primitives import (
+    BAR_CLOSE_LABEL,
     DEFAULT_INITIAL_CAPITAL,
     REDUCE_ONLY_ACTIONS,
     CompletedBarsView,
@@ -61,6 +62,14 @@ class PreparedExecutionDataset:
     bars: CompletedBarsView
     metadata: dict[str, Any] = field(default_factory=dict)
     market_events: list[MarketEvent] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        label_convention = self.metadata.get("label_convention")
+        if label_convention is not None and label_convention != BAR_CLOSE_LABEL:
+            raise ValueError(
+                "dataset metadata.label_convention must be "
+                f"{BAR_CLOSE_LABEL!r}; got {label_convention!r}"
+            )
 
     @classmethod
     def from_rows(

--- a/wayfinder_paths/jobs/execution/validation.py
+++ b/wayfinder_paths/jobs/execution/validation.py
@@ -21,6 +21,7 @@ from wayfinder_paths.jobs.execution.features import (
     parse_feature_specs,
 )
 from wayfinder_paths.jobs.execution.primitives import (
+    BAR_CLOSE_LABEL,
     CompletedBarsView,
     ExecutionSpec,
     ExecutionTrace,
@@ -213,6 +214,7 @@ def validate_execution_job(
     spec = ExecutionSpec.from_dict(spec_data)
     checks.extend(_execution_spec_checks(spec))
     checks.extend(_timing_checks(job_data, spec))
+    checks.extend(_dataset_timestamp_checks(root, job_data))
     checks.extend(_feature_checks(root, spec))
     script_path = store.resolve_script_entrypoint(
         job_id,
@@ -265,6 +267,67 @@ def validate_execution_job(
     if not candidate_dir:
         store.write_json(job_id, "reports/validation/latest.json", report)
     return report
+
+
+def _dataset_timestamp_checks(
+    root: Path, job_data: Mapping[str, Any]
+) -> list[dict[str, Any]]:
+    """Require an auditable close-time label before a jobs_v1 dataset gates.
+
+    Timestamp values alone cannot distinguish an opening label from a closing
+    label when both land on the interval grid. The persisted provenance is the
+    only reliable boundary contract, so hand-built datasets must declare it.
+    Pre-contract ``live_fetch`` files are safe to grandfather because that
+    source has always gone through ``MarketDataFeed.get_completed_bars``.
+    """
+    paths = (
+        root / "results" / "backtest" / "input_bars.json",
+        root / "workspace" / "config" / "backtest_bars.json",
+    )
+    path = next((candidate for candidate in paths if candidate.exists()), None)
+    if path is None:
+        return []  # fixture/scenario-driven validation contexts
+
+    blocking = str(job_data.get("execution_contract") or "") == "jobs_v1"
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        return [
+            {
+                "name": "dataset_close_time_labels",
+                "passed": False,
+                "blocking": blocking,
+                "path": str(path),
+                "error": str(exc),
+            }
+        ]
+
+    metadata = payload.get("metadata") if isinstance(payload, dict) else None
+    metadata = metadata if isinstance(metadata, dict) else {}
+    convention = metadata.get("label_convention")
+    source = str(metadata.get("source") or "")
+    legacy_live_fetch = convention is None and source == "live_fetch"
+    passed = convention == BAR_CLOSE_LABEL or legacy_live_fetch
+    check: dict[str, Any] = {
+        "name": "dataset_close_time_labels",
+        "passed": passed,
+        "blocking": blocking,
+        "path": str(path),
+        "label_convention": convention,
+    }
+    if legacy_live_fetch:
+        check["note"] = (
+            "legacy live_fetch provenance accepted: this source has always "
+            "used completed-bar venue feeds; the next refresh will stamp "
+            f"label_convention={BAR_CLOSE_LABEL!r}"
+        )
+    elif not passed:
+        check["hint"] = (
+            f"wrap bars in {{'bars': [...], 'metadata': "
+            f"{{'label_convention': {BAR_CLOSE_LABEL!r}}}}} or rebuild with "
+            "wayfinder job fetch-dataset"
+        )
+    return [check]
 
 
 # Evidence-window policy (owner-set 2026-07-27): a 5m strategy validated on

--- a/wayfinder_paths/tests/test_execution_ccxt_feed.py
+++ b/wayfinder_paths/tests/test_execution_ccxt_feed.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pandas as pd
 import pytest
 
-from wayfinder_paths.jobs.execution import ExecutionSpec
+from wayfinder_paths.jobs.execution import CompletedBarsView, ExecutionSpec
 from wayfinder_paths.jobs.execution.ccxt_feed import (
     CcxtMarketFeed,
     fetch_ccxt_dataset_rows,
@@ -272,6 +273,57 @@ def test_build_live_dataset_ccxt_source_writes_metadata(tmp_path: Path) -> None:
     assert payload["metadata"]["source"] == "ccxt"
     assert payload["bars"], "bars must be persisted"
     assert payload["bars"][0]["symbol"] == "SNX"
+
+
+def test_build_live_dataset_venue_source_writes_close_time_metadata(
+    tmp_path: Path, monkeypatch
+) -> None:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        "venue-demo",
+        script=".wayfinder/jobs/venue-demo/workspace/src/strategy.py",
+        interval_seconds=3600,
+        execution_contract="jobs_v1",
+    )
+    spec = ExecutionSpec()
+    spec.data_contract["bar_interval"] = "1h"
+    job.execution_spec = spec.to_dict()
+    job.execution_params = {"symbols": ["SNX"]}
+    store.save(job)
+    rows = [
+        {
+            "timestamp": "2026-01-01T01:00:00Z",
+            "symbol": "SNX",
+            "open": 10,
+            "high": 11,
+            "low": 9,
+            "close": 10.5,
+            "volume": 100,
+        }
+    ]
+
+    class VenueFeed:
+        async def get_completed_bars(self, symbols, interval, *, lookback_bars):
+            return CompletedBarsView.from_rows(rows)
+
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.execution.preflight._ccxt_missing_markets",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.derived_features.refresh_derived_features_if_stale",
+        lambda *args, **kwargs: {"refreshed": False},
+    )
+
+    result = build_live_dataset(
+        job.id,
+        days=1,
+        store=store,
+        adapters={"hyperliquid": SimpleNamespace(feed=VenueFeed())},
+        incremental=False,
+    )
+
+    assert result["metadata"]["label_convention"] == "close_time"
 
 
 def test_cli_fetch_dataset_source_option(monkeypatch) -> None:

--- a/wayfinder_paths/tests/test_execution_contract.py
+++ b/wayfinder_paths/tests/test_execution_contract.py
@@ -102,6 +102,11 @@ def test_completed_bars_view_truncates_future_bars() -> None:
     assert len(view.through(1).to_frame()) == 2
 
 
+def test_prepared_dataset_rejects_open_time_provenance() -> None:
+    with pytest.raises(ValueError, match="label_convention.*close_time"):
+        PreparedExecutionDataset.from_rows(_bars(), {"label_convention": "open_time"})
+
+
 def test_bracket_engine_uses_high_low_for_long_and_short() -> None:
     bar = {"open": 10, "high": 12, "low": 8, "close": 11}
 
@@ -264,7 +269,15 @@ def test_job_backtest_and_validate_write_artifacts(tmp_path: Path) -> None:
     root = store.job_dir(job.id)
     _write_strategy(root / "workspace" / "src" / "strategy.py")
     bars_path = root / "results" / "backtest" / "input_bars.json"
-    bars_path.write_text(json.dumps(_bars()), encoding="utf-8")
+    bars_path.write_text(
+        json.dumps(
+            {
+                "bars": _bars(),
+                "metadata": {"label_convention": "close_time"},
+            }
+        ),
+        encoding="utf-8",
+    )
 
     result = backtest_execution_job(job.id, store=store)
     validation = validate_execution_job(job.id, strict=True, store=store)
@@ -437,7 +450,6 @@ def _patch_engine_price_alignment(monkeypatch) -> None:
     monkeypatch.setattr(
         "wayfinder_paths.mcp.tools.hyperliquid._resolve_asset", fake_resolve
     )
-
 
 
 @pytest.mark.asyncio

--- a/wayfinder_paths/tests/test_execution_hyperliquid_prediction.py
+++ b/wayfinder_paths/tests/test_execution_hyperliquid_prediction.py
@@ -60,10 +60,10 @@ def test_candles_to_completed_view_parses_ms_epochs_correctly() -> None:
     """Real HL candle rows carry ms-int close times; they must parse as 2026
     dates, not 1970 (pd.to_datetime without unit= reads ints as ns)."""
     from wayfinder_paths.jobs.execution.hyperliquid import (
-        _candles_to_completed_view,
+        hyperliquid_candles_to_completed_view,
     )
 
-    view = _candles_to_completed_view("#1730", _candles(3))
+    view = hyperliquid_candles_to_completed_view("#1730", _candles(3))
     frame = view.to_frame()
 
     assert frame["timestamp"].dt.year.min() == 2026

--- a/wayfinder_paths/tests/test_jobs_derived_features.py
+++ b/wayfinder_paths/tests/test_jobs_derived_features.py
@@ -10,7 +10,8 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from wayfinder_paths.jobs.derived_features import derive_features_job
+from wayfinder_paths.core.clients.HyperliquidDataClient import HyperliquidDataClient
+from wayfinder_paths.jobs.derived_features import _native_hl_closes, derive_features_job
 from wayfinder_paths.jobs.execution.primitives import ExecutionSpec
 from wayfinder_paths.jobs.models import WayfinderJob
 from wayfinder_paths.jobs.store import JobStore
@@ -65,6 +66,31 @@ def _fake_fetch(coin: str, start_ms: int, end_ms: int) -> pd.Series:
     )
     values = [50_000 + i for i in range(len(stamps))]
     return pd.Series(values, index=stamps, dtype=float)
+
+
+def test_native_hl_closes_are_indexed_by_completion_time(monkeypatch) -> None:
+    open_ms = 1_767_225_600_000
+    close_ms = open_ms + 300_000 - 1
+
+    async def fake_candles(self, coin, start_ms, end_ms, interval):
+        return [
+            {
+                "t": open_ms,
+                "T": close_ms,
+                "o": "100",
+                "h": "102",
+                "l": "99",
+                "c": "101",
+                "v": "10",
+            }
+        ]
+
+    monkeypatch.setattr(HyperliquidDataClient, "get_candles", fake_candles)
+
+    closes = _native_hl_closes("BTC", open_ms, close_ms)
+
+    assert closes.index.tolist() == [pd.Timestamp(close_ms, unit="ms", tz="UTC")]
+    assert closes.iloc[0] == 101.0
 
 
 def test_derive_features_appends_and_dedupes(tmp_path: Path) -> None:

--- a/wayfinder_paths/tests/test_jobs_gating.py
+++ b/wayfinder_paths/tests/test_jobs_gating.py
@@ -36,7 +36,13 @@ def _make_job(
     script.write_text(STRATEGY.lstrip(), encoding="utf-8")
     (root / "results" / "backtest").mkdir(parents=True, exist_ok=True)
     (root / "results" / "backtest" / "input_bars.json").write_text(
-        json.dumps(_bars()), encoding="utf-8"
+        json.dumps(
+            {
+                "bars": _bars(),
+                "metadata": {"label_convention": "close_time"},
+            }
+        ),
+        encoding="utf-8",
     )
     return store, job.id, root
 
@@ -68,6 +74,40 @@ def test_gate_fails_without_artifacts(tmp_path: Path) -> None:
     assert "validation" in joined
     assert "backtest" in joined
     assert "preflight" in joined
+
+
+def test_jobs_v1_validation_requires_close_time_dataset_provenance(
+    tmp_path: Path,
+) -> None:
+    store, job_id, root = _make_job(tmp_path)
+    bars_path = root / "results" / "backtest" / "input_bars.json"
+    bars_path.write_text(json.dumps(_bars()), encoding="utf-8")
+
+    report = validate_execution_job(job_id, store=store)
+
+    check = next(
+        item for item in report["checks"] if item["name"] == "dataset_close_time_labels"
+    )
+    assert check["passed"] is False
+    assert check["blocking"] is True
+    assert report["status"] == "failed"
+
+
+def test_validation_grandfathers_legacy_live_fetch_provenance(tmp_path: Path) -> None:
+    store, job_id, root = _make_job(tmp_path)
+    bars_path = root / "results" / "backtest" / "input_bars.json"
+    bars_path.write_text(
+        json.dumps({"bars": _bars(), "metadata": {"source": "live_fetch"}}),
+        encoding="utf-8",
+    )
+
+    report = validate_execution_job(job_id, store=store)
+
+    check = next(
+        item for item in report["checks"] if item["name"] == "dataset_close_time_labels"
+    )
+    assert check["passed"] is True
+    assert "legacy live_fetch" in check["note"]
 
 
 def test_gate_fails_when_workspace_changes_after_backtest(tmp_path: Path) -> None:

--- a/wayfinder_paths/tests/test_jobs_strategies_pipeline.py
+++ b/wayfinder_paths/tests/test_jobs_strategies_pipeline.py
@@ -110,7 +110,13 @@ def _make_bundle(
     )
     (root / "results" / "backtest").mkdir(parents=True, exist_ok=True)
     (root / "results" / "backtest" / "input_bars.json").write_text(
-        json.dumps(_bars(config["closes"], config["symbol"])), encoding="utf-8"
+        json.dumps(
+            {
+                "bars": _bars(config["closes"], config["symbol"]),
+                "metadata": {"label_convention": "close_time"},
+            }
+        ),
+        encoding="utf-8",
     )
     return store, job, root
 


### PR DESCRIPTION
## Summary
- normalize derived Hyperliquid closes through the same completed-bar mapper used by live venue feeds
- stamp close-time provenance on both venue and CCXT dataset builds
- reject explicitly open-labeled datasets and block unstamped hand-built jobs_v1 datasets at validation
- grandfather legacy live_fetch datasets until their next refresh so active jobs do not wedge

## Validation
- 108 affected execution, ingestion, feature, gating, and strategy tests passed
- 37 evolution campaign tests passed (one unrelated wall-clock pricing-window test excluded)
- ruff format/check passed for all touched files
- focused mypy was attempted; the repository has existing missing-stub and unrelated baseline errors
