### PR TITLE
fix(jobs): preserve evolution handoffs across hosted paths

### DIFF
--- a/wayfinder_paths/jobs/evolution_campaign.py
+++ b/wayfinder_paths/jobs/evolution_campaign.py
@@ -464,7 +464,12 @@ def _prepare_candidate(
             "parent_source": source,
         },
     )
-    return candidate
+    # ``bundle`` stays durable and job-relative.  The tool response also gives
+    # the short-lived mutation worker an exact authorized path so a fresh stage
+    # does not spend context discovering the SDK's hosted symlink layout.
+    result = dict(candidate)
+    result["bundle_path"] = str(candidate_root.resolve())
+    return result
 
 
 def _source_baseline_revision(manifest: dict[str, Any]) -> str:
@@ -1217,9 +1222,15 @@ def campaign_prompt_block(
     )
     if awaiting_evaluation:
         candidate = awaiting_evaluation[0]
+        candidate_root = resolve_candidate_bundle(
+            store,
+            job_id,
+            candidate,
+            campaign_id=str(state["campaign_id"]),
+        )
         session_stage = f"candidate-{int(candidate.get('slot') or 0):02d}"
         next_action = (
-            f"Edit only files inside {candidate['bundle']} (workspace, job.yaml, "
+            f"Edit only files inside {candidate_root} (workspace, job.yaml, "
             "and optional search_space.json), then launch "
             'wayfinder_core_jobs with action="evolution_evaluate", '
             f'job_id="{job_id}", candidate_id="{candidate["candidate_id"]}", '
@@ -1243,7 +1254,8 @@ def campaign_prompt_block(
     elif len(candidates) < budget:
         session_stage = f"candidate-{len(candidates) + 1:02d}"
         next_action = (
-            f"{prepare_call} Then edit only the returned candidate bundle and "
+            f"{prepare_call} Then edit only the exact `bundle_path` returned by "
+            "that call and "
             'launch wayfinder_core_jobs with action="evolution_evaluate", '
             f'job_id="{job_id}", candidate_id="<returned candidate_id>", '
             "background=true. Do not wait for the detached result. END THIS "

--- a/wayfinder_paths/jobs/gating.py
+++ b/wayfinder_paths/jobs/gating.py
@@ -60,13 +60,17 @@ def clamp_leverage(
     return requested, None
 
 
-def compute_workspace_revision(root: Path) -> str:
+def compute_workspace_revision(
+    root: Path, *, retain_operator_dials: bool = False
+) -> str:
     """Content hash of workspace/* + job.yaml.
 
     Promotion copies the candidate byte-for-byte over the active workspace, so
     a hash computed on a candidate dir pre-promotion equals the promoted
     revision — artifacts stamped during candidate validation stay valid after
-    promotion.
+    promotion. ``retain_operator_dials`` reproduces the immediately preceding
+    hash definition for migrating already-approved evidence; new evidence must
+    always use the default.
     """
     digest = hashlib.sha256()
     workspace = root / "workspace"
@@ -112,8 +116,9 @@ def compute_workspace_revision(root: Path) -> str:
                 # stamps, baseline drift on staged candidates, and candidate
                 # promotion reverting the operator's selection. job_kind is
                 # derived from the same dial, so it leaves the hash with it.
-                data.pop("agent_loop", None)
-                data.pop("job_kind", None)
+                if not retain_operator_dials:
+                    data.pop("agent_loop", None)
+                    data.pop("job_kind", None)
                 match data.get("execution_params"):
                     case dict() as execution_params:
                         execution_params.pop("wallet_label", None)

--- a/wayfinder_paths/jobs/paper_experiment.py
+++ b/wayfinder_paths/jobs/paper_experiment.py
@@ -845,11 +845,11 @@ def harvest_hourly_control_candidates(
     seen = set(state.get("seen_candidates") or [])
     for proposal in store.proposals(job_id):
         report = proposal.get("candidate_report") or {}
-        revision = str(report.get("revision") or "")
+        recorded_revision = str(report.get("revision") or "")
         candidate_id = str(proposal.get("proposal_id") or "")
-        if not candidate_id or not revision:
+        if not candidate_id or not recorded_revision:
             continue
-        if f"control:{_safe_candidate_id(candidate_id)}:{revision}" in seen:
+        if f"control:{_safe_candidate_id(candidate_id)}:{recorded_revision}" in seen:
             continue
         if (
             (report.get("validation_summary") or {}).get("status") != "passed"
@@ -868,24 +868,49 @@ def harvest_hourly_control_candidates(
                 proposal,
             )
         )
-    if not candidates:
-        return None
-    _, proposal = max(candidates, key=lambda item: item[0])
-    report = proposal["candidate_report"]
-    candidate_root = _candidate_dir_from_proposal(store, job_id, proposal)
-    if not candidate_root.exists():
-        return None
-    return stage_paper_proposal(
-        store,
-        job_id,
-        arm="control",
-        candidate_id=str(proposal["proposal_id"]),
-        candidate_root=candidate_root,
-        revision=str(report["revision"]),
-        source="hourly_funnel",
-        evidence=report.get("economic") or {},
-        now=now,
-    )
+    for _, proposal in sorted(candidates, key=lambda item: item[0], reverse=True):
+        candidate_root = _candidate_dir_from_proposal(store, job_id, proposal)
+        if not candidate_root.exists():
+            continue
+        report = proposal["candidate_report"]
+        revision, migration = _normalize_control_revision(
+            candidate_root, str(report["revision"])
+        )
+        safe_id = _safe_candidate_id(str(proposal["proposal_id"]))
+        if f"control:{safe_id}:{revision}" in seen:
+            continue
+        evidence = dict(report.get("economic") or {})
+        if migration:
+            evidence["revision_migration"] = migration
+        return stage_paper_proposal(
+            store,
+            job_id,
+            arm="control",
+            candidate_id=str(proposal["proposal_id"]),
+            candidate_root=candidate_root,
+            revision=revision,
+            source="hourly_funnel",
+            evidence=evidence,
+            now=now,
+        )
+    return None
+
+
+def _normalize_control_revision(
+    candidate_root: Path, recorded_revision: str
+) -> tuple[str, dict[str, str] | None]:
+    """Restamp evidence across the operator-dial hash hygiene change only."""
+    current = compute_workspace_revision(candidate_root)
+    if current == recorded_revision:
+        return current, None
+    legacy = compute_workspace_revision(candidate_root, retain_operator_dials=True)
+    if legacy != recorded_revision:
+        raise ValueError("candidate revision does not match immutable bundle")
+    return current, {
+        "kind": "operator_dial_hash_hygiene",
+        "recorded_revision": recorded_revision,
+        "current_revision": current,
+    }
 
 
 def maybe_finalize_experiment(

--- a/wayfinder_paths/jobs/watchdog.py
+++ b/wayfinder_paths/jobs/watchdog.py
@@ -1378,6 +1378,49 @@ def _reap_finalize_group(pid: int | None) -> bool:
     return True
 
 
+def _expire_evolution_campaign(
+    store: JobStore, job_id: str, now: datetime
+) -> dict[str, Any] | None:
+    """Enforce one hard terminal horizon across every campaign stage."""
+    from wayfinder_paths.jobs.compute_lock import job_state_lock
+    from wayfinder_paths.jobs.evolution_campaign import CAMPAIGN_STATE_PATH
+    from wayfinder_paths.jobs.execution.op_process import terminate_campaign_ops
+    from wayfinder_paths.jobs.worker import retire_evolution_session
+
+    with job_state_lock(store.repo_root, job_id, name="evolution_campaign"):
+        state = store.read_json(job_id, CAMPAIGN_STATE_PATH, default={}) or {}
+        if state.get("status") not in {"active", "finalizing"}:
+            return None
+        attempts = int(state.get("finalize_attempts") or 0)
+        state.update(
+            {
+                "status": "failed",
+                "stage": "failed",
+                "failed_at": now.isoformat(),
+                "failure_reason": "campaign did not reach a terminal verdict within 24 hours",
+            }
+        )
+        store.write_json(job_id, CAMPAIGN_STATE_PATH, state)
+        store.append_journal(
+            job_id,
+            {
+                "type": "evolution_campaign_failed",
+                "campaign_id": state.get("campaign_id"),
+                "finalize_attempts": attempts,
+            },
+        )
+    campaign_id = str(state.get("campaign_id") or "")
+    reaped = terminate_campaign_ops(store, job_id, campaign_id)
+    retire_evolution_session(store, job_id, campaign_id)
+    result: dict[str, Any] = {
+        "action": "evolution_campaign_failed",
+        "campaign_id": state.get("campaign_id"),
+    }
+    if reaped:
+        result["reaped_ops"] = reaped
+    return result
+
+
 def _run_evolution_campaign_pass(
     store: JobStore, job_id: str, now: datetime
 ) -> dict[str, Any] | None:
@@ -1418,6 +1461,8 @@ def _run_evolution_campaign_pass(
         return None
     if deadline.tzinfo is None:
         deadline = deadline.replace(tzinfo=UTC)
+    if now - deadline >= _CAMPAIGN_FINALIZE_MAX_AGE:
+        return _expire_evolution_campaign(store, job_id, now)
     evaluating = op_status_summary(store.job_dir(job_id), "evolution_evaluate")
     if (evaluating or {}).get("status") == "running":
         return {
@@ -1492,15 +1537,14 @@ def _run_evolution_campaign_pass(
     retirement = retire_evolution_session(
         store, job_id, str(state.get("campaign_id") or "")
     )
-    finalize_max_age_reached = now - deadline >= _CAMPAIGN_FINALIZE_MAX_AGE
-    if retirement and not retirement.get("retired") and not finalize_max_age_reached:
+    if retirement and not retirement.get("retired"):
         return {
             "action": "evolution_campaign_waiting_for_session_retirement",
             "campaign_id": state.get("campaign_id"),
             "error": retirement.get("error"),
         }
 
-    if pending_evaluation and not finalize_max_age_reached:
+    if pending_evaluation:
         candidate_id = str(pending_evaluation[0].get("candidate_id") or "")
         spawned = spawn_detached_op(
             store,
@@ -1565,34 +1609,6 @@ def _run_evolution_campaign_pass(
         if state.get("status") not in {"active", "finalizing"}:
             return None
         attempts = int(state.get("finalize_attempts") or 0)
-        if finalize_max_age_reached:
-            state.update(
-                {
-                    "status": "failed",
-                    "stage": "failed",
-                    "failed_at": now.isoformat(),
-                    "failure_reason": "finalization did not reach a terminal verdict within 24 hours",
-                }
-            )
-            store.write_json(job_id, CAMPAIGN_STATE_PATH, state)
-            store.append_journal(
-                job_id,
-                {
-                    "type": "evolution_campaign_failed",
-                    "campaign_id": state.get("campaign_id"),
-                    "finalize_attempts": attempts,
-                },
-            )
-            reaped = terminate_campaign_ops(
-                store, job_id, str(state.get("campaign_id") or "")
-            )
-            result = {
-                "action": "evolution_campaign_failed",
-                "campaign_id": state.get("campaign_id"),
-            }
-            if reaped:
-                result["reaped_ops"] = reaped
-            return result
         last_attempt = state.get("finalize_last_attempt_at")
         if attempts and _age(now, last_attempt) < timedelta(
             seconds=_CAMPAIGN_FINALIZE_RETRY_S[

--- a/wayfinder_paths/tests/test_jobs_apply_watchdog.py
+++ b/wayfinder_paths/tests/test_jobs_apply_watchdog.py
@@ -1472,6 +1472,55 @@ def test_watchdog_waits_for_governor_paused_evaluation_past_drain_grace(
     }
 
 
+def test_watchdog_closes_paused_evaluation_at_terminal_horizon(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = JobStore(repo_root=tmp_path)
+    job = _make_job(store, "campaign-paused-evaluate-terminal")
+    deadline = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    store.write_json(
+        job.id,
+        "state/evolution_campaign.json",
+        {
+            "campaign_id": "campaign-1",
+            "status": "active",
+            "stage": "draining",
+            "deadline_at": deadline.isoformat(),
+            "candidates": [{"candidate_id": "c01", "status": "quick_running"}],
+        },
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.background.op_status_summary",
+        lambda _root, op: {"status": "running"}
+        if op == "evolution_evaluate"
+        else {"status": "failed"},
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.evolution_campaign.recover_lost_candidate_evaluations",
+        lambda *args, **kwargs: [],
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.worker.retire_evolution_session",
+        lambda *args, **kwargs: {"retired": True},
+    )
+    terminated: list[str] = []
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.execution.op_process.terminate_campaign_ops",
+        lambda _store, _job_id, campaign_id: terminated.append(campaign_id) or [],
+    )
+
+    result = _run_evolution_campaign_pass(store, job.id, deadline + timedelta(hours=24))
+
+    assert result == {
+        "action": "evolution_campaign_failed",
+        "campaign_id": "campaign-1",
+    }
+    assert terminated == ["campaign-1"]
+    state = store.read_json(job.id, "state/evolution_campaign.json")
+    assert state["status"] == "failed"
+    assert state["failure_reason"].endswith("within 24 hours")
+
+
 def test_governor_pause_requires_fresh_state_and_matching_pid(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/wayfinder_paths/tests/test_jobs_evolution_campaign.py
+++ b/wayfinder_paths/tests/test_jobs_evolution_campaign.py
@@ -281,6 +281,8 @@ def test_prepare_candidate_isolated_lineage_and_mutation_budget(tmp_path) -> Non
     assert first["mutation_kind"] == "structural"
     root = store.job_dir(job_id)
     bundle = root / first["bundle"]
+    assert first["bundle_path"] == str(bundle.resolve())
+    assert "bundle_path" not in campaign_status(store, job_id)["candidates"][0]
     assert bundle != root
     assert (bundle / "workspace" / "src" / "strategy.py").exists()
     assert (
@@ -632,6 +634,11 @@ def test_next_action_isolates_one_candidate_per_stage_session(tmp_path) -> None:
     assert 'action="evolution_evaluate"' in block["next_action"]
     assert 'action="evolution_prepare"' not in block["next_action"]
     assert f'job_id="{job_id}"' in block["next_action"]
+    expected_root = (
+        store.job_dir(job_id)
+        / campaign_status(store, job_id)["candidates"][0]["bundle"]
+    ).resolve()
+    assert str(expected_root) in block["next_action"]
     assert "background=true" in block["next_action"]
     assert "Do not wait" in block["next_action"]
     assert "END THIS STAGE" in block["next_action"]

--- a/wayfinder_paths/tests/test_jobs_gating.py
+++ b/wayfinder_paths/tests/test_jobs_gating.py
@@ -4,6 +4,8 @@ import json
 import shutil
 from pathlib import Path
 
+import yaml
+
 from wayfinder_paths.jobs.execution import ExecutionSpec
 from wayfinder_paths.jobs.execution.job import backtest_execution_job
 from wayfinder_paths.jobs.execution.preflight import run_preflight
@@ -230,3 +232,17 @@ def test_agent_memory_edits_do_not_move_the_revision(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     assert compute_workspace_revision(root) != after_code
+
+
+def test_operator_dial_legacy_revision_can_be_reproduced(tmp_path: Path) -> None:
+    _, _, root = _make_job(tmp_path)
+    current = compute_workspace_revision(root)
+    legacy = compute_workspace_revision(root, retain_operator_dials=True)
+    job_yaml = root / "job.yaml"
+    data = yaml.safe_load(job_yaml.read_text(encoding="utf-8"))
+    data["agent_loop"] = {"mode": "monitor", "wake_seconds": 28_800}
+    data["job_kind"] = "script_and_agent"
+    job_yaml.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+    assert compute_workspace_revision(root) == current
+    assert compute_workspace_revision(root, retain_operator_dials=True) != legacy

--- a/wayfinder_paths/tests/test_jobs_paper_experiment.py
+++ b/wayfinder_paths/tests/test_jobs_paper_experiment.py
@@ -9,12 +9,14 @@ import pytest
 from wayfinder_paths.jobs.gating import compute_workspace_revision
 from wayfinder_paths.jobs.models import WayfinderJob
 from wayfinder_paths.jobs.paper_experiment import (
+    _normalize_control_revision,
     _proposal_verdict,
     _resource_cost,
     _verdict_report,
     current_job_token_usage,
     ensure_paper_experiment,
     experiment_status,
+    harvest_hourly_control_candidates,
     maybe_adjudicate_proposals,
     maybe_finalize_experiment,
     record_evidence,
@@ -197,6 +199,79 @@ def test_candidate_is_frozen_but_does_not_replace_champion_before_forward_day(
         "raise RuntimeError('changed source')\n", encoding="utf-8"
     )
     assert "changed source" not in copied.read_text(encoding="utf-8")
+
+
+def test_control_revision_migrates_only_known_operator_dial_hash(
+    tmp_path: Path,
+) -> None:
+    started = datetime(2026, 8, 1, tzinfo=UTC)
+    store, job_id, _ = _job(tmp_path, now=started)
+    source, current = _candidate_source(store, job_id)
+    legacy = compute_workspace_revision(source, retain_operator_dials=True)
+    assert legacy != current
+
+    normalized, migration = _normalize_control_revision(source, legacy)
+
+    assert normalized == current
+    assert migration == {
+        "kind": "operator_dial_hash_hygiene",
+        "recorded_revision": legacy,
+        "current_revision": current,
+    }
+    source.joinpath("workspace/src/strategy.py").write_text(
+        "def decide(ctx):\n    return [{'action': 'OPEN'}]\n", encoding="utf-8"
+    )
+    with pytest.raises(ValueError, match="immutable bundle"):
+        _normalize_control_revision(source, legacy)
+
+
+def test_hourly_control_harvest_restamps_legacy_operator_dial_revision(
+    tmp_path: Path,
+) -> None:
+    started = datetime(2026, 8, 1, tzinfo=UTC)
+    store, job_id, _ = _job(tmp_path, now=started)
+    source, current = _candidate_source(store, job_id)
+    legacy = compute_workspace_revision(source, retain_operator_dials=True)
+    assert legacy != current
+    proposal_id = "prop-legacy-revision"
+    store.write_json(
+        job_id,
+        f"proposals/{proposal_id}.json",
+        {
+            "proposal_id": proposal_id,
+            "status": "approved",
+            "created_at": started.isoformat(),
+            "application": {
+                "status": "applied",
+                "candidate_dir": str(source.relative_to(store.repo_root)),
+            },
+            "candidate_report": {
+                "revision": legacy,
+                "validation_summary": {"status": "passed"},
+                "gate": {"live_ready": True},
+                "economic": {
+                    "ready": True,
+                    "paired_incumbent_delta": {"lcb": 0.1, "estimate": 0.2},
+                },
+            },
+        },
+    )
+
+    staged = harvest_hourly_control_candidates(
+        store, job_id, now=started + timedelta(hours=1)
+    )
+
+    assert staged is not None
+    assert staged["revision"] == current
+    assert staged["evidence"]["revision_migration"] == {
+        "kind": "operator_dial_hash_hygiene",
+        "recorded_revision": legacy,
+        "current_revision": current,
+    }
+    assert (
+        f"control:{staged['candidate_id']}:{current}"
+        in experiment_status(store, job_id)["seen_candidates"]
+    )
 
 
 def test_experiment_retires_only_legacy_evolution_probation(tmp_path: Path) -> None:


### PR DESCRIPTION
## What changed
- return and prompt the exact validated candidate bundle path for each fresh evolution stage
- migrate only the known operator-dial revision hash used by already-approved control candidates
- enforce the 24-hour post-generation terminal horizon across evaluation, finalization, and governor-paused work
- retain strict immutable-bundle rejection for actual strategy changes

## Why
The canary proved stage handoffs work, but fresh workers wasted context rediscovering hosted symlink paths. Its paper control lane also repeatedly rejected one unchanged proposal because the revision hash definition intentionally stopped including operator scheduling dials. A lifecycle audit found that a running evaluator returned before the terminal-horizon check, which could otherwise leave a governor-paused campaign open indefinitely.

## Validation
- ruff format/check on all changed files
- 891 jobs tests passed, including the 111 focused evolution, gating, paper experiment, and watchdog tests
- changed-file mypy output identical to base (no new errors)