### PR TITLE
feat(jobs): make evolution parentage executable

### DIFF
--- a/wayfinder_paths/jobs/evolution_campaign.py
+++ b/wayfinder_paths/jobs/evolution_campaign.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import gc
 import hashlib
+import importlib
 import json
 import math
 import os
@@ -81,15 +82,41 @@ from wayfinder_paths.jobs.resource_envelope import (
 )
 from wayfinder_paths.jobs.robustness import _strategy_warmup_bars
 from wayfinder_paths.jobs.starter_casebook import select_starter_cases
+from wayfinder_paths.jobs.starters import (
+    STARTER_DEFINITIONS,
+    StarterDefinition,
+    starter_lookback_bars,
+    starter_warmup_bars,
+)
 from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.runner.monitor_state import atomic_write_json, atomic_write_text
 
 CAMPAIGN_STATE_PATH = "state/evolution_campaign.json"
 CAMPAIGN_ROOT = "research/evolution/campaigns"
+PARENT_BUNDLE_ROOT = "research/evolution/parents"
 CAMPAIGN_DATA_ROOT = "dataset"
 FORWARD_SNAPSHOT = "forward_experience.json"
-SCHEMA_VERSION = "1.0"
+SCHEMA_VERSION = "1.1"
 _PARENT_SOURCES = ("incumbent", "qd_elite", "crossover", "de_novo")
+_EXECUTABLE_PARENT_STATUSES = {
+    "dev_frontier",
+    "paper_proposal",
+    "paper_experiment",
+    "incumbent",
+    "frontier",
+    "probation",
+}
+_TARGET_EXECUTION_PARAM_KEYS = {
+    "fee_bps",
+    "initial_capital",
+    "leverage",
+    "min_trade_notional",
+    "slippage_bps",
+    "stop_market_slippage_bps",
+    "symbols",
+    "venue",
+    "wallet_label",
+}
 CAMPAIGN_DRAIN = timedelta(minutes=30)
 _MAX_SEARCH_DIMENSIONS = 3
 _OPTUNA_SEED = 42
@@ -325,6 +352,9 @@ def _start_campaign(
     snapshots["source_bundle"]["revision"] = compute_workspace_revision(
         campaign_root / "source"
     )
+    parent_pool = _freeze_parent_pool(store, job_id, campaign_root)
+    starter_seeds = _snapshot_starter_seeds(store, job_id, campaign_root)
+    research_context = _freeze_research_context(store, job_id)
     campaign_policy = {
         **spec.evolution,
         "same_family_non_wins": spec.stuck_same_family_non_wins,
@@ -344,6 +374,9 @@ def _start_campaign(
         "execution_calibration": experience["live_execution"]["recommended"],
         "historical_lessons": historical_lessons,
         "casebook": cases,
+        "parent_pool": parent_pool,
+        "starter_seeds": starter_seeds,
+        "research_context": research_context,
         "policy": campaign_policy,
         **revision_stamp(root),
     }
@@ -406,7 +439,8 @@ def _prepare_candidate(
     state = _active_campaign(store, job_id)
     if _aware(now or datetime.now(UTC)) >= _parse(state["deadline_at"]):
         raise ValueError("evolution campaign generation deadline has elapsed")
-    policy = _campaign_policy(store, job_id, str(state["campaign_id"]))
+    manifest = _campaign_manifest(store, job_id, str(state["campaign_id"]))
+    policy = manifest["policy"]
     limit = int(policy["generated_programs"])
     slot = len(state["candidates"]) + 1
     if slot > limit:
@@ -415,7 +449,9 @@ def _prepare_candidate(
     forced_jump = _same_family_nonwins(
         state, family, int(policy["same_family_non_wins"])
     )
-    source = "de_novo" if forced_jump else _parent_source(slot, policy["parent_mix"])
+    requested_source = (
+        "de_novo" if forced_jump else _parent_source(slot, policy["parent_mix"])
+    )
     required_structural = math.ceil(
         limit * float(policy.get("min_structural_fraction") or 0.0)
     )
@@ -444,15 +480,25 @@ def _prepare_candidate(
     if forced_jump:
         chosen_mutation = "structural"
 
-    parents = _select_parents(store, job_id, source, slot)
+    parent_plan = _select_parent_plan(
+        manifest,
+        requested_source=requested_source,
+        slot=slot,
+        candidates=state["candidates"],
+    )
+    source = str(parent_plan["source"])
+    parents = [str(item["candidate_id"]) for item in parent_plan.get("parents") or []]
     candidate_id = f"{state['campaign_id']}-c{slot:02d}"
     relative = f"{CAMPAIGN_ROOT}/{state['campaign_id']}/candidates/{candidate_id}"
     candidate_root = store.job_dir(job_id) / relative
-    frozen_source = (
-        store.job_dir(job_id) / CAMPAIGN_ROOT / str(state["campaign_id"]) / "source"
+    seeded_window = _materialize_candidate_seed(
+        store,
+        job_id,
+        campaign_id=str(state["campaign_id"]),
+        candidate_root=candidate_root,
+        plan=parent_plan,
     )
-    _copy_active_bundle(frozen_source, candidate_root)
-    seeded_window = _seed_bundle_window(store, job_id, candidate_root)
+    seed_revision = compute_workspace_revision(candidate_root)
     candidate = {
         "candidate_id": candidate_id,
         "campaign_id": state["campaign_id"],
@@ -461,11 +507,16 @@ def _prepare_candidate(
         "summary": summary[:160],
         "status": "prepared",
         "parent_source": source,
+        "requested_parent_source": requested_source,
         "parent_candidate_ids": parents,
+        "starter_seed_id": (parent_plan.get("starter") or {}).get("starter_id"),
+        "secondary_parent_bundle": (parent_plan.get("secondary") or {}).get("bundle"),
         "mutation_kind": chosen_mutation,
         "forced_jump": forced_jump,
         "bundle": relative,
         "warmup_bars": seeded_window,
+        "seed_revision": seed_revision,
+        "evidence_reset": source == "starter_seed",
         "prepared_at": utc_now_iso(),
     }
     atomic_write_json(candidate_root / "candidate.json", candidate)
@@ -486,6 +537,10 @@ def _prepare_candidate(
             "bundle": relative,
             "mutation_kind": chosen_mutation,
             "parent_source": source,
+            "requested_parent_source": requested_source,
+            "starter_seed_id": candidate.get("starter_seed_id"),
+            "seed_revision": seed_revision,
+            "evidence_reset": candidate["evidence_reset"],
         },
     )
     # ``bundle`` stays durable and job-relative.  The tool response also gives
@@ -493,15 +548,30 @@ def _prepare_candidate(
     # does not spend context discovering the SDK's hosted symlink layout.
     result = dict(candidate)
     result["bundle_path"] = str(candidate_root.resolve())
+    secondary = parent_plan.get("secondary") or {}
+    if secondary.get("bundle"):
+        result["secondary_parent_bundle_path"] = str(
+            _resolve_frozen_parent_bundle(
+                store,
+                job_id,
+                str(state["campaign_id"]),
+                str(secondary["bundle"]),
+            )
+        )
     return result
 
 
-def _source_baseline_revision(manifest: dict[str, Any]) -> str:
-    """Revision an UNEDITED candidate carries: the frozen (window-seeded)
-    source bundle. Falls back to the active-root revision for campaigns
-    started before window seeding existed — the two were identical then."""
+def _source_baseline_revision(
+    manifest: dict[str, Any], candidate: dict[str, Any] | None = None
+) -> str:
+    """Revision an unedited candidate seed carries.
+
+    New campaigns stamp the actual incumbent/QD/starter/de-novo seed; legacy
+    campaigns fall back to their frozen incumbent source revision.
+    """
     return str(
-        (manifest.get("source_bundle") or {}).get("revision")
+        (candidate or {}).get("seed_revision")
+        or (manifest.get("source_bundle") or {}).get("revision")
         or manifest.get("source_revision")
         or ""
     )
@@ -647,7 +717,10 @@ def _evaluate_candidate(
         )
         or {}
     )
-    if revision == _source_baseline_revision(manifest) and search_space is None:
+    if (
+        revision == _source_baseline_revision(manifest, candidate)
+        and search_space is None
+    ):
         return {
             "status": "invalid",
             "evidence": {
@@ -1423,6 +1496,18 @@ def campaign_prompt_block(
     budget = int(policy.get("generated_programs") or 0)
     deadline_elapsed = current >= deadline
     draining = deadline - CAMPAIGN_DRAIN <= current < deadline
+    requested_next_source = _parent_source(
+        len(candidates) + 1, policy.get("parent_mix") or {}
+    )
+    next_parent_plan = _select_parent_plan(
+        manifest,
+        requested_source=requested_next_source,
+        slot=len(candidates) + 1,
+        candidates=candidates,
+    )
+    research_instruction = _research_context_instruction(
+        manifest.get("research_context") or {}
+    )
     prepare_call = (
         'Call wayfinder_core_jobs with action="evolution_prepare", '
         f'job_id="{job_id}", family="<specific strategy family>", and '
@@ -1443,8 +1528,12 @@ def campaign_prompt_block(
             if candidate.get("mutation_kind") == "parameter"
             else f"This is a structural candidate: {_STRUCTURAL_SEARCH_GUIDANCE} "
         )
+        seed_instruction = _candidate_seed_instruction(
+            store, job_id, str(state["campaign_id"]), candidate
+        )
         next_action = (
-            f"{mutation_instruction}Edit only files inside {candidate_root} "
+            f"{seed_instruction}{mutation_instruction}Edit only files inside "
+            f"{candidate_root} "
             "(workspace, job.yaml, "
             "and optional search_space.json), then launch "
             'wayfinder_core_jobs with action="evolution_evaluate", '
@@ -1468,7 +1557,10 @@ def campaign_prompt_block(
         }
     elif len(candidates) < budget:
         session_stage = f"candidate-{len(candidates) + 1:02d}"
+        preview = _parent_plan_handoff(next_parent_plan)
         next_action = (
+            f"Next source plan: {json.dumps(preview, sort_keys=True)}. "
+            f"{research_instruction} "
             f"{prepare_call} Then edit only the exact `bundle_path` returned by "
             "that call and "
             'launch wayfinder_core_jobs with action="evolution_evaluate", '
@@ -1496,16 +1588,87 @@ def campaign_prompt_block(
         "next_action": next_action,
         "candidate_outcomes": [_candidate_handoff(item) for item in candidates],
         "historical_lessons": manifest.get("historical_lessons") or {},
+        "research_context": manifest.get("research_context") or {},
+        "next_parent_plan": _parent_plan_handoff(next_parent_plan),
         "cases": manifest.get("casebook") or [],
         "forward_context_cutoff": state.get("forward_context_cutoff"),
         "constraints": {
             "paper_only": True,
             "live_requires_owner": True,
             "candidate_inputs_frozen_at_campaign_start": True,
-            "finalist_requires_24h_forward_proposal": True,
+            "finalist_requires_24h_operational_burn_in": True,
+            "starter_seed_evidence_resets": True,
+            "refuted_family_matching": "exact_free_form_family_v1",
         },
         "deadline_elapsed": deadline_elapsed,
     }
+
+
+def _parent_plan_handoff(plan: dict[str, Any]) -> dict[str, Any]:
+    starter = plan.get("starter") or {}
+    return {
+        "source": plan.get("source"),
+        "parent_candidate_ids": [
+            item.get("candidate_id") for item in plan.get("parents") or []
+        ],
+        "starter_seed_id": starter.get("starter_id"),
+        "starter_family": starter.get("family"),
+        "starter_timeframe": starter.get("timeframe"),
+        "starter_warmup_bars": starter.get("warmup_bars"),
+        "evidence_reset": bool(starter),
+    }
+
+
+def _research_context_instruction(context: dict[str, Any]) -> str:
+    refuted = [
+        str(item.get("family") or "")
+        for item in context.get("refuted_families") or []
+        if item.get("family")
+    ][:8]
+    positives = [
+        str(item.get("id") or "")
+        for item in context.get("validated_positives") or []
+        if item.get("id")
+    ][:8]
+    return (
+        "Research context is frozen for this campaign. Do not re-propose an "
+        f"exact refuted family without naming new evidence (refuted={refuted}); "
+        f"seed from validated wins when relevant (validated={positives}). A win "
+        "is named new evidence, not deletion of a refutation."
+    )
+
+
+def _candidate_seed_instruction(
+    store: JobStore, job_id: str, campaign_id: str, candidate: dict[str, Any]
+) -> str:
+    source = str(candidate.get("parent_source") or "")
+    if source == "starter_seed":
+        return (
+            f"The bundle contains audited starter `{candidate.get('starter_seed_id')}` "
+            "as an adaptation seed. Its own warmup/lookback is already set, but "
+            "its historical evidence was reset: adapt the tactic to this job's "
+            "target universe and make it re-earn every gate. "
+        )
+    if source == "crossover":
+        secondary = _resolve_frozen_parent_bundle(
+            store,
+            job_id,
+            campaign_id,
+            str(candidate.get("secondary_parent_bundle") or ""),
+        )
+        return (
+            "The candidate is seeded from the stronger executable parent. "
+            f"Use `{secondary}` as READ-ONLY secondary parent context; edit only "
+            "the candidate bundle and implement an explicit recombination. "
+        )
+    if source == "qd_elite":
+        return "The bundle is an executable QD elite, not an incumbent clone. "
+    if source == "de_novo":
+        return (
+            "The bundle is a clean target-compatible scaffold with no incumbent "
+            "alpha or research memory; author a genuinely new causal strategy. "
+        )
+    return "The bundle is the frozen incumbent baseline. "
 
 
 def _candidate_handoff(candidate: dict[str, Any]) -> dict[str, Any]:
@@ -1516,6 +1679,9 @@ def _candidate_handoff(candidate: dict[str, Any]) -> dict[str, Any]:
         "family": candidate.get("family"),
         "mutation_kind": candidate.get("mutation_kind"),
         "parent_source": candidate.get("parent_source"),
+        "requested_parent_source": candidate.get("requested_parent_source"),
+        "parent_candidate_ids": candidate.get("parent_candidate_ids") or [],
+        "starter_seed_id": candidate.get("starter_seed_id"),
         "status": candidate.get("status"),
         "summary": str(candidate.get("summary") or "")[:240],
     }
@@ -1560,6 +1726,17 @@ def _archive_campaign_candidate(
 ) -> None:
     status = str(candidate.get("status") or "generated")
     archive_status = status if status in ARCHIVE_STATUSES else "generated"
+    executable_bundle: str | None = None
+    revision = str(candidate.get("revision") or "")
+    if status == "dev_frontier" and revision:
+        source = resolve_candidate_bundle(store, job_id, candidate)
+        executable_bundle, _ = _persist_executable_bundle(
+            store,
+            job_id,
+            candidate_id=str(candidate["candidate_id"]),
+            revision=revision,
+            source=source,
+        )
     metadata = {
         key: candidate[key]
         for key in (
@@ -1567,6 +1744,10 @@ def _archive_campaign_candidate(
             "bundle",
             "mutation_kind",
             "parent_source",
+            "requested_parent_source",
+            "starter_seed_id",
+            "seed_revision",
+            "evidence_reset",
             "quick",
             "dev",
             "tuning_eligible",
@@ -1578,6 +1759,8 @@ def _archive_campaign_candidate(
         )
         if candidate.get(key) is not None
     }
+    if executable_bundle is not None:
+        metadata["executable_bundle"] = executable_bundle
     record_candidate(
         store,
         job_id,
@@ -1705,7 +1888,7 @@ def _full_dev(
         )
         or {}
     )
-    if revision == _source_baseline_revision(manifest):
+    if revision == _source_baseline_revision(manifest, candidate):
         raise ValueError("candidate has no effective mutation after tuning")
     train_result, train_stats = _window_result(subject, 0.0, train_end, params)
     train_valid = bool(train_result.validation.get("execution_valid"))
@@ -1975,33 +2158,496 @@ def _candidate_validation_passed(report: dict[str, Any]) -> bool:
     )
 
 
-def _select_parents(store: JobStore, job_id: str, source: str, slot: int) -> list[str]:
+def _archive_entry_score(entry: dict[str, Any]) -> float:
+    return _candidate_score({"objective": entry.get("objective") or {}})
+
+
+def _freeze_parent_pool(
+    store: JobStore, job_id: str, campaign_root: Path
+) -> dict[str, Any]:
+    """Freeze executable QD/frontier parents for the campaign.
+
+    Legacy campaign bundles are lazily copied into the stable parent root
+    only when their archived revision still matches their bytes.
+    """
     archive = load_archive(store, job_id).get("candidates") or []
-    incumbents = [
-        str(item["candidate_id"])
+    qd_ids = list(
+        dict.fromkeys(
+            str(item["candidate_id"])
+            for entries in quality_diversity_snapshot(store, job_id).values()
+            for item in entries
+        )
+    )
+    selected_ids = set(qd_ids)
+    selected_ids.update(
+        str(item.get("candidate_id") or "")
         for item in archive
-        if item.get("status") == "incumbent"
-    ]
-    elites = [
-        str(item["candidate_id"])
-        for entries in quality_diversity_snapshot(store, job_id).values()
-        for item in entries
-    ]
-    frontier = [
-        str(item["candidate_id"]) for item in archive if item.get("on_frontier")
-    ]
-    active = f"active:{compute_workspace_revision(store.job_dir(job_id))}"
-    pool = list(dict.fromkeys(elites + frontier + incumbents + [active]))
-    if source == "de_novo":
-        return []
-    if source == "incumbent":
-        return incumbents[:1] or [active]
-    if source == "qd_elite":
-        return [pool[(slot - 1) % len(pool)]] if pool else []
-    if source == "crossover" and pool:
+        if item.get("status") in _EXECUTABLE_PARENT_STATUSES or item.get("on_frontier")
+    )
+    frozen: list[dict[str, Any]] = []
+    for entry in archive:
+        # Backfill all candidates that reached full development, even if a
+        # later proposal verdict made them ineligible for selection. This
+        # preserves the executable receipt without reviving a rejected branch.
+        metadata = entry.get("metadata") or {}
+        reached_development = bool(
+            entry.get("status") in _EXECUTABLE_PARENT_STATUSES or metadata.get("dev")
+        )
+        if not reached_development:
+            continue
+        stable = _ensure_executable_parent(store, job_id, entry)
+        candidate_id = str(entry.get("candidate_id") or "")
+        if stable is None or candidate_id not in selected_ids:
+            continue
+        destination = campaign_root / "parents" / candidate_id
+        _copy_active_bundle(stable, destination)
+        frozen.append(
+            {
+                "candidate_id": candidate_id,
+                "family": str(entry.get("family") or "unknown"),
+                "summary": str(entry.get("summary") or "")[:160],
+                "status": entry.get("status"),
+                "revision": entry.get("revision"),
+                "objective": entry.get("objective") or {},
+                "behavior": entry.get("behavior") or {},
+                "bundle": f"parents/{candidate_id}",
+            }
+        )
+    frozen.sort(key=_archive_entry_score, reverse=True)
+    frozen_ids = {str(item["candidate_id"]) for item in frozen}
+    return {
+        "candidates": frozen,
+        "qd_elite_ids": [
+            candidate_id for candidate_id in qd_ids if candidate_id in frozen_ids
+        ],
+        "frozen_at_campaign_start": True,
+    }
+
+
+def _ensure_executable_parent(
+    store: JobStore, job_id: str, entry: dict[str, Any]
+) -> Path | None:
+    candidate_id = str(entry.get("candidate_id") or "")
+    revision = str(entry.get("revision") or "")
+    if not candidate_id or not revision:
+        return None
+    metadata = entry.get("metadata") or {}
+    stable_relative = str(metadata.get("executable_bundle") or "")
+    if stable_relative:
+        try:
+            stable = _resolve_stable_parent_bundle(
+                store, job_id, candidate_id, revision, stable_relative
+            )
+            if compute_workspace_revision(stable) == revision:
+                return stable
+        except (OSError, ValueError):
+            pass
+    legacy_relative = str(metadata.get("bundle") or "")
+    campaign_id = str(metadata.get("campaign_id") or "")
+    if not legacy_relative or not campaign_id:
+        return None
+    try:
+        legacy = resolve_candidate_bundle(
+            store,
+            job_id,
+            {
+                "candidate_id": candidate_id,
+                "campaign_id": campaign_id,
+                "bundle": legacy_relative,
+            },
+        )
+        if compute_workspace_revision(legacy) != revision:
+            return None
+        stable_relative, stable = _persist_executable_bundle(
+            store,
+            job_id,
+            candidate_id=candidate_id,
+            revision=revision,
+            source=legacy,
+        )
+    except (OSError, ValueError):
+        return None
+    record_candidate(
+        store,
+        job_id,
+        candidate_id=candidate_id,
+        family=str(entry.get("family") or "unknown"),
+        summary=str(entry.get("summary") or "evolution candidate"),
+        status=str(entry.get("status") or "generated"),
+        objective=entry.get("objective"),
+        revision=revision,
+        parent_candidate_ids=list(entry.get("parent_candidate_ids") or []),
+        behavior=entry.get("behavior"),
+        evidence=entry.get("evidence"),
+        metadata={"executable_bundle": stable_relative},
+    )
+    return stable
+
+
+def _persist_executable_bundle(
+    store: JobStore,
+    job_id: str,
+    *,
+    candidate_id: str,
+    revision: str,
+    source: Path,
+) -> tuple[str, Path]:
+    _validate_parent_component(candidate_id, "candidate id")
+    _validate_parent_component(revision, "candidate revision")
+    relative = f"{PARENT_BUNDLE_ROOT}/{candidate_id}/{revision}"
+    destination = store.job_dir(job_id) / relative
+    if destination.exists():
+        if compute_workspace_revision(destination) != revision:
+            raise ValueError("stable executable parent revision mismatch")
+    else:
+        _copy_active_bundle(source, destination)
+    return relative, destination
+
+
+def _resolve_stable_parent_bundle(
+    store: JobStore,
+    job_id: str,
+    candidate_id: str,
+    revision: str,
+    relative: str,
+) -> Path:
+    _validate_parent_component(candidate_id, "candidate id")
+    _validate_parent_component(revision, "candidate revision")
+    expected = f"{PARENT_BUNDLE_ROOT}/{candidate_id}/{revision}"
+    if relative != expected:
+        raise ValueError("stable executable parent path does not match its lineage")
+    root = store.job_dir(job_id).resolve()
+    allowed = (root / PARENT_BUNDLE_ROOT).resolve()
+    resolved = (root / relative).resolve()
+    if not resolved.is_relative_to(allowed):
+        raise ValueError("stable executable parent escapes its root")
+    return resolved
+
+
+def _validate_parent_component(value: str, label: str) -> None:
+    if not value or value in {".", ".."} or Path(value).name != value:
+        raise ValueError(f"invalid evolution parent {label}")
+
+
+def _snapshot_starter_seeds(
+    store: JobStore, job_id: str, campaign_root: Path
+) -> list[dict[str, Any]]:
+    job_data = _load_job_yaml(campaign_root / "source")
+    target_params = dict(job_data.get("execution_params") or {})
+    target_symbols = {str(symbol) for symbol in target_params.get("symbols") or []}
+    spec_data, _ = resolve_execution_spec(campaign_root / "source", job_data)
+    target_timeframe = str(
+        ((spec_data or {}).get("data_contract") or {}).get("bar_interval") or ""
+    )
+
+    def relevance(definition: StarterDefinition) -> tuple[int, int, str]:
+        overlap = len(target_symbols & set(definition.symbols))
+        return (
+            int(definition.timeframe == target_timeframe),
+            overlap,
+            definition.id,
+        )
+
+    snapshots: list[dict[str, Any]] = []
+    for definition in sorted(STARTER_DEFINITIONS, key=relevance, reverse=True):
+        module = importlib.import_module(definition.module)
+        raw_source = getattr(module, "__file__", None)
+        if not raw_source:
+            continue
+        source = Path(raw_source)
+        relative = f"starters/{definition.id}/strategy.py"
+        destination = campaign_root / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write_text(destination, source.read_text(encoding="utf-8"))
+        snapshots.append(
+            {
+                "starter_id": definition.id,
+                "family": definition.family,
+                "summary": definition.summary,
+                "timeframe": definition.timeframe,
+                "source_symbols": list(definition.symbols),
+                "target_symbols": sorted(target_symbols),
+                "params": {
+                    **definition.configured_params(),
+                    "symbols": list(definition.symbols),
+                    "venue": "hyperliquid",
+                },
+                "warmup_bars": starter_warmup_bars(definition),
+                "lookback_bars": starter_lookback_bars(definition),
+                "source": relative,
+                "source_sha256": _file_hash(destination),
+                "adaptation_required": True,
+                "research_evidence_reset": True,
+            }
+        )
+    return snapshots
+
+
+def _freeze_research_context(store: JobStore, job_id: str) -> dict[str, Any]:
+    """Two load-bearing lists, distilled from existing mechanical records."""
+    archive = load_archive(store, job_id).get("candidates") or []
+    refuted_by_family: dict[str, dict[str, Any]] = {}
+    for entry in archive:
+        if entry.get("status") != "refuted":
+            continue
+        family = str(entry.get("family") or "").strip()
+        if family and family not in refuted_by_family:
+            refuted_by_family[family] = {
+                "family": family,
+                "candidate_id": entry.get("candidate_id"),
+                "evidence": str(entry.get("evidence") or "")[:240],
+            }
+
+    positives: list[dict[str, Any]] = []
+    probation = store.read_json(job_id, "probation.json", default={}) or {}
+    for leg in probation.get("legs") or []:
+        if leg.get("status") == "graduated":
+            positives.append(
+                {
+                    "source": "probation_graduate",
+                    "id": leg.get("name"),
+                    "symbol": leg.get("symbol"),
+                    "evidence": str(
+                        (leg.get("graduate") or {}).get("progress")
+                        or leg.get("notes")
+                        or (leg.get("graduate") or {}).get("criterion")
+                        or ""
+                    )[:240],
+                    "recorded_at": leg.get("closed_at") or leg.get("updated_at"),
+                }
+            )
+    verdicts = (
+        store.read_json(job_id, "state/promotion_verdicts.json", default={}) or {}
+    )
+    for proposal_id, verdict in verdicts.items():
+        try:
+            strategy_effect = float(verdict.get("strategy_effect"))
+        except (TypeError, ValueError):
+            continue
+        if verdict.get("verdict") == "beat" and strategy_effect > 0:
+            positives.append(
+                {
+                    "source": "counterfactual_confirmed_treatment",
+                    "id": proposal_id,
+                    "strategy_effect": strategy_effect,
+                    "recorded_at": verdict.get("recorded_at"),
+                }
+            )
+    experiment = (
+        store.read_json(job_id, "state/evolution_experiment.json", default={}) or {}
+    )
+    if (
+        experiment.get("status") == "complete"
+        and (experiment.get("verdict") or {}).get("verdict") == "accrete"
+    ):
+        champion = ((experiment.get("arms") or {}).get("evolution") or {}).get(
+            "champion"
+        ) or {}
+        positives.append(
+            {
+                "source": "evolution_experiment_accrete",
+                "id": champion.get("candidate_id"),
+                "revision": champion.get("revision"),
+                "recorded_at": experiment.get("completed_at"),
+            }
+        )
+    positives.sort(key=lambda item: str(item.get("recorded_at") or ""), reverse=True)
+    return {
+        "refuted_families": list(refuted_by_family.values())[-20:],
+        "validated_positives": positives[:20],
+        "matching": "exact_free_form_family_v1",
+        "accepted_limitation": (
+            "near-duplicate free-form family names are not normalized; a validated "
+            "positive is named new evidence, not deletion of a refutation"
+        ),
+        "frozen_at_campaign_start": True,
+    }
+
+
+def _select_parent_plan(
+    manifest: dict[str, Any],
+    *,
+    requested_source: str,
+    slot: int,
+    candidates: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Resolve a requested source to material that actually exists.
+
+    Cold-start QD/crossover slots become distinct audited starter seeds; they
+    are never incumbent copies carrying a misleading lineage label.
+    """
+    pool = (manifest.get("parent_pool") or {}).get("candidates") or []
+    qd_ids = set((manifest.get("parent_pool") or {}).get("qd_elite_ids") or [])
+    qd = [item for item in pool if item.get("candidate_id") in qd_ids]
+    if requested_source == "incumbent":
+        return {"source": "incumbent", "parents": []}
+    if requested_source == "qd_elite" and qd:
+        parent = qd[(slot - 1) % len(qd)]
+        return {"source": "qd_elite", "parents": [parent], "primary": parent}
+    if requested_source == "crossover" and len(pool) >= 2:
         first = (slot - 1) % len(pool)
-        return list(dict.fromkeys([pool[first], pool[(first + 1) % len(pool)]]))
-    return []
+        pair = [pool[first], pool[(first + 1) % len(pool)]]
+        pair.sort(key=_archive_entry_score, reverse=True)
+        return {
+            "source": "crossover",
+            "parents": pair,
+            "primary": pair[0],
+            "secondary": pair[1],
+        }
+    if requested_source in {"qd_elite", "crossover"}:
+        used = {
+            str(item.get("starter_seed_id") or "")
+            for item in candidates
+            if item.get("starter_seed_id")
+        }
+        starter = next(
+            (
+                item
+                for item in manifest.get("starter_seeds") or []
+                if str(item.get("starter_id") or "") not in used
+            ),
+            None,
+        )
+        if starter is not None:
+            return {"source": "starter_seed", "parents": [], "starter": starter}
+    return {"source": "de_novo", "parents": []}
+
+
+def _materialize_candidate_seed(
+    store: JobStore,
+    job_id: str,
+    *,
+    campaign_id: str,
+    candidate_root: Path,
+    plan: dict[str, Any],
+) -> int:
+    campaign_root = store.job_dir(job_id) / CAMPAIGN_ROOT / campaign_id
+    frozen_source = campaign_root / "source"
+    source = str(plan["source"])
+    if source == "incumbent":
+        _copy_active_bundle(frozen_source, candidate_root)
+    elif source in {"qd_elite", "crossover"}:
+        primary = plan.get("primary") or {}
+        parent = _resolve_frozen_parent_bundle(
+            store, job_id, campaign_id, str(primary.get("bundle") or "")
+        )
+        _copy_active_bundle(parent, candidate_root)
+    elif source == "starter_seed":
+        _copy_clean_scaffold(store, job_id, frozen_source, candidate_root)
+        _install_starter_seed(
+            store,
+            job_id,
+            campaign_id=campaign_id,
+            candidate_root=candidate_root,
+            starter=dict(plan.get("starter") or {}),
+        )
+    else:
+        _copy_clean_scaffold(store, job_id, frozen_source, candidate_root)
+    return _seed_bundle_window(store, job_id, candidate_root)
+
+
+def _copy_clean_scaffold(
+    store: JobStore,
+    job_id: str,
+    source_root: Path,
+    destination: Path,
+) -> None:
+    """Target job shell without incumbent alpha code or research memory."""
+    _copy_active_bundle(source_root, destination)
+    risk_path = destination / "workspace" / "risk_limits.json"
+    risk_limits = risk_path.read_bytes() if risk_path.exists() else None
+    shutil.rmtree(destination / "workspace")
+    (destination / "workspace").mkdir()
+    if risk_limits is not None:
+        (destination / "workspace" / "risk_limits.json").write_bytes(risk_limits)
+    job_data = _load_job_yaml(destination)
+    target_params = dict(job_data.get("execution_params") or {})
+    job_data["execution_params"] = {
+        key: target_params[key]
+        for key in _TARGET_EXECUTION_PARAM_KEYS
+        if key in target_params
+    }
+    atomic_write_text(
+        destination / "job.yaml", yaml.safe_dump(job_data, sort_keys=False)
+    )
+    script = store.resolve_script_entrypoint(
+        job_id, job_data, candidate_dir=destination
+    )
+    if script is None or not script.resolve().is_relative_to(
+        (destination / "workspace").resolve()
+    ):
+        raise ValueError("evolution scaffold entrypoint must live inside workspace")
+    script.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_text(
+        script,
+        '"""Clean de-novo evolution scaffold."""\n\n'
+        "from __future__ import annotations\n\n"
+        "from typing import Any\n\n\n"
+        "def decide(ctx: Any) -> list[Any]:\n"
+        "    return []\n",
+    )
+
+
+def _install_starter_seed(
+    store: JobStore,
+    job_id: str,
+    *,
+    campaign_id: str,
+    candidate_root: Path,
+    starter: dict[str, Any],
+) -> None:
+    source = _resolve_starter_source(
+        store, job_id, campaign_id, str(starter.get("source") or "")
+    )
+    job_data = _load_job_yaml(candidate_root)
+    script = store.resolve_script_entrypoint(
+        job_id, job_data, candidate_dir=candidate_root
+    )
+    if script is None:
+        raise ValueError("starter seed candidate has no execution entrypoint")
+    atomic_write_text(script, source.read_text(encoding="utf-8"))
+    target_params = dict(job_data.get("execution_params") or {})
+    params = dict(starter.get("params") or {})
+    params.update(
+        {
+            key: target_params[key]
+            for key in _TARGET_EXECUTION_PARAM_KEYS
+            if key in target_params
+        }
+    )
+    params["warmup_bars"] = int(starter["warmup_bars"])
+    params["lookback_bars"] = int(starter["lookback_bars"])
+    params.pop("full_history", None)
+    job_data["execution_params"] = params
+    atomic_write_text(
+        candidate_root / "job.yaml", yaml.safe_dump(job_data, sort_keys=False)
+    )
+
+
+def _resolve_frozen_parent_bundle(
+    store: JobStore, job_id: str, campaign_id: str, relative: str
+) -> Path:
+    if not relative or Path(relative).is_absolute():
+        raise ValueError("frozen parent bundle must be campaign-relative")
+    campaign_root = (store.job_dir(job_id) / CAMPAIGN_ROOT / campaign_id).resolve()
+    allowed = (campaign_root / "parents").resolve()
+    resolved = (campaign_root / relative).resolve()
+    if not resolved.is_relative_to(allowed) or resolved.parent != allowed:
+        raise ValueError("frozen parent bundle escapes the campaign parent root")
+    return resolved
+
+
+def _resolve_starter_source(
+    store: JobStore, job_id: str, campaign_id: str, relative: str
+) -> Path:
+    if not relative or Path(relative).is_absolute():
+        raise ValueError("starter source must be campaign-relative")
+    campaign_root = (store.job_dir(job_id) / CAMPAIGN_ROOT / campaign_id).resolve()
+    allowed = (campaign_root / "starters").resolve()
+    resolved = (campaign_root / relative).resolve()
+    if not resolved.is_relative_to(allowed) or resolved.name != "strategy.py":
+        raise ValueError("starter source escapes the campaign starter root")
+    return resolved
 
 
 def _copy_active_bundle(source_root: Path, destination: Path) -> None:
@@ -2203,13 +2849,22 @@ def _row_timestamp(row: dict[str, Any]) -> pd.Timestamp | None:
     return stamp.tz_localize("UTC") if stamp.tzinfo is None else stamp.tz_convert("UTC")
 
 
-def _campaign_policy(store: JobStore, job_id: str, campaign_id: str) -> dict[str, Any]:
+def _campaign_manifest(
+    store: JobStore, job_id: str, campaign_id: str
+) -> dict[str, Any]:
     manifest = (
         store.read_json(
             job_id, f"{CAMPAIGN_ROOT}/{campaign_id}/manifest.json", default={}
         )
         or {}
     )
+    if not isinstance(manifest, dict):
+        raise ValueError(f"evolution campaign {campaign_id!r} has no manifest")
+    return manifest
+
+
+def _campaign_policy(store: JobStore, job_id: str, campaign_id: str) -> dict[str, Any]:
+    manifest = _campaign_manifest(store, job_id, campaign_id)
     policy = manifest.get("policy")
     if not isinstance(policy, dict):
         raise ValueError(f"evolution campaign {campaign_id!r} has no policy")

--- a/wayfinder_paths/jobs/evolution_campaign.py
+++ b/wayfinder_paths/jobs/evolution_campaign.py
@@ -2294,6 +2294,8 @@ def _persist_executable_bundle(
 ) -> tuple[str, Path]:
     _validate_parent_component(candidate_id, "candidate id")
     _validate_parent_component(revision, "candidate revision")
+    if compute_workspace_revision(source) != revision:
+        raise ValueError("source executable parent revision mismatch")
     relative = f"{PARENT_BUNDLE_ROOT}/{candidate_id}/{revision}"
     destination = store.job_dir(job_id) / relative
     if destination.exists():
@@ -2479,14 +2481,18 @@ def _select_parent_plan(
     pool = (manifest.get("parent_pool") or {}).get("candidates") or []
     qd_ids = set((manifest.get("parent_pool") or {}).get("qd_elite_ids") or [])
     qd = [item for item in pool if item.get("candidate_id") in qd_ids]
+    crossover_pool = [item for item in pool if item.get("status") != "incumbent"]
     if requested_source == "incumbent":
         return {"source": "incumbent", "parents": []}
     if requested_source == "qd_elite" and qd:
         parent = qd[(slot - 1) % len(qd)]
         return {"source": "qd_elite", "parents": [parent], "primary": parent}
-    if requested_source == "crossover" and len(pool) >= 2:
-        first = (slot - 1) % len(pool)
-        pair = [pool[first], pool[(first + 1) % len(pool)]]
+    if requested_source == "crossover" and len(crossover_pool) >= 2:
+        first = (slot - 1) % len(crossover_pool)
+        pair = [
+            crossover_pool[first],
+            crossover_pool[(first + 1) % len(crossover_pool)],
+        ]
         pair.sort(key=_archive_entry_score, reverse=True)
         return {
             "source": "crossover",
@@ -2531,7 +2537,18 @@ def _materialize_candidate_seed(
         parent = _resolve_frozen_parent_bundle(
             store, job_id, campaign_id, str(primary.get("bundle") or "")
         )
+        if compute_workspace_revision(parent) != str(primary.get("revision") or ""):
+            raise ValueError("frozen executable parent revision mismatch")
         _copy_active_bundle(parent, candidate_root)
+        job_data = _load_job_yaml(candidate_root)
+        params = dict(job_data.get("execution_params") or {})
+        for key in _TARGET_EXECUTION_PARAM_KEYS:
+            params.pop(key, None)
+        params.update(_target_execution_params(frozen_source))
+        job_data["execution_params"] = params
+        atomic_write_text(
+            candidate_root / "job.yaml", yaml.safe_dump(job_data, sort_keys=False)
+        )
     elif source == "starter_seed":
         _copy_clean_scaffold(store, job_id, frozen_source, candidate_root)
         _install_starter_seed(
@@ -2561,12 +2578,7 @@ def _copy_clean_scaffold(
     if risk_limits is not None:
         (destination / "workspace" / "risk_limits.json").write_bytes(risk_limits)
     job_data = _load_job_yaml(destination)
-    target_params = dict(job_data.get("execution_params") or {})
-    job_data["execution_params"] = {
-        key: target_params[key]
-        for key in _TARGET_EXECUTION_PARAM_KEYS
-        if key in target_params
-    }
+    job_data["execution_params"] = _target_execution_params(source_root)
     atomic_write_text(
         destination / "job.yaml", yaml.safe_dump(job_data, sort_keys=False)
     )
@@ -2606,15 +2618,8 @@ def _install_starter_seed(
     if script is None:
         raise ValueError("starter seed candidate has no execution entrypoint")
     atomic_write_text(script, source.read_text(encoding="utf-8"))
-    target_params = dict(job_data.get("execution_params") or {})
     params = dict(starter.get("params") or {})
-    params.update(
-        {
-            key: target_params[key]
-            for key in _TARGET_EXECUTION_PARAM_KEYS
-            if key in target_params
-        }
-    )
+    params.update(_target_execution_params(candidate_root))
     params["warmup_bars"] = int(starter["warmup_bars"])
     params["lookback_bars"] = int(starter["lookback_bars"])
     params.pop("full_history", None)
@@ -2622,6 +2627,13 @@ def _install_starter_seed(
     atomic_write_text(
         candidate_root / "job.yaml", yaml.safe_dump(job_data, sort_keys=False)
     )
+
+
+def _target_execution_params(source_root: Path) -> dict[str, Any]:
+    params = dict(_load_job_yaml(source_root).get("execution_params") or {})
+    return {
+        key: params[key] for key in _TARGET_EXECUTION_PARAM_KEYS if key in params
+    }
 
 
 def _resolve_frozen_parent_bundle(

--- a/wayfinder_paths/jobs/improver/scheduler.py
+++ b/wayfinder_paths/jobs/improver/scheduler.py
@@ -8,13 +8,11 @@ by weighted-deficit rotation against the ImproverSpec's allocation weights.
 No RNG — the assignment is a pure function of on-disk state, so any
 sequence is auditable and replayable.
 
-Islands:
-- exploit         — refine the incumbent's neighborhood (grids, exits, params)
-- adjacent        — validated family, new cell (regime, symbol, timeframe)
-- divergent       — new basin (family not in dead map, universe, sizing axis)
-- diversification — behaviorally different candidates from the live book
-- falsifier       — attack the incumbent; a confirmed refutation is a WIN
-- historian       — mine the archive (revive frontier branches, autopsy dead)
+The island names remain stable for allocation/history compatibility. Their
+directives are sensor-first: diagnose local surfaces, transfer, missing
+diversity, refutations, and archive evidence. On jobs with open evolution,
+that campaign is the only ordinary candidate factory; intervention keeps
+safety/remediation authority.
 
 Boosts are deterministic weight multipliers derived from visible state:
 verdict stuck-streak -> divergent; opportunity_recall.missed -> historian;
@@ -57,42 +55,38 @@ _CONTINUATION_WINDOW_S = 2 * 3600
 
 ISLAND_DIRECTIVES: dict[str, str] = {
     "exploit": (
-        "Refine the incumbent's neighborhood: parameter/exit-structure "
-        "experiments on the ACTIVE families (grid for attribution, optuna "
-        "for wide spaces), promote-params on validated winners. Cite the "
-        "trial lineage before sampling — re-running a flat region is spent "
-        "budget."
+        "Sense the incumbent's local surface: run deterministic parameter or "
+        "exit attribution on ACTIVE families and record flat/fragile regions. "
+        "When open evolution is enabled, hand validated findings to its archive; "
+        "do not author an ordinary alpha candidate in this lane."
     ),
     "adjacent": (
-        "Extend a VALIDATED family to a new cell: another regime "
-        "(--condition-regime), symbol, or timeframe. The family's evidence "
-        "transfers as a prior, not as a result — the new cell earns its own "
-        "scan + walk-forward before any proposal."
+        "Test whether a VALIDATED family transfers to another regime, symbol, "
+        "or timeframe. Produce a falsifiable diagnostic with its own scan and "
+        "walk-forward evidence; transfer is a prior, never a result."
     ),
     "divergent": (
-        "Jump basins: a family not in the dead map, a universe-scan, or the "
-        "sizing/leverage axis. Wide typed search spaces with "
-        "optimizer=optuna (multi-objective for structural sweeps). Do NOT "
-        "refine the incumbent this wake — that is exploit's job."
+        "Inspect an untested basin, universe slice, or sizing axis and produce "
+        "a bounded hypothesis brief grounded in data. When open evolution is "
+        "enabled, it owns executable candidate generation from that evidence."
     ),
     "diversification": (
-        "Hunt candidates whose BEHAVIOR differs from the live book: holding "
-        "period, direction bias, entry frequency (trial behavior "
-        "descriptors + archive behavior fields). A book of clones is one "
-        "bet wearing several names — score candidates by behavioral "
-        "distance, not just return."
+        "Measure where the live book lacks behavioral diversity: holding period, "
+        "direction bias, entry frequency, and cross-leg correlation. Record the "
+        "largest evidenced gap for evolution; do not build a parallel candidate."
     ),
     "falsifier": (
         "Attack the incumbent: re-run replication, probe regime-slice decay "
         "(t_recent within active cells), re-test the weakest live "
         "assumption on fresh data. You are trying to REFUTE — a confirmed "
-        "refutation (with a revert/kill proposal) is a successful wake."
+        "refutation is a successful wake. A concrete safety breach may still "
+        "produce a narrowly scoped revert, kill, or de-risk proposal."
     ),
     "historian": (
-        "Mine the archive: investigate opportunity_recall.missed candidates "
-        "FIRST (cite candidate_id), autopsy refuted branches for the "
-        "condition that killed them, map flat regions from trial lineage. "
-        "Output: revive with evidence, or bury with a written reason."
+        "Mine the existing archive: investigate opportunity_recall.missed first, "
+        "autopsy refuted branches, and verify whether named new evidence exists. "
+        "Update the existing durable verdict/evidence artifacts only; do not "
+        "create a new knowledge index or candidate engine."
     ),
 }
 

--- a/wayfinder_paths/jobs/paper_experiment.py
+++ b/wayfinder_paths/jobs/paper_experiment.py
@@ -110,7 +110,7 @@ def ensure_paper_experiment(
                     "admissions": "reported_only",
                 },
                 "candidate_entry": (
-                    "immutable_24h_forward_paper_proposal_against_current_arm_champion"
+                    "immutable_24h_operational_burn_in_on_identical_bars"
                 ),
                 "proposal_clock": (
                     "first_post_queue_common_completed_5m_bar_through_24h"
@@ -157,6 +157,7 @@ def stage_paper_proposal(
     candidate_root: Path,
     revision: str,
     source: str,
+    source_candidate_id: str | None = None,
     evidence: dict[str, Any] | None = None,
     now: datetime | None = None,
 ) -> dict[str, Any]:
@@ -164,7 +165,8 @@ def stage_paper_proposal(
 
     A proposal never replaces the arm champion directly. The candidate and the
     current champion first receive independent state and streams on identical
-    completed bars; only the mechanical adjudicator may promote it.
+    completed bars. This window judges only coverage, errors, and hard safety;
+    edge was already judged by the economic gate and belongs to the 14-day A/B.
     """
     if arm not in EXPERIMENT_ARMS:
         raise ValueError(f"unknown experiment arm {arm!r}")
@@ -230,7 +232,7 @@ def stage_paper_proposal(
             "status": "queued",
             "arm": arm,
             "candidate_id": safe_id,
-            "source_candidate_id": str(candidate_id),
+            "source_candidate_id": str(source_candidate_id or candidate_id),
             "revision": safe_revision,
             "bundle": relative,
             "source": source,
@@ -668,20 +670,7 @@ def _proposal_verdict(
     coverage: float,
 ) -> dict[str, Any]:
     from wayfinder_paths.jobs.constitution import load_constitution
-    from wayfinder_paths.jobs.probation import paper_entry_check
 
-    evidence = dict(proposal.get("evidence") or {})
-    objective = evidence.get("objective") or {}
-    candidate_objective = objective.get("candidate") or {}
-    backtest_trades = int(
-        evidence.get("backtest_trades") or candidate_objective.get("trade_count") or 0
-    )
-    entry = paper_entry_check(
-        candidate_net=float(candidate_stats["net_return"]),
-        baseline_net=float(reference_stats["net_return"]),
-        backtest_trades=backtest_trades,
-        spec=ImproverSpec.load(store.job_dir(job_id)),
-    )
     hard = load_constitution(store.job_dir(job_id))["hard_constraints"]
     max_drawdown = float(hard.get("max_drawdown_pct") or 0.25)
     reasons: list[str] = []
@@ -691,17 +680,8 @@ def _proposal_verdict(
         reasons.append("candidate raised during paper proposal")
     if int(proposal["reference"].get("error_count") or 0) > 0:
         reasons.append("reference raised during paper proposal")
-    if int(candidate_stats["closed_trades"]) < 1:
-        reasons.append("candidate produced no closed forward trade")
     if float(candidate_stats["max_drawdown_pct"]) > max_drawdown:
         reasons.append("candidate breached the owner drawdown ceiling")
-    reasons.extend(str(item) for item in entry["reasons"])
-    if str(
-        (proposal.get("reference") or {}).get("source") or "incumbent"
-    ) != "incumbent" and float(candidate_stats["net_return"]) <= float(
-        reference_stats["net_return"]
-    ):
-        reasons.append("candidate did not strictly improve the paper champion")
     return {
         "status": "qualified" if not reasons else "rejected",
         "arm": proposal["arm"],
@@ -710,7 +690,7 @@ def _proposal_verdict(
         "coverage": round(coverage, 4),
         "candidate": candidate_stats,
         "reference": reference_stats,
-        "paper_entry": entry,
+        "admission_basis": "operational_burn_in",
         "reasons": reasons,
         "paper_only": True,
     }
@@ -839,7 +819,7 @@ def _close_proposal(
                 "paper_experiment"
                 if verdict["status"] == "qualified"
                 else "proposal_rejected",
-                evidence="24-hour forward paper proposal " + verdict["status"],
+                evidence="24-hour operational burn-in " + verdict["status"],
             )
         except ValueError:
             pass

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -699,8 +699,10 @@ def _build_worker_prompt_sections(
         "the evolution campaign consumes this evidence."
         if evolution_enabled
         else (
-            "Act on a matured promotion verdict this wake: propose the next "
-            "candidate, run the next experiment, or record precisely why not."
+            "Act on it THIS wake — propose the next candidate, run the next "
+            "experiment, or record in the report precisely why not. A neutral "
+            "verdict means the change did nothing: that is license to try the "
+            "next candidate, not to wait."
         )
     )
     progress_rule = (
@@ -713,14 +715,20 @@ def _build_worker_prompt_sections(
         "staleness; evolution is the sole candidate factory.\n"
         if evolution_enabled
         else (
-            "- PROGRESS CONSTITUTION: `evolution.research_staleness` is visible "
-            "state. When the job is healthy, no verdict is pending, and "
-            f"research is stale (>{improver_spec.staleness_experiment_days:g} "
-            f"days without an experiment or >{improver_spec.staleness_wakes} "
-            "wakes since a proposal), end in exactly ONE of: a staged+executed "
-            "experiment, a paper probation leg, or an exhaustion claim FILED "
-            "for mechanical coverage audit. Stating that research is not "
-            "warranted is NOT a legal outcome.\n"
+            "- PROGRESS CONSTITUTION: `evolution.research_staleness` is "
+            "visible state. When the job is healthy, no verdict is pending, "
+            "and `research_staleness.stale` is true (no experiment in "
+            f">{improver_spec.staleness_experiment_days:g} days, or "
+            f">{improver_spec.staleness_wakes} wakes since the last "
+            "proposal), the wake MUST end in exactly ONE of: (a) a staged AND "
+            "executed experiment, (b) a new probation leg — the paper entry "
+            "tier accepts any candidate not clearly worse than baseline, no "
+            "owner approval needed (wayfinder_paths.jobs.probation."
+            "open_paper_probation_leg / `wayfinder job probation-open-paper`) "
+            "— or (c) an exhaustion claim FILED for mechanical coverage audit "
+            "(`wayfinder job exhaustion file ...`). Stating that research is "
+            "not warranted is NOT a legal outcome of a stale wake — prose "
+            "never satisfies the constitution.\n"
         )
     )
     memory_md = _read_text(root / "memory.md", max_chars=6000)
@@ -1052,6 +1060,21 @@ def _build_worker_prompt_sections(
             "exact behavior-equivalence maintenance, and owner-requested "
             "re-stage work. Forward results adjudicate changes; never fit to "
             "the forward stream.\n"
+            "- Regime alarm triage: a standing_checks."
+            "portfolio_regime_health warning/critical OVERRIDES ordinary "
+            "sensor work: stop routine diagnosis, read the detector's named "
+            "signals, then cite the automatically refreshed `attribution` "
+            "block before choosing whether to revert, de-risk, gate a regime, "
+            "or re-validate. Never explain away a critical drawdown because "
+            "one entry signal still backtests.\n"
+            "- If an allowed propose returns a failed validation, read ALL "
+            "failed check names and fix them in ONE follow-up propose; after "
+            "2 failed propose attempts in a wake, stop and report the blocker "
+            "instead of retrying.\n"
+            "- A pending proposal whose candidate_report failed with "
+            "failure_kind 'infrastructure' is a box condition, not evidence: "
+            "run `wayfinder job revalidate <job_id> <proposal_id>` on the "
+            "same candidate instead of rejecting or re-proposing.\n"
         )
         if evolution_enabled
         else (

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -680,6 +680,49 @@ def _build_worker_prompt_sections(
     from wayfinder_paths.jobs.improver.spec import ImproverSpec
 
     improver_spec = ImproverSpec.load(root)
+    evolution_enabled = improver_spec.evolution_enabled_for(job_id)
+    intervene_scope = (
+        "Intervene mode is the sensor/safety lane for this evolution-enabled "
+        "job. Ordinary alpha/parameter candidate authoring, signal-family "
+        "generation, and paper-probation admission belong exclusively to the "
+        "evolution campaign. This lane may still stage concrete risk reduction, "
+        "revert/kill, operational remediation, exact behavior-equivalence "
+        "maintenance, and owner-requested re-stage/application work. This rule "
+        "supersedes generic candidate/probation mandates below."
+        if evolution_enabled
+        else "Intervene mode may create candidate proposals under the job bundle, but cannot activate them."
+    )
+    verdict_matured_rule = (
+        "Treat a matured promotion verdict as sensing evidence: update the "
+        "existing verdict/archive artifacts and run the next diagnostic or "
+        "falsification. Do not author the next ordinary strategy candidate; "
+        "the evolution campaign consumes this evidence."
+        if evolution_enabled
+        else (
+            "Act on a matured promotion verdict this wake: propose the next "
+            "candidate, run the next experiment, or record precisely why not."
+        )
+    )
+    progress_rule = (
+        "- SENSOR PROGRESS CONSTITUTION: when research_staleness is true, this "
+        "evolution-enabled job's intervention wake must produce exactly ONE "
+        "bounded "
+        "deterministic diagnostic, falsification, or adjudication and record its "
+        "result in an existing archive/verdict/evidence artifact. It must not "
+        "open probation or author an ordinary alpha candidate merely to satisfy "
+        "staleness; evolution is the sole candidate factory.\n"
+        if evolution_enabled
+        else (
+            "- PROGRESS CONSTITUTION: `evolution.research_staleness` is visible "
+            "state. When the job is healthy, no verdict is pending, and "
+            f"research is stale (>{improver_spec.staleness_experiment_days:g} "
+            f"days without an experiment or >{improver_spec.staleness_wakes} "
+            "wakes since a proposal), end in exactly ONE of: a staged+executed "
+            "experiment, a paper probation leg, or an exhaustion claim FILED "
+            "for mechanical coverage audit. Stating that research is not "
+            "warranted is NOT a legal outcome.\n"
+        )
+    )
     memory_md = _read_text(root / "memory.md", max_chars=6000)
     # The research prior library: idea families, prior strengths, archetype
     # mapping, and test paths. Lives in the STABLE prefix so it prompt-caches
@@ -818,7 +861,7 @@ def _build_worker_prompt_sections(
         "rules, or lessons materially change.\n\n"
         "Rules:\n"
         "- Monitor mode is read-only except reports/memory.\n"
-        "- Intervene mode may create candidate proposals under the job bundle, but cannot activate them.\n"
+        f"- {intervene_scope}\n"
         "- Proposals stage ONLY `workspace/` + `job.yaml`; code outside `workspace/` "
         "cannot be versioned, proposed, or promoted. If the active script entrypoint "
         "resolves outside `workspace/`, your FIRST proposal must migrate it into "
@@ -884,10 +927,7 @@ def _build_worker_prompt_sections(
         "already fixed.\n"
         "- A `verdict_matured` trigger (or a fresh non-pending verdict in "
         "`evolution.promotion_reliability`) is a RESEARCH EVENT: the forward "
-        "window has judged the last promotion. Act on it THIS wake — propose "
-        "the next candidate, run the next experiment, or record in the "
-        "report precisely why not. A neutral verdict means the change did "
-        "nothing: that is license to try the next candidate, not to wait.\n"
+        f"window has judged the last promotion. {verdict_matured_rule}\n"
         "- Infrastructure failures are BOX conditions, not research "
         "verdicts: any claim that a lane is OOM-blocked, locked, or "
         "timed-out must cite the `compute_status` block from THIS wake — "
@@ -908,20 +948,7 @@ def _build_worker_prompt_sections(
         "down: verify backend health ONLY via a resident MCP tool result, "
         "and void any agenda/memory claim of 'backend DOWN' that is not "
         "backed by an MCP-tool failure observed THIS wake.\n"
-        "- PROGRESS CONSTITUTION: `evolution.research_staleness` is "
-        "visible state. When the job is healthy, no verdict is pending, "
-        "and `research_staleness.stale` is true (no experiment in "
-        f">{improver_spec.staleness_experiment_days:g} days, or "
-        f">{improver_spec.staleness_wakes} wakes since the last "
-        "proposal), the wake MUST end in exactly ONE of: (a) a staged AND "
-        "executed experiment, (b) a new probation leg — the paper entry "
-        "tier accepts any candidate not clearly worse than baseline, no "
-        "owner approval needed (wayfinder_paths.jobs.probation."
-        "open_paper_probation_leg / `wayfinder job probation-open-paper`) "
-        "— or (c) an exhaustion claim FILED for mechanical coverage audit "
-        "(`wayfinder job exhaustion file ...`). Stating that research is "
-        "not warranted is NOT a legal outcome of a stale wake — prose "
-        "never satisfies the constitution.\n"
+        f"{progress_rule}"
         "- Self-rejections are development evidence, never verdicts: a "
         "proposal YOU rejected cannot mark a lane settled in the agenda/"
         "dead map, and reopening bars ('requires named new evidence') may "
@@ -1013,6 +1040,20 @@ def _build_worker_prompt_sections(
         "immediately instead of running open-ended exploratory tests. If validation "
         "fails, complete the application as failed so runner loops resume cleanly.\n"
         if apply_proposal_id
+        else (
+            "- EVOLUTION SENSOR CONTRACT: inspect structured forward/live "
+            "results, attribution, counterfactuals, gate state, and completed "
+            "experiments. Produce one bounded deterministic diagnosis, "
+            "falsification, or adjudication and record it in an existing "
+            "archive/verdict/evidence artifact. Ordinary strategy/parameter "
+            "candidates, signal-family authoring, and paper probation belong "
+            "to the evolution campaign. The only proposals allowed here are "
+            "concrete risk reduction or revert/kill, operational remediation, "
+            "exact behavior-equivalence maintenance, and owner-requested "
+            "re-stage work. Forward results adjudicate changes; never fit to "
+            "the forward stream.\n"
+        )
+        if evolution_enabled
         else (
             "- Review the dynamic context against the stable job contract. "
             "When you want to RECOMMEND a strategy/params change, do not "
@@ -1268,7 +1309,18 @@ def _build_worker_prompt_sections(
     impasse_directive = ""
     impasse_marker = store.read_json(job_id, "state/research_impasse.json") or {}
     if impasse_marker.get("alerted_at"):
-        if impasse_marker.get("status") == "mandated_work":
+        if evolution_enabled:
+            mandate = impasse_marker.get("mandate") or {}
+            required = mandate.get("required_next_experiments") or []
+            impasse_directive = (
+                "RESEARCH IMPASSE — evolution owns candidate generation. This "
+                "sensor wake must execute one bounded deterministic diagnostic "
+                "or falsification and write its result to an existing archive/"
+                "verdict/evidence artifact. Do not open probation or build a "
+                "parallel candidate.\n"
+                f"REQUIRED_DIAGNOSTICS={json.dumps(required, default=str)}\n\n"
+            )
+        elif impasse_marker.get("status") == "mandated_work":
             mandate = impasse_marker.get("mandate") or {}
             required = mandate.get("required_next_experiments") or []
             impasse_directive = (

--- a/wayfinder_paths/tests/test_jobs_evolution_campaign.py
+++ b/wayfinder_paths/tests/test_jobs_evolution_campaign.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import json
+import shutil
 from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
@@ -22,8 +23,10 @@ from wayfinder_paths.jobs.evolution_campaign import (
     _claim_full_dev,
     _commit_full_dev,
     _isolated_full_dev,
+    _materialize_candidate_seed,
     _parameter_tuning_preview,
     _parent_source,
+    _persist_executable_bundle,
     _same_family_nonwins,
     _select_full_dev_candidate,
     _select_parent_plan,
@@ -247,6 +250,9 @@ def test_evolution_enabled_intervention_prompt_is_sensor_and_safety_only(
     assert "supersedes generic candidate/probation mandates" in prefix
     assert "exact behavior-equivalence maintenance" in prefix
     assert "EVOLUTION SENSOR CONTRACT" in prompt
+    assert "Regime alarm triage" in prompt
+    assert "read ALL failed check names" in prompt
+    assert "wayfinder job revalidate <job_id> <proposal_id>" in prompt
     assert "open_paper_probation_leg" not in prompt
     assert "When you want to RECOMMEND a strategy/params change" not in prompt
 
@@ -465,6 +471,16 @@ def test_de_novo_seed_keeps_target_infra_but_drops_incumbent_alpha(tmp_path) -> 
 
 def test_next_campaign_materializes_real_qd_parent_bytes(tmp_path) -> None:
     store, job_id = _job(tmp_path, "majors-5m-lab")
+    job_path = store.job_dir(job_id) / "job.yaml"
+    job_data = yaml.safe_load(job_path.read_text(encoding="utf-8"))
+    job_data["execution_params"] = {
+        "symbols": ["SOL"],
+        "fee_bps": 1.0,
+        "leverage": 1.0,
+        "wallet_label": "old-wallet",
+        "parent_alpha_threshold": 0.7,
+    }
+    job_path.write_text(yaml.safe_dump(job_data, sort_keys=False), encoding="utf-8")
     started = datetime(2026, 8, 25, 12, tzinfo=UTC)
     first_state = start_campaign(store, job_id, now=started)
     elite = prepare_candidate(
@@ -504,6 +520,17 @@ def test_next_campaign_materializes_real_qd_parent_bytes(tmp_path) -> None:
     store.write_json(job_id, "state/evolution_campaign.json", state)
     _archive_campaign_candidate(store, job_id, state["candidates"][0])
 
+    job_data = yaml.safe_load(job_path.read_text(encoding="utf-8"))
+    job_data["execution_params"].update(
+        {
+            "symbols": ["BTC", "ETH"],
+            "fee_bps": 4.5,
+            "leverage": 2.0,
+            "wallet_label": "current-wallet",
+        }
+    )
+    job_path.write_text(yaml.safe_dump(job_data, sort_keys=False), encoding="utf-8")
+
     second_state = start_campaign(
         store, job_id, now=started + timedelta(days=1), force=True
     )
@@ -524,6 +551,7 @@ def test_next_campaign_materializes_real_qd_parent_bytes(tmp_path) -> None:
     child_script = (
         store.job_dir(job_id) / child["bundle"] / "workspace" / "src" / "strategy.py"
     ).read_text(encoding="utf-8")
+    child_params = _read_bundle_params(store, job_id, child["bundle"])
     manifest = json.loads(
         (store.job_dir(job_id) / second_state["manifest"]).read_text(encoding="utf-8")
     )
@@ -531,8 +559,13 @@ def test_next_campaign_materializes_real_qd_parent_bytes(tmp_path) -> None:
     assert second_state["campaign_id"] != first_state["campaign_id"]
     assert child["parent_source"] == "qd_elite"
     assert child["parent_candidate_ids"] == [elite["candidate_id"]]
-    assert child["seed_revision"] == revision
+    assert child["seed_revision"] != revision
     assert "ELITE_MARKER = 'real-parent'" in child_script
+    assert child_params["parent_alpha_threshold"] == 0.7
+    assert child_params["symbols"] == ["BTC", "ETH"]
+    assert child_params["fee_bps"] == 4.5
+    assert child_params["leverage"] == 2.0
+    assert child_params["wallet_label"] == "current-wallet"
     assert manifest["parent_pool"]["qd_elite_ids"] == [elite["candidate_id"]]
     archived = next(
         item
@@ -553,9 +586,18 @@ def test_crossover_requires_two_real_parents_and_uses_stronger_primary() -> None
         "bundle": "parents/strong",
         "objective": {"net_log_growth": 0.5},
     }
+    incumbent = {
+        "candidate_id": "archived-incumbent",
+        "bundle": "parents/archived-incumbent",
+        "status": "incumbent",
+        "objective": {"net_log_growth": 1.0},
+    }
     plan = _select_parent_plan(
         {
-            "parent_pool": {"candidates": [weak, strong], "qd_elite_ids": []},
+            "parent_pool": {
+                "candidates": [incumbent, weak, strong],
+                "qd_elite_ids": [],
+            },
             "starter_seeds": [],
         },
         requested_source="crossover",
@@ -566,6 +608,49 @@ def test_crossover_requires_two_real_parents_and_uses_stronger_primary() -> None
     assert plan["source"] == "crossover"
     assert plan["primary"]["candidate_id"] == "strong"
     assert plan["secondary"]["candidate_id"] == "weak"
+    assert "archived-incumbent" not in {
+        item["candidate_id"] for item in plan["parents"]
+    }
+
+
+def test_parent_bundle_integrity_is_checked_at_both_copy_boundaries(tmp_path) -> None:
+    store, job_id = _job(tmp_path, "majors-5m-lab")
+    started = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    state = start_campaign(store, job_id, now=started)
+    manifest_path = store.job_dir(job_id) / state["manifest"]
+    campaign_root = manifest_path.parent
+    frozen_source = campaign_root / "source"
+    revision = compute_workspace_revision(frozen_source)
+
+    with pytest.raises(ValueError, match="source executable parent revision mismatch"):
+        _persist_executable_bundle(
+            store,
+            job_id,
+            candidate_id="tampered-source",
+            revision="wrong-revision",
+            source=frozen_source,
+        )
+
+    parent = campaign_root / "parents" / "elite"
+    parent.mkdir(parents=True)
+    shutil.copy2(frozen_source / "job.yaml", parent / "job.yaml")
+    shutil.copytree(frozen_source / "workspace", parent / "workspace")
+    assert compute_workspace_revision(parent) == revision
+    (parent / "workspace" / "src" / "strategy.py").write_text(
+        "def decide(ctx):\n    raise RuntimeError('tampered')\n", encoding="utf-8"
+    )
+
+    with pytest.raises(ValueError, match="frozen executable parent revision mismatch"):
+        _materialize_candidate_seed(
+            store,
+            job_id,
+            campaign_id=state["campaign_id"],
+            candidate_root=campaign_root / "candidates" / "poisoned-child",
+            plan={
+                "source": "qd_elite",
+                "primary": {"bundle": "parents/elite", "revision": revision},
+            },
+        )
 
 
 def test_campaign_freezes_only_existing_refutations_and_validated_wins(

--- a/wayfinder_paths/tests/test_jobs_evolution_campaign.py
+++ b/wayfinder_paths/tests/test_jobs_evolution_campaign.py
@@ -18,6 +18,7 @@ from wayfinder_paths.jobs.archive import (
 )
 from wayfinder_paths.jobs.compute_lock import ComputeLockBusy
 from wayfinder_paths.jobs.evolution_campaign import (
+    _archive_campaign_candidate,
     _claim_full_dev,
     _commit_full_dev,
     _isolated_full_dev,
@@ -25,6 +26,7 @@ from wayfinder_paths.jobs.evolution_campaign import (
     _parent_source,
     _same_family_nonwins,
     _select_full_dev_candidate,
+    _select_parent_plan,
     _write_timeseries_prefix,
     campaign_due,
     campaign_prompt_block,
@@ -48,10 +50,16 @@ from wayfinder_paths.jobs.starter_casebook import (
     load_starter_casebook,
     select_starter_cases,
 )
+from wayfinder_paths.jobs.starters import (
+    STARTER_DEFINITIONS,
+    starter_lookback_bars,
+    starter_warmup_bars,
+)
 from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.jobs.worker import (
     _queue_evolution_worker,
     nudge_evolution_session,
+    prepare_job_worker_prompt,
     recover_evolution_stage_session,
     retire_evolution_session,
     run_job_worker,
@@ -140,7 +148,9 @@ def test_rollout_is_gated_and_campaign_context_is_bounded(tmp_path) -> None:
         "paper_only": True,
         "live_requires_owner": True,
         "candidate_inputs_frozen_at_campaign_start": True,
-        "finalist_requires_24h_forward_proposal": True,
+        "finalist_requires_24h_operational_burn_in": True,
+        "starter_seed_evidence_resets": True,
+        "refuted_family_matching": "exact_free_form_family_v1",
     }
     assert len(load_starter_casebook()) > len(block["cases"])
 
@@ -221,6 +231,24 @@ def test_active_evolution_suppresses_the_parallel_intervention_llm(
     assert report["queued"] is False
     assert report["session_id"] == "evolution-session"
     assert "deferred while evolution owns the lane" in report["summary"]
+
+
+def test_evolution_enabled_intervention_prompt_is_sensor_and_safety_only(
+    tmp_path,
+) -> None:
+    store, job_id = _job(tmp_path, "majors-5m-lab")
+
+    sections = prepare_job_worker_prompt(store=store, job_id=job_id, mode="intervene")
+
+    prefix = sections["stable_prefix"]
+    prompt = sections["prompt"]
+    assert "sensor/safety lane" in prefix
+    assert "belong exclusively to the evolution campaign" in prefix
+    assert "supersedes generic candidate/probation mandates" in prefix
+    assert "exact behavior-equivalence maintenance" in prefix
+    assert "EVOLUTION SENSOR CONTRACT" in prompt
+    assert "open_paper_probation_leg" not in prompt
+    assert "When you want to RECOMMEND a strategy/params change" not in prompt
 
 
 def test_governor_diagnostic_error_does_not_wedge_the_intervention_lane(
@@ -341,7 +369,10 @@ def test_prepare_candidate_isolated_lineage_and_mutation_budget(tmp_path) -> Non
         summary="stuck rule jumps basin",
         now=datetime(2026, 8, 25, 13, tzinfo=UTC),
     )
-    assert second["parent_source"] == "qd_elite"
+    assert second["requested_parent_source"] == "qd_elite"
+    assert second["parent_source"] == "starter_seed"
+    assert second["starter_seed_id"]
+    assert second["parent_candidate_ids"] == []
     assert third["forced_jump"] is True
     assert third["parent_source"] == "de_novo"
 
@@ -356,6 +387,259 @@ def test_prepare_candidate_isolated_lineage_and_mutation_budget(tmp_path) -> Non
         "crossover": 2,
         "de_novo": 2,
     }
+
+
+def test_cold_start_seed_uses_starter_window_and_resets_evidence(tmp_path) -> None:
+    store, job_id = _job(tmp_path, "majors-5m-lab")
+    job_path = store.job_dir(job_id) / "job.yaml"
+    job_data = yaml.safe_load(job_path.read_text(encoding="utf-8"))
+    job_data["execution_params"] = {
+        "symbols": ["BTC", "ETH"],
+        "fee_bps": 4.5,
+        "slippage_bps": 3.5,
+    }
+    job_path.write_text(yaml.safe_dump(job_data, sort_keys=False), encoding="utf-8")
+    started = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    start_campaign(store, job_id, now=started)
+    prepare_candidate(
+        store,
+        job_id,
+        family="incumbent-neighbor",
+        summary="consume incumbent slot",
+        now=started + timedelta(hours=1),
+    )
+    seeded = prepare_candidate(
+        store,
+        job_id,
+        family="starter-transfer",
+        summary="adapt an audited starter",
+        now=started + timedelta(hours=1),
+    )
+
+    definition = next(
+        item for item in STARTER_DEFINITIONS if item.id == seeded["starter_seed_id"]
+    )
+    params = _read_bundle_params(store, job_id, seeded["bundle"])
+    script = (
+        store.job_dir(job_id) / seeded["bundle"] / "workspace" / "src" / "strategy.py"
+    ).read_text(encoding="utf-8")
+
+    assert seeded["requested_parent_source"] == "qd_elite"
+    assert seeded["parent_source"] == "starter_seed"
+    assert seeded["evidence_reset"] is True
+    assert params["warmup_bars"] == starter_warmup_bars(definition)
+    assert params["lookback_bars"] == starter_lookback_bars(definition)
+    assert definition.module.rsplit(".", 1)[-1].split("_")[0] in script.lower()
+    assert params["symbols"] == ["BTC", "ETH"]
+    assert params["fee_bps"] == 4.5
+
+
+def test_de_novo_seed_keeps_target_infra_but_drops_incumbent_alpha(tmp_path) -> None:
+    store, job_id = _job(tmp_path, "majors-5m-lab")
+    job_path = store.job_dir(job_id) / "job.yaml"
+    job_data = yaml.safe_load(job_path.read_text(encoding="utf-8"))
+    job_data["execution_params"] = {
+        "symbols": ["BTC", "ETH"],
+        "fee_bps": 4.5,
+        "slippage_bps": 3.5,
+        "incumbent_alpha_threshold": 0.73,
+    }
+    job_path.write_text(yaml.safe_dump(job_data, sort_keys=False), encoding="utf-8")
+    started = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    start_campaign(store, job_id, now=started)
+    candidates = _prepare_campaign_candidates(store, job_id, started)
+    de_novo = candidates[3]
+    params = _read_bundle_params(store, job_id, de_novo["bundle"])
+    script = (
+        store.job_dir(job_id) / de_novo["bundle"] / "workspace" / "src" / "strategy.py"
+    ).read_text(encoding="utf-8")
+
+    assert de_novo["requested_parent_source"] == "de_novo"
+    assert de_novo["parent_source"] == "de_novo"
+    assert "incumbent_alpha_threshold" not in params
+    assert params["symbols"] == ["BTC", "ETH"]
+    assert params["fee_bps"] == 4.5
+    assert params["warmup_bars"] == DEFAULT_WARMUP_BARS
+    assert "Clean de-novo evolution scaffold" in script
+
+
+def test_next_campaign_materializes_real_qd_parent_bytes(tmp_path) -> None:
+    store, job_id = _job(tmp_path, "majors-5m-lab")
+    started = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    first_state = start_campaign(store, job_id, now=started)
+    elite = prepare_candidate(
+        store,
+        job_id,
+        family="compression-breakout",
+        summary="validated executable elite",
+        now=started + timedelta(hours=1),
+    )
+    elite_root = store.job_dir(job_id) / elite["bundle"]
+    elite_script = elite_root / "workspace" / "src" / "strategy.py"
+    elite_script.write_text(
+        "def decide(ctx):\n    return []\n\nELITE_MARKER = 'real-parent'\n",
+        encoding="utf-8",
+    )
+    revision = compute_workspace_revision(elite_root)
+    state = campaign_status(store, job_id)
+    state["candidates"][0].update(
+        {
+            "status": "dev_frontier",
+            "revision": revision,
+            "objective": {
+                "net_log_growth": 1.0,
+                "downside_deviation": 0.1,
+                "tail_loss": 0.1,
+                "max_drawdown_pct": 0.1,
+            },
+            "behavior": {
+                "direction_bias": 0.5,
+                "average_hold_bars": 24,
+                "trades_per_asset_30d": 10,
+            },
+            "dev": {"validation": {"stats": {"net_return": 0.1}}},
+        }
+    )
+    state["status"] = "complete"
+    store.write_json(job_id, "state/evolution_campaign.json", state)
+    _archive_campaign_candidate(store, job_id, state["candidates"][0])
+
+    second_state = start_campaign(
+        store, job_id, now=started + timedelta(days=1), force=True
+    )
+    prepare_candidate(
+        store,
+        job_id,
+        family="incumbent-neighbor",
+        summary="consume incumbent slot",
+        now=started + timedelta(days=1, hours=1),
+    )
+    child = prepare_candidate(
+        store,
+        job_id,
+        family="compression-crossover",
+        summary="mutate the frozen elite",
+        now=started + timedelta(days=1, hours=1),
+    )
+    child_script = (
+        store.job_dir(job_id) / child["bundle"] / "workspace" / "src" / "strategy.py"
+    ).read_text(encoding="utf-8")
+    manifest = json.loads(
+        (store.job_dir(job_id) / second_state["manifest"]).read_text(encoding="utf-8")
+    )
+
+    assert second_state["campaign_id"] != first_state["campaign_id"]
+    assert child["parent_source"] == "qd_elite"
+    assert child["parent_candidate_ids"] == [elite["candidate_id"]]
+    assert child["seed_revision"] == revision
+    assert "ELITE_MARKER = 'real-parent'" in child_script
+    assert manifest["parent_pool"]["qd_elite_ids"] == [elite["candidate_id"]]
+    archived = next(
+        item
+        for item in load_archive(store, job_id)["candidates"]
+        if item["candidate_id"] == elite["candidate_id"]
+    )
+    assert archived["metadata"]["executable_bundle"].endswith(revision)
+
+
+def test_crossover_requires_two_real_parents_and_uses_stronger_primary() -> None:
+    weak = {
+        "candidate_id": "weak",
+        "bundle": "parents/weak",
+        "objective": {"net_log_growth": 0.1},
+    }
+    strong = {
+        "candidate_id": "strong",
+        "bundle": "parents/strong",
+        "objective": {"net_log_growth": 0.5},
+    }
+    plan = _select_parent_plan(
+        {
+            "parent_pool": {"candidates": [weak, strong], "qd_elite_ids": []},
+            "starter_seeds": [],
+        },
+        requested_source="crossover",
+        slot=1,
+        candidates=[],
+    )
+
+    assert plan["source"] == "crossover"
+    assert plan["primary"]["candidate_id"] == "strong"
+    assert plan["secondary"]["candidate_id"] == "weak"
+
+
+def test_campaign_freezes_only_existing_refutations_and_validated_wins(
+    tmp_path,
+) -> None:
+    store, job_id = _job(tmp_path, "majors-5m-lab")
+    record_candidate(
+        store,
+        job_id,
+        candidate_id="refuted-1",
+        family="volatility-regime-entry-gate",
+        summary="failed branch",
+        status="refuted",
+        objective=None,
+        evidence="negative paired folds",
+    )
+    store.write_json(
+        job_id,
+        "probation.json",
+        {
+            "legs": [
+                {
+                    "name": "compression-gate",
+                    "symbol": "HYPE",
+                    "status": "graduated",
+                    "graduate": {"progress": "positive forward effect"},
+                    "closed_at": "2026-08-24T00:00:00+00:00",
+                }
+            ]
+        },
+    )
+    store.write_json(
+        job_id,
+        "state/promotion_verdicts.json",
+        {
+            "prop-win": {
+                "verdict": "beat",
+                "strategy_effect": 3.5,
+                "recorded_at": "2026-08-25T00:00:00+00:00",
+            },
+            "prop-execution-only": {
+                "verdict": "beat",
+                "strategy_effect": 0.0,
+                "recorded_at": "2026-08-26T00:00:00+00:00",
+            },
+        },
+    )
+
+    state = start_campaign(store, job_id, now=datetime(2026, 8, 27, 12, tzinfo=UTC))
+    manifest = json.loads(
+        (store.job_dir(job_id) / state["manifest"]).read_text(encoding="utf-8")
+    )
+    context = manifest["research_context"]
+
+    assert context["refuted_families"] == [
+        {
+            "family": "volatility-regime-entry-gate",
+            "candidate_id": "refuted-1",
+            "evidence": "negative paired folds",
+        }
+    ]
+    assert {item["id"] for item in context["validated_positives"]} == {
+        "compression-gate",
+        "prop-win",
+    }
+    assert context["matching"] == "exact_free_form_family_v1"
+    assert "not deletion of a refutation" in context["accepted_limitation"]
+    block = campaign_prompt_block(
+        store, job_id, now=datetime(2026, 8, 27, 13, tzinfo=UTC)
+    )
+    assert block is not None
+    assert block["research_context"] == context
+    assert "volatility-regime-entry-gate" in block["next_action"]
+    assert "prop-win" in block["next_action"]
 
 
 def test_campaign_assigns_parameter_slots_and_preserves_optuna_budget(tmp_path) -> None:

--- a/wayfinder_paths/tests/test_jobs_paper_experiment.py
+++ b/wayfinder_paths/tests/test_jobs_paper_experiment.py
@@ -392,7 +392,7 @@ def test_resource_and_admissions_parity_are_reported_not_gating(
     }
 
 
-def test_non_incumbent_champion_requires_strict_forward_improvement(
+def test_operational_burn_in_does_not_rejudge_forward_edge(
     tmp_path: Path,
 ) -> None:
     started = datetime(2026, 8, 1, tzinfo=UTC)
@@ -435,10 +435,75 @@ def test_non_incumbent_champion_requires_strict_forward_improvement(
         coverage=1.0,
     )
 
-    assert tied["status"] == "rejected"
-    assert "strictly improve" in tied["reasons"][-1]
+    assert tied["status"] == "qualified"
     assert better["status"] == "qualified"
     assert first_challenger["status"] == "qualified"
+    assert tied["admission_basis"] == "operational_burn_in"
+    assert tied["reasons"] == []
+
+
+@pytest.mark.parametrize(
+    ("mature", "candidate_errors", "reference_errors", "drawdown", "reason"),
+    [
+        (False, 0, 0, 0.0, "insufficient common-bar coverage"),
+        (True, 1, 0, 0.0, "candidate raised during paper proposal"),
+        (True, 0, 1, 0.0, "reference raised during paper proposal"),
+        (True, 0, 0, 0.5, "candidate breached the owner drawdown ceiling"),
+    ],
+)
+def test_operational_burn_in_still_rejects_coverage_errors_and_safety(
+    tmp_path: Path,
+    mature: bool,
+    candidate_errors: int,
+    reference_errors: int,
+    drawdown: float,
+    reason: str,
+) -> None:
+    store, job_id, _ = _job(tmp_path, now=datetime(2026, 8, 1, tzinfo=UTC))
+    proposal = {
+        "arm": "evolution",
+        "candidate_id": "candidate-operational",
+        "revision": "revision-operational",
+        "candidate": {"error_count": candidate_errors},
+        "reference": {"error_count": reference_errors, "source": "incumbent"},
+    }
+    stats = {"closed_trades": 0, "net_return": 0.0, "max_drawdown_pct": drawdown}
+
+    verdict = _proposal_verdict(
+        store,
+        job_id,
+        proposal,
+        candidate_stats=stats,
+        reference_stats={**stats, "max_drawdown_pct": 0.0},
+        mature=mature,
+        coverage=0.5 if not mature else 1.0,
+    )
+
+    assert verdict["status"] == "rejected"
+    assert any(reason in item for item in verdict["reasons"])
+
+
+def test_restage_can_use_unique_runtime_id_without_losing_archive_lineage(
+    tmp_path: Path,
+) -> None:
+    started = datetime(2026, 8, 1, tzinfo=UTC)
+    store, job_id, _ = _job(tmp_path, now=started)
+    source, revision = _candidate_source(store, job_id)
+
+    proposal = stage_paper_proposal(
+        store,
+        job_id,
+        arm="evolution",
+        candidate_id="c03-restage-2",
+        source_candidate_id="original-c03",
+        candidate_root=source,
+        revision=revision,
+        source="evolution_campaign",
+        now=started + timedelta(hours=1),
+    )
+
+    assert proposal["candidate_id"].startswith("c03-restage-2-")
+    assert proposal["source_candidate_id"] == "original-c03"
 
 
 def test_wall_clock_expiry_closes_proposal_without_forward_bars(
@@ -529,9 +594,10 @@ def test_proposal_ignores_pre_queue_ticks_and_trades(tmp_path: Path) -> None:
         store, job_id, now=queued_at + timedelta(hours=24, minutes=5)
     )
 
-    assert outcomes[0]["status"] == "rejected"
+    assert outcomes[0]["status"] == "qualified"
     assert outcomes[0]["candidate"]["closed_trades"] == 0
-    assert "candidate produced no closed forward trade" in outcomes[0]["reasons"]
+    assert outcomes[0]["admission_basis"] == "operational_burn_in"
+    assert outcomes[0]["reasons"] == []
     history = experiment_status(store, job_id)["proposals"]["evolution"]["history"]
     assert (
         history[-1]["first_common_bar"]

--- a/wayfinder_paths/tests/test_jobs_progress_constitution.py
+++ b/wayfinder_paths/tests/test_jobs_progress_constitution.py
@@ -761,6 +761,21 @@ def test_wake_mandate_hatch_stripped_and_pinned(tmp_path: Path) -> None:
     store, job_id = _make_store(tmp_path, "mandate-pin")
     sections = prepare_job_worker_prompt(store=store, job_id=job_id, mode="intervene")
     prompt = sections["stable_prefix"]
+    original_constitution = (
+        "- PROGRESS CONSTITUTION: `evolution.research_staleness` is visible "
+        "state. When the job is healthy, no verdict is pending, and "
+        "`research_staleness.stale` is true (no experiment in >3 days, or "
+        ">100 wakes since the last proposal), the wake MUST end in exactly ONE "
+        "of: (a) a staged AND executed experiment, (b) a new probation leg — "
+        "the paper entry tier accepts any candidate not clearly worse than "
+        "baseline, no owner approval needed (wayfinder_paths.jobs.probation."
+        "open_paper_probation_leg / `wayfinder job probation-open-paper`) — or "
+        "(c) an exhaustion claim FILED for mechanical coverage audit "
+        "(`wayfinder job exhaustion file ...`). Stating that research is not "
+        "warranted is NOT a legal outcome of a stale wake — prose never "
+        "satisfies the constitution.\n"
+    )
+    assert original_constitution in prompt
     assert "PROGRESS CONSTITUTION" in prompt
     assert "exactly ONE of" in prompt
     assert "exhaustion claim FILED for mechanical coverage audit" in prompt


### PR DESCRIPTION
## Outcome

Makes the evolution lane structurally capable of leaving the incumbent basin without adding a new knowledge-management system.

- persists executable full-development/frontier bundles and freezes eligible parents at campaign start
- makes QD parentage copy the elite's actual bytes, then re-stamps the current job's fees, symbols, venue, wallet, leverage, capital, and slippage contract before hashing the seed
- makes crossover require two distinct executable non-incumbent parents, seed from the stronger one, and expose the second read-only
- verifies source and campaign-local bundle revisions at both executable-parent copy boundaries
- replaces fake cold-start QD/crossover labels with distinct audited starter seeds
- resets starter evidence, adapts target infrastructure/symbols, and uses each starter's own warmup/lookback
- gives de-novo candidates a clean target-compatible scaffold with incumbent alpha code/params removed
- freezes only the two existing load-bearing knowledge lists: exact refuted families and mechanically validated positives
- changes the 24-hour forward proposal window to operational burn-in only: identical-bar coverage, zero errors, and owner safety ceiling; edge remains in the economic gate and 14-day A/B
- allows a unique restage runtime id to retain the original archive candidate lineage
- contracts evolution-enabled intervention wakes to sensing, falsification, safety, remediation, and exact behavior-equivalence maintenance; evolution is the sole ordinary candidate factory
- retains regime-alarm de-risk precedence and proposal revalidation recovery in that sensor lane
- preserves the pre-existing non-evolution hourly wake constitution, including its exact probation and exhaustion tool paths

No cards, claim index, taxonomy, freshness clock, or second candidate registry is introduced. Exact free-form family matching remains an explicitly accepted v1 limitation.

## Validation

- `929 passed` — complete `test_jobs_*.py` suite
- `82 passed` — focused evolution + progress-constitution regression suite
- Ruff passed on every changed file
- diff check passed
- mypy remains blocked by the repository's existing global stub/type baseline (233 pre-existing errors across 73 imported files; no new changed-code diagnostic beyond existing file baselines)

## Canary sequence after merge

1. Bake and roll the canary from this SDK SHA.
2. Re-author the majors numpy/precompute refactor as an exact `behavior_equivalence` maintenance proposal and let it auto-apply before campaign one. The existing canary proposal is **not** equivalent (two trade flips) and must not be reused.
3. Restage the preserved c03 bundle with a fresh runtime id linked to the original candidate id under the corrected operational burn-in clock.
4. Start evolution outside blocked pricing hours; monitor runner health, campaign completion, and OpenCode/finalize RSS.
5. Broaden the image to the fleet after 24–48h of basic serve/runner/wake health. Evolution remains majors-only through `allowed_job_ids`.
6. Use three completed campaigns only to judge parentage/search yield and whether richer knowledge machinery earns a future slot.
