### PR TITLE
Make evolution stages resumable across restarts

### DIFF
--- a/wayfinder_paths/jobs/background.py
+++ b/wayfinder_paths/jobs/background.py
@@ -9,27 +9,20 @@ parseable result file = done)."""
 from __future__ import annotations
 
 import json
-import os
 import subprocess
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 from wayfinder_paths.jobs.compute_lock import job_state_lock
-from wayfinder_paths.jobs.execution.op_process import op_runner_command
+from wayfinder_paths.jobs.execution.op_process import (
+    op_runner_command,
+    process_identity_fields,
+    recorded_process_alive,
+)
 from wayfinder_paths.jobs.models import utc_now_iso
 from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.runner.monitor_state import atomic_write_json
-
-
-def _pid_alive(pid: Any) -> bool:
-    if not isinstance(pid, int) or pid <= 0:
-        return False
-    try:
-        os.kill(pid, 0)
-    except OSError:
-        return False
-    return True
 
 
 def op_running(job_dir: Path, op: str) -> bool:
@@ -44,7 +37,7 @@ def op_running(job_dir: Path, op: str) -> bool:
     return (
         isinstance(status, dict)
         and status.get("state") == "running"
-        and _pid_alive(status.get("pid"))
+        and recorded_process_alive(status)
     )
 
 
@@ -64,7 +57,7 @@ def op_status_summary(job_dir: Path, op: str) -> dict[str, Any] | None:
     if not isinstance(status, dict):
         return None
     state = status.get("state")
-    stale_running = state == "running" and not _pid_alive(status.get("pid"))
+    stale_running = state == "running" and not recorded_process_alive(status)
     reconciled_failure = state == "failed" and status.get("error") == (
         "detached operation exited without a result"
     )
@@ -110,7 +103,7 @@ def _spawn_detached_op(
     if (
         isinstance(existing, dict)
         and existing.get("state") == "running"
-        and _pid_alive(existing.get("pid"))
+        and recorded_process_alive(existing)
     ):
         return {"already_running": True, **existing}
 
@@ -134,6 +127,7 @@ def _spawn_detached_op(
         "state": "running",
         "pid": proc.pid,
         "started_at": utc_now_iso(),
+        **process_identity_fields(proc.pid),
     }
     atomic_write_json(status_path, status)
     return {"started": True, **status}

--- a/wayfinder_paths/jobs/evolution_campaign.py
+++ b/wayfinder_paths/jobs/evolution_campaign.py
@@ -714,6 +714,18 @@ def finalize_campaign(store: JobStore, job_id: str) -> dict[str, Any]:
 
 
 def _finalize_campaign(store: JobStore, job_id: str) -> dict[str, Any]:
+    with job_state_lock(store.repo_root, job_id, name="evolution_campaign"):
+        state = campaign_status(store, job_id)
+        pending = [
+            str(candidate.get("candidate_id") or "")
+            for candidate in state.get("candidates") or []
+            if candidate.get("status") in {"prepared", "quick_failed", "quick_running"}
+        ]
+    if pending:
+        raise TransientInfrastructureError(
+            "candidate evaluation must finish before finalization: "
+            + ", ".join(candidate_id for candidate_id in pending if candidate_id)
+        )
     while True:
         claimed = _claim_full_dev(store, job_id)
         if claimed is None:
@@ -1112,6 +1124,55 @@ def _release_finalize_claim(
         _save_campaign(store, job_id, state)
 
 
+def recover_lost_candidate_evaluations(
+    store: JobStore,
+    job_id: str,
+    *,
+    reason: str,
+    now: datetime | None = None,
+) -> list[str]:
+    """Release evaluator claims after their detached owner disappears.
+
+    Candidate bundles are durable, so a fresh stage can safely relaunch the
+    low-fidelity evaluation. The watchdog calls this only after independently
+    proving that no evaluator process is running.
+    """
+    recovered: list[str] = []
+    recovered_at = _aware(now or datetime.now(UTC)).isoformat()
+    with job_state_lock(store.repo_root, job_id, name="evolution_campaign"):
+        state = campaign_status(store, job_id)
+        if state.get("status") not in {"active", "finalizing"}:
+            return recovered
+        for candidate in state.get("candidates") or []:
+            if candidate.get("status") != "quick_running":
+                continue
+            candidate_id = str(candidate.get("candidate_id") or "")
+            candidate.update(
+                {
+                    "status": "quick_failed",
+                    "evaluation_recovered_at": recovered_at,
+                    "evaluation_recovery_reason": reason[:300],
+                }
+            )
+            candidate.pop("evaluation_claim_id", None)
+            candidate.pop("evaluation_claimed_at", None)
+            if candidate_id:
+                recovered.append(candidate_id)
+        if recovered:
+            _save_campaign(store, job_id, state)
+    for candidate_id in recovered:
+        store.append_journal(
+            job_id,
+            {
+                "type": "evolution_candidate_evaluation_recovered",
+                "campaign_id": state.get("campaign_id"),
+                "candidate_id": candidate_id,
+                "reason": reason[:300],
+            },
+        )
+    return recovered
+
+
 def campaign_prompt_block(
     store: JobStore, job_id: str, *, now: datetime | None = None
 ) -> dict[str, Any] | None:
@@ -1129,65 +1190,83 @@ def campaign_prompt_block(
         }
     current = _aware(now or datetime.now(UTC))
     deadline = _parse(state["deadline_at"])
-    if deadline - CAMPAIGN_DRAIN <= current < deadline:
+    manifest = store.read_json(job_id, str(state["manifest"]), default={}) or {}
+    candidates = state.get("candidates") or []
+    running = [item for item in candidates if item.get("status") == "quick_running"]
+    if running:
         return {
             "status": "blocked",
             "campaign_id": state["campaign_id"],
-            "reason": "evolution campaign is draining before finalization",
+            "reason": (
+                f"candidate {running[0].get('candidate_id')} evaluation is running"
+            ),
         }
-    manifest = store.read_json(job_id, str(state["manifest"]), default={}) or {}
-    candidates = state.get("candidates") or []
-    prepared = [item for item in candidates if item.get("status") == "prepared"]
+    awaiting_evaluation = [
+        item
+        for item in candidates
+        if item.get("status") in {"prepared", "quick_failed"}
+    ]
     policy = manifest.get("policy") or {}
     budget = int(policy.get("generated_programs") or 0)
     deadline_elapsed = current >= deadline
+    draining = deadline - CAMPAIGN_DRAIN <= current < deadline
     prepare_call = (
         'Call wayfinder_core_jobs with action="evolution_prepare", '
         f'job_id="{job_id}", family="<specific structural family>", '
         'summary="<concise testable hypothesis>", and mutation_kind="structural".'
     )
-    if deadline_elapsed:
+    if awaiting_evaluation:
+        candidate = awaiting_evaluation[0]
+        session_stage = f"candidate-{int(candidate.get('slot') or 0):02d}"
+        next_action = (
+            f"Edit only files inside {candidate['bundle']} (workspace, job.yaml, "
+            "and optional search_space.json), then launch "
+            'wayfinder_core_jobs with action="evolution_evaluate", '
+            f'job_id="{job_id}", candidate_id="{candidate["candidate_id"]}", '
+            "and background=true. Do not wait for the detached result. END THIS "
+            "STAGE immediately after launch; do not prepare another candidate. "
+            "A fresh stage session will receive the persisted outcome."
+        )
+    elif deadline_elapsed:
+        session_stage = "finalize"
         next_action = (
             "Generation deadline elapsed. Call wayfinder_core_jobs with "
-            f'action="evolution_finalize", job_id="{job_id}", background=true.'
+            f'action="evolution_finalize", job_id="{job_id}", background=true, '
+            "then END THIS STAGE. Finalization is detached and deterministic."
         )
-    elif prepared and len(candidates) < budget and len(prepared) < 3:
-        # Pipelined authoring: evaluation runs as a detached op, so the agent
-        # keeps writing the next candidate instead of idling on the result.
-        next_action = (
-            f"Edit only files inside {prepared[0]['bundle']} (workspace, job.yaml, "
-            "and optional search_space.json) if you have not already, then launch "
-            'wayfinder_core_jobs with action="evolution_evaluate", '
-            f'job_id="{job_id}", candidate_id="{prepared[0]["candidate_id"]}", '
-            "and background=true. It runs "
-            "detached — do not wait for its result, and an already_running "
-            "response just means the launch already happened; that is normal, "
-            f"move on. While it runs, {prepare_call}"
-        )
-    elif prepared:
-        next_action = (
-            f"Edit only files inside {prepared[0]['bundle']} (workspace, job.yaml, "
-            "and optional search_space.json), then call wayfinder_core_jobs with "
-            f'action="evolution_evaluate", job_id="{job_id}", '
-            f'candidate_id="{prepared[0]["candidate_id"]}", background=true.'
-        )
+    elif draining:
+        return {
+            "status": "blocked",
+            "campaign_id": state["campaign_id"],
+            "reason": "evolution campaign is draining before finalization",
+        }
     elif len(candidates) < budget:
+        session_stage = f"candidate-{len(candidates) + 1:02d}"
         next_action = (
-            f"{prepare_call} At least half the campaign must change "
-            "signal/exit/regime/portfolio structure."
+            f"{prepare_call} Then edit only the returned candidate bundle and "
+            'launch wayfinder_core_jobs with action="evolution_evaluate", '
+            f'job_id="{job_id}", candidate_id="<returned candidate_id>", '
+            "background=true. Do not wait for the detached result. END THIS "
+            "STAGE immediately after launch; do not prepare another candidate. "
+            "At least half the campaign must change signal/exit/regime/portfolio "
+            "structure."
         )
     else:
+        session_stage = "finalize"
         next_action = (
             'Call wayfinder_core_jobs with action="evolution_finalize", '
-            f'job_id="{job_id}", background=true.'
+            f'job_id="{job_id}", background=true, then END THIS STAGE. '
+            "Finalization is detached and deterministic."
         )
     return {
         "job_id": job_id,
         "campaign_id": state["campaign_id"],
         "stage": state["stage"],
+        "session_stage": session_stage,
         "deadline_at": state["deadline_at"],
         "counts": state["counts"],
         "next_action": next_action,
+        "candidate_outcomes": [_candidate_handoff(item) for item in candidates],
         "cases": manifest.get("casebook") or [],
         "forward_context_cutoff": state.get("forward_context_cutoff"),
         "constraints": {
@@ -1198,6 +1277,49 @@ def campaign_prompt_block(
         },
         "deadline_elapsed": deadline_elapsed,
     }
+
+
+def _candidate_handoff(candidate: dict[str, Any]) -> dict[str, Any]:
+    """Bounded durable context passed between isolated authoring stages."""
+    handoff = {
+        "candidate_id": candidate.get("candidate_id"),
+        "slot": candidate.get("slot"),
+        "family": candidate.get("family"),
+        "mutation_kind": candidate.get("mutation_kind"),
+        "parent_source": candidate.get("parent_source"),
+        "status": candidate.get("status"),
+        "summary": str(candidate.get("summary") or "")[:240],
+    }
+    for key in ("objective", "behavior"):
+        value = candidate.get(key)
+        if isinstance(value, dict):
+            handoff[key] = value
+    quick = candidate.get("quick")
+    quick_stats = quick.get("stats") if isinstance(quick, dict) else None
+    if isinstance(quick_stats, dict):
+        handoff["quick_stats"] = {
+            key: quick_stats.get(key)
+            for key in (
+                "net_return",
+                "cagr",
+                "sharpe",
+                "sortino",
+                "max_drawdown_pct",
+                "trade_count",
+                "win_rate",
+                "profit_factor",
+            )
+            if quick_stats.get(key) is not None
+        }
+    evidence = candidate.get("evidence")
+    if evidence and not isinstance(evidence, dict):
+        handoff["evidence"] = str(evidence)[:240]
+    elif isinstance(evidence, dict):
+        handoff["evidence"] = json.dumps(evidence, default=str)[:240]
+    recovery_reason = candidate.get("evaluation_recovery_reason")
+    if recovery_reason:
+        handoff["evaluation_recovery_reason"] = str(recovery_reason)[:240]
+    return handoff
 
 
 def _full_dev(

--- a/wayfinder_paths/jobs/execution/op_process.py
+++ b/wayfinder_paths/jobs/execution/op_process.py
@@ -6,8 +6,10 @@ import json
 import os
 import signal
 import sys
+import time
 from collections.abc import Iterator
 from contextlib import contextmanager
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -58,6 +60,61 @@ def proc_parent_pid(pid: int) -> int | None:
         return int(fields.split()[1])
     except (OSError, IndexError, ValueError):
         return None
+
+
+def process_identity_fields(pid: int) -> dict[str, Any]:
+    """Stable identity fields for a detached process status record."""
+    fields: dict[str, Any] = {}
+    start_ticks = proc_start_ticks(pid)
+    if start_ticks is not None:
+        fields["process_start_ticks"] = start_ticks
+    try:
+        boot_id = (
+            Path("/proc/sys/kernel/random/boot_id").read_text(encoding="utf-8").strip()
+        )
+    except OSError:
+        boot_id = ""
+    if boot_id:
+        fields["boot_id"] = boot_id
+    return fields
+
+
+def _linux_booted_at() -> datetime | None:
+    try:
+        uptime_s = float(Path("/proc/uptime").read_text(encoding="utf-8").split()[0])
+    except (OSError, IndexError, ValueError):
+        return None
+    return datetime.fromtimestamp(time.time() - uptime_s, tz=UTC)
+
+
+def recorded_process_alive(record: dict[str, Any]) -> bool:
+    """Validate a recorded pid without trusting reuse across machine boots."""
+    pid = record.get("pid")
+    if not isinstance(pid, int) or not _pid_alive(pid):
+        return False
+    current = process_identity_fields(pid)
+    recorded_boot = record.get("boot_id")
+    if recorded_boot and current.get("boot_id") != recorded_boot:
+        return False
+    recorded_ticks = record.get("process_start_ticks")
+    if isinstance(recorded_ticks, int):
+        return current.get("process_start_ticks") == recorded_ticks
+    if recorded_boot:
+        return True
+
+    # Backward compatibility for status files written before identity fields
+    # existed. A process recorded before this Linux boot cannot still own the
+    # pid, even if the new machine has already reused that number.
+    try:
+        started_at = datetime.fromisoformat(str(record["started_at"]))
+        if started_at.tzinfo is None:
+            started_at = started_at.replace(tzinfo=UTC)
+        booted_at = _linux_booted_at()
+        if booted_at is not None and started_at < booted_at:
+            return False
+    except (KeyError, TypeError, ValueError):
+        pass
+    return True
 
 
 def pid_is_op_runner(pid: int) -> bool:

--- a/wayfinder_paths/jobs/watchdog.py
+++ b/wayfinder_paths/jobs/watchdog.py
@@ -1271,10 +1271,9 @@ def _audit_pending_claims(store: JobStore, job_id: str) -> dict[str, Any] | None
 # kill/graduate flips out of the 5-minute noise floor.
 _LIFECYCLE_MARKER = "state/lifecycle_pass.json"
 _LIFECYCLE_INTERVAL_S = 6 * 3600
-_CAMPAIGN_FINALIZE_RETRY_S = (0, 5 * 60, 15 * 60, 30 * 60)
+_CAMPAIGN_FINALIZE_RETRY_S = (0, 5 * 60, 15 * 60, 30 * 60, 60 * 60)
 _CAMPAIGN_FINALIZE_GRACE = timedelta(minutes=60)
-_CAMPAIGN_EVALUATE_DRAIN_GRACE = timedelta(minutes=15)
-_CAMPAIGN_BOOTSTRAP_GRACE = timedelta(minutes=15)
+_CAMPAIGN_FINALIZE_MAX_AGE = timedelta(hours=24)
 # A finalize op still writing output past the grace is extended, not expired:
 # expiry once fired mid-Optuna at exactly the grace boundary and the orphaned
 # finalize ran 8+ hours holding the replication lock. Freshness = op log
@@ -1388,14 +1387,19 @@ def _run_evolution_campaign_pass(
     from wayfinder_paths.jobs.evolution_campaign import (
         CAMPAIGN_DRAIN,
         CAMPAIGN_STATE_PATH,
+        recover_lost_candidate_evaluations,
     )
     from wayfinder_paths.jobs.execution.op_process import terminate_campaign_ops
-    from wayfinder_paths.jobs.worker import retire_evolution_session
+    from wayfinder_paths.jobs.worker import (
+        recover_evolution_stage_session,
+        retire_evolution_session,
+    )
 
     state = store.read_json(job_id, CAMPAIGN_STATE_PATH, default={}) or {}
-    campaign_id = str(state.get("campaign_id") or "")
     if state.get("status") not in {"active", "finalizing"}:
-        if state.get("status") in {"complete", "expired"} and state.get("campaign_id"):
+        if state.get("status") in {"complete", "expired", "failed"} and state.get(
+            "campaign_id"
+        ):
             terminate_campaign_ops(store, job_id, str(state["campaign_id"]))
             retired = retire_evolution_session(store, job_id, str(state["campaign_id"]))
             if (
@@ -1414,73 +1418,52 @@ def _run_evolution_campaign_pass(
         return None
     if deadline.tzinfo is None:
         deadline = deadline.replace(tzinfo=UTC)
-    started_at: datetime | None = None
-    try:
-        started_at = datetime.fromisoformat(str(state["started_at"]))
-        if started_at.tzinfo is None:
-            started_at = started_at.replace(tzinfo=UTC)
-    except (KeyError, TypeError, ValueError):
-        pass
-    if (
-        state.get("status") == "active"
-        and started_at is not None
-        and now - started_at >= _CAMPAIGN_BOOTSTRAP_GRACE
-        and int((state.get("counts") or {}).get("generated") or 0) == 0
-    ):
-        expired_bootstrap = False
-        with job_state_lock(store.repo_root, job_id, name="evolution_campaign"):
-            state = store.read_json(job_id, CAMPAIGN_STATE_PATH, default={}) or {}
-            if (
-                str(state.get("campaign_id") or "") == campaign_id
-                and state.get("status") == "active"
-                and int((state.get("counts") or {}).get("generated") or 0) == 0
-            ):
-                state.update(
-                    {
-                        "status": "expired",
-                        "stage": "expired",
-                        "expired_at": now.isoformat(),
-                        "expiry_reason": "no_candidates_generated",
-                    }
-                )
-                store.write_json(job_id, CAMPAIGN_STATE_PATH, state)
-                store.append_journal(
-                    job_id,
-                    {
-                        "type": "evolution_campaign_bootstrap_failed",
-                        "campaign_id": state.get("campaign_id"),
-                        "reason": "no_candidates_generated",
-                    },
-                )
-                expired_bootstrap = True
-        if expired_bootstrap:
-            reaped = terminate_campaign_ops(
-                store, job_id, str(state.get("campaign_id") or "")
-            )
-            if reaped:
-                store.append_journal(
-                    job_id,
-                    {
-                        "type": "evolution_campaign_ops_reaped",
-                        "campaign_id": state.get("campaign_id"),
-                        "ops": reaped,
-                    },
-                )
-            retirement = retire_evolution_session(
-                store, job_id, str(state.get("campaign_id") or "")
-            )
-            result = {
-                "action": "evolution_campaign_bootstrap_failed",
-                "campaign_id": state.get("campaign_id"),
-                "session_retired": bool(retirement and retirement.get("retired")),
-            }
-            if reaped:
-                result["reaped_ops"] = reaped
-            if retirement and retirement.get("error"):
-                result["retirement_error"] = retirement["error"]
-            return result
+    evaluating = op_status_summary(store.job_dir(job_id), "evolution_evaluate")
+    if (evaluating or {}).get("status") == "running":
+        return {
+            "action": "evolution_campaign_waiting_for_evaluation",
+            "campaign_id": state.get("campaign_id"),
+            "governor_paused": _op_governor_paused(
+                store.job_dir(job_id), "evolution_evaluate", now
+            ),
+        }
+    recovered = recover_lost_candidate_evaluations(
+        store,
+        job_id,
+        reason=(
+            "detached evaluator is no longer running"
+            if evaluating is None
+            else f"detached evaluator status is {evaluating.get('status')}"
+        ),
+        now=now,
+    )
+    if recovered:
+        return {
+            "action": "evolution_candidate_evaluation_recovered",
+            "campaign_id": state.get("campaign_id"),
+            "candidate_ids": recovered,
+        }
+    state = store.read_json(job_id, CAMPAIGN_STATE_PATH, default={}) or {}
+    pending_evaluation = [
+        candidate
+        for candidate in state.get("candidates") or []
+        if candidate.get("status") in {"prepared", "quick_failed"}
+    ]
     if now < deadline and state.get("status") == "active":
-        if now < deadline - CAMPAIGN_DRAIN:
+        if now < deadline - CAMPAIGN_DRAIN or pending_evaluation:
+            recovery = recover_evolution_stage_session(store, job_id, now=now)
+            if recovery:
+                return {
+                    "action": "evolution_stage_session_recovered",
+                    "campaign_id": state.get("campaign_id"),
+                    **recovery,
+                }
+            if pending_evaluation:
+                return {
+                    "action": "evolution_campaign_waiting_for_candidate_stage",
+                    "campaign_id": state.get("campaign_id"),
+                    "candidate_id": pending_evaluation[0].get("candidate_id"),
+                }
             return None
         with job_state_lock(store.repo_root, job_id, name="evolution_campaign"):
             state = store.read_json(job_id, CAMPAIGN_STATE_PATH, default={}) or {}
@@ -1506,37 +1489,38 @@ def _run_evolution_campaign_pass(
             "session_retired": bool(retired and retired.get("retired")),
         }
 
-    evaluating = op_status_summary(store.job_dir(job_id), "evolution_evaluate")
-    if (evaluating or {}).get("status") == "running" and (
-        now - deadline < _CAMPAIGN_EVALUATE_DRAIN_GRACE
-        or _op_governor_paused(store.job_dir(job_id), "evolution_evaluate", now)
-    ):
-        return {
-            "action": "evolution_campaign_waiting_for_evaluation",
-            "campaign_id": state.get("campaign_id"),
-        }
-
     retirement = retire_evolution_session(
         store, job_id, str(state.get("campaign_id") or "")
     )
-    if (
-        retirement
-        and not retirement.get("retired")
-        and now - deadline < _CAMPAIGN_FINALIZE_GRACE
-    ):
+    finalize_max_age_reached = now - deadline >= _CAMPAIGN_FINALIZE_MAX_AGE
+    if retirement and not retirement.get("retired") and not finalize_max_age_reached:
         return {
             "action": "evolution_campaign_waiting_for_session_retirement",
             "campaign_id": state.get("campaign_id"),
             "error": retirement.get("error"),
         }
 
+    if pending_evaluation and not finalize_max_age_reached:
+        candidate_id = str(pending_evaluation[0].get("candidate_id") or "")
+        spawned = spawn_detached_op(
+            store,
+            job_id,
+            "evolution_evaluate",
+            {"job_id": job_id, "candidate_id": candidate_id},
+        )
+        return {
+            "action": "evolution_candidate_evaluation_started",
+            "campaign_id": state.get("campaign_id"),
+            "candidate_id": candidate_id,
+            "pid": spawned.get("pid"),
+        }
+
     op = op_status_summary(store.job_dir(job_id), "evolution_finalize")
     past_grace = now - deadline >= _CAMPAIGN_FINALIZE_GRACE
     if past_grace:
-        # Finalize-aware expiry: a live finalize still writing output past
-        # the grace extends the campaign (journaled once per campaign); a
-        # dead or wedged one is reaped BEFORE the expiry takes the campaign
-        # lock the wedged process itself may be holding.
+        # A healthy finalizer may outlive the four-hour generation window.
+        # A stale process is reaped and relaunched from its durable candidate
+        # claims instead of expiring the whole campaign at the old 60m wall.
         pid, healthy = _finalize_op_health(store.job_dir(job_id), now)
         if healthy:
             marker = store.read_json(job_id, _FINALIZE_EXTEND_MARKER) or {}
@@ -1581,20 +1565,20 @@ def _run_evolution_campaign_pass(
         if state.get("status") not in {"active", "finalizing"}:
             return None
         attempts = int(state.get("finalize_attempts") or 0)
-        if now - deadline >= _CAMPAIGN_FINALIZE_GRACE:
+        if finalize_max_age_reached:
             state.update(
                 {
-                    "status": "expired",
-                    "stage": "expired",
-                    "expired_at": now.isoformat(),
-                    "expiry_reason": "finalization did not complete within 60 minutes",
+                    "status": "failed",
+                    "stage": "failed",
+                    "failed_at": now.isoformat(),
+                    "failure_reason": "finalization did not reach a terminal verdict within 24 hours",
                 }
             )
             store.write_json(job_id, CAMPAIGN_STATE_PATH, state)
             store.append_journal(
                 job_id,
                 {
-                    "type": "evolution_campaign_expired",
+                    "type": "evolution_campaign_failed",
                     "campaign_id": state.get("campaign_id"),
                     "finalize_attempts": attempts,
                 },
@@ -1603,17 +1587,17 @@ def _run_evolution_campaign_pass(
                 store, job_id, str(state.get("campaign_id") or "")
             )
             result = {
-                "action": "evolution_campaign_expired",
+                "action": "evolution_campaign_failed",
                 "campaign_id": state.get("campaign_id"),
             }
             if reaped:
                 result["reaped_ops"] = reaped
             return result
-        if attempts >= len(_CAMPAIGN_FINALIZE_RETRY_S):
-            return None
         last_attempt = state.get("finalize_last_attempt_at")
         if attempts and _age(now, last_attempt) < timedelta(
-            seconds=_CAMPAIGN_FINALIZE_RETRY_S[attempts]
+            seconds=_CAMPAIGN_FINALIZE_RETRY_S[
+                min(attempts, len(_CAMPAIGN_FINALIZE_RETRY_S) - 1)
+            ]
         ):
             return None
         state.update(

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -43,6 +43,7 @@ JOB_RESULT_MARKER = "WAYFINDER_JOB_RESULT "
 STABLE_PREFIX_END_MARKER = "## End Stable Cache Prefix"
 DYNAMIC_CONTEXT_MARKER = "## Dynamic Wakeup Context"
 VOLATILE_STABLE_KEYS = {"created_at", "updated_at", "ts"}
+EVOLUTION_STAGE_RETRY_AFTER = dt.timedelta(minutes=10)
 
 
 def _read_text(path: Path, *, max_chars: int = 12_000) -> str:
@@ -1764,10 +1765,7 @@ def _queue_evolution_worker(store: JobStore, job_id: str) -> dict[str, Any] | No
 
 
 def nudge_evolution_session(store: JobStore, job_id: str) -> dict[str, Any] | None:
-    """Re-prompt the persistent evolution session as soon as a detached
-    campaign op (start/evaluate) lands, instead of leaving the fresh state
-    idle until the next hourly wake. Best-effort: callers must tolerate None.
-    """
+    """Advance the campaign into a fresh stage session after an op lands."""
     if os.environ.get("WAYFINDER_EVOLUTION_NUDGE") == "0":
         return None
     if not OPENCODE_CLIENT.healthy():
@@ -1788,6 +1786,53 @@ def nudge_evolution_session(store: JobStore, job_id: str) -> dict[str, Any] | No
     return _prompt_evolution_session(store, job_id, campaign, source="op_completion")
 
 
+def recover_evolution_stage_session(
+    store: JobStore, job_id: str, *, now: dt.datetime
+) -> dict[str, Any] | None:
+    """Restart a missing or stale idle stage without reviving its old context."""
+    if not OPENCODE_CLIENT.healthy():
+        return None
+    from wayfinder_paths.jobs.evolution_campaign import campaign_prompt_block
+
+    campaign = campaign_prompt_block(store, job_id, now=now)
+    if not campaign or campaign.get("status") == "blocked":
+        return None
+    desired_stage = str(campaign.get("session_stage") or "")
+    session = store.read_json(job_id, EVOLUTION_SESSION_PATH, default={}) or {}
+    session_id = str(session.get("session_id") or "")
+    if session_id and OPENCODE_CLIENT.session_statuses().get(session_id):
+        return None
+    missing = bool(
+        not session_id
+        or session.get("retired_at")
+        or OPENCODE_CLIENT.session_exists(session_id) is False
+    )
+    stage_changed = str(session.get("session_stage") or "") != desired_stage
+    stale = False
+    try:
+        prompted_at = dt.datetime.fromisoformat(str(session["last_prompt_at"]))
+        if prompted_at.tzinfo is None:
+            prompted_at = prompted_at.replace(tzinfo=dt.UTC)
+        stale = now - prompted_at >= EVOLUTION_STAGE_RETRY_AFTER
+    except (KeyError, TypeError, ValueError):
+        stale = bool(session_id)
+    if not (missing or stage_changed or stale):
+        return None
+    if session_id and not session.get("retired_at") and not missing:
+        retired = retire_evolution_session(
+            store, job_id, str(session.get("campaign_id") or "")
+        )
+        if not retired or not retired.get("retired"):
+            return {
+                "queued": False,
+                "transition_pending": True,
+                "error": (retired or {}).get("error") or "stage retirement failed",
+            }
+    return _prompt_evolution_session(
+        store, job_id, campaign, source="watchdog_recovery"
+    )
+
+
 def _prompt_evolution_session(
     store: JobStore, job_id: str, campaign: dict[str, Any], *, source: str
 ) -> dict[str, Any] | None:
@@ -1796,15 +1841,67 @@ def _prompt_evolution_session(
     campaign_id = str(campaign.get("campaign_id") or "").strip()
     if not campaign_id:
         return {"queued": False, "error": "evolution campaign id missing"}
+    session_stage = str(campaign.get("session_stage") or "").strip()
+    if not session_stage:
+        return {"queued": False, "error": "evolution session stage missing"}
+    campaign_payload = dict(campaign)
+    prior_handoff = _latest_evolution_stage_handoff(store, job_id, campaign_id)
+    existing = store.read_json(job_id, EVOLUTION_SESSION_PATH, default={}) or {}
+    existing_id = str(existing.get("session_id") or "")
+    existing_campaign = str(existing.get("campaign_id") or "")
+    existing_stage = str(existing.get("session_stage") or "")
+    existing_gone = bool(
+        existing_id and OPENCODE_CLIENT.session_exists(existing_id) is False
+    )
+    transition = bool(
+        existing_id
+        and not existing.get("retired_at")
+        and (
+            existing_campaign != campaign_id
+            or existing_stage != session_stage
+            or existing_gone
+        )
+    )
+    if transition:
+        retired = retire_evolution_session(
+            store, job_id, existing_campaign, abort_busy=False
+        )
+        if not retired or not retired.get("retired"):
+            return {
+                "queued": False,
+                "transition_pending": True,
+                "session_id": existing_id,
+                "from_stage": existing_stage or None,
+                "to_stage": session_stage,
+                "error": (retired or {}).get("error")
+                or (
+                    "previous stage session is still busy"
+                    if (retired or {}).get("busy")
+                    else "stage session retirement failed"
+                ),
+            }
+        if existing_campaign == campaign_id:
+            prior_handoff = retired.get("handoff") or prior_handoff
+    prior_stage_text = (
+        _canonical_json(prior_handoff, max_chars=2_200) if prior_handoff else "null"
+    )
+    candidate_outcomes = list(reversed(campaign_payload.pop("candidate_outcomes", [])))
+    outcomes_text = _canonical_json(
+        {"order": "newest_first", "candidates": candidate_outcomes}, max_chars=4_000
+    )
     controller_session_id = os.environ.get("OPENCODE_SESSION_ID") or os.environ.get(
         "OPENCODE_SESSIONID"
     )
-    title = f"job/{job_id}/evolution/{campaign_id}"
+    title = f"job/{job_id}/evolution/{campaign_id}/{session_stage}"
     prompt = (
-        "Continue this PAPER-ONLY evolution campaign. Follow `next_action`; "
-        "do not wait on detached evaluation. The dedicated agent instructions "
-        "already contain the safety and research contract.\n\nCampaign:\n"
-        + _canonical_json(campaign, max_chars=6_000)
+        f"Run PAPER-ONLY evolution stage `{session_stage}`. Use the persisted "
+        "candidate outcomes and prior-stage handoff; do not reload the retired "
+        "session or its raw tool results. Perform exactly this next action, then "
+        "end the stage:\n"
+        f"{campaign_payload.get('next_action')}\n\n"
+        f"Prior stage handoff:\n{prior_stage_text}\n\n"
+        f"Persisted candidate outcomes:\n{outcomes_text}\n\n"
+        "Campaign control state:\n" + _canonical_json(campaign_payload, max_chars=3_500)
     )
     fingerprint = hashlib.sha256(prompt.encode()).hexdigest()
     created_at = utc_now_iso()
@@ -1813,9 +1910,11 @@ def _prompt_evolution_session(
             session = store.read_json(job_id, EVOLUTION_SESSION_PATH, default={}) or {}
             session_id = str(session.get("session_id") or "")
             stored_campaign = str(session.get("campaign_id") or "")
+            stored_stage = str(session.get("session_stage") or "")
             reusable = bool(
                 session_id
-                and stored_campaign in {"", campaign_id}
+                and stored_campaign == campaign_id
+                and stored_stage == session_stage
                 and not session.get("retired_at")
                 and OPENCODE_CLIENT.session_exists(session_id) is not False
             )
@@ -1831,8 +1930,9 @@ def _prompt_evolution_session(
                     or ""
                 )
                 session = {
-                    "schema_version": "1.0",
+                    "schema_version": "1.1",
                     "campaign_id": campaign_id,
+                    "session_stage": session_stage,
                     "session_id": session_id,
                     "created_at": created_at,
                 }
@@ -1855,6 +1955,7 @@ def _prompt_evolution_session(
                 session.update(
                     {
                         "campaign_id": campaign_id,
+                        "session_stage": session_stage,
                         "last_prompt_at": created_at,
                         "last_prompt_fingerprint": fingerprint,
                         "last_source": source,
@@ -1874,6 +1975,7 @@ def _prompt_evolution_session(
             if queued
             else "Dedicated evolution wake could not be queued",
             "session_id": session_id,
+            "session_stage": session_stage,
             "queued": queued,
             "source": source,
             "created_at": created_at,
@@ -1884,6 +1986,7 @@ def _prompt_evolution_session(
         {
             "type": "evolution_worker_wakeup",
             "campaign_id": campaign.get("campaign_id"),
+            "session_stage": session_stage,
             "session_id": session_id,
             "queued": queued,
             "source": source,
@@ -1892,8 +1995,53 @@ def _prompt_evolution_session(
     return {"queued": queued, "session_id": session_id}
 
 
-def retire_evolution_session(
+def _evolution_stage_handoff(entry: dict[str, Any]) -> dict[str, Any]:
+    diagnostics = entry.get("diagnostics") or {}
+    metrics = entry.get("metrics") or {}
+    tool_calls = diagnostics.get("tool_calls") or []
+    return {
+        "from_stage": entry.get("session_stage"),
+        "retired_at": entry.get("retired_at") or entry.get("exported_at"),
+        "final_summary": str(diagnostics.get("final_assistant_text") or "")[-1_500:],
+        "tool_calls": [
+            {
+                key: call.get(key)
+                for key in ("tool", "action", "status", "error")
+                if call.get(key)
+            }
+            for call in tool_calls[-8:]
+            if isinstance(call, dict)
+        ],
+        "resource_usage": {
+            key: metrics.get(key)
+            for key in (
+                "tokens_in",
+                "tokens_out",
+                "tokens_reasoning",
+                "tool_calls",
+                "tool_result_bytes",
+            )
+            if metrics.get(key) is not None
+        },
+    }
+
+
+def _latest_evolution_stage_handoff(
     store: JobStore, job_id: str, campaign_id: str
+) -> dict[str, Any] | None:
+    archive = store.read_json(job_id, EVOLUTION_SESSION_ARCHIVE_PATH, default={}) or {}
+    for entry in reversed(list(archive.get("sessions") or [])):
+        if str(entry.get("campaign_id") or "") == campaign_id:
+            return _evolution_stage_handoff(entry)
+    return None
+
+
+def retire_evolution_session(
+    store: JobStore,
+    job_id: str,
+    campaign_id: str,
+    *,
+    abort_busy: bool = True,
 ) -> dict[str, Any] | None:
     """Export and delete exactly the automation-owned session for a campaign.
 
@@ -1911,14 +2059,18 @@ def retire_evolution_session(
         if str(session.get("campaign_id") or "") != str(campaign_id):
             return None
         if session.get("retired_at"):
+            handoff = _latest_evolution_stage_handoff(store, job_id, str(campaign_id))
             return {
                 "retired": True,
                 "already_retired": True,
                 "session_id": session.get("session_id"),
+                "handoff": handoff,
             }
         session_id = str(session.get("session_id") or "")
         if not session_id:
             return None
+        if not abort_busy and OPENCODE_CLIENT.session_statuses().get(session_id):
+            return {"retired": False, "session_id": session_id, "busy": True}
         try:
             metrics = meter_session_ids([session_id])
         except Exception as exc:  # noqa: BLE001 - never delete before export
@@ -1947,6 +2099,7 @@ def retire_evolution_session(
         entries = list(archive.get("sessions") or [])
         exported = {
             "campaign_id": str(campaign_id),
+            "session_stage": session.get("session_stage"),
             "session_id": session_id,
             "created_at": session.get("created_at"),
             "exported_at": utc_now_iso(),
@@ -1993,7 +2146,12 @@ def retire_evolution_session(
                 "metrics": metrics,
             },
         )
-        return {"retired": True, "session_id": session_id, "metrics": metrics}
+        return {
+            "retired": True,
+            "session_id": session_id,
+            "metrics": metrics,
+            "handoff": _evolution_stage_handoff(entries[-1]),
+        }
 
 
 def _write_report(

--- a/wayfinder_paths/mcp/tools/jobs.py
+++ b/wayfinder_paths/mcp/tools/jobs.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
 from pathlib import Path
 from typing import Any, Literal
 
@@ -18,7 +17,11 @@ from wayfinder_paths.jobs.apply_launcher import launch_application
 from wayfinder_paths.jobs.backtest_artifacts import diagnose_backtest
 from wayfinder_paths.jobs.compiler import JobCompiler
 from wayfinder_paths.jobs.execution.experiments import list_experiments
-from wayfinder_paths.jobs.execution.op_process import op_runner_command
+from wayfinder_paths.jobs.execution.op_process import (
+    op_runner_command,
+    process_identity_fields,
+    recorded_process_alive,
+)
 from wayfinder_paths.jobs.execution.validation import validate_execution_job
 from wayfinder_paths.jobs.halt import clear_halt, request_halt
 from wayfinder_paths.jobs.models import (
@@ -152,16 +155,6 @@ def _op_status_hint(job_id: str, op: str) -> str:
     )
 
 
-def _pid_alive(pid: Any) -> bool:
-    if not isinstance(pid, int) or pid <= 0:
-        return False
-    try:
-        os.kill(pid, 0)
-    except OSError:
-        return False
-    return True
-
-
 def _load_json_file(path: Path) -> dict[str, Any] | None:
     try:
         loaded = json.loads(path.read_text(encoding="utf-8"))
@@ -187,7 +180,7 @@ async def _start_background_op(
     if (
         existing
         and existing.get("state") == "running"
-        and _pid_alive(existing.get("pid"))
+        and recorded_process_alive(existing)
     ):
         return ok(
             {
@@ -227,6 +220,7 @@ async def _start_background_op(
         "state": "running",
         "pid": proc.pid,
         "started_at": utc_now_iso(),
+        **process_identity_fields(proc.pid),
         **({"island": island} if island else {}),
     }
     atomic_write_json(status_path, status)
@@ -267,7 +261,7 @@ def _background_op_status(store: JobStore, job_id: str, op: str) -> dict[str, An
     status = _load_json_file(ops_dir / f"{op}.json")
     if not status:
         return err("not_found", f"no background {op} run recorded for {job_id}")
-    if status.get("state") == "running" and not _pid_alive(status.get("pid")):
+    if status.get("state") == "running" and not recorded_process_alive(status):
         # The reaper lived in an MCP server that restarted mid-run. The child
         # was detached (own session), so a parseable result file means it
         # finished anyway; otherwise the run is lost.

--- a/wayfinder_paths/tests/test_jobs_apply_watchdog.py
+++ b/wayfinder_paths/tests/test_jobs_apply_watchdog.py
@@ -1007,7 +1007,7 @@ def test_watchdog_gate_restamp_escalates_instead_of_looping(
     assert len(escalations) == 1, "escalates once, then stands down"
 
 
-def test_watchdog_mechanically_finalizes_then_expires_campaign(
+def test_watchdog_retries_finalization_beyond_the_generation_grace(
     tmp_path: Path, monkeypatch
 ) -> None:
     store = JobStore(repo_root=tmp_path)
@@ -1055,13 +1055,57 @@ def test_watchdog_mechanically_finalizes_then_expires_campaign(
     )
     assert retried["attempt"] == 2
 
-    expired = _run_evolution_campaign_pass(
+    retried_again = _run_evolution_campaign_pass(
         store, job.id, deadline + timedelta(minutes=61)
     )
-    assert expired["action"] == "evolution_campaign_expired"
+    assert retried_again["action"] == "evolution_campaign_finalize_started"
+    assert retried_again["attempt"] == 3
     assert store.read_json(job.id, "state/evolution_campaign.json")["status"] == (
-        "expired"
+        "finalizing"
     )
+
+
+def test_watchdog_closes_a_permanently_failed_finalizer_after_24_hours(
+    tmp_path: Path, monkeypatch
+) -> None:
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "campaign-finalize-terminal-failure")
+    deadline = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    store.write_json(
+        job.id,
+        "state/evolution_campaign.json",
+        {
+            "campaign_id": "campaign-1",
+            "status": "finalizing",
+            "stage": "finalizing",
+            "deadline_at": deadline.isoformat(),
+            "finalize_attempts": 9,
+            "finalize_last_attempt_at": (deadline + timedelta(hours=23)).isoformat(),
+        },
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.background.op_status_summary",
+        lambda *args, **kwargs: {"status": "failed"},
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.worker.retire_evolution_session",
+        lambda *args, **kwargs: {
+            "retired": False,
+            "error": "session store unavailable",
+        },
+    )
+
+    result = _run_evolution_campaign_pass(store, job.id, deadline + timedelta(hours=24))
+
+    assert result == {
+        "action": "evolution_campaign_failed",
+        "campaign_id": "campaign-1",
+    }
+    state = store.read_json(job.id, "state/evolution_campaign.json")
+    assert state["status"] == "failed"
+    assert state["stage"] == "failed"
+    assert state["failure_reason"].endswith("within 24 hours")
+    assert "evolution_campaign_failed" in _journal_types(store, job.id)
 
 
 def test_watchdog_drains_and_retires_session_before_finalize(
@@ -1102,7 +1146,132 @@ def test_watchdog_drains_and_retires_session_before_finalize(
     assert state["drain_started_at"]
 
 
-def test_watchdog_expires_campaign_that_never_generates_a_candidate(
+def test_watchdog_waits_for_an_evaluator_during_generation(
+    tmp_path: Path, monkeypatch
+) -> None:
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "campaign-generating-evaluator")
+    now = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    store.write_json(
+        job.id,
+        "state/evolution_campaign.json",
+        {
+            "campaign_id": "campaign-1",
+            "status": "active",
+            "stage": "generate",
+            "deadline_at": (now + timedelta(hours=2)).isoformat(),
+            "candidates": [{"candidate_id": "c01", "status": "prepared"}],
+        },
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.background.op_status_summary",
+        lambda *args, **kwargs: {"status": "running"},
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.worker.recover_evolution_stage_session",
+        lambda *args, **kwargs: pytest.fail("a second stage was started"),
+    )
+
+    assert _run_evolution_campaign_pass(store, job.id, now) == {
+        "action": "evolution_campaign_waiting_for_evaluation",
+        "campaign_id": "campaign-1",
+        "governor_paused": False,
+    }
+
+
+def test_watchdog_recovers_a_lost_evaluator_claim_before_reprompting(
+    tmp_path: Path, monkeypatch
+) -> None:
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "campaign-lost-evaluator")
+    now = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    store.write_json(
+        job.id,
+        "state/evolution_campaign.json",
+        {
+            "campaign_id": "campaign-1",
+            "status": "active",
+            "stage": "generate",
+            "deadline_at": (now + timedelta(hours=2)).isoformat(),
+            "candidates": [
+                {
+                    "candidate_id": "c01",
+                    "status": "quick_running",
+                    "evaluation_claim_id": "lost",
+                    "evaluation_claimed_at": now.isoformat(),
+                }
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.background.op_status_summary",
+        lambda *args, **kwargs: {"status": "failed"},
+    )
+
+    result = _run_evolution_campaign_pass(store, job.id, now)
+
+    assert result == {
+        "action": "evolution_candidate_evaluation_recovered",
+        "campaign_id": "campaign-1",
+        "candidate_ids": ["c01"],
+    }
+    candidate = store.read_json(job.id, "state/evolution_campaign.json")["candidates"][
+        0
+    ]
+    assert candidate["status"] == "quick_failed"
+    assert "evaluation_claim_id" not in candidate
+
+
+def test_watchdog_finishes_a_prepared_candidate_after_generation_deadline(
+    tmp_path: Path, monkeypatch
+) -> None:
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "campaign-deadline-candidate")
+    deadline = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    store.write_json(
+        job.id,
+        "state/evolution_campaign.json",
+        {
+            "campaign_id": "campaign-1",
+            "status": "active",
+            "stage": "draining",
+            "deadline_at": deadline.isoformat(),
+            "candidates": [{"candidate_id": "c01", "status": "prepared"}],
+        },
+    )
+    launches: list[tuple[str, dict]] = []
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.background.op_status_summary",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.worker.retire_evolution_session",
+        lambda *args, **kwargs: {"retired": True},
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.background.spawn_detached_op",
+        lambda store, job_id, op, payload: (
+            launches.append((op, payload)) or {"pid": 4321}
+        ),
+    )
+
+    result = _run_evolution_campaign_pass(store, job.id, deadline)
+
+    assert result == {
+        "action": "evolution_candidate_evaluation_started",
+        "campaign_id": "campaign-1",
+        "candidate_id": "c01",
+        "pid": 4321,
+    }
+    assert launches == [
+        (
+            "evolution_evaluate",
+            {"job_id": job.id, "candidate_id": "c01"},
+        )
+    ]
+
+
+def test_watchdog_keeps_recovering_campaign_that_has_not_generated_a_candidate(
     tmp_path: Path, monkeypatch
 ) -> None:
     store = JobStore(repo_root=tmp_path)
@@ -1120,53 +1289,24 @@ def test_watchdog_expires_campaign_that_never_generates_a_candidate(
             "counts": {"generated": 0},
         },
     )
-    retired: list[str] = []
     monkeypatch.setattr(
-        "wayfinder_paths.jobs.worker.retire_evolution_session",
-        lambda store, job_id, campaign_id: (
-            retired.append(campaign_id) or {"retired": True}
-        ),
-    )
-    monkeypatch.setattr(
-        "wayfinder_paths.jobs.execution.op_process.terminate_campaign_ops",
-        lambda store, job_id, campaign_id: [
-            {
-                "pid": 4242,
-                "op": "evolution_prepare",
-                "resource_tier": "control",
-            }
-        ],
+        "wayfinder_paths.jobs.worker.recover_evolution_stage_session",
+        lambda store, job_id, now: {"queued": True, "session_id": "recovery-1"},
     )
 
-    assert (
-        _run_evolution_campaign_pass(
-            store, job.id, started + timedelta(minutes=14, seconds=59)
-        )
-        is None
-    )
     result = _run_evolution_campaign_pass(
         store, job.id, started + timedelta(minutes=15)
     )
 
     assert result == {
-        "action": "evolution_campaign_bootstrap_failed",
+        "action": "evolution_stage_session_recovered",
         "campaign_id": "campaign-1",
-        "session_retired": True,
-        "reaped_ops": [
-            {
-                "pid": 4242,
-                "op": "evolution_prepare",
-                "resource_tier": "control",
-            }
-        ],
+        "queued": True,
+        "session_id": "recovery-1",
     }
-    assert retired == ["campaign-1"]
     state = store.read_json(job.id, "state/evolution_campaign.json")
-    assert state["status"] == "expired"
-    assert state["stage"] == "expired"
-    assert state["expiry_reason"] == "no_candidates_generated"
-    assert "evolution_campaign_bootstrap_failed" in _journal_types(store, job.id)
-    assert "evolution_campaign_ops_reaped" in _journal_types(store, job.id)
+    assert state["status"] == "active"
+    assert state["stage"] == "generate"
 
 
 def test_watchdog_keeps_campaign_after_first_candidate(tmp_path: Path) -> None:
@@ -1328,6 +1468,7 @@ def test_watchdog_waits_for_governor_paused_evaluation_past_drain_grace(
     assert _run_evolution_campaign_pass(store, job.id, now) == {
         "action": "evolution_campaign_waiting_for_evaluation",
         "campaign_id": "campaign-1",
+        "governor_paused": True,
     }
 
 
@@ -1425,11 +1566,11 @@ def test_watchdog_extends_grace_while_finalize_is_healthy(tmp_path: Path) -> Non
     assert _journal_types(store, job.id).count("evolution_finalize_still_running") == 1
 
 
-def test_watchdog_reaps_stale_live_finalize_on_expiry(
+def test_watchdog_reaps_and_retries_stale_live_finalize(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A live pid whose log went stale is wedged: the watchdog SIGKILLs the
-    op's process group (pgid == pid via start_new_session) BEFORE expiring,
+    op's process group (pgid == pid via start_new_session) before retrying,
     and journals the reap with the pid."""
     import signal
 
@@ -1446,21 +1587,21 @@ def test_watchdog_reaps_stale_live_finalize_on_expiry(
         lambda pid, sig: killed.append((pid, sig)),
     )
 
-    expired = _run_evolution_campaign_pass(store, job.id, now)
+    retried = _run_evolution_campaign_pass(store, job.id, now)
 
-    assert expired["action"] == "evolution_campaign_expired"
+    assert retried["action"] == "evolution_campaign_finalize_started"
+    assert retried["attempt"] == 2
     assert killed == [(os.getpid(), 0), (os.getpid(), signal.SIGKILL)]
     assert store.read_json(job.id, "state/evolution_campaign.json")["status"] == (
-        "expired"
+        "finalizing"
     )
     types = _journal_types(store, job.id)
     assert "evolution_finalize_reaped" in types
-    assert "evolution_campaign_expired" in types
+    assert "evolution_campaign_expired" not in types
 
 
-def test_watchdog_expires_dead_finalize_without_reap(tmp_path: Path) -> None:
-    """A dead finalize pid past the grace expires exactly as before — no
-    process group to reap, no reap journal."""
+def test_watchdog_retries_dead_finalize_without_reap(tmp_path: Path) -> None:
+    """A dead finalize pid is retried without signaling a nonexistent group."""
     import subprocess
     import sys
 
@@ -1471,12 +1612,13 @@ def test_watchdog_expires_dead_finalize_without_reap(tmp_path: Path) -> None:
     proc.wait()
     _finalizing_campaign(store, job.id, deadline, pid=proc.pid)
 
-    expired = _run_evolution_campaign_pass(
+    retried = _run_evolution_campaign_pass(
         store, job.id, deadline + timedelta(minutes=61)
     )
 
-    assert expired["action"] == "evolution_campaign_expired"
+    assert retried["action"] == "evolution_campaign_finalize_started"
+    assert retried["attempt"] == 2
     assert store.read_json(job.id, "state/evolution_campaign.json")["status"] == (
-        "expired"
+        "finalizing"
     )
     assert "evolution_finalize_reaped" not in _journal_types(store, job.id)

--- a/wayfinder_paths/tests/test_jobs_evolution_campaign.py
+++ b/wayfinder_paths/tests/test_jobs_evolution_campaign.py
@@ -28,6 +28,7 @@ from wayfinder_paths.jobs.evolution_campaign import (
     finalize_campaign,
     maybe_start_campaign,
     prepare_candidate,
+    recover_lost_candidate_evaluations,
     resolve_candidate_bundle,
     start_campaign,
 )
@@ -45,6 +46,7 @@ from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.jobs.worker import (
     _queue_evolution_worker,
     nudge_evolution_session,
+    recover_evolution_stage_session,
     retire_evolution_session,
     run_job_worker,
 )
@@ -615,7 +617,7 @@ def test_jsonl_features_are_frozen_at_the_campaign_cutoff(tmp_path) -> None:
     assert [row["value"] for row in rows] == [0, 1]
 
 
-def test_next_action_pipelines_authoring_against_detached_evaluation(tmp_path) -> None:
+def test_next_action_isolates_one_candidate_per_stage_session(tmp_path) -> None:
     store, job_id = _job(tmp_path, "majors-5m-lab")
     started = datetime(2026, 8, 25, 12, tzinfo=UTC)
     start_campaign(store, job_id, now=started)
@@ -626,17 +628,21 @@ def test_next_action_pipelines_authoring_against_detached_evaluation(tmp_path) -
 
     block = campaign_prompt_block(store, job_id, now=working)
     assert block is not None
+    assert block["session_stage"] == "candidate-01"
     assert 'action="evolution_evaluate"' in block["next_action"]
-    assert 'action="evolution_prepare"' in block["next_action"]
+    assert 'action="evolution_prepare"' not in block["next_action"]
     assert f'job_id="{job_id}"' in block["next_action"]
     assert "background=true" in block["next_action"]
-    assert "do not wait" in block["next_action"]
+    assert "Do not wait" in block["next_action"]
+    assert "END THIS STAGE" in block["next_action"]
+    assert block["candidate_outcomes"][0]["summary"] == "pipeline probe"
 
     for index in range(2):
         prepare_candidate(
             store, job_id, family="breakout", summary=f"queued {index}", now=working
         )
     drain = campaign_prompt_block(store, job_id, now=working)
+    assert drain["session_stage"] == "candidate-01"
     assert 'action="evolution_evaluate"' in drain["next_action"]
     assert 'action="evolution_prepare"' not in drain["next_action"]
 
@@ -651,6 +657,7 @@ def test_next_action_pipelines_authoring_against_detached_evaluation(tmp_path) -
         state["candidates"].append({"status": "quick_complete"})
     store.write_json(job_id, "state/evolution_campaign.json", state)
     done = campaign_prompt_block(store, job_id, now=working)
+    assert done["session_stage"] == "finalize"
     assert 'action="evolution_finalize"' in done["next_action"]
     assert f'job_id="{job_id}"' in done["next_action"]
     assert "background=true" in done["next_action"]
@@ -659,18 +666,25 @@ def test_next_action_pipelines_authoring_against_detached_evaluation(tmp_path) -
     state["candidates"][0]["status"] = "prepared"
     store.write_json(job_id, "state/evolution_campaign.json", state)
     exhausted = campaign_prompt_block(store, job_id, now=working)
+    assert exhausted["session_stage"] == "candidate-01"
     assert 'action="evolution_evaluate"' in exhausted["next_action"]
     assert 'action="evolution_prepare"' not in exhausted["next_action"]
 
     draining = campaign_prompt_block(
         store, job_id, now=datetime(2026, 8, 25, 15, 40, tzinfo=UTC)
     )
-    assert draining == {
-        "status": "blocked",
-        "campaign_id": state["campaign_id"],
-        "reason": "evolution campaign is draining before finalization",
-    }
+    assert draining["session_stage"] == "candidate-01"
+    assert 'action="evolution_evaluate"' in draining["next_action"]
 
+    elapsed = campaign_prompt_block(
+        store, job_id, now=datetime(2026, 8, 25, 16, 30, tzinfo=UTC)
+    )
+    assert elapsed["session_stage"] == "candidate-01"
+    assert 'action="evolution_evaluate"' in elapsed["next_action"]
+    assert elapsed["deadline_elapsed"] is True
+
+    state["candidates"][0]["status"] = "quick_complete"
+    store.write_json(job_id, "state/evolution_campaign.json", state)
     elapsed = campaign_prompt_block(
         store, job_id, now=datetime(2026, 8, 25, 16, 30, tzinfo=UTC)
     )
@@ -679,8 +693,61 @@ def test_next_action_pipelines_authoring_against_detached_evaluation(tmp_path) -
     assert "background=true" in elapsed["next_action"]
     assert elapsed["deadline_elapsed"] is True
 
+    state["candidates"][0]["status"] = "quick_running"
+    store.write_json(job_id, "state/evolution_campaign.json", state)
+    running = campaign_prompt_block(store, job_id, now=working)
+    assert running == {
+        "status": "blocked",
+        "campaign_id": state["campaign_id"],
+        "reason": f"candidate {state['candidates'][0]['candidate_id']} evaluation is running",
+    }
 
-def test_evolution_uses_a_dedicated_long_lived_session(tmp_path, monkeypatch) -> None:
+
+def test_stage_context_carries_bounded_candidate_evidence(tmp_path) -> None:
+    store, job_id = _job(tmp_path, "majors-5m-lab")
+    started = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    start_campaign(store, job_id, now=started)
+    prepare_candidate(
+        store,
+        job_id,
+        family="asymmetric-exit",
+        summary="retain gains while clipping reversals",
+        now=started + timedelta(minutes=5),
+    )
+    state = campaign_status(store, job_id)
+    state["candidates"][0].update(
+        {
+            "status": "quick_complete",
+            "objective": {"net_log_growth": 0.03},
+            "behavior": {"average_hold_bars": 8.0},
+            "quick": {
+                "stats": {
+                    "net_return": 0.031,
+                    "sharpe": 1.4,
+                    "trade_count": 27,
+                    "equity_curve": [1] * 5_000,
+                }
+            },
+            "evidence": "low-fidelity train screen passed",
+        }
+    )
+    store.write_json(job_id, "state/evolution_campaign.json", state)
+
+    block = campaign_prompt_block(store, job_id, now=started + timedelta(minutes=10))
+
+    assert block and block["session_stage"] == "candidate-02"
+    outcome = block["candidate_outcomes"][0]
+    assert outcome["objective"] == {"net_log_growth": 0.03}
+    assert outcome["behavior"] == {"average_hold_bars": 8.0}
+    assert outcome["quick_stats"] == {
+        "net_return": 0.031,
+        "sharpe": 1.4,
+        "trade_count": 27,
+    }
+    assert "equity_curve" not in json.dumps(outcome)
+
+
+def test_evolution_uses_a_dedicated_stage_session(tmp_path, monkeypatch) -> None:
     store, job_id = _job(tmp_path, "majors-5m-lab")
     store.write_json(
         job_id,
@@ -702,7 +769,7 @@ def test_evolution_uses_a_dedicated_long_lived_session(tmp_path, monkeypatch) ->
             return {}
 
         def find_child_session(self, *, parent_id, title):
-            assert title == f"job/{job_id}/evolution/campaign-1"
+            assert title == f"job/{job_id}/evolution/campaign-1/candidate-01"
             return "evolution-session"
 
         def create_session(self, **kwargs):
@@ -718,6 +785,7 @@ def test_evolution_uses_a_dedicated_long_lived_session(tmp_path, monkeypatch) ->
         "wayfinder_paths.jobs.evolution_campaign.campaign_prompt_block",
         lambda store, job_id: {
             "campaign_id": "campaign-1",
+            "session_stage": "candidate-01",
             "next_action": "prepare the next candidate",
         },
     )
@@ -726,11 +794,12 @@ def test_evolution_uses_a_dedicated_long_lived_session(tmp_path, monkeypatch) ->
 
     assert result == {"queued": True, "session_id": "evolution-session"}
     assert len(client.prompts) == 1
-    assert "PAPER-ONLY evolution campaign" in client.prompts[0][1]
-    assert "do not wait on detached evaluation" in client.prompts[0][1]
+    assert "PAPER-ONLY evolution stage" in client.prompts[0][1]
+    assert "end the stage" in client.prompts[0][1]
     assert client.prompts[0][2] == "wayfinder-evolution-worker"
     session = store.read_json(job_id, "reports/evolution/session.json")
     assert session["session_id"] == "evolution-session"
+    assert session["session_stage"] == "candidate-01"
 
 
 class _FakeEvolutionClient:
@@ -748,7 +817,7 @@ class _FakeEvolutionClient:
         return {}
 
     def find_child_session(self, *, parent_id: Any, title: str) -> str:
-        assert title == f"job/{self.job_id}/evolution/campaign-1"
+        assert title == f"job/{self.job_id}/evolution/campaign-1/candidate-01"
         return "evolution-session"
 
     def create_session(self, **kwargs: Any) -> str:
@@ -774,6 +843,7 @@ def test_op_completion_nudge_reuses_session_and_respects_kill_switch(
         "wayfinder_paths.jobs.evolution_campaign.campaign_prompt_block",
         lambda store, job_id: {
             "campaign_id": "campaign-1",
+            "session_stage": "candidate-01",
             "next_action": "prepare the next candidate",
         },
     )
@@ -820,11 +890,12 @@ def test_parentless_evolution_nudges_reuse_persisted_campaign_session(
         "state/evolution_campaign.json",
         {"campaign_id": "campaign-1", "status": "active"},
     )
-    actions = iter(["prepare c1", "prepare c2", "prepare c2"])
+    actions = iter(["prepare c1", "edit c1", "edit c1"])
     monkeypatch.setattr(
         "wayfinder_paths.jobs.evolution_campaign.campaign_prompt_block",
         lambda store, job_id: {
             "campaign_id": "campaign-1",
+            "session_stage": "candidate-01",
             "next_action": next(actions),
         },
     )
@@ -876,6 +947,263 @@ def test_parentless_evolution_nudges_reuse_persisted_campaign_session(
     }
     assert client.created == 1
     assert client.prompts == ["session-1", "session-1"]
+
+
+def test_evaluation_completion_rotates_stage_and_passes_bounded_handoff(
+    tmp_path, monkeypatch
+) -> None:
+    store, job_id = _job(tmp_path, "majors-5m-lab")
+    store.write_json(
+        job_id,
+        "state/evolution_campaign.json",
+        {"campaign_id": "campaign-1", "status": "active"},
+    )
+    store.write_json(
+        job_id,
+        "reports/evolution/session.json",
+        {
+            "schema_version": "1.1",
+            "campaign_id": "campaign-1",
+            "session_stage": "candidate-01",
+            "session_id": "session-1",
+            "created_at": "2026-08-25T12:00:00+00:00",
+        },
+    )
+
+    class StageClient:
+        def __init__(self) -> None:
+            self.sessions = {"session-1"}
+            self.deleted: list[str] = []
+            self.prompts: list[tuple[str, str]] = []
+
+        def healthy(self) -> bool:
+            return True
+
+        def session_exists(self, session_id: str) -> bool:
+            return session_id in self.sessions
+
+        def session_statuses(self) -> dict[str, Any]:
+            return {}
+
+        def find_child_session(self, *, parent_id: Any, title: str) -> None:
+            assert title.endswith("/candidate-02")
+            return None
+
+        def create_session(self, **kwargs: Any) -> str:
+            self.sessions.add("session-2")
+            return "session-2"
+
+        def delete_session(self, session_id: str) -> bool:
+            self.deleted.append(session_id)
+            self.sessions.discard(session_id)
+            return True
+
+        def prompt_async(self, *, session_id: str, text: str, agent: str) -> bool:
+            self.prompts.append((session_id, text))
+            return True
+
+    client = StageClient()
+    monkeypatch.setattr("wayfinder_paths.jobs.worker.OPENCODE_CLIENT", client)
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.evolution_campaign.campaign_prompt_block",
+        lambda store, job_id: {
+            "campaign_id": "campaign-1",
+            "session_stage": "candidate-02",
+            "next_action": "author candidate two",
+            "candidate_outcomes": [
+                {
+                    "candidate_id": "candidate-01",
+                    "status": "quick_complete",
+                    "summary": "candidate one improved drawdown",
+                }
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.benchmarks.agent_adapter.meter_session_ids",
+        lambda session_ids: {
+            "sessions": 1,
+            "tokens_in": 100,
+            "tokens_out": 20,
+            "tokens_reasoning": 40,
+            "tool_calls": 3,
+            "tool_result_bytes": 500,
+        },
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.benchmarks.agent_adapter.session_diagnostic_summary",
+        lambda session_id: {
+            "schema_version": "1.0",
+            "tool_calls": [
+                {
+                    "tool": "wayfinder_core_jobs",
+                    "action": "evolution_evaluate",
+                    "status": "completed",
+                    "output": "raw result must never enter the next prompt",
+                }
+            ],
+            "omitted_tool_calls": 0,
+            "final_assistant_text": "candidate one authored and evaluation launched",
+        },
+    )
+
+    result = nudge_evolution_session(store, job_id)
+
+    assert result == {"queued": True, "session_id": "session-2"}
+    assert client.deleted == ["session-1"]
+    assert len(client.prompts) == 1
+    prompt = client.prompts[0][1]
+    assert "candidate-02" in prompt
+    assert "candidate one improved drawdown" in prompt
+    assert "candidate one authored and evaluation launched" in prompt
+    assert "tool_result_bytes" in prompt
+    assert "raw result must never enter the next prompt" not in prompt
+    current = store.read_json(job_id, "reports/evolution/session.json")
+    assert current["session_id"] == "session-2"
+    assert current["session_stage"] == "candidate-02"
+    archive = store.read_json(job_id, "reports/evolution/sessions.json")
+    assert archive["sessions"][0]["session_stage"] == "candidate-01"
+
+
+def test_stage_transition_waits_for_the_previous_session_to_be_idle(
+    tmp_path, monkeypatch
+) -> None:
+    store, job_id = _job(tmp_path, "majors-5m-lab")
+    store.write_json(
+        job_id,
+        "state/evolution_campaign.json",
+        {"campaign_id": "campaign-1", "status": "active"},
+    )
+    store.write_json(
+        job_id,
+        "reports/evolution/session.json",
+        {
+            "schema_version": "1.1",
+            "campaign_id": "campaign-1",
+            "session_stage": "candidate-01",
+            "session_id": "session-1",
+        },
+    )
+
+    class BusyClient:
+        def healthy(self) -> bool:
+            return True
+
+        def session_exists(self, session_id: str) -> bool:
+            return True
+
+        def session_statuses(self) -> dict[str, Any]:
+            return {"session-1": {"type": "busy"}}
+
+        def abort_session(self, session_id: str) -> bool:
+            pytest.fail("a stage transition must not abort active authoring")
+
+        def delete_session(self, session_id: str) -> bool:
+            pytest.fail("a busy stage must not be deleted")
+
+    monkeypatch.setattr("wayfinder_paths.jobs.worker.OPENCODE_CLIENT", BusyClient())
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.evolution_campaign.campaign_prompt_block",
+        lambda store, job_id: {
+            "campaign_id": "campaign-1",
+            "session_stage": "candidate-02",
+            "next_action": "author candidate two",
+        },
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.benchmarks.agent_adapter.meter_session_ids",
+        lambda session_ids: pytest.fail("busy session was exported prematurely"),
+    )
+
+    result = nudge_evolution_session(store, job_id)
+
+    assert result == {
+        "queued": False,
+        "transition_pending": True,
+        "session_id": "session-1",
+        "from_stage": "candidate-01",
+        "to_stage": "candidate-02",
+        "error": "previous stage session is still busy",
+    }
+
+
+def test_watchdog_restarts_stale_idle_stage_in_a_fresh_session(
+    tmp_path, monkeypatch
+) -> None:
+    store, job_id = _job(tmp_path, "majors-5m-lab")
+    store.write_json(
+        job_id,
+        "reports/evolution/session.json",
+        {
+            "schema_version": "1.1",
+            "campaign_id": "campaign-1",
+            "session_stage": "candidate-01",
+            "session_id": "session-1",
+            "created_at": "2026-08-25T12:00:00+00:00",
+            "last_prompt_at": "2026-08-25T12:00:00+00:00",
+        },
+    )
+
+    class RecoveryClient:
+        def __init__(self) -> None:
+            self.sessions = {"session-1"}
+            self.created = 0
+
+        def healthy(self) -> bool:
+            return True
+
+        def session_exists(self, session_id: str) -> bool:
+            return session_id in self.sessions
+
+        def session_statuses(self) -> dict[str, Any]:
+            return {}
+
+        def delete_session(self, session_id: str) -> bool:
+            self.sessions.discard(session_id)
+            return True
+
+        def find_child_session(self, **kwargs: Any) -> None:
+            return None
+
+        def create_session(self, **kwargs: Any) -> str:
+            self.created += 1
+            session_id = f"recovery-{self.created}"
+            self.sessions.add(session_id)
+            return session_id
+
+        def prompt_async(self, **kwargs: Any) -> bool:
+            return True
+
+    client = RecoveryClient()
+    monkeypatch.setattr("wayfinder_paths.jobs.worker.OPENCODE_CLIENT", client)
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.evolution_campaign.campaign_prompt_block",
+        lambda store, job_id, now=None: {
+            "campaign_id": "campaign-1",
+            "session_stage": "candidate-01",
+            "next_action": "finish candidate one",
+        },
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.benchmarks.agent_adapter.meter_session_ids",
+        lambda session_ids: {"sessions": 1},
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.benchmarks.agent_adapter.session_diagnostic_summary",
+        lambda session_id: {
+            "tool_calls": [],
+            "final_assistant_text": "partial candidate work is persisted",
+        },
+    )
+
+    recovered = recover_evolution_stage_session(
+        store, job_id, now=datetime(2026, 8, 25, 12, 11, tzinfo=UTC)
+    )
+
+    assert recovered == {"queued": True, "session_id": "recovery-1"}
+    session = store.read_json(job_id, "reports/evolution/session.json")
+    assert session["session_id"] == "recovery-1"
+    assert session["session_stage"] == "candidate-01"
 
 
 def test_evolution_session_retirement_exports_before_exact_delete(
@@ -1227,6 +1555,60 @@ def test_evaluate_releases_claim_when_compute_is_transiently_busy(
     assert recovered["status"] == "quick_failed"
     assert "evaluation_claim_id" not in recovered
     assert state["counts"]["quick_evaluated"] == 0
+
+
+def test_lost_evaluator_claim_is_released_for_a_fresh_stage(tmp_path) -> None:
+    store, job_id = _evaluatable_job(tmp_path)
+    start_campaign(store, job_id, now=datetime(2026, 8, 25, 12, tzinfo=UTC))
+    candidate = prepare_candidate(
+        store,
+        job_id,
+        family="breakout",
+        summary="recover after machine restart",
+        now=datetime(2026, 8, 25, 13, tzinfo=UTC),
+    )
+    state = campaign_status(store, job_id)
+    state["candidates"][0].update(
+        {
+            "status": "quick_running",
+            "evaluation_claim_id": "lost-claim",
+            "evaluation_claimed_at": "2026-08-25T13:05:00+00:00",
+        }
+    )
+    store.write_json(job_id, "state/evolution_campaign.json", state)
+
+    recovered = recover_lost_candidate_evaluations(
+        store,
+        job_id,
+        reason="detached evaluator exited during machine roll",
+        now=datetime(2026, 8, 25, 13, 6, tzinfo=UTC),
+    )
+
+    assert recovered == [candidate["candidate_id"]]
+    current = campaign_status(store, job_id)["candidates"][0]
+    assert current["status"] == "quick_failed"
+    assert "evaluation_claim_id" not in current
+    assert current["evaluation_recovery_reason"].endswith("machine roll")
+    assert "evolution_candidate_evaluation_recovered" in (
+        store.job_dir(job_id) / "journal.jsonl"
+    ).read_text(encoding="utf-8")
+
+
+def test_finalize_refuses_to_skip_a_pending_candidate_stage(tmp_path) -> None:
+    store, job_id = _evaluatable_job(tmp_path)
+    start_campaign(store, job_id, now=datetime(2026, 8, 25, 12, tzinfo=UTC))
+    candidate = prepare_candidate(
+        store,
+        job_id,
+        family="breakout",
+        summary="must be evaluated before finalization",
+        now=datetime(2026, 8, 25, 13, tzinfo=UTC),
+    )
+
+    with pytest.raises(TransientInfrastructureError, match=candidate["candidate_id"]):
+        finalize_campaign(store, job_id)
+
+    assert campaign_status(store, job_id)["status"] == "active"
 
 
 def test_full_dev_runs_real_small_simulations_in_disposable_child(tmp_path) -> None:

--- a/wayfinder_paths/tests/test_mcp_jobs_background_ops.py
+++ b/wayfinder_paths/tests/test_mcp_jobs_background_ops.py
@@ -7,12 +7,16 @@ from __future__ import annotations
 
 import asyncio
 import json
+from datetime import UTC, datetime
 
 import pytest
 
 import wayfinder_paths.mcp.tools.jobs as jobs_module
 from wayfinder_paths.jobs.background import op_status_summary
-from wayfinder_paths.jobs.execution.op_process import terminate_campaign_ops
+from wayfinder_paths.jobs.execution.op_process import (
+    recorded_process_alive,
+    terminate_campaign_ops,
+)
 from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.mcp.tools.jobs import (
     _background_op_status,
@@ -108,6 +112,46 @@ def test_sync_status_reconciles_dead_detached_operation(tmp_path) -> None:
     assert reconciled["state"] == "failed"
     assert reconciled["reconciled_at"]
     assert "without a result" in reconciled["error"]
+
+
+def test_detached_process_identity_rejects_pid_reuse_after_restart(monkeypatch) -> None:
+    import wayfinder_paths.jobs.execution.op_process as process_module
+
+    monkeypatch.setattr(process_module, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(
+        process_module,
+        "process_identity_fields",
+        lambda pid: {"boot_id": "new-boot", "process_start_ticks": 222},
+    )
+    assert not recorded_process_alive(
+        {
+            "pid": 42,
+            "boot_id": "old-boot",
+            "process_start_ticks": 111,
+        }
+    )
+    assert not recorded_process_alive(
+        {"pid": 42, "boot_id": "new-boot", "process_start_ticks": 111}
+    )
+    assert recorded_process_alive(
+        {"pid": 42, "boot_id": "new-boot", "process_start_ticks": 222}
+    )
+
+
+def test_legacy_detached_status_older_than_boot_is_not_alive(monkeypatch) -> None:
+    import wayfinder_paths.jobs.execution.op_process as process_module
+
+    monkeypatch.setattr(process_module, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(process_module, "process_identity_fields", lambda pid: {})
+    monkeypatch.setattr(
+        process_module,
+        "_linux_booted_at",
+        lambda: datetime(2026, 8, 28, 5, tzinfo=UTC),
+    )
+
+    assert not recorded_process_alive(
+        {"pid": 42, "started_at": "2026-08-28T04:38:54+00:00"}
+    )
 
 
 def test_campaign_close_reaps_registered_runner_group(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## What changed

- rotate the evolution worker into one OpenCode session per candidate stage, exporting bounded metrics, the final assistant summary, and a compact tool trace before deletion
- pass persisted candidate outcomes and the immediately prior stage handoff into each fresh session, with newest evidence prioritized and raw tool results excluded
- recover missing or stale idle sessions without interrupting a busy authoring stage
- reconcile evaluator claims when their detached owner disappears, preserve already-prepared candidates past the 4-hour generation cutoff, and refuse finalization while evaluation remains pending
- keep healthy/paused evaluation and finalization work alive past the generation deadline; retry failed finalization from durable claims for up to 24 hours before an explicit terminal failure
- stamp detached operations with boot id and process start ticks, including a legacy pre-boot fallback, so PID reuse after a machine roll cannot pin a campaign

The four-hour setting remains the **generation cutoff**. Evaluation/finalization are now durable completion stages and can extend the campaign beyond it.

## Validation

- `ruff format --check` and `ruff check` on all changed files
- isolated mypy check on changed source modules: clean (repo-wide legacy/import-stub errors remain outside this diff)
- 94 focused lifecycle/background-op tests passed
- 1,039 jobs/runner regression tests passed, 8 skipped
- one unrelated local regression-suite failure: `test_quality_diversity_lane_spends_matched_budget_across_cells` could not import the declared `optuna` dependency because this cached local venv does not have the ML group installed
