### PR TITLE
fix(jobs): start paper proposals on forward bars

### DIFF
--- a/wayfinder_paths/jobs/paper_experiment.py
+++ b/wayfinder_paths/jobs/paper_experiment.py
@@ -112,7 +112,9 @@ def ensure_paper_experiment(
                 "candidate_entry": (
                     "immutable_24h_forward_paper_proposal_against_current_arm_champion"
                 ),
-                "proposal_clock": "first_common_completed_5m_bar_through_24h",
+                "proposal_clock": (
+                    "first_post_queue_common_completed_5m_bar_through_24h"
+                ),
                 "proposal_pnl_in_primary_endpoint": False,
                 "multiplicity": "shared_benjamini_hochberg_evidence_ledger",
                 "evolution_compute_duty_cap": float(
@@ -243,7 +245,7 @@ def stage_paper_proposal(
                 "revision": safe_revision,
                 "bundle": relative,
                 "stream": f"{stream_base}/candidate",
-                "last_processed_bar": None,
+                "last_processed_bar": current.isoformat(),
                 "error_count": 0,
             },
             "reference": {
@@ -253,7 +255,7 @@ def stage_paper_proposal(
                 "bundle": reference["bundle"],
                 "source": reference.get("source"),
                 "stream": f"{stream_base}/reference",
-                "last_processed_bar": None,
+                "last_processed_bar": current.isoformat(),
                 "error_count": 0,
             },
             "evidence": dict(evidence or {}),
@@ -591,10 +593,12 @@ def _maybe_adjudicate_proposals(
             _save_proposal_progress(store, job_id, arm, proposal)
             continue
         candidate_stats = _proposal_stats(
-            store.job_dir(job_id) / str(proposal["candidate"]["stream"])
+            store.job_dir(job_id) / str(proposal["candidate"]["stream"]),
+            after=pd.Timestamp(proposal["queued_at"]),
         )
         reference_stats = _proposal_stats(
-            store.job_dir(job_id) / str(proposal["reference"]["stream"])
+            store.job_dir(job_id) / str(proposal["reference"]["stream"]),
+            after=pd.Timestamp(proposal["queued_at"]),
         )
         verdict = _proposal_verdict(
             store,
@@ -715,6 +719,7 @@ def _proposal_verdict(
 def _common_proposal_bars(
     store: JobStore, job_id: str, proposal: dict[str, Any]
 ) -> list[pd.Timestamp]:
+    queued_at = pd.Timestamp(proposal["queued_at"])
     streams = []
     for role in ("candidate", "reference"):
         path = store.job_dir(job_id) / str(proposal[role]["stream"]) / "ticks.jsonl"
@@ -723,20 +728,30 @@ def _common_proposal_bars(
             for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
                 try:
                     row = json.loads(line)
-                    stamps.add(pd.Timestamp(row.get("bar_ts") or row.get("ts")))
+                    stamp = pd.Timestamp(row.get("bar_ts") or row.get("ts"))
+                    if stamp > queued_at:
+                        stamps.add(stamp)
                 except (TypeError, ValueError):
                     continue
         streams.append(stamps)
     return sorted(streams[0] & streams[1])
 
 
-def _proposal_stats(stream: Path) -> dict[str, Any]:
+def _proposal_stats(stream: Path, *, after: pd.Timestamp) -> dict[str, Any]:
     pnls: list[float] = []
     path = stream / "trades.jsonl"
     if path.exists():
         for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
             try:
                 row = json.loads(line)
+                stamp = pd.Timestamp(
+                    row.get("closed_at")
+                    or row.get("bar_ts")
+                    or row.get("timestamp")
+                    or row.get("ts")
+                )
+                if stamp <= after:
+                    continue
                 pnls.append(
                     float(
                         row.get("net_pnl")

--- a/wayfinder_paths/tests/test_jobs_candidate_shadow.py
+++ b/wayfinder_paths/tests/test_jobs_candidate_shadow.py
@@ -17,6 +17,8 @@ from wayfinder_paths.jobs.store import JobStore
 
 
 def test_candidate_shadow_uses_separate_paper_state_and_stream(tmp_path) -> None:
+    started = pd.Timestamp("2026-08-24T11:00:00Z")
+    queued_at = pd.Timestamp("2026-08-24T12:00:00Z")
     store = JobStore(repo_root=tmp_path)
     job = WayfinderJob.new("majors-5m-lab", script="workspace/src/strategy.py")
     store.save(job)
@@ -59,7 +61,7 @@ def test_candidate_shadow_uses_separate_paper_state_and_stream(tmp_path) -> None
         ),
         encoding="utf-8",
     )
-    experiment = ensure_paper_experiment(store, job.id)
+    experiment = ensure_paper_experiment(store, job.id, now=started.to_pydatetime())
     assert experiment is not None
     revision = experiment["initial_revision"]
     stage_paper_proposal(
@@ -73,14 +75,12 @@ def test_candidate_shadow_uses_separate_paper_state_and_stream(tmp_path) -> None
         evidence={
             "objective": {"candidate": {"trade_count": 12}},
         },
+        now=queued_at.to_pydatetime(),
     )
     view = CompletedBarsView.from_rows(
         [
             {
-                "timestamp": (
-                    pd.Timestamp("2026-08-24T12:00:00Z")
-                    + pd.Timedelta(minutes=5 * index)
-                ).isoformat(),
+                "timestamp": (started + pd.Timedelta(minutes=5 * index)).isoformat(),
                 "symbol": "BTC",
                 "open": 100 + index * 0.01,
                 "high": 101 + index * 0.01,
@@ -88,7 +88,7 @@ def test_candidate_shadow_uses_separate_paper_state_and_stream(tmp_path) -> None
                 "close": 100 + index * 0.01,
                 "volume": 10,
             }
-            for index in range(289)
+            for index in range(302)
         ]
     )
     first = asyncio.run(
@@ -119,9 +119,7 @@ def test_candidate_shadow_uses_separate_paper_state_and_stream(tmp_path) -> None
             / "engine_state.json"
         ).exists()
     ticks_paths = list(
-        (root / "results" / "forward" / "experiment" / "proposals").rglob(
-            "ticks.jsonl"
-        )
+        (root / "results" / "forward" / "experiment" / "proposals").rglob("ticks.jsonl")
     )
     assert ticks_paths
     # Shadow replays hand candidates the SAME bounded window the simulator and
@@ -133,4 +131,5 @@ def test_candidate_shadow_uses_separate_paper_state_and_stream(tmp_path) -> None
             for line in ticks_path.read_text(encoding="utf-8").splitlines()
         ]
         assert rows and max(row["view_window"]["rows"] for row in rows) <= 20
+        assert min(pd.Timestamp(row["bar_ts"]) for row in rows) > queued_at
     assert asyncio.run(run_candidate_shadows(store, job.id)) == []

--- a/wayfinder_paths/tests/test_jobs_paper_experiment.py
+++ b/wayfinder_paths/tests/test_jobs_paper_experiment.py
@@ -475,6 +475,70 @@ def test_wall_clock_expiry_closes_proposal_without_forward_bars(
     assert slot["history"][-1]["status"] == "rejected"
 
 
+def test_proposal_ignores_pre_queue_ticks_and_trades(tmp_path: Path) -> None:
+    started = datetime(2026, 8, 1, tzinfo=UTC)
+    store, job_id, _ = _job(tmp_path, now=started)
+    source, revision = _candidate_source(store, job_id)
+    queued_at = started + timedelta(days=1)
+    proposal = stage_paper_proposal(
+        store,
+        job_id,
+        arm="evolution",
+        candidate_id="candidate-forward-only",
+        candidate_root=source,
+        revision=revision,
+        source="evolution_campaign",
+        evidence={
+            "objective": {"candidate": {"trade_count": 10}},
+            "token_usage": {"tokens_in": 1, "tokens_out": 1},
+        },
+        now=queued_at,
+    )
+    stale_ticks = [
+        json.dumps(
+            {
+                "bar_ts": (
+                    queued_at - timedelta(hours=24) + timedelta(minutes=5 * i)
+                ).isoformat()
+            }
+        )
+        for i in range(289)
+    ]
+    forward_ticks = [
+        json.dumps({"bar_ts": (queued_at + timedelta(minutes=5 * i)).isoformat()})
+        for i in range(1, 290)
+    ]
+    for role, pnl in (("candidate", 10.0), ("reference", 1.0)):
+        stream = store.job_dir(job_id) / proposal[role]["stream"]
+        stream.mkdir(parents=True, exist_ok=True)
+        (stream / "ticks.jsonl").write_text(
+            "\n".join([*stale_ticks, *forward_ticks]) + "\n", encoding="utf-8"
+        )
+        (stream / "trades.jsonl").write_text(
+            json.dumps(
+                {
+                    "timestamp": (queued_at - timedelta(hours=1)).isoformat(),
+                    "net_pnl": pnl,
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    outcomes = maybe_adjudicate_proposals(
+        store, job_id, now=queued_at + timedelta(hours=24, minutes=5)
+    )
+
+    assert outcomes[0]["status"] == "rejected"
+    assert outcomes[0]["candidate"]["closed_trades"] == 0
+    assert "candidate produced no closed forward trade" in outcomes[0]["reasons"]
+    history = experiment_status(store, job_id)["proposals"]["evolution"]["history"]
+    assert (
+        history[-1]["first_common_bar"]
+        == (queued_at + timedelta(minutes=5)).isoformat()
+    )
+
+
 def test_late_qualified_proposal_closes_after_experiment_completion(
     tmp_path: Path,
 ) -> None:
@@ -495,7 +559,7 @@ def test_late_qualified_proposal_closes_after_experiment_completion(
         },
         now=started + timedelta(hours=1),
     )
-    first_bar = started + timedelta(hours=1)
+    first_bar = started + timedelta(hours=1, minutes=5)
     ticks = [
         json.dumps({"bar_ts": (first_bar + timedelta(minutes=5 * i)).isoformat()})
         for i in range(289)


### PR DESCRIPTION
## Summary

- initialize both proposal shadow cursors at the proposal queue time so the rolling experiment view cannot replay historical bars into a fresh candidate
- require common-bar coverage to begin strictly after `queued_at` and exclude pre-queue trades from paper statistics
- make the protocol metadata explicit that the 24-hour clock starts on the first post-queue common completed bar
- add regressions covering both the shadow replay path and defensive adjudication of streams containing stale ticks/PnL

## Incident addressed

The Aug 28 evolution finalist staged at 21:14Z was adjudicated five minutes later using an Aug 27–28 bar window. It therefore received a false “no closed forward trade” rejection without a genuine forward day.

## Safety and compatibility

- historical economic and finalist gates are unchanged
- owner/live promotion gates are unchanged
- proposal streams remain paper-only and immutable
- wall-clock expiry behavior is unchanged
- stale rows may remain on disk, but they no longer count toward coverage or proposal PnL

## Validation

- `ruff check` and `git diff --check`
- 16 paper-experiment and candidate-shadow tests
- 65 evolution-campaign and wake-economy tests