### PR TITLE
fix(jobs): surface evolution campaign activity

### DIFF
--- a/wayfinder_paths/jobs/decision_log.py
+++ b/wayfinder_paths/jobs/decision_log.py
@@ -39,6 +39,9 @@ def build_decision_log(
     root = store.job_dir(job_id)
     proposals = _load_proposals(root)
     entries: list[dict[str, Any]] = []
+    active_evolution = _active_evolution_entry(root)
+    if active_evolution:
+        entries.append(active_evolution)
     entries.extend(_journal_entries(root, proposals))
     entries.extend(_ledger_entries(root))
     entries.extend(_universe_entries(root))
@@ -292,6 +295,44 @@ def _journal_entries(
                     actor="system",
                 )
             )
+        elif kind == "evolution_campaign_completed":
+            counts = event.get("counts") or {}
+            paper_proposals = _count(event, "paper_proposals")
+            title = "Evolution campaign completed"
+            if paper_proposals:
+                title += (
+                    f" — {paper_proposals} advanced to forward paper testing"
+                )
+            elif "paper_proposals" in event:
+                title += " — no candidate advanced"
+            entries.append(
+                _entry(
+                    ts,
+                    "research",
+                    title,
+                    _evolution_counts_detail(counts),
+                    "info",
+                    actor="harness",
+                )
+            )
+        elif kind == "evolution_campaign_failed":
+            reason = str(
+                event.get("reason")
+                or "campaign did not reach a terminal verdict within its safety horizon"
+            )
+            attempts = _count(event, "finalize_attempts")
+            if attempts:
+                reason += f"; {attempts} finalization attempt(s)"
+            entries.append(
+                _entry(
+                    ts,
+                    "recovery",
+                    "Evolution campaign stopped before completion",
+                    reason,
+                    "info",
+                    actor="watchdog",
+                )
+            )
         elif kind == "data_feed_recovered":
             entries.append(
                 _entry(
@@ -317,6 +358,71 @@ def _journal_entries(
                 )
             )
     return entries
+
+
+def _active_evolution_entry(root: Path) -> dict[str, Any] | None:
+    """Project mutable campaign state into one compact live feed row.
+
+    Worker wakes and candidate evaluations are intentionally not journal rows:
+    the UI needs the campaign's progress, not its orchestration chatter.  The
+    row disappears once the campaign is terminal, when the durable completion
+    or failure journal event takes over.
+    """
+    state = _read_json(root / "state" / "evolution_campaign.json")
+    if not state or state.get("status") not in {"active", "finalizing"}:
+        return None
+    stage = str(state.get("stage") or "generate")
+    title = {
+        "generate": "Evolution campaign generating candidates",
+        "draining": "Evolution campaign preparing full development",
+        "full_dev": "Evolution campaign running full development",
+        "paper_proposal": "Evolution campaign checking finalists",
+    }.get(stage, "Evolution campaign in progress")
+    return _entry(
+        _latest_evolution_ts(state),
+        "research",
+        title,
+        _evolution_counts_detail(state.get("counts") or {}),
+        "info",
+        actor="harness",
+    )
+
+
+def _latest_evolution_ts(state: dict[str, Any]) -> str:
+    timestamp_keys = (
+        "started_at",
+        "finalize_started_at",
+        "prepared_at",
+        "evaluation_claimed_at",
+        "evaluated_at",
+        "full_dev_claimed_at",
+        "full_dev_at",
+        "proposal_claimed_at",
+        "proposed_at",
+    )
+    values = [str(state.get(key) or "") for key in timestamp_keys]
+    for candidate in state.get("candidates") or []:
+        if isinstance(candidate, dict):
+            values.extend(str(candidate.get(key) or "") for key in timestamp_keys)
+    return max((value for value in values if value), default="")
+
+
+def _count(counts: Any, name: str) -> int:
+    if not isinstance(counts, dict):
+        return 0
+    try:
+        return max(int(counts.get(name) or 0), 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _evolution_counts_detail(counts: Any) -> str:
+    return (
+        f"{_count(counts, 'generated')} generated · "
+        f"{_count(counts, 'quick_evaluated')} screened · "
+        f"{_count(counts, 'full_dev')} full-development evaluations · "
+        f"{_count(counts, 'proposed')} finalist-gate evaluations"
+    )
 
 
 def _ledger_entries(root: Path) -> list[dict[str, Any]]:

--- a/wayfinder_paths/jobs/evolution_campaign.py
+++ b/wayfinder_paths/jobs/evolution_campaign.py
@@ -882,6 +882,10 @@ def _finalize_campaign(store: JobStore, job_id: str) -> dict[str, Any]:
             "type": "evolution_campaign_completed",
             "campaign_id": state["campaign_id"],
             "counts": state["counts"],
+            "paper_proposals": sum(
+                candidate.get("status") == "paper_proposal"
+                for candidate in state.get("candidates") or []
+            ),
         },
     )
     return state
@@ -1026,6 +1030,7 @@ def _commit_full_dev(
         candidate.update(outcome)
         candidate.pop("full_dev_claim_id", None)
         candidate.pop("full_dev_claimed_at", None)
+        candidate["full_dev_at"] = utc_now_iso()
         state["counts"]["full_dev"] += 1
         _save_campaign(store, job_id, state)
         return dict(candidate)
@@ -1086,6 +1091,7 @@ def _commit_proposal(
         candidate.update(outcome)
         candidate.pop("proposal_claim_id", None)
         candidate.pop("proposal_claimed_at", None)
+        candidate["proposed_at"] = utc_now_iso()
         state["counts"]["proposed"] = int(state["counts"].get("proposed") or 0) + 1
         _save_campaign(store, job_id, state)
         return dict(candidate)

--- a/wayfinder_paths/jobs/execution/op_runner.py
+++ b/wayfinder_paths/jobs/execution/op_runner.py
@@ -250,6 +250,7 @@ def _lower_priority() -> None:
 
 
 _NUDGE_OPS = {"evolution_start", "evolution_evaluate"}
+_EVOLUTION_ACTIVITY_OPS = _NUDGE_OPS | {"evolution_finalize"}
 
 
 def _nudge_evolution(op: str, kwargs: dict[str, Any]) -> None:
@@ -267,6 +268,19 @@ def _nudge_evolution(op: str, kwargs: dict[str, Any]) -> None:
         pass
 
 
+def _sync_evolution_activity(op: str, kwargs: dict[str, Any]) -> None:
+    """Publish campaign milestones without waiting for an unrelated wake."""
+    if op not in _EVOLUTION_ACTIVITY_OPS or not kwargs.get("job_id"):
+        return
+    try:
+        from wayfinder_paths.jobs.store import JobStore
+        from wayfinder_paths.jobs.sync import sync_all_jobs
+
+        sync_all_jobs(store=JobStore())
+    except Exception:  # noqa: BLE001 - observability lane only
+        pass
+
+
 def main() -> None:
     _lower_priority()
     request = json.load(sys.stdin)
@@ -279,6 +293,7 @@ def main() -> None:
     # the completed op's result file, not a half-written one.
     sys.stdout.flush()
     _nudge_evolution(op, kwargs)
+    _sync_evolution_activity(op, kwargs)
 
 
 if __name__ == "__main__":

--- a/wayfinder_paths/jobs/watchdog.py
+++ b/wayfinder_paths/jobs/watchdog.py
@@ -1407,6 +1407,7 @@ def _expire_evolution_campaign(
                 "type": "evolution_campaign_failed",
                 "campaign_id": state.get("campaign_id"),
                 "finalize_attempts": attempts,
+                "reason": state["failure_reason"],
             },
         )
     campaign_id = str(state.get("campaign_id") or "")

--- a/wayfinder_paths/tests/test_jobs_decision_log.py
+++ b/wayfinder_paths/tests/test_jobs_decision_log.py
@@ -186,6 +186,115 @@ def test_caps_and_empty_job(tmp_path) -> None:
     assert log["stats"]["proposals_created"] == 80
 
 
+def test_active_evolution_campaign_is_one_compact_progress_row(tmp_path) -> None:
+    store, job_id = _mk(tmp_path)
+    store.write_json(
+        job_id,
+        "state/evolution_campaign.json",
+        {
+            "campaign_id": "campaign-1",
+            "status": "active",
+            "stage": "generate",
+            "started_at": "2026-08-28T16:00:00+00:00",
+            "counts": {
+                "generated": 3,
+                "quick_evaluated": 2,
+                "full_dev": 0,
+                "proposed": 0,
+            },
+            "candidates": [
+                {
+                    "candidate_id": "c03",
+                    "prepared_at": "2026-08-28T17:00:00+00:00",
+                }
+            ],
+        },
+    )
+    root = store.job_dir(job_id)
+    (root / "journal.jsonl").write_text(
+        "\n".join(
+            json.dumps(
+                {
+                    "ts": f"2026-08-28T16:0{i}:00+00:00",
+                    "type": event_type,
+                }
+            )
+            for i, event_type in enumerate(
+                (
+                    "evolution_campaign_started",
+                    "evolution_worker_wakeup",
+                    "evolution_session_retired",
+                )
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    entries = build_decision_log(store, job_id)["entries"]
+
+    assert len(entries) == 1
+    assert entries[0] == {
+        "ts": "2026-08-28T17:00:00+00:00",
+        "kind": "research",
+        "title": "Evolution campaign generating candidates",
+        "detail": (
+            "3 generated · 2 screened · 0 full-development evaluations · "
+            "0 finalist-gate evaluations"
+        ),
+        "outcome": "info",
+        "actor": "harness",
+    }
+
+
+def test_terminal_evolution_campaigns_show_outcomes_without_live_duplicate(
+    tmp_path,
+) -> None:
+    store, job_id = _mk(tmp_path)
+    store.write_json(
+        job_id,
+        "state/evolution_campaign.json",
+        {"campaign_id": "campaign-2", "status": "complete", "stage": "complete"},
+    )
+    root = store.job_dir(job_id)
+    journal = [
+        {
+            "ts": "2026-08-27T12:00:00+00:00",
+            "type": "evolution_campaign_failed",
+            "campaign_id": "campaign-1",
+            "finalize_attempts": 3,
+            "reason": "campaign exceeded its safety horizon",
+        },
+        {
+            "ts": "2026-08-28T12:00:00+00:00",
+            "type": "evolution_campaign_completed",
+            "campaign_id": "campaign-2",
+            "paper_proposals": 1,
+            "counts": {
+                "generated": 12,
+                "quick_evaluated": 12,
+                "full_dev": 4,
+                "proposed": 1,
+            },
+        },
+    ]
+    (root / "journal.jsonl").write_text(
+        "\n".join(json.dumps(row) for row in journal) + "\n", encoding="utf-8"
+    )
+
+    entries = build_decision_log(store, job_id)["entries"]
+
+    assert len(entries) == 2
+    assert entries[0]["title"] == (
+        "Evolution campaign completed — 1 advanced to forward paper testing"
+    )
+    assert entries[0]["kind"] == "research"
+    assert "12 generated · 12 screened" in entries[0]["detail"]
+    assert entries[1]["title"] == "Evolution campaign stopped before completion"
+    assert entries[1]["kind"] == "recovery"
+    assert entries[1]["detail"].endswith("3 finalization attempt(s)")
+
+
 def test_apply_lifecycle_events(tmp_path) -> None:
     """The apply pipeline narrates itself: stale-baseline deferral, re-stage,
     genuine apply failure, and owner repair each become feed entries; applied

--- a/wayfinder_paths/tests/test_jobs_evolution_campaign.py
+++ b/wayfinder_paths/tests/test_jobs_evolution_campaign.py
@@ -1859,11 +1859,16 @@ def test_op_runner_nudges_after_evolution_ops_and_contains_failures(
     from wayfinder_paths.jobs.execution import op_runner
 
     nudged: list[str] = []
+    synced: list[str] = []
     monkeypatch.setattr(op_runner, "_lower_priority", lambda: None)
     monkeypatch.setattr(op_runner, "_run", lambda op, kwargs: {"ok": True})
     monkeypatch.setattr(
         "wayfinder_paths.jobs.worker.nudge_evolution_session",
         lambda store, job_id: nudged.append(job_id),
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.sync.sync_all_jobs",
+        lambda *, store: synced.append("sync"),
     )
 
     def run_main(op: str, kwargs: dict[str, Any]) -> None:
@@ -1876,17 +1881,23 @@ def test_op_runner_nudges_after_evolution_ops_and_contains_failures(
     # evolution_start completion nudges too: the first campaign prompt no
     # longer waits out a full hourly wake interval.
     run_main("evolution_start", {"job_id": "majors-5m-lab"})
+    run_main("evolution_finalize", {"job_id": "majors-5m-lab"})
     run_main("backtest_job", {"job_id": "majors-5m-lab"})
     assert nudged == ["majors-5m-lab", "majors-5m-lab"]
+    assert synced == ["sync", "sync", "sync"]
 
     def boom(store: Any, job_id: str) -> None:
         raise RuntimeError("nudge failed")
 
+    def sync_boom(*, store: Any) -> None:
+        raise RuntimeError("sync failed")
+
     monkeypatch.setattr("wayfinder_paths.jobs.worker.nudge_evolution_session", boom)
+    monkeypatch.setattr("wayfinder_paths.jobs.sync.sync_all_jobs", sync_boom)
     run_main("evolution_evaluate", {"job_id": "majors-5m-lab", "candidate_id": "c1"})
-    # The op result was written all four times; the failed nudge stayed inside
-    # its guard instead of failing the op.
-    assert capsys.readouterr().out.count('{"ok": true}') == 4
+    # The op result was written all five times; failed observability hooks stay
+    # inside their guards instead of failing the compute operation.
+    assert capsys.readouterr().out.count('{"ok": true}') == 5
 
 
 def test_cli_evolution_start_nudges_the_session(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Summary
- project the active evolution campaign into one compact, updating Decision Log row
- surface completed and safety-stopped campaigns with accurate finalist and forward-paper outcomes
- sync start/evaluation/finalization milestones through the existing authenticated jobs sync
- keep orchestration noise such as worker wakes and session rotations out of Activity

## Why
Evolution campaigns were recorded in `journal.jsonl` and campaign state, but the Activity tab only receives the SDK-generated Decision Log. Because the projector ignored `evolution_*` events, healthy campaign work was invisible in the frontend.

## Safety and compatibility
- no frontend or backend schema change
- uses existing `research` / `recovery` activity kinds and `info` outcome
- campaign code remains paper-only; promotion governance is unchanged
- sync is best-effort and cannot fail evolution compute

## Validation
- `ruff check` on all touched Python files
- `pytest --no-cov -q wayfinder_paths/tests/test_jobs_evolution_campaign.py wayfinder_paths/tests/test_jobs_apply_watchdog.py wayfinder_paths/tests/test_jobs_decision_log.py` (95 passed)