### PR TITLE
Make evolution CPU pauses targeted and recoverable

### DIFF
--- a/wayfinder_paths/core/clients/ScheduledJobsClient.py
+++ b/wayfinder_paths/core/clients/ScheduledJobsClient.py
@@ -30,7 +30,7 @@ class ScheduledJobsClient:
             hdrs["X-API-KEY"] = api_key
         return hdrs
 
-    def bulk_sync(self, jobs: list[dict[str, Any]]) -> None:
+    def bulk_sync(self, jobs: list[dict[str, Any]]) -> dict[str, Any] | None:
         try:
             resp = self._client.post(
                 f"{self._base_url()}/sync/",
@@ -38,8 +38,11 @@ class ScheduledJobsClient:
                 headers=self._headers(),
             )
             resp.raise_for_status()
+            payload = resp.json()
+            return payload if isinstance(payload, dict) else None
         except Exception:
             logger.opt(exception=True).warning("Failed to bulk-sync jobs to backend")
+            return None
 
     def report_run(self, job_name: str, run_data: dict[str, Any]) -> None:
         try:

--- a/wayfinder_paths/jobs/execution/op_process.py
+++ b/wayfinder_paths/jobs/execution/op_process.py
@@ -40,7 +40,7 @@ def op_runner_command(op: str) -> list[str]:
     ]
 
 
-def _proc_start_ticks(pid: int) -> int | None:
+def proc_start_ticks(pid: int) -> int | None:
     try:
         fields = (
             Path(f"/proc/{pid}/stat").read_text(encoding="utf-8").rsplit(") ", 1)[1]
@@ -48,6 +48,24 @@ def _proc_start_ticks(pid: int) -> int | None:
         return int(fields.split()[19])
     except (OSError, IndexError, ValueError):
         return None
+
+
+def proc_parent_pid(pid: int) -> int | None:
+    try:
+        fields = (
+            Path(f"/proc/{pid}/stat").read_text(encoding="utf-8").rsplit(") ", 1)[1]
+        )
+        return int(fields.split()[1])
+    except (OSError, IndexError, ValueError):
+        return None
+
+
+def pid_is_op_runner(pid: int) -> bool:
+    try:
+        parts = Path(f"/proc/{pid}/cmdline").read_bytes().rstrip(b"\0").split(b"\0")
+    except OSError:
+        return False
+    return _RUNNER_MODULE.encode() in parts
 
 
 def _pid_alive(pid: Any) -> bool:
@@ -66,7 +84,7 @@ def _pid_matches_runner(pid: int, op: str, start_ticks: int) -> bool:
     except OSError:
         return False
     return (
-        _proc_start_ticks(pid) == start_ticks
+        proc_start_ticks(pid) == start_ticks
         and b"wayfinder_paths.jobs.execution.op_runner" in parts
         and f"--op-name={op}".encode() in parts
     )
@@ -85,7 +103,7 @@ def track_evolution_process(op: str, kwargs: dict[str, Any]) -> Iterator[None]:
 
     store = JobStore()
     campaign_id = str(campaign_status(store, job_id).get("campaign_id") or "").strip()
-    process_start_ticks = _proc_start_ticks(os.getpid())
+    process_start_ticks = proc_start_ticks(os.getpid())
     if not campaign_id or process_start_ticks is None:
         yield
         return

--- a/wayfinder_paths/jobs/isolated_phase.py
+++ b/wayfinder_paths/jobs/isolated_phase.py
@@ -2,15 +2,25 @@
 
 from __future__ import annotations
 
+import json
 import multiprocessing
 import os
 import signal
+import sys
 import time
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 from wayfinder_paths.jobs.compute_lock import ComputeLockBusy
+from wayfinder_paths.jobs.execution.op_process import pid_is_op_runner, proc_start_ticks
 from wayfinder_paths.jobs.failures import TransientInfrastructureError, classify_failure
+from wayfinder_paths.runner.monitor_state import atomic_write_json
+
+GOVERNOR_STATE_PATH = Path("/tmp/wayfinder-burst-governor.json")
+HEAVY_OP_REGISTRY_DIR = Path("/tmp/wayfinder-heavy-ops")
+GOVERNOR_STATE_MAX_AGE_SECONDS = 10.0
+HEARTBEAT_SECONDS = 60.0
 
 
 def run_isolated_phase(
@@ -31,15 +41,61 @@ def run_isolated_phase(
     context = multiprocessing.get_context("fork")
     receiver, sender = context.Pipe(duplex=False)
     process = context.Process(target=_child_entry, args=(sender, target, args))
-    process.start()
+    registration = _register_starting_supervisor()
+    try:
+        process.start()
+        if registration is not None and process.pid:
+            _update_registration(registration, child_pid=process.pid)
+    except Exception:
+        _remove_registration(registration)
+        raise
     sender.close()
     deadline = time.monotonic() + timeout_s
     rss_limit = max_rss_mb or float(
         os.environ.get("WAYFINDER_EVOLUTION_PHASE_MAX_RSS_MB", "1700")
     )
     payload: dict[str, Any] | None = None
+    paused = False
+    paused_total_s = 0.0
+    stale_pause_s = 0.0
+    last_sample = time.monotonic()
+    last_heartbeat = last_sample - HEARTBEAT_SECONDS
     try:
-        while time.monotonic() < deadline:
+        while True:
+            now = time.monotonic()
+            elapsed = max(0.0, now - last_sample)
+            pause_state = _governor_pause_state(process.pid)
+            if paused:
+                deadline += elapsed
+                paused_total_s += elapsed
+                stale_pause_s = stale_pause_s + elapsed if pause_state is None else 0.0
+                if pause_state is False:
+                    paused = False
+                elif stale_pause_s > GOVERNOR_STATE_MAX_AGE_SECONDS:
+                    _resume(process.pid)
+                    _kill(process.pid)
+                    raise TransientInfrastructureError(
+                        "burst governor state went stale while evolution was paused"
+                    )
+            elif pause_state is True:
+                paused = True
+                stale_pause_s = 0.0
+            last_sample = now
+            if now - last_heartbeat >= HEARTBEAT_SECONDS:
+                _heartbeat(
+                    process.pid,
+                    active_s=max(0.0, timeout_s - (deadline - now)),
+                    paused_s=paused_total_s,
+                    paused=paused,
+                )
+                if registration is not None and process.pid:
+                    _update_registration(registration, child_pid=process.pid)
+                last_heartbeat = now
+            if not paused and now >= deadline:
+                _kill(process.pid)
+                raise TransientInfrastructureError(
+                    f"evolution phase timed out after {timeout_s:.0f}s active time"
+                )
             if receiver.poll(1.0):
                 payload = receiver.recv()
                 break
@@ -51,14 +107,12 @@ def run_isolated_phase(
                 raise TransientInfrastructureError(
                     f"evolution phase RSS {rss:.0f}MB exceeded {rss_limit:.0f}MB"
                 )
-        if payload is None and process.is_alive():
-            _kill(process.pid)
-            raise TransientInfrastructureError(
-                f"evolution phase timed out after {timeout_s:.0f}s"
-            )
     finally:
+        if paused:
+            _resume(process.pid)
         process.join(timeout=5)
         receiver.close()
+        _remove_registration(registration)
     if payload is None:
         raise TransientInfrastructureError(
             f"evolution phase exited without a result (exit={process.exitcode})"
@@ -109,3 +163,95 @@ def _kill(pid: int | None) -> None:
         os.kill(pid, signal.SIGKILL)
     except OSError:
         pass
+
+
+def _resume(pid: int | None) -> None:
+    if not pid:
+        return
+    try:
+        os.kill(pid, signal.SIGCONT)
+    except OSError:
+        pass
+
+
+def _registry_dir() -> Path:
+    return Path(
+        os.environ.get("WAYFINDER_HEAVY_OP_REGISTRY_DIR", str(HEAVY_OP_REGISTRY_DIR))
+    )
+
+
+def _register_starting_supervisor() -> Path | None:
+    supervisor_pid = os.getpid()
+    start_ticks = proc_start_ticks(supervisor_pid)
+    if start_ticks is None or not pid_is_op_runner(supervisor_pid):
+        return None
+    path = _registry_dir() / f"{supervisor_pid}-{start_ticks}.json"
+    atomic_write_json(
+        path,
+        {
+            "schema_version": "1.0",
+            "state": "starting",
+            "supervisor_pid": supervisor_pid,
+            "supervisor_start_ticks": start_ticks,
+            "updated_at": time.time(),
+        },
+    )
+    os.chmod(path, 0o600)
+    return path
+
+
+def _update_registration(path: Path, *, child_pid: int) -> None:
+    supervisor_ticks = proc_start_ticks(os.getpid())
+    child_ticks = proc_start_ticks(child_pid)
+    if supervisor_ticks is None or child_ticks is None:
+        return
+    atomic_write_json(
+        path,
+        {
+            "schema_version": "1.0",
+            "state": "running",
+            "supervisor_pid": os.getpid(),
+            "supervisor_start_ticks": supervisor_ticks,
+            "child_pid": child_pid,
+            "child_start_ticks": child_ticks,
+            "updated_at": time.time(),
+        },
+    )
+    os.chmod(path, 0o600)
+
+
+def _remove_registration(path: Path | None) -> None:
+    if path is None:
+        return
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def _governor_pause_state(pid: int | None) -> bool | None:
+    """Return whether this exact child is paused; ``None`` means stale/absent."""
+    if not pid:
+        return False
+    path = Path(os.environ.get("WAYFINDER_BURST_STATE_PATH", str(GOVERNOR_STATE_PATH)))
+    try:
+        state = json.loads(path.read_text(encoding="utf-8"))
+        age = max(0.0, time.time() - float(state["updated_at"]))
+    except (OSError, KeyError, TypeError, ValueError):
+        return None
+    if not isinstance(state, dict) or age > GOVERNOR_STATE_MAX_AGE_SECONDS:
+        return None
+    affected = state.get("affected_pids")
+    return bool(state.get("paused")) and isinstance(affected, list) and pid in affected
+
+
+def _heartbeat(
+    pid: int | None, *, active_s: float, paused_s: float, paused: bool
+) -> None:
+    print(
+        "evolution phase heartbeat "
+        f"child={pid or 0} active_s={active_s:.0f} paused_s={paused_s:.0f} "
+        f"state={'paused' if paused else 'running'}",
+        file=sys.stderr,
+        flush=True,
+    )

--- a/wayfinder_paths/jobs/resource_envelope.py
+++ b/wayfinder_paths/jobs/resource_envelope.py
@@ -43,14 +43,10 @@ def require_evolution_headroom() -> dict[str, Any]:
     min_available = float(
         os.environ.get("WAYFINDER_EVOLUTION_MIN_AVAILABLE_MB", "1100")
     )
-    max_steal = float(os.environ.get("WAYFINDER_EVOLUTION_MAX_STEAL_PCT", "90"))
     available = snapshot.get("mem_available_mb")
-    steal = snapshot.get("cpu_steal_pct")
     reasons = []
     if isinstance(available, (int, float)) and available < min_available:
         reasons.append(f"MemAvailable {available:.0f}MB < {min_available:.0f}MB")
-    if isinstance(steal, (int, float)) and steal > max_steal:
-        reasons.append(f"CPU steal {steal:.1f}% > {max_steal:.1f}%")
     if reasons:
         raise TransientInfrastructureError(
             "evolution resource guard deferred heavy compute: " + "; ".join(reasons)
@@ -85,6 +81,9 @@ def evolution_launch_readiness(*, now: datetime | None = None) -> dict[str, Any]
         "ready": ready,
         "source": "governor",
         "balance_pct": state.get("balance_pct"),
+        "balance_cpu_seconds": state.get("balance_cpu_seconds"),
+        "capacity_cpu_seconds": state.get("capacity_cpu_seconds"),
+        "budget_source": state.get("source"),
         "paused": bool(state.get("paused")),
         "age_seconds": round(age, 1),
     }

--- a/wayfinder_paths/jobs/watchdog.py
+++ b/wayfinder_paths/jobs/watchdog.py
@@ -1282,6 +1282,63 @@ _CAMPAIGN_BOOTSTRAP_GRACE = timedelta(minutes=15)
 # during finalize backtests.
 _FINALIZE_LOG_FRESH = timedelta(minutes=10)
 _FINALIZE_EXTEND_MARKER = "state/evolution_finalize_extend.json"
+_BURST_STATE_PATH = "/tmp/wayfinder-burst-governor.json"
+_HEAVY_OP_REGISTRY_DIR = "/tmp/wayfinder-heavy-ops"
+_BURST_STATE_MAX_AGE_S = 10.0
+
+
+def _op_governor_paused(job_dir: Path, op: str, now: datetime) -> bool:
+    """True only when fresh governor state names this op or its heavy child."""
+    from wayfinder_paths.jobs.execution.op_process import (
+        proc_parent_pid,
+        proc_start_ticks,
+    )
+
+    try:
+        status = json.loads(
+            (job_dir / "state" / "background_ops" / f"{op}.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        op_pid = status.get("pid")
+        if not isinstance(op_pid, int) or status.get("state") != "running":
+            return False
+        state_path = Path(
+            os.environ.get("WAYFINDER_BURST_STATE_PATH", _BURST_STATE_PATH)
+        )
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        age = max(0.0, now.timestamp() - float(state["updated_at"]))
+        affected = state.get("affected_pids")
+        if (
+            age > _BURST_STATE_MAX_AGE_S
+            or not bool(state.get("paused"))
+            or not isinstance(affected, list)
+        ):
+            return False
+        if op_pid in affected:
+            return True
+        registry_dir = Path(
+            os.environ.get("WAYFINDER_HEAVY_OP_REGISTRY_DIR", _HEAVY_OP_REGISTRY_DIR)
+        )
+        for path in registry_dir.glob("*.json"):
+            try:
+                record = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, TypeError, ValueError):
+                continue
+            child_pid = record.get("child_pid") if isinstance(record, dict) else None
+            if (
+                isinstance(record, dict)
+                and record.get("supervisor_pid") == op_pid
+                and record.get("supervisor_start_ticks") == proc_start_ticks(op_pid)
+                and isinstance(child_pid, int)
+                and child_pid in affected
+                and record.get("child_start_ticks") == proc_start_ticks(child_pid)
+                and proc_parent_pid(child_pid) == op_pid
+            ):
+                return True
+    except (OSError, TypeError, ValueError, KeyError):
+        return False
+    return False
 
 
 def _finalize_op_health(job_dir: Path, now: datetime) -> tuple[int | None, bool]:
@@ -1300,8 +1357,10 @@ def _finalize_op_health(job_dir: Path, now: datetime) -> tuple[int | None, bool]
     try:
         log_age = now.timestamp() - (ops_dir / "evolution_finalize.log").stat().st_mtime
     except OSError:
-        return pid, False
-    return pid, log_age < _FINALIZE_LOG_FRESH.total_seconds()
+        return pid, _op_governor_paused(job_dir, "evolution_finalize", now)
+    return pid, log_age < _FINALIZE_LOG_FRESH.total_seconds() or _op_governor_paused(
+        job_dir, "evolution_finalize", now
+    )
 
 
 def _reap_finalize_group(pid: int | None) -> bool:
@@ -1448,9 +1507,10 @@ def _run_evolution_campaign_pass(
         }
 
     evaluating = op_status_summary(store.job_dir(job_id), "evolution_evaluate")
-    if (evaluating or {}).get(
-        "status"
-    ) == "running" and now - deadline < _CAMPAIGN_EVALUATE_DRAIN_GRACE:
+    if (evaluating or {}).get("status") == "running" and (
+        now - deadline < _CAMPAIGN_EVALUATE_DRAIN_GRACE
+        or _op_governor_paused(store.job_dir(job_id), "evolution_evaluate", now)
+    ):
         return {
             "action": "evolution_campaign_waiting_for_evaluation",
             "campaign_id": state.get("campaign_id"),

--- a/wayfinder_paths/runner/burst.py
+++ b/wayfinder_paths/runner/burst.py
@@ -1,61 +1,72 @@
-"""Estimate the machine's shared-CPU burst-credit balance so the runner can
-postpone background jobs *before* the balance hits zero and the whole machine
-gets throttled to its baseline share (after which every request — including the
-interactive agent — crawls).
+"""Consume the image CPU-budget governor, with a conservative local fallback.
 
-A shared-CPU machine gets a small guaranteed baseline (~1/16 core per vCPU) and
-banks unused time as burst credits (capped). Sustained CPU above baseline drains
-the credits; at zero the machine is pinned at baseline. The guest can't read the
-hypervisor's real credit counter, so this integrates ``baseline - observed_burn``
-over time from ``/proc/stat`` — a deliberately conservative proxy.
-
-Off the target platform (no readable ``/proc/stat``) it disables itself and
-never reports "over quota", so gating on it is a safe no-op there.
+On hosted shared-CPU Machines the shell governor is authoritative: it anchors
+its local integrator to Fly telemetry delivered through the authenticated jobs
+sync and publishes a small state file.  The runner only estimates locally when
+that state is absent or stale, so upgrades remain backward compatible.
 """
 
 from __future__ import annotations
 
+import json
+import math
 import os
 import time
 from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
 
-# Fly shared-cpu baseline: 6.25% of a core per vCPU.
+from wayfinder_paths.runner.monitor_state import atomic_write_json
+
 BASELINE_CORES_PER_VCPU = 0.0625
+INITIAL_BALANCE_CPU_S_PER_VCPU = 5.0
+MAX_BALANCE_CPU_S_PER_VCPU = 500.0
+GOVERNOR_STATE_PATH = Path("/tmp/wayfinder-burst-governor.json")
+CPU_BUDGET_ANCHOR_PATH = Path("/tmp/wayfinder-fly-cpu-anchor.json")
+GOVERNOR_STATE_MAX_AGE_SECONDS = 10.0
 
 
 def _read_busy_jiffies() -> int | None:
-    """Aggregate busy CPU jiffies across all cores (user+nice+system+irq+softirq)
-    from the first line of /proc/stat. None if unreadable."""
+    """Return aggregate busy CPU jiffies, or ``None`` off Linux."""
     try:
-        with open("/proc/stat") as f:
-            fields = [int(x) for x in f.readline().split()[1:]]
-        # user nice system idle iowait irq softirq ...
+        with open("/proc/stat") as handle:
+            fields = [int(value) for value in handle.readline().split()[1:]]
         return fields[0] + fields[1] + fields[2] + fields[5] + fields[6]
     except (OSError, ValueError, IndexError):
         return None
 
 
 class BurstEstimator:
+    """Guest-only estimate used when the image governor is unavailable."""
+
     def __init__(
         self,
         *,
         cap_cpu_s: float,
         low_water_cpu_s: float,
         baseline_cores: float | None = None,
+        initial_balance_cpu_s: float | None = None,
         clock: Callable[[], float] = time.monotonic,
     ) -> None:
         vcpus = os.cpu_count() or 1
         self._baseline = (
-            baseline_cores if baseline_cores is not None else BASELINE_CORES_PER_VCPU * vcpus
+            baseline_cores
+            if baseline_cores is not None
+            else BASELINE_CORES_PER_VCPU * vcpus
         )
         self._cap = float(cap_cpu_s)
         self._low_water = float(low_water_cpu_s)
         self._clock = clock
         self._hz = os.sysconf("SC_CLK_TCK") if hasattr(os, "sysconf") else 100
-        self._balance = float(cap_cpu_s)  # optimistic start; converges within minutes
+        initial = (
+            INITIAL_BALANCE_CPU_S_PER_VCPU * vcpus
+            if initial_balance_cpu_s is None
+            else initial_balance_cpu_s
+        )
+        self._balance = min(self._cap, max(0.0, float(initial)))
         self._last_jiffies = _read_busy_jiffies()
         self._last_t = clock()
-        # Disabled when /proc/stat can't be read (non-Linux, sandbox) → no-op.
         self._enabled = self._last_jiffies is not None
 
     @property
@@ -66,21 +77,172 @@ class BurstEstimator:
     def balance(self) -> float:
         return self._balance
 
+    @property
+    def capacity(self) -> float:
+        return self._cap
+
     def update(self) -> None:
-        """Advance the estimate. Call once per tick."""
         if not self._enabled:
             return
         jiffies = _read_busy_jiffies()
         now = self._clock()
-        dt = now - self._last_t
-        if jiffies is None or self._last_jiffies is None or dt <= 0:
+        elapsed = now - self._last_t
+        if jiffies is None or self._last_jiffies is None or elapsed <= 0:
             self._last_jiffies, self._last_t = jiffies, now
             return
-        burn = (jiffies - self._last_jiffies) / self._hz / dt  # core-equivalents
-        self._balance = max(0.0, min(self._cap, self._balance + (self._baseline - burn) * dt))
+        used_cores = (jiffies - self._last_jiffies) / self._hz / elapsed
+        self._balance = max(
+            0.0,
+            min(
+                self._cap,
+                self._balance + (self._baseline - used_cores) * elapsed,
+            ),
+        )
         self._last_jiffies, self._last_t = jiffies, now
 
     def over_quota(self) -> bool:
-        """True when the estimated balance is low enough that launching more
-        background work risks pinning the machine. Always False when disabled."""
         return self._enabled and self._balance < self._low_water
+
+
+def write_cpu_budget_anchor(
+    payload: Any,
+    *,
+    path: Path = CPU_BUDGET_ANCHOR_PATH,
+    received_at: float | None = None,
+) -> bool:
+    """Validate and atomically publish the backend's narrow Fly projection."""
+    if not isinstance(payload, dict):
+        return False
+    try:
+        balance = float(payload["balance_cpu_seconds"])
+        throttle = float(payload["throttle_total_seconds"])
+        baseline = float(payload["baseline_cores"])
+        observed_text = str(payload["observed_at"])
+        observed = datetime.fromisoformat(observed_text)
+        if observed.tzinfo is None:
+            observed = observed.replace(tzinfo=UTC)
+        observed_timestamp = observed.timestamp()
+        received_timestamp = time.time() if received_at is None else float(received_at)
+    except (KeyError, TypeError, ValueError, OverflowError):
+        return False
+    if not all(
+        math.isfinite(value)
+        for value in (
+            balance,
+            throttle,
+            baseline,
+            observed_timestamp,
+            received_timestamp,
+        )
+    ):
+        return False
+    if balance < 0 or throttle < 0 or baseline <= 0:
+        return False
+    atomic_write_json(
+        path,
+        {
+            "schema_version": "1.0",
+            "balance_cpu_seconds": balance,
+            "throttle_total_seconds": throttle,
+            "baseline_cores": baseline,
+            "observed_at": observed.isoformat(),
+            "received_at": received_timestamp,
+        },
+    )
+    os.chmod(path, 0o600)
+    return True
+
+
+class BurstBudget:
+    """Runner admission view over fresh governor state or local estimation."""
+
+    def __init__(
+        self,
+        fallback: BurstEstimator,
+        *,
+        state_path: Path = GOVERNOR_STATE_PATH,
+        wall_clock: Callable[[], float] = time.time,
+    ) -> None:
+        self._fallback = fallback
+        self._state_path = state_path
+        self._wall_clock = wall_clock
+
+    def _state(self) -> tuple[dict[str, Any], float] | None:
+        try:
+            state = json.loads(self._state_path.read_text(encoding="utf-8"))
+            age = max(0.0, self._wall_clock() - float(state["updated_at"]))
+        except (OSError, KeyError, TypeError, ValueError):
+            return None
+        if not isinstance(state, dict) or age > GOVERNOR_STATE_MAX_AGE_SECONDS:
+            return None
+        return state, age
+
+    @staticmethod
+    def _governor_balance(state: dict[str, Any], capacity: float) -> float:
+        raw = state.get("balance_cpu_seconds")
+        if isinstance(raw, (int, float)) and math.isfinite(float(raw)):
+            return max(0.0, float(raw))
+        percent = state.get("balance_pct")
+        if isinstance(percent, (int, float)) and math.isfinite(float(percent)):
+            return max(0.0, float(percent)) / 100.0 * capacity
+        return 0.0
+
+    @property
+    def balance(self) -> float:
+        current = self._state()
+        if current is None:
+            return self._fallback.balance
+        state, _ = current
+        capacity = float(state.get("capacity_cpu_seconds") or self._fallback.capacity)
+        return self._governor_balance(state, capacity)
+
+    def update(self) -> None:
+        if self._state() is None:
+            self._fallback.update()
+
+    def over_quota(self) -> bool:
+        current = self._state()
+        if current is None:
+            return self._fallback.over_quota()
+        state, _ = current
+        return bool(state.get("paused")) or state.get("allow_new_heavy") is not True
+
+    def snapshot(self) -> dict[str, Any]:
+        current = self._state()
+        if current is None:
+            capacity = self._fallback.capacity
+            return {
+                "source": "local_estimator" if self._fallback.enabled else "disabled",
+                "balance_cpu_seconds": round(self._fallback.balance, 3),
+                "capacity_cpu_seconds": capacity,
+                "balance_pct": round(self._fallback.balance / capacity * 100, 2)
+                if capacity > 0
+                else None,
+                "allow_new_heavy": not self._fallback.over_quota(),
+            }
+        state, age = current
+        capacity = float(state.get("capacity_cpu_seconds") or self._fallback.capacity)
+        result = {
+            key: state.get(key)
+            for key in (
+                "schema_version",
+                "source",
+                "balance_pct",
+                "allow_new_heavy",
+                "budget_low",
+                "paused",
+                "affected_pids",
+                "anchor_age_seconds",
+                "throttle_total_seconds",
+            )
+        }
+        result.update(
+            {
+                "state_age_seconds": round(age, 2),
+                "balance_cpu_seconds": round(
+                    self._governor_balance(state, capacity), 3
+                ),
+                "capacity_cpu_seconds": capacity,
+            }
+        )
+        return result

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -22,7 +22,13 @@ from wayfinder_paths import __version__
 from wayfinder_paths.core.clients.OpenCodeClient import OPENCODE_CLIENT
 from wayfinder_paths.core.clients.ScheduledJobsClient import SCHEDULED_JOBS_CLIENT
 from wayfinder_paths.core.config import is_opencode_instance
-from wayfinder_paths.runner.burst import BurstEstimator
+from wayfinder_paths.runner.burst import (
+    INITIAL_BALANCE_CPU_S_PER_VCPU,
+    MAX_BALANCE_CPU_S_PER_VCPU,
+    BurstBudget,
+    BurstEstimator,
+    write_cpu_budget_anchor,
+)
 from wayfinder_paths.runner.constants import (
     JOB_TYPE_SCRIPT,
     JOB_TYPE_STRATEGY,
@@ -47,8 +53,9 @@ JOB_RESULT_MARKER = "WAYFINDER_JOB_RESULT "
 # the worst-case cost of a single in-flight job so one already-running job can't
 # overshoot the budget to zero (validated in the docker burst-lab); max-postpone
 # bounds starvation so a due job can't be held behind a permanent backlog.
-BURST_CAP_CPU_S = 500.0
-BURST_LOW_WATER_CPU_S = 120.0
+_VCPUS = os.cpu_count() or 1
+BURST_CAP_CPU_S = MAX_BALANCE_CPU_S_PER_VCPU * _VCPUS
+BURST_LOW_WATER_CPU_S = 0.35 * BURST_CAP_CPU_S
 BURST_MAX_POSTPONE_S = 600.0
 # Short starvation floor for trading-adjacent work (paper script ticks,
 # indeterminate-mode jobs) so a drain episode can't hold them for the full
@@ -399,8 +406,12 @@ class RunnerDaemon:
         # a real burst budget. Elsewhere (dev, local runs) the /proc estimate is
         # meaningless, so leave jobs ungated.
         self._burst = (
-            BurstEstimator(
-                cap_cpu_s=BURST_CAP_CPU_S, low_water_cpu_s=BURST_LOW_WATER_CPU_S
+            BurstBudget(
+                BurstEstimator(
+                    cap_cpu_s=BURST_CAP_CPU_S,
+                    low_water_cpu_s=BURST_LOW_WATER_CPU_S,
+                    initial_balance_cpu_s=INITIAL_BALANCE_CPU_S_PER_VCPU * _VCPUS,
+                )
             )
             if burst_admission and is_opencode_instance()
             else None
@@ -800,7 +811,8 @@ class RunnerDaemon:
                     )
             finally:
                 db.close()
-            SCHEDULED_JOBS_CLIENT.bulk_sync(jobs)
+            response = SCHEDULED_JOBS_CLIENT.bulk_sync(jobs)
+            write_cpu_budget_anchor((response or {}).get("cpu_budget"))
 
             # 2. Wayfinder-jobs snapshot (per-mode session ids for the
             #    Conversations panel, proposals, and the reconciled
@@ -1152,6 +1164,9 @@ class RunnerDaemon:
                 "sock_path": str(self._paths.sock_path),
                 "running_workers": len(self._running),
                 "max_workers": self._max_workers,
+                "burst_budget": self._burst.snapshot()
+                if self._burst is not None
+                else {"source": "disabled"},
                 "jobs": self._db.list_jobs(),
                 "recent_runs": self._db.last_runs(limit=20),
             },

--- a/wayfinder_paths/tests/test_jobs_apply_watchdog.py
+++ b/wayfinder_paths/tests/test_jobs_apply_watchdog.py
@@ -19,6 +19,7 @@ from wayfinder_paths.jobs.models import WayfinderJob, utc_now_iso
 from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.jobs.watchdog import (
     WATCHDOG_RUNNER_JOB_NAME,
+    _op_governor_paused,
     _run_evolution_campaign_pass,
     ensure_application_watchdog,
     recover_stalled_applications,
@@ -1277,6 +1278,123 @@ def _finalizing_campaign(
     log = ops / "evolution_finalize.log"
     log.write_text("[backtest] bar 100/27648 · 12 bars/s\n", encoding="utf-8")
     return log
+
+
+def _write_governor_pause(
+    path: Path, *, now: datetime, affected_pids: list[int], age_s: float = 0
+) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "updated_at": now.timestamp() - age_s,
+                "paused": True,
+                "affected_pids": affected_pids,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_watchdog_waits_for_governor_paused_evaluation_past_drain_grace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "campaign-paused-evaluate")
+    deadline = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    now = deadline + timedelta(minutes=20)
+    store.write_json(
+        job.id,
+        "state/evolution_campaign.json",
+        {
+            "campaign_id": "campaign-1",
+            "status": "active",
+            "stage": "draining",
+            "deadline_at": deadline.isoformat(),
+        },
+    )
+    ops = store.job_dir(job.id) / "state" / "background_ops"
+    ops.mkdir(parents=True, exist_ok=True)
+    (ops / "evolution_evaluate.json").write_text(
+        json.dumps({"state": "running", "pid": os.getpid()}), encoding="utf-8"
+    )
+    governor = tmp_path / "governor.json"
+    _write_governor_pause(governor, now=now, affected_pids=[os.getpid()])
+    monkeypatch.setenv("WAYFINDER_BURST_STATE_PATH", str(governor))
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.worker.retire_evolution_session",
+        lambda *args, **kwargs: pytest.fail("paused evaluation was not awaited"),
+    )
+
+    assert _run_evolution_campaign_pass(store, job.id, now) == {
+        "action": "evolution_campaign_waiting_for_evaluation",
+        "campaign_id": "campaign-1",
+    }
+
+
+def test_governor_pause_requires_fresh_state_and_matching_pid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "campaign-pause-identity")
+    now = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    ops = store.job_dir(job.id) / "state" / "background_ops"
+    ops.mkdir(parents=True, exist_ok=True)
+    (ops / "evolution_evaluate.json").write_text(
+        json.dumps({"state": "running", "pid": os.getpid()}), encoding="utf-8"
+    )
+    governor = tmp_path / "governor.json"
+    monkeypatch.setenv("WAYFINDER_BURST_STATE_PATH", str(governor))
+
+    _write_governor_pause(governor, now=now, affected_pids=[os.getpid()], age_s=11)
+    assert not _op_governor_paused(store.job_dir(job.id), "evolution_evaluate", now)
+    _write_governor_pause(governor, now=now, affected_pids=[os.getpid() + 1])
+    assert not _op_governor_paused(store.job_dir(job.id), "evolution_evaluate", now)
+
+
+def test_watchdog_extends_finalize_while_registered_child_is_paused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "campaign-paused-finalize")
+    deadline = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    now = deadline + timedelta(minutes=61)
+    log = _finalizing_campaign(store, job.id, deadline, pid=os.getpid())
+    os.utime(log, (now.timestamp() - 20 * 60, now.timestamp() - 20 * 60))
+    child_pid = os.getpid() + 1000
+    governor = tmp_path / "governor.json"
+    registry = tmp_path / "heavy"
+    registry.mkdir()
+    (registry / "op.json").write_text(
+        json.dumps(
+            {
+                "supervisor_pid": os.getpid(),
+                "supervisor_start_ticks": 100,
+                "child_pid": child_pid,
+                "child_start_ticks": 200,
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_governor_pause(governor, now=now, affected_pids=[child_pid])
+    monkeypatch.setenv("WAYFINDER_BURST_STATE_PATH", str(governor))
+    monkeypatch.setenv("WAYFINDER_HEAVY_OP_REGISTRY_DIR", str(registry))
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.execution.op_process.proc_start_ticks",
+        lambda pid: 100 if pid == os.getpid() else 200,
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.execution.op_process.proc_parent_pid",
+        lambda pid: os.getpid() if pid == child_pid else None,
+    )
+
+    assert _run_evolution_campaign_pass(store, job.id, now) == {
+        "action": "evolution_finalize_still_running",
+        "campaign_id": "campaign-1",
+        "pid": os.getpid(),
+    }
+    assert store.read_json(job.id, "state/evolution_campaign.json")["status"] == (
+        "finalizing"
+    )
 
 
 def test_watchdog_extends_grace_while_finalize_is_healthy(tmp_path: Path) -> None:

--- a/wayfinder_paths/tests/test_jobs_evolution_campaign.py
+++ b/wayfinder_paths/tests/test_jobs_evolution_campaign.py
@@ -126,7 +126,7 @@ def test_campaign_start_defers_while_intervention_worker_is_busy(
     )
 
     with pytest.raises(TransientInfrastructureError, match="intervention worker"):
-        start_campaign(store, job_id)
+        start_campaign(store, job_id, now=datetime(2026, 8, 25, 19, tzinfo=UTC))
 
     assert campaign_status(store, job_id) == {}
 

--- a/wayfinder_paths/tests/test_jobs_isolated_phase.py
+++ b/wayfinder_paths/tests/test_jobs_isolated_phase.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import json
 import multiprocessing
 import os
+import time
+from pathlib import Path
 
 import pytest
 
+import wayfinder_paths.jobs.isolated_phase as isolated_phase
 from wayfinder_paths.jobs.failures import TransientInfrastructureError
 from wayfinder_paths.jobs.isolated_phase import run_isolated_phase
 
@@ -19,6 +23,11 @@ def _child_failure() -> dict[str, int]:
 
 def _child_transient_failure() -> dict[str, int]:
     raise TransientInfrastructureError("box is saturated")
+
+
+def _sleeping_child(seconds: float) -> dict[str, bool]:
+    time.sleep(seconds)
+    return {"complete": True}
 
 
 def test_isolated_phase_returns_compact_result_from_disposable_child() -> None:
@@ -37,3 +46,60 @@ def test_isolated_phase_preserves_candidate_failure_as_evidence() -> None:
 def test_isolated_phase_preserves_transient_failure_for_retry() -> None:
     with pytest.raises(TransientInfrastructureError, match="box is saturated"):
         run_isolated_phase(_child_transient_failure, timeout_s=10)
+
+
+def test_heavy_child_registration_is_atomic_and_pid_specific(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYFINDER_HEAVY_OP_REGISTRY_DIR", str(tmp_path))
+    monkeypatch.setattr(isolated_phase, "pid_is_op_runner", lambda _pid: True)
+    monkeypatch.setattr(isolated_phase, "proc_start_ticks", lambda pid: pid + 100)
+
+    path = isolated_phase._register_starting_supervisor()
+    assert path is not None
+    isolated_phase._update_registration(path, child_pid=321)
+
+    record = json.loads(path.read_text(encoding="utf-8"))
+    assert record["state"] == "running"
+    assert record["supervisor_pid"] == os.getpid()
+    assert record["child_pid"] == 321
+    assert record["child_start_ticks"] == 421
+    assert path.stat().st_mode & 0o777 == 0o600
+    isolated_phase._remove_registration(path)
+    assert not path.exists()
+
+
+def test_governor_pause_time_does_not_consume_phase_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    if "fork" not in multiprocessing.get_all_start_methods():
+        pytest.skip("pause supervision requires fork")
+    started = time.monotonic()
+    monkeypatch.setattr(
+        isolated_phase,
+        "_governor_pause_state",
+        lambda _pid: time.monotonic() - started < 1.2,
+    )
+
+    result = run_isolated_phase(_sleeping_child, 1.4, timeout_s=0.5)
+
+    assert result == {"complete": True}
+
+
+def test_stale_governor_cannot_strand_a_paused_child(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    if "fork" not in multiprocessing.get_all_start_methods():
+        pytest.skip("pause supervision requires fork")
+    calls = 0
+
+    def pause_then_stale(_pid: int | None) -> bool | None:
+        nonlocal calls
+        calls += 1
+        return True if calls == 1 else None
+
+    monkeypatch.setattr(isolated_phase, "_governor_pause_state", pause_then_stale)
+    monkeypatch.setattr(isolated_phase, "GOVERNOR_STATE_MAX_AGE_SECONDS", 0.1)
+
+    with pytest.raises(TransientInfrastructureError, match="went stale"):
+        run_isolated_phase(_sleeping_child, 5.0, timeout_s=10)

--- a/wayfinder_paths/tests/test_jobs_resource_envelope.py
+++ b/wayfinder_paths/tests/test_jobs_resource_envelope.py
@@ -8,6 +8,7 @@ import pytest
 from wayfinder_paths.jobs.failures import TransientInfrastructureError
 from wayfinder_paths.jobs.resource_envelope import (
     evolution_launch_readiness,
+    require_evolution_headroom,
     require_evolution_launch_headroom,
 )
 
@@ -41,6 +42,34 @@ def test_launch_readiness_uses_fresh_governor_state(tmp_path, monkeypatch) -> No
     assert readiness["balance_pct"] == 12.0
     with pytest.raises(TransientInfrastructureError, match="burst reserve"):
         require_evolution_launch_headroom()
+
+
+def test_launch_readiness_exposes_cpu_second_anchor(tmp_path, monkeypatch) -> None:
+    now = datetime.now(UTC)
+    path = tmp_path / "burst.json"
+    monkeypatch.setenv("WAYFINDER_BURST_STATE_PATH", str(path))
+    _write_state(
+        path,
+        now=now,
+        balance_cpu_seconds=640.0,
+        capacity_cpu_seconds=1000.0,
+        source="fly_anchor",
+    )
+
+    readiness = evolution_launch_readiness(now=now)
+
+    assert readiness["balance_cpu_seconds"] == 640.0
+    assert readiness["capacity_cpu_seconds"] == 1000.0
+    assert readiness["budget_source"] == "fly_anchor"
+
+
+def test_cpu_steal_is_diagnostic_not_a_second_launch_gate(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.resource_envelope.resource_snapshot",
+        lambda **kwargs: {"mem_available_mb": 2000.0, "cpu_steal_pct": 99.0},
+    )
+
+    assert require_evolution_headroom()["cpu_steal_pct"] == 99.0
 
 
 def test_launch_readiness_fails_closed_on_stale_governor_state(

--- a/wayfinder_paths/tests/test_runner_burst.py
+++ b/wayfinder_paths/tests/test_runner_burst.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
+import json
+
 import wayfinder_paths.runner.burst as burst_mod
-from wayfinder_paths.runner.burst import BurstEstimator
+from wayfinder_paths.runner.burst import (
+    BurstBudget,
+    BurstEstimator,
+    write_cpu_budget_anchor,
+)
 
 
 class _Clock:
@@ -62,6 +68,110 @@ def test_over_quota_threshold(monkeypatch):
     assert est.over_quota() is False
     est._balance = 15.0
     assert est.over_quota() is True
+
+
+def test_estimator_starts_conservatively_instead_of_at_capacity(monkeypatch):
+    monkeypatch.setattr(burst_mod, "_read_busy_jiffies", lambda: 0)
+    monkeypatch.setattr(burst_mod.os, "cpu_count", lambda: 2)
+
+    est = BurstEstimator(cap_cpu_s=1000.0, low_water_cpu_s=350.0)
+
+    assert est.balance == 10.0
+
+
+def test_fresh_governor_state_is_authoritative(tmp_path, monkeypatch):
+    state_path = tmp_path / "governor.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "2.0",
+                "updated_at": 1000.0,
+                "source": "fly_anchor",
+                "balance_cpu_seconds": 620.0,
+                "capacity_cpu_seconds": 1000.0,
+                "balance_pct": 62.0,
+                "allow_new_heavy": False,
+                "paused": False,
+                "affected_pids": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(burst_mod, "_read_busy_jiffies", lambda: 0)
+    fallback = BurstEstimator(cap_cpu_s=1000.0, low_water_cpu_s=350.0)
+    budget = BurstBudget(fallback, state_path=state_path, wall_clock=lambda: 1005.0)
+
+    assert budget.balance == 620.0
+    assert budget.over_quota() is True
+    assert budget.snapshot()["source"] == "fly_anchor"
+    assert budget.snapshot()["state_age_seconds"] == 5.0
+
+
+def test_stale_governor_state_falls_back_to_local_estimator(tmp_path, monkeypatch):
+    state_path = tmp_path / "governor.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "updated_at": 900.0,
+                "balance_cpu_seconds": 0.0,
+                "allow_new_heavy": False,
+                "paused": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(burst_mod, "_read_busy_jiffies", lambda: 0)
+    fallback = BurstEstimator(
+        cap_cpu_s=100.0,
+        low_water_cpu_s=20.0,
+        initial_balance_cpu_s=50.0,
+    )
+    budget = BurstBudget(fallback, state_path=state_path, wall_clock=lambda: 1000.0)
+
+    assert budget.balance == 50.0
+    assert budget.over_quota() is False
+    assert budget.snapshot()["source"] == "local_estimator"
+
+
+def test_backend_budget_anchor_is_narrow_atomic_and_private(tmp_path):
+    path = tmp_path / "anchor.json"
+    assert write_cpu_budget_anchor(
+        {
+            "balance_cpu_seconds": 1296.749,
+            "throttle_total_seconds": 784.294,
+            "baseline_cores": 0.25,
+            "observed_at": "2026-08-28T02:11:10+00:00",
+            "ignored": "never persisted",
+        },
+        path=path,
+        received_at=1000.0,
+    )
+
+    assert json.loads(path.read_text(encoding="utf-8")) == {
+        "schema_version": "1.0",
+        "balance_cpu_seconds": 1296.749,
+        "throttle_total_seconds": 784.294,
+        "baseline_cores": 0.25,
+        "observed_at": "2026-08-28T02:11:10+00:00",
+        "received_at": 1000.0,
+    }
+    assert path.stat().st_mode & 0o777 == 0o600
+
+
+def test_invalid_backend_budget_does_not_replace_anchor(tmp_path):
+    path = tmp_path / "anchor.json"
+    path.write_text('{"existing": true}', encoding="utf-8")
+
+    assert not write_cpu_budget_anchor(
+        {
+            "balance_cpu_seconds": -1,
+            "throttle_total_seconds": 0,
+            "baseline_cores": 0.25,
+            "observed_at": "2026-08-28T02:11:10+00:00",
+        },
+        path=path,
+    )
+    assert json.loads(path.read_text(encoding="utf-8")) == {"existing": True}
 
 
 def test_disabled_when_proc_unreadable(monkeypatch):

--- a/wayfinder_paths/tests/test_runner_burst_gate.py
+++ b/wayfinder_paths/tests/test_runner_burst_gate.py
@@ -156,7 +156,7 @@ def test_paper_jobs_v1_tick_gets_short_floor(tmp_path: Path, monkeypatch) -> Non
     assert d._maybe_start_job(job=job, now=1_000, reason="schedule") is not None
 
 
-def test_agent_wake_gets_short_floor_even_when_live(
+def test_scheduled_agent_wake_skips_occurrence_even_past_short_floor(
     tmp_path: Path, monkeypatch
 ) -> None:
     d = _daemon(
@@ -172,7 +172,7 @@ def test_agent_wake_gets_short_floor_even_when_live(
     assert d._maybe_start_job(job=job, now=1_000, reason="schedule") is None
     d._postponed_since[job["id"]] = time.monotonic() - (BURST_SHORT_POSTPONE_S + 1)
     _mock_popen(monkeypatch)
-    assert d._maybe_start_job(job=job, now=1_000, reason="schedule") is not None
+    assert d._maybe_start_job(job=job, now=1_000, reason="schedule") is None
 
 
 def test_indeterminate_mode_defaults_to_short_floor(

--- a/wayfinder_paths/tests/test_runner_sync_debounce.py
+++ b/wayfinder_paths/tests/test_runner_sync_debounce.py
@@ -190,8 +190,21 @@ def test_debounced_fire_runs_both_backend_pushes_together(
 
     bulk_calls: list[list[dict]] = []
     sync_all_calls: list[dict] = []
+    anchor_calls: list[dict] = []
+    budget = {
+        "balance_cpu_seconds": 640.0,
+        "throttle_total_seconds": 12.0,
+        "baseline_cores": 0.25,
+        "observed_at": "2026-08-28T02:11:10+00:00",
+    }
     monkeypatch.setattr(
-        SCHEDULED_JOBS_CLIENT, "bulk_sync", lambda jobs: bulk_calls.append(jobs)
+        SCHEDULED_JOBS_CLIENT,
+        "bulk_sync",
+        lambda jobs: bulk_calls.append(jobs) or {"cpu_budget": budget},
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.runner.daemon.write_cpu_budget_anchor",
+        lambda payload: anchor_calls.append(payload),
     )
     monkeypatch.setattr(
         "wayfinder_paths.jobs.sync.sync_all_jobs",
@@ -205,3 +218,4 @@ def test_debounced_fire_runs_both_backend_pushes_together(
     time.sleep(0.2)
     assert len(bulk_calls) == 1
     assert len(sync_all_calls) == 1
+    assert anchor_calls == [budget]

--- a/wayfinder_paths/tests/test_scheduled_jobs_client.py
+++ b/wayfinder_paths/tests/test_scheduled_jobs_client.py
@@ -35,18 +35,19 @@ def test_bulk_sync_posts_jobs(cloud_env) -> None:
         return httpx.Response(200, json={"synced": 1, "deleted": 0})
 
     c = _make_client(handler)
-    c.bulk_sync(
+    result = c.bulk_sync(
         [{"job_name": "a", "status": "active", "interval_seconds": 60, "payload": {}}]
     )
 
     assert captured["method"] == "POST"
     assert captured["url"] == "https://api.test/opencode/instances/inst-xyz/jobs/sync/"
     assert b"job_name" in captured["body"]
+    assert result == {"synced": 1, "deleted": 0}
 
 
 def test_bulk_sync_swallows_5xx(cloud_env) -> None:
     c = _make_client(lambda _req: httpx.Response(500))
-    c.bulk_sync([{"job_name": "a"}])
+    assert c.bulk_sync([{"job_name": "a"}]) is None
 
 
 def test_report_run_posts_run_data(cloud_env) -> None:


### PR DESCRIPTION
## Summary
- consume fresh shell-governor state and publish backend CPU telemetry anchors during authenticated sync
- register the disposable isolated compute child so the supervisor remains alive and heartbeating
- count evolution phase deadlines in active compute time and fail safely if governor state goes stale mid-pause
- prevent watchdog drain/finalize expiry while the exact operation or validated child is paused
- keep CPU steal diagnostic-only and preserve mixed-version fallback behavior

## Validation
- 1,002 affected jobs/runner tests passed
- focused mypy passed on new and extracted helpers
- ruff check and format passed on all touched files