### PR TITLE
Show evolution funnel outcomes in Activity metadata

### DIFF
--- a/wayfinder_paths/jobs/decision_log.py
+++ b/wayfinder_paths/jobs/decision_log.py
@@ -21,6 +21,10 @@ import re
 from pathlib import Path
 from typing import Any
 
+from wayfinder_paths.jobs.evolution_funnel import (
+    format_evolution_funnel,
+    summarize_evolution_funnel,
+)
 from wayfinder_paths.jobs.store import JobStore
 
 DEFAULT_LIMIT = 50
@@ -297,6 +301,7 @@ def _journal_entries(
             )
         elif kind == "evolution_campaign_completed":
             counts = event.get("counts") or {}
+            funnel = event.get("funnel")
             paper_proposals = _count(event, "paper_proposals")
             title = "Evolution campaign completed"
             if paper_proposals:
@@ -310,12 +315,23 @@ def _journal_entries(
                     ts,
                     "research",
                     title,
-                    _evolution_counts_detail(counts),
+                    (
+                        format_evolution_funnel(funnel)
+                        if isinstance(funnel, dict)
+                        else _evolution_counts_detail(counts)
+                    ),
                     "info",
                     actor="harness",
+                    metadata={
+                        "campaign_id": event.get("campaign_id"),
+                        "funnel": funnel,
+                    }
+                    if isinstance(funnel, dict)
+                    else None,
                 )
             )
         elif kind == "evolution_campaign_failed":
+            funnel = event.get("funnel")
             reason = str(
                 event.get("reason")
                 or "campaign did not reach a terminal verdict within its safety horizon"
@@ -323,6 +339,8 @@ def _journal_entries(
             attempts = _count(event, "finalize_attempts")
             if attempts:
                 reason += f"; {attempts} finalization attempt(s)"
+            if isinstance(funnel, dict):
+                reason += f" · {format_evolution_funnel(funnel)}"
             entries.append(
                 _entry(
                     ts,
@@ -331,6 +349,12 @@ def _journal_entries(
                     reason,
                     "info",
                     actor="watchdog",
+                    metadata={
+                        "campaign_id": event.get("campaign_id"),
+                        "funnel": funnel,
+                    }
+                    if isinstance(funnel, dict)
+                    else None,
                 )
             )
         elif kind == "data_feed_recovered":
@@ -378,13 +402,15 @@ def _active_evolution_entry(root: Path) -> dict[str, Any] | None:
         "full_dev": "Evolution campaign running full development",
         "paper_proposal": "Evolution campaign checking finalists",
     }.get(stage, "Evolution campaign in progress")
+    funnel = summarize_evolution_funnel(state)
     return _entry(
         _latest_evolution_ts(state),
         "research",
         title,
-        _evolution_counts_detail(state.get("counts") or {}),
+        format_evolution_funnel(funnel),
         "info",
         actor="harness",
+        metadata={"campaign_id": state.get("campaign_id"), "funnel": funnel},
     )
 
 
@@ -579,6 +605,7 @@ def _entry(
     actor: str,
     proposal_id: str | None = None,
     family: str | None = None,
+    metadata: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     entry: dict[str, Any] = {
         "ts": ts,
@@ -592,6 +619,8 @@ def _entry(
         entry["proposal_id"] = proposal_id
     if family:
         entry["family"] = family
+    if metadata:
+        entry["metadata"] = metadata
     return entry
 
 

--- a/wayfinder_paths/jobs/evolution_campaign.py
+++ b/wayfinder_paths/jobs/evolution_campaign.py
@@ -37,6 +37,7 @@ from wayfinder_paths.jobs.compute_lock import (
     experiment_compute_lock,
     job_state_lock,
 )
+from wayfinder_paths.jobs.evolution_funnel import summarize_evolution_funnel
 from wayfinder_paths.jobs.execution.features import parse_feature_specs
 from wayfinder_paths.jobs.execution.job import _load_dataset, _load_job_yaml
 from wayfinder_paths.jobs.execution.optimize import is_search_space, run_optuna_search
@@ -353,6 +354,7 @@ def _start_campaign(
             "full_dev": 0,
             "proposed": 0,
         },
+        "budgets": _campaign_budgets(campaign_policy),
     }
     store.write_json(job_id, CAMPAIGN_STATE_PATH, state)
     store.append_journal(
@@ -872,6 +874,8 @@ def _finalize_campaign(store: JobStore, job_id: str) -> dict[str, Any]:
         state = campaign_status(store, job_id)
         if state.get("status") not in {"active", "finalizing"}:
             return state
+        policy = _campaign_policy(store, job_id, str(state["campaign_id"]))
+        state.setdefault("budgets", _campaign_budgets(policy))
         state["status"] = "complete"
         state["stage"] = "complete"
         state["completed_at"] = utc_now_iso()
@@ -882,6 +886,7 @@ def _finalize_campaign(store: JobStore, job_id: str) -> dict[str, Any]:
             "type": "evolution_campaign_completed",
             "campaign_id": state["campaign_id"],
             "counts": state["counts"],
+            "funnel": summarize_evolution_funnel(state),
             "paper_proposals": sum(
                 candidate.get("status") == "paper_proposal"
                 for candidate in state.get("candidates") or []
@@ -889,6 +894,15 @@ def _finalize_campaign(store: JobStore, job_id: str) -> dict[str, Any]:
         },
     )
     return state
+
+
+def _campaign_budgets(policy: dict[str, Any]) -> dict[str, int]:
+    return {
+        "generated": int(policy["generated_programs"]),
+        "full_development": int(policy["full_dev_survivors"]),
+        "optuna": int(policy["inner_optuna_finalists"]),
+        "finalist_gate": int(policy["proposal_finalists"]),
+    }
 
 
 def _claim_full_dev(

--- a/wayfinder_paths/jobs/evolution_funnel.py
+++ b/wayfinder_paths/jobs/evolution_funnel.py
@@ -1,0 +1,160 @@
+"""Mechanical evolution-campaign funnel summary for reports and activity."""
+
+from __future__ import annotations
+
+from typing import Any
+
+_QUICK_REJECTION_STATUSES = {"invalid", "low_fidelity_rejected"}
+_FULL_DEV_PASS_STATUSES = {
+    "dev_frontier",
+    "proposal_running",
+    "proposal_rejected",
+    "proposal_deferred",
+    "paper_proposal",
+    "paper_experiment",
+}
+
+
+def summarize_evolution_funnel(state: dict[str, Any]) -> dict[str, Any]:
+    """Derive gate outcomes from durable campaign state without new writes."""
+    candidates = [
+        candidate
+        for candidate in state.get("candidates") or []
+        if isinstance(candidate, dict)
+    ]
+    counts = state.get("counts") or {}
+    budgets = state.get("budgets") or {}
+    generated = _count(counts, "generated")
+    quick_evaluated = _count(counts, "quick_evaluated")
+    full_dev_evaluated = _count(counts, "full_dev")
+    gate_evaluated = _count(counts, "proposed")
+
+    # A quick rejection never receives a full-dev allocation.  Checking the
+    # durable allocation marker also classifies campaigns completed before
+    # full_dev_at was added to candidate records.
+    quick_rejected = sum(
+        str(candidate.get("status") or "") in _QUICK_REJECTION_STATUSES
+        and "full_dev_tune" not in candidate
+        for candidate in candidates
+    )
+    full_dev_passed = sum(
+        str(candidate.get("status") or "") in _FULL_DEV_PASS_STATUSES
+        for candidate in candidates
+    )
+    optuna_completed = sum(
+        isinstance(candidate.get("tuning"), dict) for candidate in candidates
+    )
+    optuna_running = sum(
+        candidate.get("full_dev_tune") is True
+        and candidate.get("status") == "full_dev_running"
+        for candidate in candidates
+    )
+    paper_admitted = sum(
+        candidate.get("status") in {"paper_proposal", "paper_experiment"}
+        for candidate in candidates
+    )
+
+    return {
+        "generated": {
+            "total": generated,
+            "target": _optional_count(budgets, "generated"),
+            "structural": sum(
+                candidate.get("mutation_kind") == "structural"
+                for candidate in candidates
+            ),
+            "parameter": sum(
+                candidate.get("mutation_kind") == "parameter"
+                for candidate in candidates
+            ),
+        },
+        "quick_screen": {
+            "evaluated": quick_evaluated,
+            "passed": max(quick_evaluated - quick_rejected, 0),
+            "rejected": quick_rejected,
+            "pending": max(generated - quick_evaluated, 0),
+        },
+        "full_development": {
+            "evaluated": full_dev_evaluated,
+            "target": _optional_count(budgets, "full_development"),
+            "passed": full_dev_passed,
+            "rejected": max(full_dev_evaluated - full_dev_passed, 0),
+            "running": sum(
+                candidate.get("status") == "full_dev_running"
+                for candidate in candidates
+            ),
+        },
+        "optuna": {
+            "completed": optuna_completed,
+            "budget": _optional_count(budgets, "optuna"),
+            "running": optuna_running,
+        },
+        "finalist_gate": {
+            "evaluated": gate_evaluated,
+            "target": _optional_count(budgets, "finalist_gate"),
+            "advanced_to_paper": paper_admitted,
+            "rejected": sum(
+                candidate.get("status") == "proposal_rejected"
+                for candidate in candidates
+            ),
+            "deferred": sum(
+                candidate.get("status") == "proposal_deferred"
+                for candidate in candidates
+            ),
+            "running": sum(
+                candidate.get("status") == "proposal_running"
+                for candidate in candidates
+            ),
+        },
+    }
+
+
+def format_evolution_funnel(funnel: dict[str, Any]) -> str:
+    """Compact one-line form for the existing Activity detail surface."""
+    generated = funnel.get("generated") or {}
+    quick = funnel.get("quick_screen") or {}
+    full_dev = funnel.get("full_development") or {}
+    optuna = funnel.get("optuna") or {}
+    gate = funnel.get("finalist_gate") or {}
+    generated_progress = _progress(generated.get("total"), generated.get("target"))
+    full_dev_progress = _progress(full_dev.get("evaluated"), full_dev.get("target"))
+    optuna_budget = optuna.get("budget")
+    gate_progress = _progress(gate.get("evaluated"), gate.get("target"))
+    optuna_running = _value(optuna.get("running"))
+    optuna_suffix = f", {optuna_running} running" if optuna_running else ""
+    budget_suffix = (
+        f", budget {_value(optuna_budget)}" if optuna_budget is not None else ""
+    )
+    return (
+        f"{generated_progress} generated "
+        f"({_value(generated.get('structural'))} structural, "
+        f"{_value(generated.get('parameter'))} parameter) → "
+        f"quick {_value(quick.get('passed'))} pass, "
+        f"{_value(quick.get('rejected'))} reject → "
+        f"full dev {_value(full_dev.get('passed'))} pass, "
+        f"{_value(full_dev.get('rejected'))} reject "
+        f"({full_dev_progress} complete; Optuna "
+        f"{_value(optuna.get('completed'))} tuned{budget_suffix}{optuna_suffix}) → "
+        f"gate {gate_progress}; paper {_value(gate.get('advanced_to_paper'))}"
+    )
+
+
+def _progress(value: Any, target: Any) -> str:
+    current = _value(value)
+    return f"{current}/{_value(target)}" if target is not None else str(current)
+
+
+def _value(value: Any) -> int:
+    try:
+        return max(int(value or 0), 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _count(values: Any, name: str) -> int:
+    return _value(values.get(name)) if isinstance(values, dict) else 0
+
+
+def _optional_count(values: Any, name: str) -> int | None:
+    if not isinstance(values, dict) or name not in values:
+        return None
+    return _value(values.get(name))

--- a/wayfinder_paths/jobs/watchdog.py
+++ b/wayfinder_paths/jobs/watchdog.py
@@ -1384,6 +1384,7 @@ def _expire_evolution_campaign(
     """Enforce one hard terminal horizon across every campaign stage."""
     from wayfinder_paths.jobs.compute_lock import job_state_lock
     from wayfinder_paths.jobs.evolution_campaign import CAMPAIGN_STATE_PATH
+    from wayfinder_paths.jobs.evolution_funnel import summarize_evolution_funnel
     from wayfinder_paths.jobs.execution.op_process import terminate_campaign_ops
     from wayfinder_paths.jobs.worker import retire_evolution_session
 
@@ -1408,6 +1409,7 @@ def _expire_evolution_campaign(
                 "campaign_id": state.get("campaign_id"),
                 "finalize_attempts": attempts,
                 "reason": state["failure_reason"],
+                "funnel": summarize_evolution_funnel(state),
             },
         )
     campaign_id = str(state.get("campaign_id") or "")

--- a/wayfinder_paths/tests/test_jobs_decision_log.py
+++ b/wayfinder_paths/tests/test_jobs_decision_log.py
@@ -7,6 +7,7 @@ import datetime as dt
 import json
 
 from wayfinder_paths.jobs.decision_log import build_decision_log
+from wayfinder_paths.jobs.evolution_funnel import summarize_evolution_funnel
 from wayfinder_paths.jobs.models import WayfinderJob
 from wayfinder_paths.jobs.store import JobStore
 
@@ -28,6 +29,70 @@ def _write_proposal(root, pid: str, summary: str) -> None:
         json.dumps({"proposal_id": pid, "payload": {"summary": summary}}),
         encoding="utf-8",
     )
+
+
+def test_evolution_funnel_does_not_count_full_dev_failures_as_quick_rejects() -> None:
+    candidates = [
+        {"status": "quick_complete", "mutation_kind": "structural"}
+        for _ in range(9)
+    ]
+    candidates.extend(
+        [
+            {
+                "status": "low_fidelity_rejected",
+                "mutation_kind": "structural",
+                "full_dev_tune": False,
+                "full_dev_at": "2026-08-28T18:53:05+00:00",
+                "tuning": None,
+            },
+            {
+                "status": "low_fidelity_rejected",
+                "mutation_kind": "structural",
+                "full_dev_tune": False,
+                "full_dev_at": "2026-08-28T19:12:43+00:00",
+                "tuning": None,
+            },
+            {
+                "status": "dev_frontier",
+                "mutation_kind": "structural",
+                "full_dev_tune": False,
+                "tuning": None,
+            },
+        ]
+    )
+
+    funnel = summarize_evolution_funnel(
+        {
+            "counts": {
+                "generated": 12,
+                "quick_evaluated": 12,
+                "full_dev": 3,
+                "proposed": 0,
+            },
+            "budgets": {
+                "generated": 12,
+                "full_development": 4,
+                "optuna": 2,
+                "finalist_gate": 1,
+            },
+            "candidates": candidates,
+        }
+    )
+
+    assert funnel["quick_screen"] == {
+        "evaluated": 12,
+        "passed": 12,
+        "rejected": 0,
+        "pending": 0,
+    }
+    assert funnel["full_development"] == {
+        "evaluated": 3,
+        "target": 4,
+        "passed": 1,
+        "rejected": 2,
+        "running": 0,
+    }
+    assert funnel["optuna"] == {"completed": 0, "budget": 2, "running": 0}
 
 
 def test_threading_outcomes_and_stats(tmp_path) -> None:
@@ -202,9 +267,29 @@ def test_active_evolution_campaign_is_one_compact_progress_row(tmp_path) -> None
                 "full_dev": 0,
                 "proposed": 0,
             },
+            "budgets": {
+                "generated": 12,
+                "full_development": 4,
+                "optuna": 2,
+                "finalist_gate": 1,
+            },
             "candidates": [
                 {
+                    "candidate_id": "c01",
+                    "status": "quick_complete",
+                    "mutation_kind": "structural",
+                    "evaluated_at": "2026-08-28T16:30:00+00:00",
+                },
+                {
+                    "candidate_id": "c02",
+                    "status": "quick_complete",
+                    "mutation_kind": "parameter",
+                    "evaluated_at": "2026-08-28T16:40:00+00:00",
+                },
+                {
                     "candidate_id": "c03",
+                    "status": "prepared",
+                    "mutation_kind": "structural",
                     "prepared_at": "2026-08-28T17:00:00+00:00",
                 }
             ],
@@ -239,11 +324,46 @@ def test_active_evolution_campaign_is_one_compact_progress_row(tmp_path) -> None
         "kind": "research",
         "title": "Evolution campaign generating candidates",
         "detail": (
-            "3 generated · 2 screened · 0 full-development evaluations · "
-            "0 finalist-gate evaluations"
+            "3/12 generated (2 structural, 1 parameter) → quick 2 pass, "
+            "0 reject → full dev 0 pass, 0 reject "
+            "(0/4 complete; Optuna 0 tuned, budget 2) "
+            "→ gate 0/1; paper 0"
         ),
         "outcome": "info",
         "actor": "harness",
+        "metadata": {
+            "campaign_id": "campaign-1",
+            "funnel": {
+                "generated": {
+                    "total": 3,
+                    "target": 12,
+                    "structural": 2,
+                    "parameter": 1,
+                },
+                "quick_screen": {
+                    "evaluated": 2,
+                    "passed": 2,
+                    "rejected": 0,
+                    "pending": 1,
+                },
+                "full_development": {
+                    "evaluated": 0,
+                    "target": 4,
+                    "passed": 0,
+                    "rejected": 0,
+                    "running": 0,
+                },
+                "optuna": {"completed": 0, "budget": 2, "running": 0},
+                "finalist_gate": {
+                    "evaluated": 0,
+                    "target": 1,
+                    "advanced_to_paper": 0,
+                    "rejected": 0,
+                    "deferred": 0,
+                    "running": 0,
+                },
+            },
+        },
     }
 
 
@@ -270,6 +390,36 @@ def test_terminal_evolution_campaigns_show_outcomes_without_live_duplicate(
             "type": "evolution_campaign_completed",
             "campaign_id": "campaign-2",
             "paper_proposals": 1,
+            "funnel": {
+                "generated": {
+                    "total": 12,
+                    "target": 12,
+                    "structural": 9,
+                    "parameter": 3,
+                },
+                "quick_screen": {
+                    "evaluated": 12,
+                    "passed": 10,
+                    "rejected": 2,
+                    "pending": 0,
+                },
+                "full_development": {
+                    "evaluated": 4,
+                    "target": 4,
+                    "passed": 1,
+                    "rejected": 3,
+                    "running": 0,
+                },
+                "optuna": {"completed": 1, "budget": 2, "running": 0},
+                "finalist_gate": {
+                    "evaluated": 1,
+                    "target": 1,
+                    "advanced_to_paper": 1,
+                    "rejected": 0,
+                    "deferred": 0,
+                    "running": 0,
+                },
+            },
             "counts": {
                 "generated": 12,
                 "quick_evaluated": 12,
@@ -289,7 +439,16 @@ def test_terminal_evolution_campaigns_show_outcomes_without_live_duplicate(
         "Evolution campaign completed — 1 advanced to forward paper testing"
     )
     assert entries[0]["kind"] == "research"
-    assert "12 generated · 12 screened" in entries[0]["detail"]
+    assert "quick 10 pass, 2 reject" in entries[0]["detail"]
+    assert "Optuna 1 tuned, budget 2" in entries[0]["detail"]
+    assert entries[0]["metadata"]["funnel"]["finalist_gate"] == {
+        "evaluated": 1,
+        "target": 1,
+        "advanced_to_paper": 1,
+        "rejected": 0,
+        "deferred": 0,
+        "running": 0,
+    }
     assert entries[1]["title"] == "Evolution campaign stopped before completion"
     assert entries[1]["kind"] == "recovery"
     assert entries[1]["detail"].endswith("3 finalization attempt(s)")

--- a/wayfinder_paths/tests/test_jobs_evolution_campaign.py
+++ b/wayfinder_paths/tests/test_jobs_evolution_campaign.py
@@ -85,6 +85,12 @@ def test_rollout_is_gated_and_campaign_context_is_bounded(tmp_path) -> None:
     state = start_campaign(store, job_id, now=now)
     assert state["status"] == "active"
     assert state["counts"]["generated"] == 0
+    assert state["budgets"] == {
+        "generated": 12,
+        "full_development": 4,
+        "optuna": 2,
+        "finalist_gate": 1,
+    }
     assert campaign_status(store, job_id)["campaign_id"] == state["campaign_id"]
     root = store.job_dir(job_id)
     manifest_path = root / state["manifest"]
@@ -569,6 +575,19 @@ def test_finalize_enforces_stage_budgets_and_isolates_candidate_failure(
     }
     assert calls == {"dev": 3, "gate": 1, "proposal": 1}
     assert any(item["status"] == "invalid" for item in result["candidates"])
+    completed = next(
+        row
+        for row in store.read_jsonl(job_id, "journal.jsonl")
+        if row.get("type") == "evolution_campaign_completed"
+    )
+    assert completed["funnel"]["full_development"] == {
+        "evaluated": 4,
+        "target": 4,
+        "passed": 3,
+        "rejected": 1,
+        "running": 0,
+    }
+    assert completed["funnel"]["finalist_gate"]["advanced_to_paper"] == 1
 
 
 def test_finalize_rejects_economically_unready_finalist(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- add a structured `metadata.funnel` payload to active, completed, and failed evolution Activity entries
- show quick-screen pass/reject, full-development pass/reject, completed Optuna tuning, finalist-gate, and paper admissions in the existing Activity detail line
- persist campaign budgets and terminal funnel snapshots so historical rows retain their breakdown
- distinguish a downstream full-development rejection from a quick-screen rejection using the durable full-development allocation marker

## Current canary finding
The current campaign has 12/12 quick-screen passes, 3 completed full-development evaluations (1 pass, 2 rejects), 0 completed Optuna runs, and 0 finalist-gate evaluations. One full-development slot remains.

## Validation
- Ruff on all touched files
- 96 campaign, watchdog, and decision-log tests passed
- clean diff against current `wayfinder-jobs-v1` tip (`a62334b2`)
