### PR TITLE
Unify evolution, probation, and risk containment

### DIFF
--- a/wayfinder_paths/jobs/archive.py
+++ b/wayfinder_paths/jobs/archive.py
@@ -19,6 +19,7 @@ from wayfinder_paths.jobs.store import JobStore
 ARCHIVE_PATH = "state/archive.json"
 ARCHIVE_STATUSES = {
     "generated",
+    "research_seed",
     "quick_complete",
     "invalid",
     "low_fidelity_rejected",
@@ -27,6 +28,7 @@ ARCHIVE_STATUSES = {
     "paper_probation",
     "proposal_rejected",
     "proposal_deferred",
+    "probation_deferred",
     "paper_proposal",
     "paper_experiment",
     "incumbent",
@@ -41,12 +43,14 @@ _MAXIMIZE = ("net_log_growth",)
 _MINIMIZE = ("downside_deviation", "tail_loss", "max_drawdown_pct")
 _NON_RANKED_STATUSES = {
     "generated",
+    "research_seed",
     "quick_complete",
     "invalid",
     "low_fidelity_rejected",
     "audit_rejected",
     "proposal_rejected",
     "proposal_deferred",
+    "probation_deferred",
     "refuted",
     "retired",
 }
@@ -59,6 +63,7 @@ _EVOLUTION_LESSON_STATUSES = {
     "audit_rejected",
     "proposal_rejected",
     "proposal_deferred",
+    "probation_deferred",
     "paper_proposal",
     "paper_experiment",
     "refuted",
@@ -69,6 +74,7 @@ _EVOLUTION_REJECTION_STATUSES = {
     "audit_rejected",
     "proposal_rejected",
     "proposal_deferred",
+    "probation_deferred",
     "refuted",
 }
 _LESSON_STAT_KEYS = (

--- a/wayfinder_paths/jobs/bundles.py
+++ b/wayfinder_paths/jobs/bundles.py
@@ -1,0 +1,39 @@
+"""Helpers for freezing executable job bundles."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+
+def copy_job_bundle(
+    source: Path,
+    destination: Path,
+    *,
+    existing_ok: bool = False,
+) -> None:
+    """Atomically copy the files that define an executable job bundle."""
+    required = (source / "job.yaml", source / "workspace")
+    if not required[0].is_file() or not required[1].is_dir():
+        raise FileNotFoundError("job bundle requires job.yaml and workspace/")
+    if destination.exists():
+        if existing_ok:
+            return
+        raise FileExistsError(destination)
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = Path(
+        tempfile.mkdtemp(prefix=f".{destination.name}.", dir=destination.parent)
+    )
+    try:
+        shutil.copy2(required[0], temporary / "job.yaml")
+        shutil.copytree(required[1], temporary / "workspace")
+        execution_spec = source / "execution_spec.json"
+        if execution_spec.is_file():
+            shutil.copy2(execution_spec, temporary / execution_spec.name)
+        os.replace(temporary, destination)
+    except Exception:
+        shutil.rmtree(temporary, ignore_errors=True)
+        raise

--- a/wayfinder_paths/jobs/candidate_shadow.py
+++ b/wayfinder_paths/jobs/candidate_shadow.py
@@ -28,29 +28,22 @@ from wayfinder_paths.jobs.execution.validation import resolve_execution_spec
 from wayfinder_paths.jobs.forward import ForwardRecorder
 from wayfinder_paths.jobs.gating import compute_workspace_revision
 from wayfinder_paths.jobs.models import utc_now_iso
-from wayfinder_paths.jobs.paper_experiment import (
-    EXPERIMENT_ARMS,
-    EXPERIMENT_FORWARD_ROOT,
-    EXPERIMENT_STATE_PATH,
-    EXPERIMENT_VIEW_PATH,
-    enqueue_experiment_view,
-    experiment_status,
-    maybe_adjudicate_proposals,
-    maybe_finalize_experiment,
-    resolve_experiment_bundle,
+from wayfinder_paths.jobs.probation import (
+    PROBATION_FORWARD_ROOT,
+    PROBATION_VIEW_PATH,
+    active_probation_trials,
+    enqueue_probation_view,
+    maybe_adjudicate_probation,
+    probation_targets,
+    resolve_probation_bundle,
+    update_probation_target,
 )
 from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.runner.monitor_state import atomic_write_json
 
 
 def active_candidate_shadows(store: JobStore, job_id: str) -> bool:
-    state = experiment_status(store, job_id)
-    if state.get("status") == "active":
-        return True
-    return state.get("status") == "qualifying" and any(
-        (((state.get("proposals") or {}).get(arm) or {}).get("active"))
-        for arm in EXPERIMENT_ARMS
-    )
+    return active_probation_trials(store, job_id)
 
 
 async def run_candidate_shadows(
@@ -60,8 +53,8 @@ async def run_candidate_shadows(
     view: CompletedBarsView | None = None,
     now: pd.Timestamp | None = None,
 ) -> list[dict[str, Any]]:
-    """Catch both paper arms up to every unseen completed five-minute bar."""
-    with job_state_lock(store.repo_root, job_id, name="evolution_shadow_runner"):
+    """Catch every probation pair up to each unseen completed bar."""
+    with job_state_lock(store.repo_root, job_id, name="probation_shadow_runner"):
         return await _run_candidate_shadows(store, job_id, view=view, now=now)
 
 
@@ -74,7 +67,7 @@ async def _run_candidate_shadows(
 ) -> list[dict[str, Any]]:
     if view is not None:
         captured_at = now or pd.Timestamp.now(tz="UTC")
-        enqueue_experiment_view(
+        enqueue_probation_view(
             store,
             job_id,
             rows=[
@@ -86,40 +79,32 @@ async def _run_candidate_shadows(
             ],
             now=captured_at,
         )
-    payload = store.read_json(job_id, EXPERIMENT_VIEW_PATH, default={}) or {}
+    payload = store.read_json(job_id, PROBATION_VIEW_PATH, default={}) or {}
     rows = payload.get("rows") or []
     if not rows:
         return []
     full_view = CompletedBarsView.from_rows(rows)
-    state = experiment_status(store, job_id)
-    if state.get("status") not in {"qualifying", "active"}:
+    if not active_probation_trials(store, job_id):
         return []
     results: list[dict[str, Any]] = []
+    targets = probation_targets(store, job_id)
     for stamp in full_view.timestamps:
-        loop_state = experiment_status(store, job_id)
-        if loop_state.get("status") == "active" and stamp >= pd.Timestamp(
-            loop_state["ends_at"]
-        ):
-            maybe_finalize_experiment(
-                store, job_id, now=pd.Timestamp(loop_state["ends_at"]).to_pydatetime()
-            )
-            break
         replay_view = full_view.through(stamp)
-        for target in _paper_targets(experiment_status(store, job_id)):
-            state = experiment_status(store, job_id)
+        advanced = False
+        for target in targets:
             last = target.get("last_processed_bar")
             if last and stamp <= pd.Timestamp(last):
                 continue
+            advanced = True
             try:
                 row = await _run_target(
                     store,
                     job_id,
-                    state=state,
                     target=target,
                     view=replay_view,
                     timestamp=stamp,
                 )
-            except Exception as exc:  # noqa: BLE001 - one arm cannot stop its peer
+            except Exception as exc:  # noqa: BLE001 - one trial cannot stop its peers
                 row = _record_error(
                     store,
                     job_id,
@@ -128,58 +113,44 @@ async def _run_candidate_shadows(
                     error=str(exc)[:300],
                 )
             results.append(row)
-        maybe_adjudicate_proposals(store, job_id, now=stamp.to_pydatetime())
-    maybe_finalize_experiment(store, job_id)
-    return results
-
-
-def _paper_targets(state: dict[str, Any]) -> list[dict[str, Any]]:
-    targets: list[dict[str, Any]] = []
-    if state.get("status") == "active":
-        for arm in EXPERIMENT_ARMS:
-            champion = dict(state["arms"][arm]["champion"])
-            champion.update(
-                {
-                    "arm": arm,
-                    "role": "champion",
-                    "last_processed_bar": state["arms"][arm].get("last_processed_bar"),
-                }
+        if advanced:
+            outcomes = maybe_adjudicate_probation(
+                store, job_id, now=stamp.to_pydatetime()
             )
-            targets.append(champion)
-    if state.get("status") in {"qualifying", "active"}:
-        for arm in EXPERIMENT_ARMS:
-            proposal = ((state.get("proposals") or {}).get(arm) or {}).get("active")
-            if not isinstance(proposal, dict):
-                continue
-            for key in ("candidate", "reference"):
-                target = dict(proposal[key])
-                target["arm"] = arm
-                targets.append(target)
-    return targets
+            if outcomes:
+                targets = probation_targets(store, job_id)
+    maybe_adjudicate_probation(store, job_id)
+    return results
 
 
 async def _run_target(
     store: JobStore,
     job_id: str,
     *,
-    state: dict[str, Any],
     target: dict[str, Any],
     view: CompletedBarsView,
     timestamp: pd.Timestamp,
 ) -> dict[str, Any]:
     root = store.job_dir(job_id).resolve()
-    candidate_root = resolve_experiment_bundle(store, job_id, state, target)
+    candidate_root = resolve_probation_bundle(store, job_id, target)
     if compute_workspace_revision(candidate_root) != str(target["revision"]):
         raise ValueError("paper candidate revision changed after freeze")
     stream_root = (root / str(target["stream"])).resolve()
-    allowed_streams = (root / EXPERIMENT_FORWARD_ROOT).resolve()
-    if not stream_root.is_relative_to(allowed_streams):
-        raise ValueError("experiment stream escapes its paper root")
+    allowed_streams = (root / PROBATION_FORWARD_ROOT).resolve()
+    legacy_streams = (root / "results/forward/experiment").resolve()
+    if not (
+        stream_root.is_relative_to(allowed_streams)
+        or (
+            target.get("bundle_scope") == "legacy_experiment"
+            and stream_root.is_relative_to(legacy_streams)
+        )
+    ):
+        raise ValueError("probation stream escapes its paper root")
     bar_iso = timestamp.isoformat()
     if _stream_has_bar(stream_root / "ticks.jsonl", bar_iso):
         _advance_cursor(store, job_id, target, bar_iso)
         return {
-            "arm": target["arm"],
+            "trial_id": target["trial_id"],
             "role": target["role"],
             "bar_timestamp": bar_iso,
             "reused": True,
@@ -203,12 +174,7 @@ async def _run_target(
     window = resolve_compute_window(params, strategy)
     view = window.slice_view(view, len(view.timestamps) - 1)
     candidate_view = apply_precompute(strategy, view)
-    shadow_root = _shadow_state_root(
-        root,
-        arm=str(target["arm"]),
-        role=str(target["role"]),
-        revision=str(target["revision"]),
-    )
+    shadow_root = _target_shadow_state_root(root, target)
     engine_state = EngineState.load(shadow_root / "engine_state.json")
     engine_state.mode = "paper"
     engine_state.revision = str(target["revision"])
@@ -228,7 +194,12 @@ async def _run_target(
         timestamp=timestamp,
         snapshot=StateSnapshot(status="valid"),
         client_order_prefix=(
-            f"paper-ab-{target['arm']}-{target['role']}-{target['revision'][:8]}"
+            f"paper-ab-{target['legacy_shadow_arm']}-champion-{target['revision'][:8]}"
+            if target.get("bundle_scope") == "legacy_experiment"
+            else (
+                f"probation-{target['trial_id'][:12]}-{target['role']}-"
+                f"{target['revision'][:8]}"
+            )
         ),
     )
     engine_state.save(shadow_root / "engine_state.json")
@@ -251,7 +222,7 @@ async def _run_target(
     _advance_cursor(store, job_id, target, bar_iso)
     (shadow_root / "last_error.json").unlink(missing_ok=True)
     return {
-        "arm": target["arm"],
+        "trial_id": target["trial_id"],
         "role": target["role"],
         "candidate_id": target["candidate_id"],
         "bar_timestamp": bar_iso,
@@ -264,21 +235,7 @@ async def _run_target(
 def _advance_cursor(
     store: JobStore, job_id: str, target: dict[str, Any], bar_iso: str
 ) -> None:
-    with job_state_lock(store.repo_root, job_id, name="evolution_experiment"):
-        state = experiment_status(store, job_id)
-        arm = str(target["arm"])
-        if target["role"] == "champion":
-            champion = state["arms"][arm]["champion"]
-            if champion.get("revision") == target.get("revision"):
-                state["arms"][arm]["last_processed_bar"] = bar_iso
-        else:
-            active = state["proposals"][arm].get("active")
-            key = "candidate" if target["role"] == "proposal_candidate" else "reference"
-            if isinstance(active, dict) and (active.get(key) or {}).get(
-                "revision"
-            ) == target.get("revision"):
-                active[key]["last_processed_bar"] = bar_iso
-        store.write_json(job_id, EXPERIMENT_STATE_PATH, state)
+    update_probation_target(store, job_id, target, bar_iso=bar_iso)
 
 
 def _stream_has_bar(path: Path, bar_iso: str) -> bool:
@@ -304,12 +261,7 @@ def _record_error(
     error: str,
 ) -> dict[str, Any]:
     root = store.job_dir(job_id).resolve()
-    error_root = _shadow_state_root(
-        root,
-        arm=str(target["arm"]),
-        role=str(target["role"]),
-        revision=str(target.get("revision") or "invalid"),
-    )
+    error_root = _target_shadow_state_root(root, target)
     error_path = error_root / "last_error.json"
     try:
         previous = json.loads(error_path.read_text(encoding="utf-8"))
@@ -319,7 +271,7 @@ def _record_error(
     atomic_write_json(
         error_path,
         {
-            "arm": target["arm"],
+            "trial_id": target["trial_id"],
             "role": target["role"],
             "candidate_id": target.get("candidate_id"),
             "error": error,
@@ -329,7 +281,7 @@ def _record_error(
     )
     _increment_error(store, job_id, target, timestamp.isoformat())
     return {
-        "arm": target["arm"],
+        "trial_id": target["trial_id"],
         "role": target["role"],
         "error": error,
         "notify": notify,
@@ -339,26 +291,40 @@ def _record_error(
 def _increment_error(
     store: JobStore, job_id: str, target: dict[str, Any], bar_iso: str
 ) -> None:
-    with job_state_lock(store.repo_root, job_id, name="evolution_experiment"):
-        state = experiment_status(store, job_id)
-        arm = str(target["arm"])
-        if target["role"] == "champion":
-            if state["arms"][arm]["champion"].get("revision") == target.get("revision"):
-                state["arms"][arm]["last_processed_bar"] = bar_iso
-        else:
-            active = state["proposals"][arm].get("active")
-            key = "candidate" if target["role"] == "proposal_candidate" else "reference"
-            if isinstance(active, dict):
-                selected = active.get(key) or {}
-                if selected.get("revision") == target.get("revision"):
-                    selected["last_processed_bar"] = bar_iso
-                    selected["error_count"] = int(selected.get("error_count") or 0) + 1
-        store.write_json(job_id, EXPERIMENT_STATE_PATH, state)
+    update_probation_target(store, job_id, target, bar_iso=bar_iso, error=True)
 
 
-def _shadow_state_root(root: Path, *, arm: str, role: str, revision: str) -> Path:
-    base = (root / "state" / "evolution_shadows").resolve()
-    candidate = (base / arm / role / revision).resolve()
+def _shadow_state_root(
+    root: Path,
+    *,
+    trial_id: str,
+    phase: str,
+    role: str,
+    revision: str,
+) -> Path:
+    base = (root / "state" / "probation_shadows").resolve()
+    candidate = (base / trial_id / phase / role / revision).resolve()
     if not candidate.is_relative_to(base):
-        raise ValueError("paper arm state escapes the shadow state root")
+        raise ValueError("probation state escapes the shadow state root")
+    return candidate
+
+
+def _target_shadow_state_root(root: Path, target: dict[str, Any]) -> Path:
+    """Preserve legacy champion engine state when migrating a live A/B."""
+    if target.get("bundle_scope") != "legacy_experiment":
+        return _shadow_state_root(
+            root,
+            trial_id=str(target["trial_id"]),
+            phase=str(target["phase"]),
+            role=str(target["role"]),
+            revision=str(target.get("revision") or "invalid"),
+        )
+    arm = str(target.get("legacy_shadow_arm") or "")
+    role = str(target.get("legacy_shadow_role") or "")
+    if arm not in {"control", "evolution"} or role != "champion":
+        raise ValueError("legacy probation target has an invalid shadow state key")
+    base = (root / "state" / "evolution_shadows").resolve()
+    candidate = (base / arm / role / str(target["revision"])).resolve()
+    if not candidate.is_relative_to(base):
+        raise ValueError("legacy probation state escapes the shadow state root")
     return candidate

--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -33,6 +33,7 @@ from wayfinder_paths.jobs.evolution_campaign import (
     campaign_status,
     prepare_candidate,
     start_campaign,
+    submit_research_seed,
 )
 from wayfinder_paths.jobs.execution.driver import tick_job
 from wayfinder_paths.jobs.execution.experiments import (
@@ -89,6 +90,7 @@ from wayfinder_paths.jobs.research import (
     signal_check_job,
     signal_scan_job,
 )
+from wayfinder_paths.jobs.risk_overrides import risk_block_symbol, risk_unblock_symbol
 from wayfinder_paths.jobs.robustness import robustness_check_job
 from wayfinder_paths.jobs.runner_bridge import RunnerBridge
 from wayfinder_paths.jobs.starters import create_starter_job, starter_catalog
@@ -1183,6 +1185,83 @@ def evolution_prepare_cmd(
             family=family,
             summary=summary,
             mutation_kind=mutation_kind,
+        )
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+    _echo_json({"ok": True, "result": result})
+
+
+@job_cli.command(
+    name="evolution-submit-seed",
+    help="Freeze a sensor-authored executable candidate for the next campaign.",
+)
+@click.argument("job_id")
+@click.argument("candidate_dir", type=click.Path(path_type=Path, exists=True))
+@click.option("--family", required=True)
+@click.option("--hypothesis", required=True)
+@click.option("--base-revision", required=True)
+@click.option("--evidence-ref", "evidence_refs", multiple=True)
+def evolution_submit_seed_cmd(
+    job_id: str,
+    candidate_dir: Path,
+    family: str,
+    hypothesis: str,
+    base_revision: str,
+    evidence_refs: tuple[str, ...],
+) -> None:
+    try:
+        result = submit_research_seed(
+            JobStore(),
+            job_id,
+            candidate_root=candidate_dir,
+            family=family,
+            hypothesis=hypothesis,
+            base_revision=base_revision,
+            evidence_refs=list(evidence_refs),
+        )
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+    _echo_json({"ok": True, "result": result})
+
+
+@job_cli.command(name="risk-block-symbol", help="Block new entries for one symbol.")
+@click.argument("job_id")
+@click.argument("symbol")
+@click.option("--reason", required=True)
+@click.option("--evidence-ref", "evidence_refs", multiple=True, required=True)
+@click.option("--wake-id", default=None)
+def risk_block_symbol_cmd(
+    job_id: str,
+    symbol: str,
+    reason: str,
+    evidence_refs: tuple[str, ...],
+    wake_id: str | None,
+) -> None:
+    try:
+        result = risk_block_symbol(
+            JobStore(),
+            job_id,
+            symbol=symbol,
+            reason=reason,
+            evidence_refs=list(evidence_refs),
+            wake_id=wake_id,
+        )
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+    _echo_json({"ok": True, "result": result})
+
+
+@job_cli.command(name="risk-unblock-symbol", help="Owner-only symbol re-arm.")
+@click.argument("job_id")
+@click.argument("symbol")
+@click.option("--by", type=click.Choice(["owner"]), required=True)
+@click.option("--reason", default=None)
+def risk_unblock_symbol_cmd(
+    job_id: str, symbol: str, by: str, reason: str | None
+) -> None:
+    try:
+        result = risk_unblock_symbol(
+            JobStore(), job_id, symbol=symbol, by=by, reason=reason
         )
     except ValueError as exc:
         raise click.ClickException(str(exc)) from exc

--- a/wayfinder_paths/jobs/compute_lock.py
+++ b/wayfinder_paths/jobs/compute_lock.py
@@ -19,6 +19,7 @@ exceptions.
 from __future__ import annotations
 
 import fcntl
+import json
 import os
 import threading
 import time
@@ -29,6 +30,7 @@ from pathlib import Path
 from typing import Any
 
 LOCK_RELATIVE = ".wayfinder/compute.lock"
+EVOLUTION_BUDGET_RELATIVE = ".wayfinder/evolution_compute_budget.json"
 DEFAULT_TIMEOUT_S = 600.0
 _POLL_S = 2.0
 _local = threading.local()
@@ -136,36 +138,74 @@ def job_state_lock(
 
 
 @contextmanager
+def machine_state_lock(
+    repo_root: Path,
+    *,
+    name: str,
+    timeout_s: float = DEFAULT_TIMEOUT_S,
+) -> Iterator[None]:
+    """Serialize one machine-wide read/modify/write state funnel."""
+    path = Path(repo_root) / ".wayfinder" / f"{name}.lock"
+    with _exclusive_file_lock(
+        path,
+        label=f"machine:{name}",
+        timeout_s=timeout_s,
+    ):
+        yield
+
+
+@contextmanager
 def experiment_compute_lock(
     store: Any,
     job_id: str,
     *,
     label: str,
     duty_fraction: float = 0.20,
+    completion_duty_fraction: float = 0.25,
     window_hours: float = 12.0,
-) -> Iterator[None]:
-    """Serialize evolution work and enforce its rolling compute-duty budget."""
-    relative = "state/evolution_compute_budget.json"
+    completion_reserve: bool = False,
+) -> Iterator[dict[str, Any]]:
+    """Serialize evolution work under a machine-wide rolling duty budget.
+
+    Routine work stops at the 20% soft cap.  Only an already-started
+    finalist/full-development step may consume the small completion reserve
+    up to 25%; generation and new campaigns can never spend it.
+    """
+    if not 0 < duty_fraction <= completion_duty_fraction <= 1:
+        raise ValueError("evolution duty fractions must satisfy 0 < soft <= hard <= 1")
+    path = Path(store.repo_root) / EVOLUTION_BUDGET_RELATIVE
     now = datetime.now(UTC)
     cutoff = now - timedelta(hours=window_hours)
-    with job_state_lock(store.repo_root, job_id, name="evolution_compute_budget"):
-        budget = store.read_json(job_id, relative, default={}) or {}
+    with machine_state_lock(store.repo_root, name="evolution_compute_budget"):
+        try:
+            budget = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            budget = {}
         events = [
             event
             for event in budget.get("events") or []
             if _event_time(event) >= cutoff
         ]
         used = sum(float(event.get("wall_seconds") or 0.0) for event in events)
-        limit = float(duty_fraction) * float(window_hours) * 3600.0
+        soft_limit = float(duty_fraction) * float(window_hours) * 3600.0
+        hard_limit = float(completion_duty_fraction) * float(window_hours) * 3600.0
+        limit = hard_limit if completion_reserve else soft_limit
         if used >= limit:
             raise ComputeLockBusy(
-                f"evolution compute duty exhausted ({used:.1f}/{limit:.1f}s "
-                f"over {window_hours:g}h); retry in the next budget window"
+                f"evolution {'completion' if completion_reserve else 'routine'} "
+                f"compute duty exhausted ({used:.1f}/{limit:.1f}s over "
+                f"{window_hours:g}h); retry after rolling debt clears"
             )
         with heavy_compute_lock(repo_root=store.repo_root, label=label):
             started = time.monotonic()
             try:
-                yield
+                yield {
+                    "used_seconds": round(used, 3),
+                    "soft_limit_seconds": round(soft_limit, 3),
+                    "hard_limit_seconds": round(hard_limit, 3),
+                    "completion_reserve": completion_reserve,
+                    "remaining_seconds": round(max(0.0, limit - used), 3),
+                }
             finally:
                 elapsed = max(0.0, time.monotonic() - started)
                 current = datetime.now(UTC)
@@ -178,16 +218,21 @@ def experiment_compute_lock(
                 events.append(
                     {
                         "ts": current.isoformat(),
+                        "job_id": job_id,
                         "label": label,
                         "wall_seconds": round(elapsed, 3),
+                        "class": "completion" if completion_reserve else "routine",
                     }
                 )
-                store.write_json(
-                    job_id,
-                    relative,
+                from wayfinder_paths.runner.monitor_state import atomic_write_json
+
+                atomic_write_json(
+                    path,
                     {
+                        "schema_version": "2.0",
                         "window_hours": window_hours,
-                        "duty_fraction": duty_fraction,
+                        "soft_duty_fraction": duty_fraction,
+                        "hard_duty_fraction": completion_duty_fraction,
                         "total_wall_seconds": round(
                             float(budget.get("total_wall_seconds") or 0.0) + elapsed,
                             3,
@@ -195,6 +240,48 @@ def experiment_compute_lock(
                         "events": events,
                     },
                 )
+
+
+def evolution_compute_budget_status(
+    repo_root: Path,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Compact UI/reporting view of the shared evolution duty ledger."""
+    path = Path(repo_root) / EVOLUTION_BUDGET_RELATIVE
+    try:
+        budget = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        budget = {}
+    window_hours = float(budget.get("window_hours") or 12.0)
+    soft_fraction = float(budget.get("soft_duty_fraction") or 0.20)
+    hard_fraction = float(budget.get("hard_duty_fraction") or 0.25)
+    cutoff = (now or datetime.now(UTC)) - timedelta(hours=window_hours)
+    events = [
+        event for event in budget.get("events") or [] if _event_time(event) >= cutoff
+    ]
+    routine = sum(
+        float(event.get("wall_seconds") or 0.0)
+        for event in events
+        if event.get("class") != "completion"
+    )
+    completion = sum(
+        float(event.get("wall_seconds") or 0.0)
+        for event in events
+        if event.get("class") == "completion"
+    )
+    used = routine + completion
+    window_seconds = window_hours * 3600.0
+    return {
+        "window_hours": window_hours,
+        "routine_seconds": round(routine, 3),
+        "completion_seconds": round(completion, 3),
+        "used_seconds": round(used, 3),
+        "soft_limit_seconds": round(soft_fraction * window_seconds, 3),
+        "hard_limit_seconds": round(hard_fraction * window_seconds, 3),
+        "debt_paused": used >= soft_fraction * window_seconds,
+        "hard_exhausted": used >= hard_fraction * window_seconds,
+    }
 
 
 def _event_time(event: dict[str, Any]) -> datetime:

--- a/wayfinder_paths/jobs/decision_log.py
+++ b/wayfinder_paths/jobs/decision_log.py
@@ -137,6 +137,68 @@ def _journal_entries(
                     proposal_id=str(event.get("proposal_id") or "") or None,
                 )
             )
+        elif kind in {
+            "evolution_probation_queued",
+            "evolution_probation_burn_in_started",
+            "probation_forward_started",
+            "probation_checkpoint_inconclusive",
+            "probation_graduated",
+            "probation_killed",
+            "probation_inconclusive",
+            "evolution_experiment_migrated_to_probation",
+        }:
+            title_by_kind = {
+                "evolution_probation_queued": "Evolution candidate queued for probation",
+                "evolution_probation_burn_in_started": "Probation burn-in started",
+                "probation_forward_started": "Probation advanced to paired forward testing",
+                "probation_checkpoint_inconclusive": (
+                    "Probation remains active after a scheduled checkpoint"
+                ),
+                "probation_graduated": "Probation candidate graduated",
+                "probation_killed": "Probation candidate retired",
+                "probation_inconclusive": "Probation ended inconclusive",
+                "evolution_experiment_migrated_to_probation": (
+                    "Existing evolution test moved to permanent probation"
+                ),
+            }
+            entries.append(
+                _entry(
+                    ts,
+                    "probation",
+                    title_by_kind[kind],
+                    str(event.get("reason") or event.get("candidate_id") or ""),
+                    "info",
+                    actor="harness",
+                )
+            )
+        elif kind in {"risk_symbol_blocked", "risk_symbol_unblocked"}:
+            blocked = kind == "risk_symbol_blocked"
+            entries.append(
+                _entry(
+                    ts,
+                    "halt",
+                    (
+                        f"New {event.get('symbol')} entries blocked"
+                        if blocked
+                        else f"{event.get('symbol')} entries re-armed by owner"
+                    ),
+                    str(event.get("reason") or ""),
+                    "info",
+                    actor="system" if blocked else "owner",
+                )
+            )
+        elif kind == "evolution_research_seed_submitted":
+            entries.append(
+                _entry(
+                    ts,
+                    "research",
+                    "Research sensor submitted an executable evolution seed",
+                    str(event.get("family") or event.get("seed_id") or ""),
+                    "info",
+                    actor="agent",
+                    family=str(event.get("family") or "") or None,
+                )
+            )
         elif kind == "application_watchdog_recovered":
             entries.append(
                 _entry(
@@ -302,12 +364,15 @@ def _journal_entries(
         elif kind == "evolution_campaign_completed":
             counts = event.get("counts") or {}
             funnel = event.get("funnel")
+            probation_trials = _count(event, "probation_trials")
             paper_proposals = _count(event, "paper_proposals")
             title = "Evolution campaign completed"
-            if paper_proposals:
-                title += (
-                    f" — {paper_proposals} advanced to forward paper testing"
-                )
+            if probation_trials:
+                title += f" — {probation_trials} advanced to probation"
+            elif "probation_trials" in event:
+                title += " — no candidate advanced"
+            elif paper_proposals:
+                title += f" — {paper_proposals} advanced to forward paper testing"
             elif "paper_proposals" in event:
                 title += " — no candidate advanced"
             entries.append(
@@ -401,6 +466,7 @@ def _active_evolution_entry(root: Path) -> dict[str, Any] | None:
         "draining": "Evolution campaign preparing full development",
         "full_dev": "Evolution campaign running full development",
         "paper_proposal": "Evolution campaign checking finalists",
+        "probation": "Evolution campaign checking finalists",
     }.get(stage, "Evolution campaign in progress")
     funnel = summarize_evolution_funnel(state)
     return _entry(

--- a/wayfinder_paths/jobs/evidence.py
+++ b/wayfinder_paths/jobs/evidence.py
@@ -1,0 +1,47 @@
+"""Containment checks for job-owned evidence artifacts."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+
+def verify_job_evidence_refs(
+    root: Path,
+    refs: Iterable[str],
+    *,
+    allowed_roots: Sequence[str],
+    now: datetime | None = None,
+    max_age: timedelta | None = None,
+) -> list[str]:
+    """Return canonical refs to existing files inside approved job subtrees."""
+    job_root = root.resolve()
+    allowed = [(job_root / relative).resolve() for relative in allowed_roots]
+    current = _aware(now or datetime.now(UTC))
+    verified: list[str] = []
+    for value in refs:
+        relative = Path(str(value))
+        if relative.is_absolute():
+            continue
+        path = (job_root / relative).resolve()
+        if not any(path.is_relative_to(base) for base in allowed):
+            continue
+        try:
+            stat = path.stat()
+        except OSError:
+            continue
+        if not path.is_file():
+            continue
+        if max_age is not None:
+            age = current - datetime.fromtimestamp(stat.st_mtime, tz=UTC)
+            if age > max_age:
+                continue
+        canonical = path.relative_to(job_root).as_posix()
+        if canonical not in verified:
+            verified.append(canonical)
+    return verified
+
+
+def _aware(value: datetime) -> datetime:
+    return value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)

--- a/wayfinder_paths/jobs/evolution_campaign.py
+++ b/wayfinder_paths/jobs/evolution_campaign.py
@@ -40,6 +40,7 @@ from wayfinder_paths.jobs.compute_lock import (
     job_state_lock,
     machine_state_lock,
 )
+from wayfinder_paths.jobs.evidence import verify_job_evidence_refs
 from wayfinder_paths.jobs.evolution_funnel import summarize_evolution_funnel
 from wayfinder_paths.jobs.execution.features import parse_feature_specs
 from wayfinder_paths.jobs.execution.job import _load_dataset, _load_job_yaml
@@ -508,7 +509,14 @@ def submit_research_seed(
     seed_id = f"seed-{hashlib.sha256(seed_raw.encode()).hexdigest()[:12]}"
     seed_family = str(family).strip() or "research"
     seed_hypothesis = str(hypothesis).strip()[:500]
-    seed_evidence = [str(item) for item in evidence_refs or []][:20]
+    seed_evidence = verify_job_evidence_refs(
+        root,
+        list(evidence_refs or [])[:20],
+        allowed_roots=("results/research",),
+        now=current,
+    )
+    if not seed_evidence:
+        raise ValueError("research seed requires a checked-in research result")
     relative = f"{RESEARCH_SEED_ROOT}/{seed_id}/{revision}"
     destination = root / relative
     with job_state_lock(store.repo_root, job_id, name="evolution_research_seeds"):

--- a/wayfinder_paths/jobs/evolution_campaign.py
+++ b/wayfinder_paths/jobs/evolution_campaign.py
@@ -16,7 +16,6 @@ import json
 import math
 import os
 import shutil
-import tempfile
 import uuid
 from datetime import UTC, datetime, time, timedelta
 from pathlib import Path
@@ -34,10 +33,12 @@ from wayfinder_paths.jobs.archive import (
     record_candidate,
     set_candidate_status,
 )
+from wayfinder_paths.jobs.bundles import copy_job_bundle
 from wayfinder_paths.jobs.compute_lock import (
     ComputeLockBusy,
     experiment_compute_lock,
     job_state_lock,
+    machine_state_lock,
 )
 from wayfinder_paths.jobs.evolution_funnel import summarize_evolution_funnel
 from wayfinder_paths.jobs.execution.features import parse_feature_specs
@@ -94,6 +95,8 @@ from wayfinder_paths.runner.monitor_state import atomic_write_json, atomic_write
 CAMPAIGN_STATE_PATH = "state/evolution_campaign.json"
 CAMPAIGN_ROOT = "research/evolution/campaigns"
 PARENT_BUNDLE_ROOT = "research/evolution/parents"
+RESEARCH_SEED_ROOT = "research/evolution/research_seeds"
+RESEARCH_SEED_STATE_PATH = "state/evolution_research_seeds.json"
 CAMPAIGN_DATA_ROOT = "dataset"
 FORWARD_SNAPSHOT = "forward_experience.json"
 SCHEMA_VERSION = "1.1"
@@ -136,6 +139,49 @@ _STRUCTURAL_SEARCH_GUIDANCE = (
 
 def campaign_status(store: JobStore, job_id: str) -> dict[str, Any]:
     return store.read_json(job_id, CAMPAIGN_STATE_PATH, default={}) or {}
+
+
+def _fleet_campaign_turn(
+    store: JobStore,
+    job_id: str,
+    *,
+    now: datetime,
+) -> bool:
+    """One campaign per box; oldest due eligible job wins deterministically."""
+    jobs = sorted(store.list_jobs(), key=lambda item: item.id)
+    for job in jobs:
+        state = campaign_status(store, job.id)
+        if state.get("status") in {"active", "finalizing"}:
+            return job.id == job_id
+    due: list[tuple[datetime, str]] = []
+    for job in jobs:
+        try:
+            spec = ImproverSpec.load(store.job_dir(job.id))
+            if not spec.evolution_eligibility(store.job_dir(job.id), job.id)[
+                "eligible"
+            ]:
+                continue
+            state = campaign_status(store, job.id)
+            anchor = state.get("started_at")
+            anchor_time = _parse(anchor) if anchor else datetime.min.replace(tzinfo=UTC)
+            cadence = timedelta(
+                hours=float(
+                    spec.evolution.get("start_interval_hours")
+                    or spec.evolution.get("cooldown_hours")
+                    or 24
+                )
+            )
+            if anchor and now - anchor_time < cadence:
+                continue
+            if not evolution_compute_window_open(
+                store, job.id, now=now, reserve_campaign=True
+            ):
+                continue
+            due.append((anchor_time, job.id))
+        except (OSError, TypeError, ValueError):
+            continue
+    due.sort(key=lambda item: (item[0], item[1]))
+    return bool(due and due[0][1] == job_id)
 
 
 def evolution_compute_window_open(
@@ -196,7 +242,7 @@ def _parse_utc_clock(value: Any) -> time:
 def campaign_due(store: JobStore, job_id: str, *, now: datetime | None = None) -> bool:
     """Cheap, read-only cadence check used before spawning campaign setup."""
     spec = ImproverSpec.load(store.job_dir(job_id))
-    if not spec.evolution_enabled_for(job_id):
+    if not spec.evolution_eligibility(store.job_dir(job_id), job_id)["eligible"]:
         return False
     existing = campaign_status(store, job_id)
     if existing.get("status") in {"active", "finalizing"}:
@@ -206,9 +252,7 @@ def campaign_due(store: JobStore, job_id: str, *, now: datetime | None = None) -
         store, job_id, now=current, reserve_campaign=True
     ):
         return False
-    from wayfinder_paths.jobs.paper_experiment import experiment_status
-
-    if experiment_status(store, job_id).get("status") == "complete":
+    if not _fleet_campaign_turn(store, job_id, now=current):
         return False
     anchor = existing.get("started_at")
     if not anchor:
@@ -226,34 +270,32 @@ def maybe_start_campaign(
     store: JobStore, job_id: str, *, now: datetime | None = None
 ) -> dict[str, Any] | None:
     """Start the due rollout campaign; return None outside its feature gate."""
-    with job_state_lock(store.repo_root, job_id, name="evolution_campaign"):
-        spec = ImproverSpec.load(store.job_dir(job_id))
-        if not spec.evolution_enabled_for(job_id):
-            return None
-        existing = campaign_status(store, job_id)
-        from wayfinder_paths.jobs.paper_experiment import experiment_status
-
-        experiment = experiment_status(store, job_id)
-        if experiment.get("status") == "complete":
-            return existing or None
-        if existing.get("status") in {"active", "finalizing"}:
-            return existing
-        cadence_anchor = existing.get("started_at")
-        if cadence_anchor:
-            elapsed = _aware(now or datetime.now(UTC)) - _parse(cadence_anchor)
-            cadence = timedelta(
-                hours=float(
-                    spec.evolution.get("start_interval_hours")
-                    or spec.evolution["cooldown_hours"]
-                )
-            )
-            if elapsed < cadence:
+    with machine_state_lock(store.repo_root, name="evolution_campaign_slot"):
+        with job_state_lock(store.repo_root, job_id, name="evolution_campaign"):
+            spec = ImproverSpec.load(store.job_dir(job_id))
+            if not spec.evolution_eligibility(store.job_dir(job_id), job_id)[
+                "eligible"
+            ]:
+                return None
+            existing = campaign_status(store, job_id)
+            if existing.get("status") in {"active", "finalizing"}:
                 return existing
-        if not evolution_compute_window_open(
-            store, job_id, now=now, reserve_campaign=True
-        ):
-            return existing or None
-        return start_campaign(store, job_id, now=now)
+            cadence_anchor = existing.get("started_at")
+            if cadence_anchor:
+                elapsed = _aware(now or datetime.now(UTC)) - _parse(cadence_anchor)
+                cadence = timedelta(
+                    hours=float(
+                        spec.evolution.get("start_interval_hours")
+                        or spec.evolution["cooldown_hours"]
+                    )
+                )
+                if elapsed < cadence:
+                    return existing
+            if not evolution_compute_window_open(
+                store, job_id, now=now, reserve_campaign=True
+            ):
+                return existing or None
+            return _start_campaign(store, job_id, now=now)
 
 
 def start_campaign(
@@ -263,8 +305,9 @@ def start_campaign(
     now: datetime | None = None,
     force: bool = False,
 ) -> dict[str, Any]:
-    with job_state_lock(store.repo_root, job_id, name="evolution_campaign"):
-        return _start_campaign(store, job_id, now=now, force=force)
+    with machine_state_lock(store.repo_root, name="evolution_campaign_slot"):
+        with job_state_lock(store.repo_root, job_id, name="evolution_campaign"):
+            return _start_campaign(store, job_id, now=now, force=force)
 
 
 def _start_campaign(
@@ -275,8 +318,12 @@ def _start_campaign(
     force: bool = False,
 ) -> dict[str, Any]:
     spec = ImproverSpec.load(store.job_dir(job_id))
-    if not spec.evolution_enabled_for(job_id):
-        raise ValueError(f"open evolution is not enabled for job {job_id!r}")
+    eligibility = spec.evolution_eligibility(store.job_dir(job_id), job_id)
+    if not eligibility["eligible"]:
+        raise ValueError(
+            f"open evolution is not eligible for job {job_id!r}: "
+            + ", ".join(eligibility["reasons"])
+        )
     existing = campaign_status(store, job_id)
     current = _aware(now or datetime.now(UTC))
     if existing.get("status") in {"active", "finalizing"} and not force:
@@ -296,6 +343,10 @@ def _start_campaign(
         store, job_id, now=current, reserve_campaign=True
     ):
         raise ValueError("evolution campaign does not fit outside peak pricing")
+    if not _fleet_campaign_turn(store, job_id, now=current):
+        raise TransientInfrastructureError(
+            "another eligible job owns the machine evolution campaign slot"
+        )
     require_evolution_launch_headroom()
     from wayfinder_paths.jobs.worker import job_worker_session_busy
 
@@ -309,17 +360,9 @@ def _start_campaign(
     if not dataset_path.exists():
         raise FileNotFoundError("evolution needs the job's canonical backtest dataset")
     source_revision = compute_workspace_revision(root)
-    from wayfinder_paths.jobs.paper_experiment import ensure_paper_experiment
+    from wayfinder_paths.jobs.probation import ensure_unified_probation
 
-    experiment = ensure_paper_experiment(store, job_id, now=current)
-    if experiment and (
-        experiment.get("status") not in {"qualifying", "active"}
-        or (
-            experiment.get("status") == "active"
-            and current >= _parse(experiment.get("ends_at"))
-        )
-    ):
-        raise ValueError("the fixed-horizon paper experiment has ended")
+    ensure_unified_probation(store, job_id, now=current)
     campaign_stem = f"{current.strftime('%Y%m%dT%H%M%SZ')}-{source_revision[:8]}"
     campaign_id = campaign_stem
     suffix = 2
@@ -353,6 +396,7 @@ def _start_campaign(
         campaign_root / "source"
     )
     parent_pool = _freeze_parent_pool(store, job_id, campaign_root)
+    research_seeds = _freeze_research_seeds(store, job_id, campaign_root)
     starter_seeds = _snapshot_starter_seeds(store, job_id, campaign_root)
     research_context = _freeze_research_context(store, job_id)
     campaign_policy = {
@@ -375,6 +419,7 @@ def _start_campaign(
         "historical_lessons": historical_lessons,
         "casebook": cases,
         "parent_pool": parent_pool,
+        "research_seeds": research_seeds,
         "starter_seeds": starter_seeds,
         "research_context": research_context,
         "policy": campaign_policy,
@@ -427,6 +472,103 @@ def prepare_candidate(
         )
 
 
+def submit_research_seed(
+    store: JobStore,
+    job_id: str,
+    *,
+    candidate_root: Path,
+    family: str,
+    hypothesis: str,
+    base_revision: str,
+    evidence_refs: list[str] | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Freeze a sensor-authored executable seed for the next campaign.
+
+    Submission confers no evidence or deployment authority.  The seed is a
+    source-aware parent only and must re-earn every evolution/probation gate.
+    """
+    current = _aware(now or datetime.now(UTC))
+    root = store.job_dir(job_id).resolve()
+    source = candidate_root.resolve()
+    if not source.is_relative_to(root):
+        raise ValueError("research seed must be authored inside its job root")
+    current_revision = compute_workspace_revision(root)
+    if str(base_revision) != current_revision:
+        raise ValueError(
+            "research seed base revision is stale; rebase it on the current job"
+        )
+    validation = validate_execution_job(job_id, candidate_dir=source, store=store)
+    if not _candidate_validation_passed(validation):
+        raise ValueError("research seed does not satisfy the executable job contract")
+    revision = compute_workspace_revision(source)
+    if revision == current_revision:
+        raise ValueError("research seed is byte-identical to the incumbent")
+    seed_raw = f"{family}|{revision}"
+    seed_id = f"seed-{hashlib.sha256(seed_raw.encode()).hexdigest()[:12]}"
+    seed_family = str(family).strip() or "research"
+    seed_hypothesis = str(hypothesis).strip()[:500]
+    seed_evidence = [str(item) for item in evidence_refs or []][:20]
+    relative = f"{RESEARCH_SEED_ROOT}/{seed_id}/{revision}"
+    destination = root / relative
+    with job_state_lock(store.repo_root, job_id, name="evolution_research_seeds"):
+        state = store.read_json(job_id, RESEARCH_SEED_STATE_PATH, default={}) or {}
+        seeds = list(state.get("seeds") or [])
+        duplicate = next(
+            (item for item in seeds if item.get("revision") == revision), None
+        )
+        if duplicate is not None:
+            return {
+                "status": "duplicate",
+                "seed_id": duplicate.get("seed_id"),
+                "revision": duplicate.get("revision"),
+                "seed_status": duplicate.get("status"),
+            }
+        copy_job_bundle(source, destination)
+        if compute_workspace_revision(destination) != revision:
+            raise ValueError("research seed revision changed during freeze")
+        seed = {
+            "seed_id": seed_id,
+            "family": seed_family,
+            "hypothesis": seed_hypothesis,
+            "base_revision": current_revision,
+            "revision": revision,
+            "bundle": relative,
+            "status": "pending",
+            "submitted_at": current.isoformat(),
+            "evidence_refs": seed_evidence,
+            **revision_stamp(root),
+        }
+        seeds.append(seed)
+        atomic_write_json(
+            root / RESEARCH_SEED_STATE_PATH,
+            {"schema_version": "1.0", "seeds": seeds},
+        )
+    record_candidate(
+        store,
+        job_id,
+        candidate_id=seed_id,
+        family=seed_family,
+        summary=seed_hypothesis,
+        status="research_seed",
+        objective=None,
+        revision=revision,
+        parent_id=current_revision,
+        evidence="; ".join(seed_evidence)[:300],
+        metadata={"executable_bundle": relative, "source": "research_sensor"},
+    )
+    store.append_journal(
+        job_id,
+        {
+            "type": "evolution_research_seed_submitted",
+            "seed_id": seed_id,
+            "family": seed_family,
+            "revision": revision,
+        },
+    )
+    return seed
+
+
 def _prepare_candidate(
     store: JobStore,
     job_id: str,
@@ -452,6 +594,9 @@ def _prepare_candidate(
     requested_source = (
         "de_novo" if forced_jump else _parent_source(slot, policy["parent_mix"])
     )
+    research_seed_slots = int(policy.get("research_seed_slots") or 0)
+    if slot <= research_seed_slots and manifest.get("research_seeds"):
+        requested_source = "research_seed"
     required_structural = math.ceil(
         limit * float(policy.get("min_structural_fraction") or 0.0)
     )
@@ -510,13 +655,14 @@ def _prepare_candidate(
         "requested_parent_source": requested_source,
         "parent_candidate_ids": parents,
         "starter_seed_id": (parent_plan.get("starter") or {}).get("starter_id"),
+        "research_seed_id": (parent_plan.get("research_seed") or {}).get("seed_id"),
         "secondary_parent_bundle": (parent_plan.get("secondary") or {}).get("bundle"),
         "mutation_kind": chosen_mutation,
         "forced_jump": forced_jump,
         "bundle": relative,
         "warmup_bars": seeded_window,
         "seed_revision": seed_revision,
-        "evidence_reset": source == "starter_seed",
+        "evidence_reset": source in {"starter_seed", "research_seed"},
         "prepared_at": utc_now_iso(),
     }
     atomic_write_json(candidate_root / "candidate.json", candidate)
@@ -539,6 +685,7 @@ def _prepare_candidate(
             "parent_source": source,
             "requested_parent_source": requested_source,
             "starter_seed_id": candidate.get("starter_seed_id"),
+            "research_seed_id": candidate.get("research_seed_id"),
             "seed_revision": seed_revision,
             "evidence_reset": candidate["evidence_reset"],
         },
@@ -928,6 +1075,7 @@ def _finalize_campaign(store: JobStore, job_id: str) -> dict[str, Any]:
                 store,
                 job_id,
                 label=f"evolution-full-dev:{job_id}:{candidate['candidate_id']}",
+                completion_reserve=True,
             ):
                 outcome = _isolated_full_dev(store, job_id, candidate, tune=tune)
         except (ComputeLockBusy, TransientInfrastructureError):
@@ -971,6 +1119,7 @@ def _finalize_campaign(store: JobStore, job_id: str) -> dict[str, Any]:
                 store,
                 job_id,
                 label=f"evolution-proposal-gate:{job_id}:{candidate['candidate_id']}",
+                completion_reserve=True,
             ):
                 candidate_root = resolve_candidate_bundle(
                     store, job_id, candidate, campaign_id=campaign_id
@@ -990,32 +1139,33 @@ def _finalize_campaign(store: JobStore, job_id: str) -> dict[str, Any]:
                         "economic": economic,
                     }
                 else:
-                    from wayfinder_paths.jobs.paper_experiment import (
-                        stage_paper_proposal,
+                    from wayfinder_paths.jobs.probation import (
+                        stage_evolution_probation,
                     )
 
-                    staged = stage_paper_proposal(
+                    staged = stage_evolution_probation(
                         store,
                         job_id,
-                        arm="evolution",
                         candidate_id=str(candidate["candidate_id"]),
                         candidate_root=candidate_root,
                         revision=str(candidate.get("revision") or ""),
                         source="evolution_campaign",
+                        family=str(candidate.get("family") or "evolution"),
+                        campaign_id=campaign_id,
                         evidence=economic,
                     )
                     status = str(staged.get("status") or "queued")
                     outcome = {
                         "status": (
-                            "proposal_deferred"
+                            "probation_deferred"
                             if status == "deferred"
-                            else "paper_proposal"
+                            else "probation"
                         ),
                         "proposal": staged,
                         "economic": economic,
                         "evidence": (
                             staged.get("reason")
-                            or "staged for one immutable forward paper day"
+                            or "staged for immutable burn-in and paired probation"
                         ),
                     }
         except (ComputeLockBusy, TransientInfrastructureError):
@@ -1071,8 +1221,8 @@ def _finalize_campaign(store: JobStore, job_id: str) -> dict[str, Any]:
             "campaign_id": state["campaign_id"],
             "counts": state["counts"],
             "funnel": summarize_evolution_funnel(state),
-            "paper_proposals": sum(
-                candidate.get("status") == "paper_proposal"
+            "probation_trials": sum(
+                candidate.get("status") == "probation"
                 for candidate in state.get("candidates") or []
             ),
         },
@@ -1310,7 +1460,7 @@ def _claim_proposal(
                 "proposal_claimed_at": utc_now_iso(),
             }
         )
-        state["stage"] = "paper_proposal"
+        state["stage"] = "probation"
         _save_campaign(store, job_id, state)
         return campaign_id, claim_id, dict(candidate)
 
@@ -1649,6 +1799,13 @@ def _candidate_seed_instruction(
             "its historical evidence was reset: adapt the tactic to this job's "
             "target universe and make it re-earn every gate. "
         )
+    if source == "research_seed":
+        return (
+            f"The bundle contains sensor-authored research seed "
+            f"`{candidate.get('research_seed_id')}`. Treat its hypothesis as a "
+            "starting point only: its prior evidence was reset and it must re-earn "
+            "every campaign gate. Preserve the current job's operational contract."
+        )
     if source == "crossover":
         secondary = _resolve_frozen_parent_bundle(
             store,
@@ -1682,6 +1839,7 @@ def _candidate_handoff(candidate: dict[str, Any]) -> dict[str, Any]:
         "requested_parent_source": candidate.get("requested_parent_source"),
         "parent_candidate_ids": candidate.get("parent_candidate_ids") or [],
         "starter_seed_id": candidate.get("starter_seed_id"),
+        "research_seed_id": candidate.get("research_seed_id"),
         "status": candidate.get("status"),
         "summary": str(candidate.get("summary") or "")[:240],
     }
@@ -1746,6 +1904,7 @@ def _archive_campaign_candidate(
             "parent_source",
             "requested_parent_source",
             "starter_seed_id",
+            "research_seed_id",
             "seed_revision",
             "evidence_reset",
             "quick",
@@ -2200,7 +2359,7 @@ def _freeze_parent_pool(
         if stable is None or candidate_id not in selected_ids:
             continue
         destination = campaign_root / "parents" / candidate_id
-        _copy_active_bundle(stable, destination)
+        copy_job_bundle(stable, destination)
         frozen.append(
             {
                 "candidate_id": candidate_id,
@@ -2302,7 +2461,7 @@ def _persist_executable_bundle(
         if compute_workspace_revision(destination) != revision:
             raise ValueError("stable executable parent revision mismatch")
     else:
-        _copy_active_bundle(source, destination)
+        copy_job_bundle(source, destination)
     return relative, destination
 
 
@@ -2385,6 +2544,37 @@ def _snapshot_starter_seeds(
     return snapshots
 
 
+def _freeze_research_seeds(
+    store: JobStore, job_id: str, campaign_root: Path
+) -> list[dict[str, Any]]:
+    state = store.read_json(job_id, RESEARCH_SEED_STATE_PATH, default={}) or {}
+    frozen: list[dict[str, Any]] = []
+    for seed in state.get("seeds") or []:
+        if seed.get("status") != "pending":
+            continue
+        relative = str(seed.get("bundle") or "")
+        source = (store.job_dir(job_id) / relative).resolve()
+        allowed = (store.job_dir(job_id) / RESEARCH_SEED_ROOT).resolve()
+        revision = str(seed.get("revision") or "")
+        if (
+            not source.is_relative_to(allowed)
+            or compute_workspace_revision(source) != revision
+        ):
+            continue
+        destination = campaign_root / "research_seeds" / str(seed["seed_id"])
+        copy_job_bundle(source, destination)
+        if compute_workspace_revision(destination) != revision:
+            raise ValueError("campaign research-seed copy revision mismatch")
+        frozen.append(
+            {
+                **seed,
+                "bundle": f"research_seeds/{seed['seed_id']}",
+                "evidence_reset": True,
+            }
+        )
+    return frozen
+
+
 def _freeze_research_context(store: JobStore, job_id: str) -> dict[str, Any]:
     """Two load-bearing lists, distilled from existing mechanical records."""
     archive = load_archive(store, job_id).get("candidates") or []
@@ -2418,6 +2608,24 @@ def _freeze_research_context(store: JobStore, job_id: str) -> dict[str, Any]:
                     "recorded_at": leg.get("closed_at") or leg.get("updated_at"),
                 }
             )
+    for trial in probation.get("trials") or []:
+        if trial.get("status") != "graduated":
+            continue
+        metrics = (trial.get("forward") or {}).get("metrics") or {}
+        positives.append(
+            {
+                "source": "evolution_probation_graduate",
+                "id": trial.get("candidate_id") or trial.get("trial_id"),
+                "family": trial.get("family"),
+                "evidence": (
+                    f"paired_days={metrics.get('paired_days')}; "
+                    f"lcb={metrics.get('lcb')}; "
+                    f"net_delta="
+                    f"{float(metrics.get('candidate_net_pnl') or 0.0) - float(metrics.get('reference_net_pnl') or 0.0):.4f}"
+                )[:240],
+                "recorded_at": trial.get("closed_at") or trial.get("updated_at"),
+            }
+        )
     verdicts = (
         store.read_json(job_id, "state/promotion_verdicts.json", default={}) or {}
     )
@@ -2479,6 +2687,27 @@ def _select_parent_plan(
     are never incumbent copies carrying a misleading lineage label.
     """
     pool = (manifest.get("parent_pool") or {}).get("candidates") or []
+    if requested_source == "research_seed":
+        used = {
+            str(item.get("research_seed_id") or "")
+            for item in candidates
+            if item.get("research_seed_id")
+        }
+        seed = next(
+            (
+                item
+                for item in manifest.get("research_seeds") or []
+                if str(item.get("seed_id") or "") not in used
+            ),
+            None,
+        )
+        if seed is not None:
+            return {
+                "source": "research_seed",
+                "parents": [],
+                "research_seed": seed,
+            }
+        requested_source = _parent_source(slot, manifest["policy"]["parent_mix"])
     qd_ids = set((manifest.get("parent_pool") or {}).get("qd_elite_ids") or [])
     qd = [item for item in pool if item.get("candidate_id") in qd_ids]
     crossover_pool = [item for item in pool if item.get("status") != "incumbent"]
@@ -2531,7 +2760,7 @@ def _materialize_candidate_seed(
     frozen_source = campaign_root / "source"
     source = str(plan["source"])
     if source == "incumbent":
-        _copy_active_bundle(frozen_source, candidate_root)
+        copy_job_bundle(frozen_source, candidate_root)
     elif source in {"qd_elite", "crossover"}:
         primary = plan.get("primary") or {}
         parent = _resolve_frozen_parent_bundle(
@@ -2539,7 +2768,7 @@ def _materialize_candidate_seed(
         )
         if compute_workspace_revision(parent) != str(primary.get("revision") or ""):
             raise ValueError("frozen executable parent revision mismatch")
-        _copy_active_bundle(parent, candidate_root)
+        copy_job_bundle(parent, candidate_root)
         job_data = _load_job_yaml(candidate_root)
         params = dict(job_data.get("execution_params") or {})
         for key in _TARGET_EXECUTION_PARAM_KEYS:
@@ -2548,6 +2777,26 @@ def _materialize_candidate_seed(
         job_data["execution_params"] = params
         atomic_write_text(
             candidate_root / "job.yaml", yaml.safe_dump(job_data, sort_keys=False)
+        )
+    elif source == "research_seed":
+        seed = dict(plan.get("research_seed") or {})
+        parent = _resolve_research_seed_source(
+            store, job_id, campaign_id, str(seed.get("bundle") or "")
+        )
+        if compute_workspace_revision(parent) != str(seed.get("revision") or ""):
+            raise ValueError("frozen research seed revision mismatch")
+        copy_job_bundle(parent, candidate_root)
+        job_data = _load_job_yaml(candidate_root)
+        params = dict(job_data.get("execution_params") or {})
+        for key in _TARGET_EXECUTION_PARAM_KEYS:
+            params.pop(key, None)
+        params.update(_target_execution_params(frozen_source))
+        job_data["execution_params"] = params
+        atomic_write_text(
+            candidate_root / "job.yaml", yaml.safe_dump(job_data, sort_keys=False)
+        )
+        _consume_research_seed(
+            store, job_id, str(seed.get("seed_id") or ""), campaign_id
         )
     elif source == "starter_seed":
         _copy_clean_scaffold(store, job_id, frozen_source, candidate_root)
@@ -2570,7 +2819,7 @@ def _copy_clean_scaffold(
     destination: Path,
 ) -> None:
     """Target job shell without incumbent alpha code or research memory."""
-    _copy_active_bundle(source_root, destination)
+    copy_job_bundle(source_root, destination)
     risk_path = destination / "workspace" / "risk_limits.json"
     risk_limits = risk_path.read_bytes() if risk_path.exists() else None
     shutil.rmtree(destination / "workspace")
@@ -2631,9 +2880,7 @@ def _install_starter_seed(
 
 def _target_execution_params(source_root: Path) -> dict[str, Any]:
     params = dict(_load_job_yaml(source_root).get("execution_params") or {})
-    return {
-        key: params[key] for key in _TARGET_EXECUTION_PARAM_KEYS if key in params
-    }
+    return {key: params[key] for key in _TARGET_EXECUTION_PARAM_KEYS if key in params}
 
 
 def _resolve_frozen_parent_bundle(
@@ -2662,21 +2909,35 @@ def _resolve_starter_source(
     return resolved
 
 
-def _copy_active_bundle(source_root: Path, destination: Path) -> None:
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    temporary = Path(
-        tempfile.mkdtemp(prefix=f".{destination.name}.", dir=destination.parent)
-    )
-    try:
-        shutil.copy2(source_root / "job.yaml", temporary / "job.yaml")
-        shutil.copytree(source_root / "workspace", temporary / "workspace")
-        spec = source_root / "execution_spec.json"
-        if spec.exists():
-            shutil.copy2(spec, temporary / "execution_spec.json")
-        os.replace(temporary, destination)
-    except Exception:
-        shutil.rmtree(temporary, ignore_errors=True)
-        raise
+def _resolve_research_seed_source(
+    store: JobStore, job_id: str, campaign_id: str, relative: str
+) -> Path:
+    if not relative or Path(relative).is_absolute():
+        raise ValueError("research seed source must be campaign-relative")
+    campaign_root = (store.job_dir(job_id) / CAMPAIGN_ROOT / campaign_id).resolve()
+    allowed = (campaign_root / "research_seeds").resolve()
+    resolved = (campaign_root / relative).resolve()
+    if not resolved.is_relative_to(allowed) or resolved.parent != allowed:
+        raise ValueError("research seed source escapes its campaign root")
+    return resolved
+
+
+def _consume_research_seed(
+    store: JobStore, job_id: str, seed_id: str, campaign_id: str
+) -> None:
+    with job_state_lock(store.repo_root, job_id, name="evolution_research_seeds"):
+        state = store.read_json(job_id, RESEARCH_SEED_STATE_PATH, default={}) or {}
+        for seed in state.get("seeds") or []:
+            if seed.get("seed_id") == seed_id and seed.get("status") == "pending":
+                seed.update(
+                    {
+                        "status": "consumed",
+                        "consumed_by_campaign": campaign_id,
+                        "consumed_at": utc_now_iso(),
+                    }
+                )
+                store.write_json(job_id, RESEARCH_SEED_STATE_PATH, state)
+                return
 
 
 def _snapshot_campaign_inputs(
@@ -2690,7 +2951,7 @@ def _snapshot_campaign_inputs(
     """Freeze every input known when candidate generation begins."""
     campaign_root.mkdir(parents=True, exist_ok=False)
     source_bundle = campaign_root / "source"
-    _copy_active_bundle(active_root, source_bundle)
+    copy_job_bundle(active_root, source_bundle)
     data_root = campaign_root / CAMPAIGN_DATA_ROOT
     bars_path = data_root / "results" / "backtest" / "input_bars.json"
     bars_path.parent.mkdir(parents=True, exist_ok=True)
@@ -2911,7 +3172,9 @@ def _same_family_nonwins(state: dict[str, Any], family: str, streak: int) -> boo
             "low_fidelity_rejected",
             "proposal_rejected",
             "proposal_deferred",
+            "probation_deferred",
             "dev_frontier",
+            "probation",
             "paper_proposal",
             "paper_experiment",
         }
@@ -2921,6 +3184,7 @@ def _same_family_nonwins(state: dict[str, Any], family: str, streak: int) -> boo
         "low_fidelity_rejected",
         "proposal_rejected",
         "proposal_deferred",
+        "probation_deferred",
     }
     return len(outcomes) >= streak and all(
         item.get("status") in failures for item in outcomes[:streak]

--- a/wayfinder_paths/jobs/evolution_funnel.py
+++ b/wayfinder_paths/jobs/evolution_funnel.py
@@ -12,6 +12,8 @@ _FULL_DEV_PASS_STATUSES = {
     "proposal_deferred",
     "paper_proposal",
     "paper_experiment",
+    "probation",
+    "probation_deferred",
 }
 
 
@@ -51,8 +53,8 @@ def summarize_evolution_funnel(state: dict[str, Any]) -> dict[str, Any]:
         and candidate.get("status") == "full_dev_running"
         for candidate in candidates
     )
-    paper_admitted = sum(
-        candidate.get("status") in {"paper_proposal", "paper_experiment"}
+    probation_admitted = sum(
+        candidate.get("status") in {"paper_proposal", "paper_experiment", "probation"}
         for candidate in candidates
     )
 
@@ -104,13 +106,16 @@ def summarize_evolution_funnel(state: dict[str, Any]) -> dict[str, Any]:
         "finalist_gate": {
             "evaluated": gate_evaluated,
             "target": _optional_count(budgets, "finalist_gate"),
-            "advanced_to_paper": paper_admitted,
+            # Keep the historical key for older frontend clients while adding
+            # the permanent lifecycle name used by new snapshots.
+            "advanced_to_paper": probation_admitted,
+            "advanced_to_probation": probation_admitted,
             "rejected": sum(
                 candidate.get("status") == "proposal_rejected"
                 for candidate in candidates
             ),
             "deferred": sum(
-                candidate.get("status") == "proposal_deferred"
+                candidate.get("status") in {"proposal_deferred", "probation_deferred"}
                 for candidate in candidates
             ),
             "running": sum(
@@ -155,7 +160,8 @@ def format_evolution_funnel(funnel: dict[str, Any]) -> str:
         f"{_value(optuna.get('previewed'))} previewed, "
         f"{_value(optuna.get('selected'))} selected"
         f"{limits_suffix}{optuna_suffix})) → "
-        f"gate {gate_progress}; paper {_value(gate.get('advanced_to_paper'))}"
+        f"gate {gate_progress}; probation "
+        f"{_value(gate.get('advanced_to_probation', gate.get('advanced_to_paper')))}"
     )
 
 

--- a/wayfinder_paths/jobs/execution/driver.py
+++ b/wayfinder_paths/jobs/execution/driver.py
@@ -38,6 +38,7 @@ from wayfinder_paths.jobs.execution.risk import RISK_STATE_PATH, check_risk_halt
 from wayfinder_paths.jobs.execution.simulator import _load_strategy
 from wayfinder_paths.jobs.execution.validation import resolve_execution_spec
 from wayfinder_paths.jobs.execution.venues import (
+    RestingOrderCancelBroker,
     VenueAdapter,
     VenueState,
     build_adapter,
@@ -368,6 +369,34 @@ async def tick_job(
         venue_states=venue_states,
         now=now,
     )
+    from wayfinder_paths.jobs.risk_overrides import active_symbol_blocks
+
+    symbol_blocks = active_symbol_blocks(store, job.id)
+    symbol_block_notes = await _apply_symbol_entry_blocks(
+        state=state,
+        brokers=brokers,
+        blocked_symbols=set(symbol_blocks),
+        now=now,
+    )
+    failed_block_cancels = [
+        note
+        for note in symbol_block_notes
+        if note.get("kind") == "resting_entry_cancel_failed_by_symbol_block"
+    ]
+    if failed_block_cancels:
+        failed_symbols = sorted(
+            {str(note.get("symbol") or "unknown") for note in failed_block_cancels}
+        )
+        request_halt(
+            store,
+            job.id,
+            reason=(
+                "symbol risk block could not confirm cancellation of resting "
+                f"entry orders for {', '.join(failed_symbols)}"
+            ),
+            flatten=False,
+            source="symbol_risk_override",
+        )
     if protection_halt:
         request_halt(
             store,
@@ -493,11 +522,13 @@ async def tick_job(
             events=events,
             auto_limits=dict(job.agent_loop.auto_limits or {}) or None,
             client_order_prefix=job.id,
+            blocked_entry_symbols=set(symbol_blocks),
         )
     tick.guard_events.extend(mode_notes)
     tick.guard_events.extend(leverage_notes)
     tick.guard_events.extend(reconcile_notes)
     tick.guard_events.extend(protection_notes)
+    tick.guard_events.extend(symbol_block_notes)
     tick.guard_events.extend(risk_notes)
     tick.guard_events.extend(feature_guards)
     tick.fills = protection_fills + tick.fills
@@ -585,14 +616,14 @@ async def tick_job(
     try:
         from wayfinder_paths.jobs.background import spawn_detached_op
         from wayfinder_paths.jobs.candidate_shadow import active_candidate_shadows
-        from wayfinder_paths.jobs.paper_experiment import enqueue_experiment_view
+        from wayfinder_paths.jobs.probation import enqueue_probation_view
 
         if active_candidate_shadows(store, job.id):
             rows = [
                 {**row, "timestamp": row["timestamp"].isoformat()}
                 for row in shadow_view.to_rows()
             ]
-            enqueue_experiment_view(store, job.id, rows=rows, now=now)
+            enqueue_probation_view(store, job.id, rows=rows, now=now)
             spawn_detached_op(
                 store,
                 job.id,
@@ -1017,6 +1048,68 @@ def _trade_close_payload(
             }
         )
     return payload
+
+
+async def _apply_symbol_entry_blocks(
+    *,
+    state: EngineState,
+    brokers: Mapping[str, Any],
+    blocked_symbols: set[str],
+    now: pd.Timestamp,
+) -> list[dict[str, Any]]:
+    """Cancel already-queued entry exposure while preserving exits."""
+    if not blocked_symbols:
+        return []
+    events: list[dict[str, Any]] = []
+    kept = []
+    for intent in state.pending_intents:
+        if intent.symbol not in blocked_symbols or intent.reduce_only:
+            kept.append(intent)
+            continue
+        events.append(
+            {
+                "kind": "pending_entry_canceled_by_symbol_block",
+                "symbol": intent.symbol,
+                "intent": intent.to_dict(),
+                "timestamp": now.isoformat(),
+            }
+        )
+    state.pending_intents = kept
+    for client_order_id, order in list(state.resting_orders.items()):
+        intent = order.intent
+        if intent.symbol not in blocked_symbols or intent.reduce_only:
+            continue
+        broker = brokers.get(intent.venue) or brokers.get("*")
+        cancel_confirmed = state.mode != "live"
+        error: str | None = "no broker for resting entry"
+        if state.mode == "live" and broker is not None:
+            try:
+                if isinstance(broker, RestingOrderCancelBroker):
+                    fill = await broker.cancel_resting_order(order)
+                else:
+                    fill = await broker.cancel(client_order_id)
+                cancel_confirmed = fill.status == "filled"
+                error = fill.error or (
+                    None if cancel_confirmed else f"cancel status: {fill.status}"
+                )
+            except Exception as exc:  # noqa: BLE001 - failure must preserve state
+                error = str(exc)[:300]
+        if cancel_confirmed:
+            state.resting_orders.pop(client_order_id, None)
+        events.append(
+            {
+                "kind": (
+                    "resting_entry_canceled_by_symbol_block"
+                    if cancel_confirmed
+                    else "resting_entry_cancel_failed_by_symbol_block"
+                ),
+                "symbol": intent.symbol,
+                "client_order_id": client_order_id,
+                "timestamp": now.isoformat(),
+                **({"cancel_error": error} if error else {}),
+            }
+        )
+    return events
 
 
 def view_hash(view: CompletedBarsView) -> str:

--- a/wayfinder_paths/jobs/execution/driver.py
+++ b/wayfinder_paths/jobs/execution/driver.py
@@ -31,6 +31,7 @@ from wayfinder_paths.jobs.execution.primitives import (
     ExecutionTrace,
     StateSnapshot,
     bar_interval_seconds,
+    is_risk_reducing_intent,
     resolve_compute_window,
 )
 from wayfinder_paths.jobs.execution.protection import monitor_native_protection
@@ -369,9 +370,9 @@ async def tick_job(
         venue_states=venue_states,
         now=now,
     )
-    from wayfinder_paths.jobs.risk_overrides import active_symbol_blocks
+    from wayfinder_paths.jobs.risk_overrides import enforced_symbol_blocks
 
-    symbol_blocks = active_symbol_blocks(store, job.id)
+    symbol_blocks = enforced_symbol_blocks(store, job.id)
     symbol_block_notes = await _apply_symbol_entry_blocks(
         state=state,
         brokers=brokers,
@@ -449,7 +450,7 @@ async def tick_job(
         )
         kept_intents = []
         for intent in state.pending_intents:
-            if intent.reduce_only:
+            if is_risk_reducing_intent(intent):
                 kept_intents.append(intent)
                 continue
             risk_notes.append(
@@ -1063,7 +1064,7 @@ async def _apply_symbol_entry_blocks(
     events: list[dict[str, Any]] = []
     kept = []
     for intent in state.pending_intents:
-        if intent.symbol not in blocked_symbols or intent.reduce_only:
+        if intent.symbol not in blocked_symbols or is_risk_reducing_intent(intent):
             kept.append(intent)
             continue
         events.append(
@@ -1077,7 +1078,7 @@ async def _apply_symbol_entry_blocks(
     state.pending_intents = kept
     for client_order_id, order in list(state.resting_orders.items()):
         intent = order.intent
-        if intent.symbol not in blocked_symbols or intent.reduce_only:
+        if intent.symbol not in blocked_symbols or is_risk_reducing_intent(intent):
             continue
         broker = brokers.get(intent.venue) or brokers.get("*")
         cancel_confirmed = state.mode != "live"

--- a/wayfinder_paths/jobs/execution/engine.py
+++ b/wayfinder_paths/jobs/execution/engine.py
@@ -202,6 +202,7 @@ async def run_tick(
     trace: ExecutionTrace | None = None,
     enforce_purity: bool = True,
     client_order_prefix: str | None = None,
+    blocked_entry_symbols: set[str] | None = None,
     liquidation: LiquidationConfig | None = None,
 ) -> TickResult:
     """One engine tick, identical across backtest, paper, and live.
@@ -233,6 +234,7 @@ async def run_tick(
             trace=trace,
             enforce_purity=enforce_purity,
             client_order_prefix=client_order_prefix,
+            blocked_entry_symbols=blocked_entry_symbols,
             liquidation=liquidation,
             result=result,
         )
@@ -256,6 +258,7 @@ async def _run_tick_inner(
     trace: ExecutionTrace,
     enforce_purity: bool,
     client_order_prefix: str | None,
+    blocked_entry_symbols: set[str] | None,
     liquidation: LiquidationConfig | None,
     result: TickResult,
 ) -> TickResult:
@@ -322,6 +325,7 @@ async def _run_tick_inner(
         trace=trace,
         result=result,
         reduce_only=False,
+        blocked_entry_symbols=blocked_entry_symbols,
     )
 
     # A symbol absent from this timestamp's bars has no market to fill against.
@@ -331,6 +335,16 @@ async def _run_tick_inner(
     # dropped and the strategy re-emits when it can be priced honestly.
     deferred_intents: list[OrderIntent] = []
     for intent in state.pending_intents:
+        if intent.symbol in (blocked_entry_symbols or set()) and not intent.reduce_only:
+            result.guard_events.append(
+                {
+                    "kind": "pending_entry_canceled_by_symbol_block",
+                    "symbol": intent.symbol,
+                    "intent": intent.to_dict(),
+                    "timestamp": bar_iso,
+                }
+            )
+            continue
         bar = bars_by_symbol.get(intent.symbol)
         if bar is None:
             deferred_intents.append(intent)
@@ -388,6 +402,7 @@ async def _run_tick_inner(
         trace=trace,
         result=result,
         reduce_only=True,
+        blocked_entry_symbols=blocked_entry_symbols,
     )
 
     if liquidation is not None and state.ledger.positions:
@@ -473,6 +488,19 @@ async def _run_tick_inner(
             digest = hashlib.sha256(seed.encode()).hexdigest()
             intent.client_order_id = f"0x{digest[:32]}"
         trace.intents.append({"timestamp": bar_iso, **intent.to_dict()})
+        if intent.symbol in (blocked_entry_symbols or set()) and not intent.reduce_only:
+            result.guard_events.append(
+                {
+                    "kind": "intent_rejected",
+                    "reason": (
+                        f"new entries for {intent.symbol} are blocked by a "
+                        "durable symbol risk override"
+                    ),
+                    "intent": intent.to_dict(),
+                    "timestamp": bar_iso,
+                }
+            )
+            continue
         if snapshot.status != "valid" and not intent.reduce_only:
             # Reduce-only mode: never add risk against stale/ambiguous state.
             result.guard_events.append(
@@ -627,6 +655,7 @@ async def _settle_resting_orders(
     trace: ExecutionTrace,
     result: TickResult,
     reduce_only: bool,
+    blocked_entry_symbols: set[str] | None,
 ) -> None:
     """Resolve paper/backtest limit orders against the next completed OHLC bar.
 
@@ -645,6 +674,16 @@ async def _settle_resting_orders(
             continue
         intent = order.intent
         if intent.reduce_only != reduce_only:
+            continue
+        if intent.symbol in (blocked_entry_symbols or set()) and not intent.reduce_only:
+            result.guard_events.append(
+                {
+                    "kind": "resting_entry_held_by_symbol_block",
+                    "symbol": intent.symbol,
+                    "client_order_id": client_order_id,
+                    "timestamp": timestamp,
+                }
+            )
             continue
         bar = bars_by_symbol.get(intent.symbol)
         if bar is None:

--- a/wayfinder_paths/jobs/execution/engine.py
+++ b/wayfinder_paths/jobs/execution/engine.py
@@ -28,6 +28,7 @@ from wayfinder_paths.jobs.execution.primitives import (
     TradeCapacity,
     _float_or_none,
     bar_interval_seconds,
+    is_risk_reducing_intent,
 )
 from wayfinder_paths.jobs.execution.purity import purity_sandbox
 from wayfinder_paths.jobs.execution.venues import (
@@ -335,7 +336,9 @@ async def _run_tick_inner(
     # dropped and the strategy re-emits when it can be priced honestly.
     deferred_intents: list[OrderIntent] = []
     for intent in state.pending_intents:
-        if intent.symbol in (blocked_entry_symbols or set()) and not intent.reduce_only:
+        if intent.symbol in (blocked_entry_symbols or set()) and not (
+            is_risk_reducing_intent(intent)
+        ):
             result.guard_events.append(
                 {
                     "kind": "pending_entry_canceled_by_symbol_block",
@@ -488,7 +491,9 @@ async def _run_tick_inner(
             digest = hashlib.sha256(seed.encode()).hexdigest()
             intent.client_order_id = f"0x{digest[:32]}"
         trace.intents.append({"timestamp": bar_iso, **intent.to_dict()})
-        if intent.symbol in (blocked_entry_symbols or set()) and not intent.reduce_only:
+        if intent.symbol in (blocked_entry_symbols or set()) and not (
+            is_risk_reducing_intent(intent)
+        ):
             result.guard_events.append(
                 {
                     "kind": "intent_rejected",
@@ -501,7 +506,7 @@ async def _run_tick_inner(
                 }
             )
             continue
-        if snapshot.status != "valid" and not intent.reduce_only:
+        if snapshot.status != "valid" and not is_risk_reducing_intent(intent):
             # Reduce-only mode: never add risk against stale/ambiguous state.
             result.guard_events.append(
                 {
@@ -560,7 +565,7 @@ async def _run_tick_inner(
         result.intents.append(intent)
         if intent.reduce_only and intent.limit_price is None:
             _drop_resting_orders(state, symbol=intent.symbol, reduce_only=True)
-        if not intent.reduce_only:
+        if not is_risk_reducing_intent(intent):
             notional = _intent_notional(intent, ref_price)
             if notional is not None:
                 day = bar_iso[:10]
@@ -675,7 +680,9 @@ async def _settle_resting_orders(
         intent = order.intent
         if intent.reduce_only != reduce_only:
             continue
-        if intent.symbol in (blocked_entry_symbols or set()) and not intent.reduce_only:
+        if intent.symbol in (blocked_entry_symbols or set()) and not (
+            is_risk_reducing_intent(intent)
+        ):
             result.guard_events.append(
                 {
                     "kind": "resting_entry_held_by_symbol_block",
@@ -1486,12 +1493,16 @@ def _validate_intent(
     if (
         max_per_decision is not None
         and notional is not None
-        and not intent.reduce_only
+        and not is_risk_reducing_intent(intent)
         and notional > max_per_decision
     ):
         return f"notional {notional:.2f} exceeds max_notional_per_decision"
     max_daily = _float_or_none(auto_limits.get("max_daily_notional"))
-    if max_daily is not None and notional is not None and not intent.reduce_only:
+    if (
+        max_daily is not None
+        and notional is not None
+        and not is_risk_reducing_intent(intent)
+    ):
         day = bar_iso[:10]
         if state.daily_notional.get(day, 0.0) + notional > max_daily:
             return f"daily notional cap {max_daily:.2f} reached"

--- a/wayfinder_paths/jobs/execution/hyperliquid.py
+++ b/wayfinder_paths/jobs/execution/hyperliquid.py
@@ -20,6 +20,7 @@ from wayfinder_paths.jobs.execution.primitives import (
     FillEvent,
     OrderIntent,
     PositionRecord,
+    RestingOrder,
     StateSnapshot,
     TradeCapacity,
     _float_or_none,
@@ -388,6 +389,13 @@ class HyperliquidPerpBroker:
     async def cancel(self, client_order_id: str) -> FillEvent:
         return _cancel_needs_asset_context("hyperliquid", client_order_id)
 
+    async def cancel_resting_order(self, order: RestingOrder) -> FillEvent:
+        return await _cancel_hyperliquid_resting_order(
+            wallet_label=self.wallet_label,
+            venue="hyperliquid",
+            order=order,
+        )
+
     async def place_stop_loss(
         self,
         *,
@@ -745,6 +753,58 @@ def _cancel_needs_asset_context(venue: str, client_order_id: str) -> FillEvent:
         side="",
         error="cancel by cloid requires asset context; use hyperliquid_cancel_order",
         client_order_id=client_order_id,
+    )
+
+
+async def _cancel_hyperliquid_resting_order(
+    *, wallet_label: str, venue: str, order: RestingOrder
+) -> FillEvent:
+    from wayfinder_paths.mcp.tools.hyperliquid import hyperliquid_cancel_order
+
+    intent = order.intent
+    client_order_id = str(intent.client_order_id or "")
+    kwargs: dict[str, Any] = {
+        "wallet_label": wallet_label,
+        "asset_name": intent.symbol,
+    }
+    if order.order_id and str(order.order_id).isdigit():
+        kwargs["order_id"] = int(order.order_id)
+    elif client_order_id:
+        kwargs["cancel_cloid"] = client_order_id
+    else:
+        return FillEvent(
+            status="rejected",
+            venue=venue,
+            symbol=intent.symbol,
+            side=intent.side,
+            order_id=order.order_id,
+            error="resting order has no exchange or client order id",
+        )
+    try:
+        outcome = await hyperliquid_cancel_order(**kwargs)
+    except Exception as exc:
+        return FillEvent(
+            status="ambiguous",
+            venue=venue,
+            symbol=intent.symbol,
+            side=intent.side,
+            order_id=order.order_id,
+            client_order_id=client_order_id or None,
+            error=str(exc),
+        )
+    confirmed = (
+        outcome.get("ok") is True
+        and (outcome.get("result") or {}).get("status") == "confirmed"
+    )
+    return FillEvent(
+        status="filled" if confirmed else "rejected",
+        venue=venue,
+        symbol=intent.symbol,
+        side=intent.side,
+        order_id=order.order_id,
+        client_order_id=client_order_id or None,
+        error=None if confirmed else str(_mcp_error(outcome) or "cancellation failed"),
+        raw=outcome.get("result") or {},
     )
 
 

--- a/wayfinder_paths/jobs/execution/hyperliquid_prediction.py
+++ b/wayfinder_paths/jobs/execution/hyperliquid_prediction.py
@@ -9,6 +9,7 @@ import httpx
 
 from wayfinder_paths.jobs.execution.hyperliquid import (
     SafeHyperliquidMarketClient,
+    _cancel_hyperliquid_resting_order,
     _cancel_needs_asset_context,
     _hl_state_result,
     _lookback_hours,
@@ -21,6 +22,7 @@ from wayfinder_paths.jobs.execution.primitives import (
     FillEvent,
     OrderIntent,
     PositionRecord,
+    RestingOrder,
     StateSnapshot,
     TradeCapacity,
     _float_or_none,
@@ -318,6 +320,13 @@ class HyperliquidPredictionBroker:
 
     async def cancel(self, client_order_id: str) -> FillEvent:
         return _cancel_needs_asset_context("hyperliquid_prediction", client_order_id)
+
+    async def cancel_resting_order(self, order: RestingOrder) -> FillEvent:
+        return await _cancel_hyperliquid_resting_order(
+            wallet_label=self.wallet_label,
+            venue="hyperliquid_prediction",
+            order=order,
+        )
 
     def _reject(self, intent: OrderIntent, timestamp: str, error: str) -> FillEvent:
         return FillEvent(

--- a/wayfinder_paths/jobs/execution/op_process.py
+++ b/wayfinder_paths/jobs/execution/op_process.py
@@ -20,7 +20,9 @@ if TYPE_CHECKING:
     from wayfinder_paths.jobs.store import JobStore
 
 _RUNNER_MODULE = "wayfinder_paths.jobs.execution.op_runner"
-_CONTROL_PLANE_OPS = frozenset({"evolution_start", "evolution_prepare"})
+_CONTROL_PLANE_OPS = frozenset(
+    {"evolution_start", "evolution_prepare", "evolution_submit_seed"}
+)
 _CAMPAIGN_OWNED_OPS = frozenset(
     {"evolution_prepare", "evolution_evaluate", "evolution_finalize"}
 )

--- a/wayfinder_paths/jobs/execution/op_runner.py
+++ b/wayfinder_paths/jobs/execution/op_runner.py
@@ -137,6 +137,14 @@ def _run_op(op: str, kwargs: dict[str, Any]) -> Any:
         from wayfinder_paths.jobs.store import JobStore
 
         return prepare_candidate(JobStore(), kwargs.pop("job_id"), **kwargs)
+    if op == "evolution_submit_seed":
+        from pathlib import Path
+
+        from wayfinder_paths.jobs.evolution_campaign import submit_research_seed
+        from wayfinder_paths.jobs.store import JobStore
+
+        kwargs["candidate_root"] = Path(kwargs["candidate_root"])
+        return submit_research_seed(JobStore(), kwargs.pop("job_id"), **kwargs)
     if op == "evolution_evaluate":
         from wayfinder_paths.jobs.evolution_campaign import evaluate_candidate
         from wayfinder_paths.jobs.store import JobStore

--- a/wayfinder_paths/jobs/execution/polymarket.py
+++ b/wayfinder_paths/jobs/execution/polymarket.py
@@ -12,6 +12,7 @@ from wayfinder_paths.jobs.execution.primitives import (
     FillEvent,
     OrderIntent,
     PositionRecord,
+    RestingOrder,
     TradeCapacity,
     _float_or_none,
     bar_interval_seconds,
@@ -385,6 +386,40 @@ class PolymarketBroker:
             symbol="",
             side="",
             client_order_id=client_order_id,
+            order_id=order_id,
+            error=None if ok else str(resp),
+        )
+
+    async def cancel_resting_order(self, order: RestingOrder) -> FillEvent:
+        client_order_id = str(order.intent.client_order_id or "")
+        order_id = order.order_id or self._order_ids.get(client_order_id)
+        if not order_id:
+            return FillEvent(
+                status="rejected",
+                venue="polymarket",
+                symbol=order.intent.symbol,
+                side=order.intent.side,
+                client_order_id=client_order_id or None,
+                error="resting order has no exchange order id",
+            )
+        try:
+            ok, resp = await self.adapter.cancel_order(order_id=order_id)
+        except Exception as exc:
+            return FillEvent(
+                status="ambiguous",
+                venue="polymarket",
+                symbol=order.intent.symbol,
+                side=order.intent.side,
+                client_order_id=client_order_id or None,
+                order_id=order_id,
+                error=str(exc),
+            )
+        return FillEvent(
+            status="filled" if ok else "rejected",
+            venue="polymarket",
+            symbol=order.intent.symbol,
+            side=order.intent.side,
+            client_order_id=client_order_id or None,
             order_id=order_id,
             error=None if ok else str(resp),
         )

--- a/wayfinder_paths/jobs/execution/primitives.py
+++ b/wayfinder_paths/jobs/execution/primitives.py
@@ -505,6 +505,11 @@ class OrderIntent:
         }
 
 
+def is_risk_reducing_intent(intent: OrderIntent) -> bool:
+    """Recognize semantic exits even when a strategy omits `reduce_only`."""
+    return intent.reduce_only or str(intent.action).upper() in REDUCE_ONLY_ACTIONS
+
+
 @dataclass
 class RestingOrder:
     """Durable state for a submitted limit order awaiting fills or expiry."""

--- a/wayfinder_paths/jobs/execution/venues.py
+++ b/wayfinder_paths/jobs/execution/venues.py
@@ -10,6 +10,7 @@ from wayfinder_paths.jobs.execution.primitives import (
     FillEvent,
     OrderIntent,
     PositionRecord,
+    RestingOrder,
     TradeCapacity,
 )
 
@@ -141,6 +142,17 @@ class NativeProtectionBroker(Protocol):
     async def cancel_stop_loss(
         self, *, symbol: str, client_order_id: str
     ) -> NativeProtectionResult: ...
+
+
+@runtime_checkable
+class RestingOrderCancelBroker(Protocol):
+    """Optional live-broker extension with the context needed to cancel.
+
+    The base Broker API only carries a client order id. Some venues also need
+    the asset or exchange order id, both of which live in RestingOrder.
+    """
+
+    async def cancel_resting_order(self, order: RestingOrder) -> FillEvent: ...
 
 
 @runtime_checkable

--- a/wayfinder_paths/jobs/halt.py
+++ b/wayfinder_paths/jobs/halt.py
@@ -26,7 +26,9 @@ HALTED_EXECUTION_STATUS = "halted"
 
 # Halts latched by the risk/protection layer: owner-clearable only. The loop
 # that tripped a circuit breaker must not be able to reset it.
-RISK_LATCH_SOURCES = frozenset({"risk_limits", "native_protection", "regime_health"})
+RISK_LATCH_SOURCES = frozenset(
+    {"risk_limits", "native_protection", "regime_health", "symbol_risk_override"}
+)
 
 
 def read_halt(root: Path) -> dict[str, Any] | None:

--- a/wayfinder_paths/jobs/improver/spec.py
+++ b/wayfinder_paths/jobs/improver/spec.py
@@ -84,11 +84,13 @@ DEFAULT_IMPROVER: dict[str, Any] = {
         },
         "exploration_floor": 0.25,
     },
-    # Isolated open-ended code evolution. The rollout is deliberately limited
-    # to the named lab job; other jobs see no campaign state or extra work.
+    # Isolated open-ended code evolution. Eligibility is mechanical and jobs
+    # may opt out; a legacy non-empty allowlist remains supported for local
+    # policy files written before fleet rollout.
     "evolution": {
         "enabled": True,
-        "allowed_job_ids": ["majors-5m-lab"],
+        "allowed_job_ids": [],
+        "excluded_job_ids": [],
         "campaign_hours": 4,
         "start_interval_hours": 24,
         # DeepSeek has announced 2x pricing during 09:00-12:00 and
@@ -130,8 +132,18 @@ DEFAULT_IMPROVER: dict[str, Any] = {
             "qualification_days": 7,
             "proposal_hours": 24,
             "compute_duty_fraction": 0.20,
+            "completion_duty_fraction": 0.25,
             "confidence": 0.90,
         },
+        "probation": {
+            "max_active": 3,
+            "max_queued": 3,
+            "burn_in_hours": 24,
+            "min_paired_days": 7,
+            "max_paired_days": 14,
+            "confidence": 0.90,
+        },
+        "research_seed_slots": 2,
     },
 }
 
@@ -228,7 +240,40 @@ class ImproverSpec:
     def evolution_enabled_for(self, job_id: str) -> bool:
         evolution = self.policy["evolution"]
         allowed = {str(item) for item in evolution.get("allowed_job_ids") or []}
-        return bool(evolution.get("enabled")) and job_id in allowed
+        excluded = {str(item) for item in evolution.get("excluded_job_ids") or []}
+        if not evolution.get("enabled") or job_id in excluded:
+            return False
+        if allowed and job_id not in allowed:
+            return False
+        return True
+
+    def evolution_eligibility(self, root: Path, job_id: str) -> dict[str, Any]:
+        """Cheap fleet gate for runnable jobs with a canonical local dataset."""
+        if not self.evolution_enabled_for(job_id):
+            return {"eligible": False, "reasons": ["disabled_or_excluded"]}
+        reasons: list[str] = []
+        try:
+            raw = yaml.safe_load((Path(root) / "job.yaml").read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError):
+            raw = None
+        if not isinstance(raw, dict):
+            return {"eligible": False, "reasons": ["job_yaml_unreadable"]}
+        if raw.get("execution_contract") != "jobs_v1":
+            reasons.append("execution_contract_not_jobs_v1")
+        script_loop = raw.get("script_loop") or {}
+        agent_loop = raw.get("agent_loop") or {}
+        if not isinstance(script_loop, dict) or not script_loop.get("enabled"):
+            reasons.append("script_loop_disabled")
+        if (
+            not isinstance(agent_loop, dict)
+            or not agent_loop.get("enabled")
+            or str(agent_loop.get("mode") or "off") not in {"intervene", "auto"}
+        ):
+            reasons.append("agent_loop_not_intervene_or_auto")
+        dataset = Path(root) / "results" / "backtest" / "input_bars.json"
+        if not dataset.is_file():
+            reasons.append("canonical_dataset_missing")
+        return {"eligible": not reasons, "reasons": reasons}
 
     def tier(self, name: str) -> dict[str, Any]:
         return dict(self.policy["tiers"][name])

--- a/wayfinder_paths/jobs/improver/spec.py
+++ b/wayfinder_paths/jobs/improver/spec.py
@@ -84,12 +84,11 @@ DEFAULT_IMPROVER: dict[str, Any] = {
         },
         "exploration_floor": 0.25,
     },
-    # Isolated open-ended code evolution. Eligibility is mechanical and jobs
-    # may opt out; a legacy non-empty allowlist remains supported for local
-    # policy files written before fleet rollout.
+    # Isolated open-ended code evolution. Keep the default canary-scoped;
+    # fleet rollout is an explicit job-local policy change after canary health.
     "evolution": {
         "enabled": True,
-        "allowed_job_ids": [],
+        "allowed_job_ids": ["majors-5m-lab"],
         "excluded_job_ids": [],
         "campaign_hours": 4,
         "start_interval_hours": 24,

--- a/wayfinder_paths/jobs/probation.py
+++ b/wayfinder_paths/jobs/probation.py
@@ -392,10 +392,16 @@ def ensure_unified_probation(
                 trial_id = _safe_trial_id(
                     str(candidate.get("candidate_id") or candidate["revision"])
                 )
-                if not any(
-                    trial.get("legacy_experiment_id") == experiment.get("experiment_id")
-                    for trial in doc["trials"]
-                ):
+                migrated_trial = next(
+                    (
+                        trial
+                        for trial in doc["trials"]
+                        if trial.get("legacy_experiment_id")
+                        == experiment.get("experiment_id")
+                    ),
+                    None,
+                )
+                if migrated_trial is None:
                     trial = {
                         "trial_id": trial_id,
                         "candidate_id": candidate.get("candidate_id"),
@@ -452,21 +458,25 @@ def ensure_unified_probation(
                     }
                     doc["trials"].append(trial)
                     changed = True
-                    experiment["status"] = "migrated"
-                    experiment["migrated_at"] = current.isoformat()
-                    experiment["migrated_to_probation"] = trial_id
-                    store.write_json(
-                        job_id, "state/evolution_experiment.json", experiment
-                    )
-                    store.append_journal(
-                        job_id,
-                        {
-                            "type": "evolution_experiment_migrated_to_probation",
-                            "experiment_id": experiment.get("experiment_id"),
-                            "trial_id": trial_id,
-                            "candidate_id": candidate.get("candidate_id"),
-                        },
-                    )
+                    # Persist the live trial before retiring the legacy owner.
+                    # If the second write fails, the next call finds this trial
+                    # and finishes the migration without duplicating it.
+                    store.write_json(job_id, PROBATION_PATH, doc)
+                    changed = False
+                    migrated_trial = trial
+                experiment["status"] = "migrated"
+                experiment["migrated_at"] = current.isoformat()
+                experiment["migrated_to_probation"] = migrated_trial["trial_id"]
+                store.write_json(job_id, "state/evolution_experiment.json", experiment)
+                store.append_journal(
+                    job_id,
+                    {
+                        "type": "evolution_experiment_migrated_to_probation",
+                        "experiment_id": experiment.get("experiment_id"),
+                        "trial_id": migrated_trial["trial_id"],
+                        "candidate_id": candidate.get("candidate_id"),
+                    },
+                )
         if changed or not (store.job_dir(job_id) / PROBATION_PATH).exists():
             store.write_json(job_id, PROBATION_PATH, doc)
         return doc
@@ -785,14 +795,28 @@ def _adjudicate_burn_in(
     coverage = len(common) / expected if expected else 0.0
     burn["coverage"] = round(coverage, 4)
     errors = int(trial["candidate"].get("error_count") or 0)
+    safety = _stream_hard_constraint_metrics(
+        store,
+        job_id,
+        stream=str(trial["candidate"]["stream"]),
+        started=_parse(burn["started_at"]),
+        current=current,
+    )
+    burn.update(safety)
+    hard_breach = bool(safety["hard_constraint_breach"])
     expired = current >= _parse(burn["expires_at"])
     mature = (
         span >= pd.Timedelta(hours=float(burn["duration_hours"])) and coverage >= 0.95
     )
-    if not mature and not expired and not errors:
+    if not mature and not expired and not errors and not hard_breach:
         return None
-    if errors or not mature:
-        reason = "candidate execution error" if errors else "burn-in coverage expired"
+    if errors or hard_breach or not mature:
+        if errors:
+            reason = "candidate execution error"
+        elif hard_breach:
+            reason = "hard safety breach"
+        else:
+            reason = "burn-in coverage expired"
         _close_trial(trial, "killed", reason=reason, current=current)
         return {
             "action": "probation_killed",
@@ -891,10 +915,8 @@ def _paired_forward_metrics(
     *,
     current: datetime,
 ) -> dict[str, Any]:
-    from wayfinder_paths.jobs.constitution import load_constitution
     from wayfinder_paths.jobs.paper_experiment import (
         _daily_pnl_for_stream,
-        _max_drawdown,
     )
 
     started = _parse(trial["forward"]["started_at"])
@@ -927,10 +949,7 @@ def _paired_forward_metrics(
         [-value for value in deltas], block_len=5, iterations=500, confidence=confidence
     )
     ucb = -reverse if reverse is not None else None
-    max_drawdown = float(
-        load_constitution(store.job_dir(job_id))["hard_constraints"]["max_drawdown_pct"]
-    )
-    drawdown = _max_drawdown(candidate, capital)
+    safety = _hard_constraint_metrics(store, job_id, candidate)
     return {
         "paired_days": len(deltas),
         "estimate": round(sum(deltas), 8),
@@ -939,9 +958,42 @@ def _paired_forward_metrics(
         "confidence": confidence,
         "candidate_net_pnl": round(sum(candidate.values()), 6),
         "reference_net_pnl": round(sum(reference.values()), 6),
+        **safety,
+        "updated_at": current.isoformat(),
+    }
+
+
+def _stream_hard_constraint_metrics(
+    store: JobStore,
+    job_id: str,
+    *,
+    stream: str,
+    started: datetime,
+    current: datetime,
+) -> dict[str, Any]:
+    from wayfinder_paths.jobs.paper_experiment import _daily_pnl_for_stream
+
+    daily = _daily_pnl_for_stream(
+        store.job_dir(job_id) / stream,
+        since=started,
+        until=current,
+    )
+    return _hard_constraint_metrics(store, job_id, daily)
+
+
+def _hard_constraint_metrics(
+    store: JobStore, job_id: str, daily: dict[str, float]
+) -> dict[str, Any]:
+    from wayfinder_paths.jobs.constitution import load_constitution
+    from wayfinder_paths.jobs.paper_experiment import _max_drawdown
+
+    drawdown = _max_drawdown(daily, 10_000.0)
+    max_drawdown = float(
+        load_constitution(store.job_dir(job_id))["hard_constraints"]["max_drawdown_pct"]
+    )
+    return {
         "candidate_max_drawdown_pct": round(drawdown, 8),
         "hard_constraint_breach": drawdown > max_drawdown,
-        "updated_at": current.isoformat(),
     }
 
 

--- a/wayfinder_paths/jobs/probation.py
+++ b/wayfinder_paths/jobs/probation.py
@@ -8,19 +8,46 @@ journaled events, not prose."""
 
 from __future__ import annotations
 
+import hashlib
+import json
+import math
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import Any
 
+import pandas as pd
+
+from wayfinder_paths.jobs.bundles import copy_job_bundle
+from wayfinder_paths.jobs.compute_lock import job_state_lock
+from wayfinder_paths.jobs.economics import block_bootstrap_lcb
+from wayfinder_paths.jobs.execution.primitives import bar_interval_seconds
+from wayfinder_paths.jobs.gating import compute_workspace_revision
 from wayfinder_paths.jobs.improver.spec import ImproverSpec, revision_stamp
 from wayfinder_paths.jobs.models import utc_now_iso
 from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.runner.monitor_state import atomic_write_json
 
 PROBATION_PATH = "probation.json"
 PROBATION_STATUSES = {"active", "graduated", "killed"}
 PAPER_TIER = "paper"
+PROBATION_SCHEMA_VERSION = "2.0"
+PROBATION_BUNDLE_ROOT = "research/evolution/probation/bundles"
+PROBATION_FORWARD_ROOT = "results/forward/probation"
+PROBATION_VIEW_PATH = "state/probation_view.json"
+TRIAL_ACTIVE_STATUSES = frozenset({"burn_in", "active"})
+TRIAL_TERMINAL_STATUSES = frozenset(
+    {"graduated", "killed", "inconclusive", "superseded"}
+)
 
 
 def load_probation(store: JobStore, job_id: str) -> dict[str, Any]:
-    return store.read_json(job_id, PROBATION_PATH, default={"legs": []}) or {"legs": []}
+    doc = store.read_json(job_id, PROBATION_PATH, default={"legs": []}) or {"legs": []}
+    if not isinstance(doc, dict):
+        doc = {"legs": []}
+    doc.setdefault("legs", [])
+    doc.setdefault("trials", [])
+    doc.setdefault("schema_version", PROBATION_SCHEMA_VERSION)
+    return doc
 
 
 def record_probation_leg(
@@ -324,3 +351,846 @@ def update_probation_leg(
     leg["updated_at"] = utc_now_iso()
     store.write_json(job_id, PROBATION_PATH, doc)
     return leg
+
+
+def ensure_unified_probation(
+    store: JobStore,
+    job_id: str,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Normalize the registry and migrate an active legacy evolution A/B.
+
+    Migration is byte/clock preserving: existing c03-style bundles, streams,
+    cursors, admission time, and deadline are referenced in place.  The old
+    experiment remains as an archived receipt and can no longer stop future
+    campaigns.
+    """
+    current = _aware(now or datetime.now(UTC))
+    with job_state_lock(store.repo_root, job_id, name="probation"):
+        persisted = store.read_json(job_id, PROBATION_PATH, default={})
+        doc = load_probation(store, job_id)
+        changed = (
+            not isinstance(persisted, dict)
+            or persisted.get("schema_version") != PROBATION_SCHEMA_VERSION
+            or not isinstance(persisted.get("trials"), list)
+        )
+        doc["schema_version"] = PROBATION_SCHEMA_VERSION
+        experiment = (
+            store.read_json(job_id, "state/evolution_experiment.json", default={}) or {}
+        )
+        if (
+            isinstance(experiment, dict)
+            and experiment.get("status") == "active"
+            and not experiment.get("migrated_to_probation")
+        ):
+            evolution = (experiment.get("arms") or {}).get("evolution") or {}
+            control = (experiment.get("arms") or {}).get("control") or {}
+            candidate = evolution.get("champion") or {}
+            reference = control.get("champion") or {}
+            if candidate.get("source") != "incumbent" and candidate.get("revision"):
+                trial_id = _safe_trial_id(
+                    str(candidate.get("candidate_id") or candidate["revision"])
+                )
+                if not any(
+                    trial.get("legacy_experiment_id") == experiment.get("experiment_id")
+                    for trial in doc["trials"]
+                ):
+                    trial = {
+                        "trial_id": trial_id,
+                        "candidate_id": candidate.get("candidate_id"),
+                        "candidate_revision": candidate.get("revision"),
+                        "family": "evolution",
+                        "source": candidate.get("source") or "evolution_campaign",
+                        "status": "active",
+                        "phase": "forward",
+                        "queued_at": candidate.get("admitted_at"),
+                        "burn_in": {
+                            "status": "passed",
+                            "completed_at": experiment.get("started_at"),
+                            "basis": "legacy_24h_operational_burn_in",
+                        },
+                        "forward": {
+                            "started_at": experiment.get("started_at"),
+                            "deadline_at": experiment.get("ends_at"),
+                            "min_paired_days": 7,
+                            "max_paired_days": 14,
+                            "decision_days": [7, 14],
+                            "last_decision_day": 0,
+                            "confidence": float(experiment.get("confidence") or 0.90),
+                            "metrics": None,
+                        },
+                        "candidate": {
+                            "role": "candidate",
+                            "candidate_id": candidate.get("candidate_id"),
+                            "revision": candidate.get("revision"),
+                            "bundle": candidate.get("bundle"),
+                            "bundle_scope": "legacy_experiment",
+                            "legacy_shadow_arm": "evolution",
+                            "legacy_shadow_role": "champion",
+                            "stream": candidate.get("stream"),
+                            "last_processed_bar": evolution.get("last_processed_bar"),
+                            "error_count": 0,
+                        },
+                        "reference": {
+                            "role": "reference",
+                            "candidate_id": reference.get("candidate_id"),
+                            "revision": reference.get("revision"),
+                            "bundle": reference.get("bundle"),
+                            "bundle_scope": "legacy_experiment",
+                            "legacy_shadow_arm": "control",
+                            "legacy_shadow_role": "champion",
+                            "stream": reference.get("stream"),
+                            "last_processed_bar": control.get("last_processed_bar"),
+                            "error_count": 0,
+                        },
+                        "evidence": {"legacy_protocol": experiment.get("protocol")},
+                        "promotion": {"status": "not_ready", "proposal_id": None},
+                        "legacy_experiment_id": experiment.get("experiment_id"),
+                        "migrated_at": current.isoformat(),
+                        **revision_stamp(store.job_dir(job_id)),
+                    }
+                    doc["trials"].append(trial)
+                    changed = True
+                    experiment["status"] = "migrated"
+                    experiment["migrated_at"] = current.isoformat()
+                    experiment["migrated_to_probation"] = trial_id
+                    store.write_json(
+                        job_id, "state/evolution_experiment.json", experiment
+                    )
+                    store.append_journal(
+                        job_id,
+                        {
+                            "type": "evolution_experiment_migrated_to_probation",
+                            "experiment_id": experiment.get("experiment_id"),
+                            "trial_id": trial_id,
+                            "candidate_id": candidate.get("candidate_id"),
+                        },
+                    )
+        if changed or not (store.job_dir(job_id) / PROBATION_PATH).exists():
+            store.write_json(job_id, PROBATION_PATH, doc)
+        return doc
+
+
+def stage_evolution_probation(
+    store: JobStore,
+    job_id: str,
+    *,
+    candidate_id: str,
+    candidate_root: Path,
+    revision: str,
+    source: str,
+    family: str,
+    campaign_id: str | None = None,
+    evidence: dict[str, Any] | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Freeze a gate-green candidate into the permanent paper probation rail."""
+    current = _aware(now or datetime.now(UTC))
+    spec = ImproverSpec.load(store.job_dir(job_id))
+    policy = spec.evolution.get("probation") or {}
+    max_active = int(policy.get("max_active") or 3)
+    max_queued = int(policy.get("max_queued") or 3)
+    min_paired_days = int(policy.get("min_paired_days") or 7)
+    max_paired_days = int(policy.get("max_paired_days") or 14)
+    safe_revision = _safe_component(revision, "candidate revision")
+    trial_id = _safe_trial_id(f"{candidate_id}-{safe_revision}")
+    root = store.job_dir(job_id).resolve()
+    source_root = candidate_root.resolve()
+    if not source_root.is_relative_to(root):
+        raise ValueError("probation candidate must be inside its job root")
+    if compute_workspace_revision(source_root) != safe_revision:
+        raise ValueError("probation candidate revision does not match its bundle")
+    with job_state_lock(store.repo_root, job_id, name="probation"):
+        doc = load_probation(store, job_id)
+        duplicate = next(
+            (
+                trial
+                for trial in doc["trials"]
+                if trial.get("candidate_revision") == safe_revision
+            ),
+            None,
+        )
+        if duplicate is not None:
+            return {
+                "status": "duplicate",
+                "trial_id": duplicate.get("trial_id"),
+                "candidate_id": duplicate.get("candidate_id"),
+                "candidate_revision": duplicate.get("candidate_revision"),
+                "trial_status": duplicate.get("status"),
+            }
+        active = [
+            trial
+            for trial in doc["trials"]
+            if trial.get("status") in TRIAL_ACTIVE_STATUSES
+        ]
+        queued = [trial for trial in doc["trials"] if trial.get("status") == "queued"]
+        if len(active) >= max_active and len(queued) >= max_queued:
+            return {
+                "status": "deferred",
+                "reason": (
+                    f"probation capacity full ({max_active} active, "
+                    f"{max_queued} queued)"
+                ),
+                "candidate_id": candidate_id,
+            }
+        bundle_relative = f"{PROBATION_BUNDLE_ROOT}/{trial_id}/candidate"
+        reference_relative = f"{PROBATION_BUNDLE_ROOT}/{trial_id}/reference"
+        copy_job_bundle(source_root, root / bundle_relative, existing_ok=True)
+        copy_job_bundle(root, root / reference_relative, existing_ok=True)
+        reference_revision = compute_workspace_revision(root / reference_relative)
+        status = "burn_in" if len(active) < max_active else "queued"
+        trial = {
+            "trial_id": trial_id,
+            "candidate_id": candidate_id,
+            "candidate_revision": safe_revision,
+            "reference_revision": reference_revision,
+            "campaign_id": campaign_id,
+            "family": family,
+            "source": source,
+            "status": status,
+            "phase": "burn_in" if status == "burn_in" else "queued",
+            "queued_at": current.isoformat(),
+            "burn_in": {
+                "status": "running" if status == "burn_in" else "queued",
+                "started_at": current.isoformat() if status == "burn_in" else None,
+                "duration_hours": float(policy.get("burn_in_hours") or 24),
+                "bar_interval_seconds": _probation_bar_interval_seconds(store, job_id),
+                "expires_at": (
+                    current
+                    + timedelta(hours=float(policy.get("burn_in_hours") or 24) + 12)
+                ).isoformat()
+                if status == "burn_in"
+                else None,
+                "coverage": 0.0,
+                "first_common_bar": None,
+                "last_common_bar": None,
+            },
+            "forward": {
+                "started_at": None,
+                "deadline_at": None,
+                "min_paired_days": min_paired_days,
+                "max_paired_days": max_paired_days,
+                "decision_days": sorted({min_paired_days, max_paired_days}),
+                "last_decision_day": 0,
+                "confidence": float(policy.get("confidence") or 0.90),
+                "metrics": None,
+            },
+            "candidate": {
+                "role": "candidate",
+                "candidate_id": candidate_id,
+                "revision": safe_revision,
+                "bundle": bundle_relative,
+                "bundle_scope": "probation",
+                "stream": f"{PROBATION_FORWARD_ROOT}/{trial_id}/burn_in/candidate",
+                "last_processed_bar": current.isoformat(),
+                "error_count": 0,
+            },
+            "reference": {
+                "role": "reference",
+                "candidate_id": f"incumbent-{reference_revision[:12]}",
+                "revision": reference_revision,
+                "bundle": reference_relative,
+                "bundle_scope": "probation",
+                "stream": f"{PROBATION_FORWARD_ROOT}/{trial_id}/burn_in/reference",
+                "last_processed_bar": current.isoformat(),
+                "error_count": 0,
+            },
+            "evidence": dict(evidence or {}),
+            "promotion": {"status": "not_ready", "proposal_id": None},
+            **revision_stamp(root),
+        }
+        doc["trials"].append(trial)
+        store.write_json(job_id, PROBATION_PATH, doc)
+        store.append_journal(
+            job_id,
+            {
+                "type": "evolution_probation_queued"
+                if status == "queued"
+                else "evolution_probation_burn_in_started",
+                "trial_id": trial_id,
+                "candidate_id": candidate_id,
+                "revision": safe_revision,
+                "source": source,
+            },
+        )
+        return trial
+
+
+def active_probation_trials(store: JobStore, job_id: str) -> bool:
+    doc = ensure_unified_probation(store, job_id)
+    return any(
+        trial.get("status") in TRIAL_ACTIVE_STATUSES
+        for trial in doc.get("trials") or []
+    )
+
+
+def enqueue_probation_view(
+    store: JobStore,
+    job_id: str,
+    *,
+    rows: list[dict[str, Any]],
+    now: pd.Timestamp,
+) -> bool:
+    if not rows or not active_probation_trials(store, job_id):
+        return False
+    latest = max(pd.Timestamp(row["timestamp"]) for row in rows)
+    atomic_write_json(
+        store.job_dir(job_id) / PROBATION_VIEW_PATH,
+        {
+            "schema_version": "1.0",
+            "captured_at": now.isoformat(),
+            "latest_bar": latest.isoformat(),
+            "rows": rows,
+        },
+    )
+    return True
+
+
+def probation_targets(store: JobStore, job_id: str) -> list[dict[str, Any]]:
+    doc = ensure_unified_probation(store, job_id)
+    targets: list[dict[str, Any]] = []
+    for trial in doc.get("trials") or []:
+        if trial.get("status") not in TRIAL_ACTIVE_STATUSES:
+            continue
+        for key in ("candidate", "reference"):
+            target = dict(trial[key])
+            target.update({"trial_id": trial["trial_id"], "phase": trial["phase"]})
+            targets.append(target)
+    return targets
+
+
+def resolve_probation_bundle(
+    store: JobStore,
+    job_id: str,
+    target: dict[str, Any],
+) -> Path:
+    relative = str(target.get("bundle") or "")
+    if not relative or Path(relative).is_absolute():
+        raise ValueError("probation bundle must be a non-empty relative path")
+    root = store.job_dir(job_id).resolve()
+    resolved = (root / relative).resolve()
+    scope = target.get("bundle_scope")
+    allowed = (
+        (root / "research/evolution/experiment").resolve()
+        if scope == "legacy_experiment"
+        else (root / PROBATION_BUNDLE_ROOT).resolve()
+    )
+    if not resolved.is_relative_to(allowed):
+        raise ValueError("probation bundle escapes its immutable root")
+    return resolved
+
+
+def update_probation_target(
+    store: JobStore,
+    job_id: str,
+    target: dict[str, Any],
+    *,
+    bar_iso: str,
+    error: bool = False,
+) -> None:
+    with job_state_lock(store.repo_root, job_id, name="probation"):
+        doc = load_probation(store, job_id)
+        trial = next(
+            (
+                item
+                for item in doc["trials"]
+                if item.get("trial_id") == target.get("trial_id")
+            ),
+            None,
+        )
+        if trial is None or trial.get("phase") != target.get("phase"):
+            return
+        key = str(target.get("role"))
+        selected = trial.get(key) or {}
+        if selected.get("revision") != target.get("revision"):
+            return
+        selected["last_processed_bar"] = bar_iso
+        if error:
+            selected["error_count"] = int(selected.get("error_count") or 0) + 1
+        store.write_json(job_id, PROBATION_PATH, doc)
+
+
+def maybe_adjudicate_probation(
+    store: JobStore,
+    job_id: str,
+    *,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Advance burn-in/forward trials and retry owner-proposal staging."""
+    current = _aware(now or datetime.now(UTC))
+    outcomes: list[dict[str, Any]] = []
+    promotions: list[str] = []
+    spec = ImproverSpec.load(store.job_dir(job_id))
+    policy = spec.evolution.get("probation") or {}
+    max_active = int(policy.get("max_active") or 3)
+    with job_state_lock(store.repo_root, job_id, name="probation"):
+        doc = load_probation(store, job_id)
+        for trial in doc.get("trials") or []:
+            if trial.get("status") == "burn_in":
+                outcome = _adjudicate_burn_in(store, job_id, trial, current=current)
+            elif trial.get("status") == "active":
+                outcome = _adjudicate_forward(store, job_id, trial, current=current)
+            else:
+                outcome = None
+            if outcome:
+                outcomes.append(outcome)
+            promotion = trial.get("promotion") or {}
+            promotion_status = promotion.get("status")
+            stale_staging = promotion_status == "staging" and _stale_promotion_staging(
+                promotion, current=current
+            )
+            if trial.get("status") == "graduated" and (
+                promotion_status in {"pending", "retry"} or stale_staging
+            ):
+                promotions.append(str(trial["trial_id"]))
+        outcomes.extend(
+            _activate_queued_trials(
+                doc,
+                current=current,
+                max_active=max_active,
+            )
+        )
+        store.write_json(job_id, PROBATION_PATH, doc)
+    for outcome in outcomes:
+        _sync_trial_archive(store, job_id, outcome)
+        store.append_journal(
+            job_id,
+            {
+                "type": str(outcome.get("action") or "probation_updated"),
+                **outcome,
+            },
+        )
+    for trial_id in promotions[:1]:
+        promotion = _stage_trial_promotion(store, job_id, trial_id)
+        outcomes.append(promotion)
+    return outcomes
+
+
+def _adjudicate_burn_in(
+    store: JobStore,
+    job_id: str,
+    trial: dict[str, Any],
+    *,
+    current: datetime,
+) -> dict[str, Any] | None:
+    common = _common_ticks(store, job_id, trial)
+    burn = trial["burn_in"]
+    if common:
+        burn["first_common_bar"] = common[0].isoformat()
+        burn["last_common_bar"] = common[-1].isoformat()
+    span = common[-1] - common[0] if len(common) >= 2 else pd.Timedelta(0)
+    interval_s = max(int(burn.get("bar_interval_seconds") or 300), 1)
+    expected = int(span.total_seconds() // interval_s) + 1
+    coverage = len(common) / expected if expected else 0.0
+    burn["coverage"] = round(coverage, 4)
+    errors = int(trial["candidate"].get("error_count") or 0)
+    expired = current >= _parse(burn["expires_at"])
+    mature = (
+        span >= pd.Timedelta(hours=float(burn["duration_hours"])) and coverage >= 0.95
+    )
+    if not mature and not expired and not errors:
+        return None
+    if errors or not mature:
+        reason = "candidate execution error" if errors else "burn-in coverage expired"
+        _close_trial(trial, "killed", reason=reason, current=current)
+        return {
+            "action": "probation_killed",
+            "trial_id": trial["trial_id"],
+            "candidate_id": trial.get("candidate_id"),
+            "reason": reason,
+        }
+    burn.update({"status": "passed", "completed_at": common[-1].isoformat()})
+    started = common[-1].to_pydatetime()
+    trial["status"] = "active"
+    trial["phase"] = "forward"
+    trial["forward"]["started_at"] = started.isoformat()
+    trial["forward"]["deadline_at"] = (
+        started + timedelta(days=int(trial["forward"]["max_paired_days"]))
+    ).isoformat()
+    for key in ("candidate", "reference"):
+        trial[key]["stream"] = (
+            f"{PROBATION_FORWARD_ROOT}/{trial['trial_id']}/forward/{key}"
+        )
+        trial[key]["last_processed_bar"] = common[-1].isoformat()
+        trial[key]["error_count"] = 0
+    trial["updated_at"] = current.isoformat()
+    return {"action": "probation_forward_started", "trial_id": trial["trial_id"]}
+
+
+def _adjudicate_forward(
+    store: JobStore,
+    job_id: str,
+    trial: dict[str, Any],
+    *,
+    current: datetime,
+) -> dict[str, Any] | None:
+    metrics = _paired_forward_metrics(store, job_id, trial, current=current)
+    trial["forward"]["metrics"] = metrics
+    trial["updated_at"] = current.isoformat()
+    paired_days = int(metrics["paired_days"])
+    min_days = int(trial["forward"]["min_paired_days"])
+    max_days = int(trial["forward"]["max_paired_days"])
+    last_decision = int(trial["forward"].get("last_decision_day") or 0)
+    checkpoint = None
+    if paired_days >= max_days and last_decision < max_days:
+        checkpoint = max_days
+    elif paired_days >= min_days and last_decision < min_days:
+        checkpoint = min_days
+    if int(trial["candidate"].get("error_count") or 0) > 0:
+        _close_trial(
+            trial, "killed", reason="candidate execution error", current=current
+        )
+    elif metrics["hard_constraint_breach"]:
+        _close_trial(trial, "killed", reason="hard safety breach", current=current)
+    elif checkpoint is not None and metrics["lcb"] is not None and metrics["lcb"] > 0:
+        _close_trial(
+            trial, "graduated", reason="paired utility LCB > 0", current=current
+        )
+        trial["promotion"] = {"status": "pending", "proposal_id": None}
+    elif checkpoint is not None and metrics["ucb"] is not None and metrics["ucb"] < 0:
+        _close_trial(trial, "killed", reason="paired utility UCB < 0", current=current)
+    elif checkpoint == max_days:
+        _close_trial(
+            trial,
+            "inconclusive",
+            reason="14-day endpoint inconclusive",
+            current=current,
+        )
+    elif checkpoint is not None:
+        trial["forward"]["last_decision_day"] = checkpoint
+        return {
+            "action": "probation_checkpoint_inconclusive",
+            "trial_id": trial["trial_id"],
+            "candidate_id": trial.get("candidate_id"),
+            "checkpoint_day": checkpoint,
+            "metrics": metrics,
+        }
+    elif current >= _parse(trial["forward"]["deadline_at"]):
+        _close_trial(
+            trial,
+            "inconclusive",
+            reason="14-day endpoint inconclusive",
+            current=current,
+        )
+    else:
+        return None
+    return {
+        "action": f"probation_{trial['status']}",
+        "trial_id": trial["trial_id"],
+        "candidate_id": trial.get("candidate_id"),
+        "reason": trial.get("verdict_reason"),
+        "metrics": metrics,
+    }
+
+
+def _paired_forward_metrics(
+    store: JobStore,
+    job_id: str,
+    trial: dict[str, Any],
+    *,
+    current: datetime,
+) -> dict[str, Any]:
+    from wayfinder_paths.jobs.constitution import load_constitution
+    from wayfinder_paths.jobs.paper_experiment import (
+        _daily_pnl_for_stream,
+        _max_drawdown,
+    )
+
+    started = _parse(trial["forward"]["started_at"])
+    candidate = _daily_pnl_for_stream(
+        store.job_dir(job_id) / trial["candidate"]["stream"],
+        since=started,
+        until=current,
+    )
+    reference = _daily_pnl_for_stream(
+        store.job_dir(job_id) / trial["reference"]["stream"],
+        since=started,
+        until=current,
+    )
+    complete_days = sorted(
+        day
+        for day in set(candidate) & set(reference)
+        if day < current.date().isoformat()
+    )
+    capital = 10_000.0
+    deltas = [
+        math.log1p(candidate[day] / capital) - math.log1p(reference[day] / capital)
+        for day in complete_days
+        if candidate[day] > -capital and reference[day] > -capital
+    ]
+    confidence = float(trial["forward"].get("confidence") or 0.90)
+    lcb = block_bootstrap_lcb(
+        deltas, block_len=5, iterations=500, confidence=confidence
+    )
+    reverse = block_bootstrap_lcb(
+        [-value for value in deltas], block_len=5, iterations=500, confidence=confidence
+    )
+    ucb = -reverse if reverse is not None else None
+    max_drawdown = float(
+        load_constitution(store.job_dir(job_id))["hard_constraints"]["max_drawdown_pct"]
+    )
+    drawdown = _max_drawdown(candidate, capital)
+    return {
+        "paired_days": len(deltas),
+        "estimate": round(sum(deltas), 8),
+        "lcb": lcb,
+        "ucb": ucb,
+        "confidence": confidence,
+        "candidate_net_pnl": round(sum(candidate.values()), 6),
+        "reference_net_pnl": round(sum(reference.values()), 6),
+        "candidate_max_drawdown_pct": round(drawdown, 8),
+        "hard_constraint_breach": drawdown > max_drawdown,
+        "updated_at": current.isoformat(),
+    }
+
+
+def _stage_trial_promotion(
+    store: JobStore, job_id: str, trial_id: str
+) -> dict[str, Any]:
+    with job_state_lock(store.repo_root, job_id, name="probation"):
+        doc = load_probation(store, job_id)
+        trial = next(item for item in doc["trials"] if item["trial_id"] == trial_id)
+        promotion = trial.setdefault("promotion", {})
+        if promotion.get("proposal_id"):
+            return {"action": "probation_promotion_exists", "trial_id": trial_id}
+        promotion.update({"status": "staging", "updated_at": utc_now_iso()})
+        store.write_json(job_id, PROBATION_PATH, doc)
+        candidate_root = resolve_probation_bundle(store, job_id, trial["candidate"])
+    try:
+        from wayfinder_paths.jobs.proposals import propose_change
+
+        proposal_id = f"prop-probation-{trial_id[:36]}"
+        existing = next(
+            (
+                item
+                for item in store.proposals(job_id)
+                if item.get("proposal_id") == proposal_id
+            ),
+            None,
+        )
+        if existing is not None:
+            return _record_existing_promotion(
+                store, job_id, trial_id, proposal=existing
+            )
+        proposal = propose_change(
+            store,
+            job_id,
+            kind="code_change",
+            summary=f"Promote probation graduate {trial.get('candidate_id')}",
+            intent_contract={
+                "goal": "promote the mechanically graduated probation candidate",
+                "invariants": [
+                    "preserve execution safety constraints",
+                    "preserve paper/live operator-owned settings",
+                ],
+            },
+            candidate_source=candidate_root,
+            proposal_id=proposal_id,
+            memo=(
+                "This candidate cleared the historical economic gate, a 24-hour "
+                "operational burn-in, and the paired forward probation rule. "
+                "Owner approval is still required before application."
+            ),
+            allow_auto_apply=False,
+        )
+    except Exception as exc:  # retry infrastructure; evidence failures supersede
+        from wayfinder_paths.jobs.failures import classify_failure
+
+        status = (
+            "retry" if classify_failure(str(exc)) == "infrastructure" else "superseded"
+        )
+        with job_state_lock(store.repo_root, job_id, name="probation"):
+            doc = load_probation(store, job_id)
+            trial = next(item for item in doc["trials"] if item["trial_id"] == trial_id)
+            trial["promotion"] = {
+                "status": status,
+                "proposal_id": None,
+                "last_error": str(exc)[:300],
+                "updated_at": utc_now_iso(),
+            }
+            store.write_json(job_id, PROBATION_PATH, doc)
+        return {"action": f"probation_promotion_{status}", "trial_id": trial_id}
+    with job_state_lock(store.repo_root, job_id, name="probation"):
+        doc = load_probation(store, job_id)
+        trial = next(item for item in doc["trials"] if item["trial_id"] == trial_id)
+        trial["promotion"] = {
+            "status": "owner_review",
+            "proposal_id": proposal["proposal_id"],
+            "created_at": utc_now_iso(),
+        }
+        store.write_json(job_id, PROBATION_PATH, doc)
+    store.append_journal(
+        job_id,
+        {
+            "type": "probation_promotion_proposed",
+            "trial_id": trial_id,
+            "proposal_id": proposal["proposal_id"],
+        },
+    )
+    return {
+        "action": "probation_promotion_proposed",
+        "trial_id": trial_id,
+        "proposal_id": proposal["proposal_id"],
+    }
+
+
+def _activate_queued_trials(
+    doc: dict[str, Any],
+    *,
+    current: datetime,
+    max_active: int,
+) -> list[dict[str, Any]]:
+    active = [
+        trial for trial in doc["trials"] if trial.get("status") in TRIAL_ACTIVE_STATUSES
+    ]
+    activated: list[dict[str, Any]] = []
+    for trial in sorted(
+        doc["trials"], key=lambda item: str(item.get("queued_at") or "")
+    ):
+        if len(active) >= max_active or trial.get("status") != "queued":
+            continue
+        trial["status"] = "burn_in"
+        trial["phase"] = "burn_in"
+        trial["burn_in"].update(
+            {
+                "status": "running",
+                "started_at": current.isoformat(),
+                "expires_at": (
+                    current
+                    + timedelta(hours=float(trial["burn_in"]["duration_hours"]) + 12)
+                ).isoformat(),
+            }
+        )
+        for key in ("candidate", "reference"):
+            trial[key]["last_processed_bar"] = current.isoformat()
+        active.append(trial)
+        activated.append(
+            {
+                "action": "evolution_probation_burn_in_started",
+                "trial_id": trial["trial_id"],
+                "candidate_id": trial.get("candidate_id"),
+                "source": "probation_queue",
+            }
+        )
+    return activated
+
+
+def _sync_trial_archive(store: JobStore, job_id: str, outcome: dict[str, Any]) -> None:
+    status_by_action = {
+        "probation_graduated": "paper_experiment",
+        "probation_killed": "refuted",
+        "probation_inconclusive": "archived",
+    }
+    status = status_by_action.get(str(outcome.get("action") or ""))
+    candidate_id = str(outcome.get("candidate_id") or "")
+    if not status or not candidate_id:
+        return
+    from wayfinder_paths.jobs.archive import set_candidate_status
+
+    try:
+        set_candidate_status(
+            store,
+            job_id,
+            candidate_id,
+            status,
+            evidence=str(outcome.get("reason") or "forward probation verdict")[:300],
+        )
+    except ValueError:
+        # Legacy experiments can predate the archive. Their immutable trial
+        # remains the authoritative receipt and must still finish.
+        return
+
+
+def _stale_promotion_staging(promotion: dict[str, Any], *, current: datetime) -> bool:
+    try:
+        updated = _parse(promotion.get("updated_at"))
+    except (TypeError, ValueError):
+        return True
+    return current - updated >= timedelta(minutes=30)
+
+
+def _record_existing_promotion(
+    store: JobStore,
+    job_id: str,
+    trial_id: str,
+    *,
+    proposal: dict[str, Any],
+) -> dict[str, Any]:
+    proposal_id = str(proposal["proposal_id"])
+    with job_state_lock(store.repo_root, job_id, name="probation"):
+        doc = load_probation(store, job_id)
+        trial = next(item for item in doc["trials"] if item["trial_id"] == trial_id)
+        trial["promotion"] = {
+            "status": "owner_review",
+            "proposal_id": proposal_id,
+            "created_at": proposal.get("created_at") or utc_now_iso(),
+        }
+        store.write_json(job_id, PROBATION_PATH, doc)
+    return {
+        "action": "probation_promotion_proposed",
+        "trial_id": trial_id,
+        "proposal_id": proposal_id,
+        "recovered": True,
+    }
+
+
+def _common_ticks(
+    store: JobStore, job_id: str, trial: dict[str, Any]
+) -> list[pd.Timestamp]:
+    sets: list[set[pd.Timestamp]] = []
+    for key in ("candidate", "reference"):
+        path = store.job_dir(job_id) / trial[key]["stream"] / "ticks.jsonl"
+        stamps: set[pd.Timestamp] = set()
+        if path.exists():
+            for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+                try:
+                    row = json.loads(line)
+                    stamp = pd.Timestamp(row.get("bar_ts") or row.get("ts"))
+                    if not pd.isna(stamp):
+                        stamps.add(stamp)
+                except (TypeError, ValueError):
+                    continue
+        sets.append(stamps)
+    return sorted(sets[0] & sets[1])
+
+
+def _close_trial(
+    trial: dict[str, Any], status: str, *, reason: str, current: datetime
+) -> None:
+    trial["status"] = status
+    trial["phase"] = "complete"
+    trial["closed_at"] = current.isoformat()
+    trial["verdict_reason"] = reason
+    trial["updated_at"] = current.isoformat()
+
+
+def _safe_trial_id(value: str) -> str:
+    raw = str(value or "").strip()
+    safe = "".join(char if char.isalnum() or char in "-_" else "-" for char in raw)
+    if not safe:
+        raise ValueError("probation trial id is required")
+    return f"{safe[:48]}-{hashlib.sha256(raw.encode()).hexdigest()[:8]}"
+
+
+def _safe_component(value: str, label: str) -> str:
+    raw = str(value or "").strip()
+    if not raw or Path(raw).name != raw or raw in {".", ".."}:
+        raise ValueError(f"invalid {label}")
+    return raw
+
+
+def _probation_bar_interval_seconds(store: JobStore, job_id: str) -> int:
+    job = store.load(job_id)
+    data_contract = (job.execution_spec or {}).get("data_contract") or {}
+    declared = bar_interval_seconds(data_contract.get("bar_interval"))
+    return max(int(declared or job.script_loop.interval_seconds or 300), 1)
+
+
+def _parse(value: Any) -> datetime:
+    parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    return _aware(parsed)
+
+
+def _aware(value: datetime) -> datetime:
+    return value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)

--- a/wayfinder_paths/jobs/proposals.py
+++ b/wayfinder_paths/jobs/proposals.py
@@ -377,6 +377,7 @@ def propose_change(
     memo: str | None = None,
     robustness_warnings_acknowledged: list[str] | None = None,
     acceptance_policy: str = ECONOMIC_IMPROVEMENT_POLICY,
+    allow_auto_apply: bool = True,
 ) -> dict[str, Any]:
     """Create a pending proposal backed by a validated pre-approval candidate.
 
@@ -666,7 +667,7 @@ def propose_change(
     except Exception:  # noqa: BLE001 — archive bookkeeping never breaks propose
         pass
     maintenance_auto: dict[str, Any] | None = None
-    if acceptance_policy == BEHAVIOR_EQUIVALENCE_POLICY:
+    if acceptance_policy == BEHAVIOR_EQUIVALENCE_POLICY and allow_auto_apply:
         try:
             maintenance_auto = maybe_auto_apply_maintenance_proposal(store, job_id, pid)
         except Exception as exc:
@@ -681,7 +682,7 @@ def propose_change(
                 kind="process",
             )
             raise
-    else:
+    elif allow_auto_apply:
         try:
             maybe_auto_apply_paper_proposal(store, job_id, pid)
         except Exception as exc:  # noqa: BLE001 — pending owner path intact

--- a/wayfinder_paths/jobs/risk_overrides.py
+++ b/wayfinder_paths/jobs/risk_overrides.py
@@ -7,34 +7,68 @@ blocked while reduce-only exits continue.  Re-arming is owner-only.
 
 from __future__ import annotations
 
+import json
 import os
 from collections.abc import Mapping
 from datetime import UTC, datetime, timedelta
-from pathlib import Path
 from typing import Any
 
 from wayfinder_paths.jobs.compute_lock import job_state_lock
+from wayfinder_paths.jobs.evidence import verify_job_evidence_refs
+from wayfinder_paths.jobs.halt import request_halt
 from wayfinder_paths.jobs.store import JobStore
 
 RISK_OVERRIDES_PATH = "state/risk_overrides.json"
+RISK_OVERRIDES_CORRUPTION_PATH = "state/risk_overrides_corruption.json"
 EVIDENCE_MAX_AGE = timedelta(hours=6)
+_UNREADABLE_KEY = "_unreadable"
 
 
 def load_risk_overrides(store: JobStore, job_id: str) -> dict[str, Any]:
-    doc = store.read_json(job_id, RISK_OVERRIDES_PATH, default={}) or {}
-    if not isinstance(doc, dict):
-        doc = {}
+    path = store.job_dir(job_id) / RISK_OVERRIDES_PATH
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        doc: dict[str, Any] = {}
+    except (OSError, UnicodeError) as exc:
+        return _unreadable_overrides(f"{type(exc).__name__}: {exc}")
+    else:
+        try:
+            loaded = json.loads(raw)
+        except (TypeError, ValueError) as exc:
+            return _unreadable_overrides(f"{type(exc).__name__}: {exc}")
+        if not isinstance(loaded, dict) or not isinstance(
+            loaded.get("symbols", {}), dict
+        ):
+            return _unreadable_overrides("risk override document has invalid shape")
+        doc = loaded
     doc.setdefault("schema_version", "1.0")
     doc.setdefault("symbols", {})
     return doc
 
 
 def active_symbol_blocks(store: JobStore, job_id: str) -> dict[str, dict[str, Any]]:
-    return {
-        symbol: dict(block)
-        for symbol, block in load_risk_overrides(store, job_id)["symbols"].items()
-        if isinstance(block, Mapping) and block.get("status") == "blocked"
-    }
+    doc = load_risk_overrides(store, job_id)
+    if doc.get(_UNREADABLE_KEY):
+        return _fail_closed_blocks(store, job_id, reason=str(doc.get("reason") or ""))
+    return _active_blocks_from_doc(doc)
+
+
+def enforced_symbol_blocks(store: JobStore, job_id: str) -> dict[str, dict[str, Any]]:
+    """Resolve blocks for execution and latch unreadable state as a halt."""
+    doc = load_risk_overrides(store, job_id)
+    if not doc.get(_UNREADABLE_KEY):
+        return _active_blocks_from_doc(doc)
+    reason = str(doc.get("reason") or "unreadable risk override file")
+    _journal_corruption_once(store, job_id, reason=reason)
+    request_halt(
+        store,
+        job_id,
+        reason="unreadable risk override file; symbol entry blocks fail closed",
+        flatten=False,
+        source="symbol_risk_override",
+    )
+    return _fail_closed_blocks(store, job_id, reason=reason)
 
 
 def risk_block_symbol(
@@ -54,7 +88,13 @@ def risk_block_symbol(
     selected = str(symbol).strip()
     if selected not in configured:
         raise ValueError(f"risk override symbol {selected!r} is not configured")
-    verified = _verify_evidence_refs(store.job_dir(job_id), evidence_refs, now=current)
+    verified = verify_job_evidence_refs(
+        store.job_dir(job_id),
+        evidence_refs,
+        allowed_roots=("results/research", "state"),
+        now=current,
+        max_age=EVIDENCE_MAX_AGE,
+    )
     if not verified:
         raise ValueError("risk block requires fresh regime/attribution evidence")
     wake = str(
@@ -65,6 +105,7 @@ def risk_block_symbol(
     )
     with job_state_lock(store.repo_root, job_id, name="risk_overrides"):
         doc = load_risk_overrides(store, job_id)
+        _require_readable(doc)
         existing = doc["symbols"].get(selected) or {}
         if existing.get("status") == "blocked":
             return {
@@ -115,6 +156,7 @@ def risk_unblock_symbol(
     current = _aware(now or datetime.now(UTC))
     with job_state_lock(store.repo_root, job_id, name="risk_overrides"):
         doc = load_risk_overrides(store, job_id)
+        _require_readable(doc)
         block = doc["symbols"].get(symbol)
         if not isinstance(block, dict) or block.get("status") != "blocked":
             raise ValueError(f"symbol {symbol!r} is not blocked")
@@ -134,26 +176,66 @@ def risk_unblock_symbol(
     return {"symbol": symbol, **block}
 
 
-def _verify_evidence_refs(root: Path, refs: list[str], *, now: datetime) -> list[str]:
-    verified: list[str] = []
-    allowed_roots = [
-        (root / "results" / "research").resolve(),
-        (root / "state").resolve(),
-    ]
-    for value in refs:
-        relative = Path(str(value))
-        if relative.is_absolute():
-            continue
-        path = (root / relative).resolve()
-        if not any(path.is_relative_to(allowed) for allowed in allowed_roots):
-            continue
-        try:
-            age = now - datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
-        except OSError:
-            continue
-        if age <= EVIDENCE_MAX_AGE:
-            verified.append(relative.as_posix())
-    return verified
+def _unreadable_overrides(reason: str) -> dict[str, Any]:
+    return {
+        "schema_version": "1.0",
+        "symbols": {},
+        _UNREADABLE_KEY: True,
+        "reason": reason[:500],
+    }
+
+
+def _active_blocks_from_doc(doc: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    return {
+        str(symbol): dict(block)
+        for symbol, block in doc["symbols"].items()
+        if isinstance(block, Mapping) and block.get("status") == "blocked"
+    }
+
+
+def _fail_closed_blocks(
+    store: JobStore, job_id: str, *, reason: str
+) -> dict[str, dict[str, Any]]:
+    job = store.load(job_id)
+    return {
+        str(symbol): {
+            "status": "blocked",
+            "blocked_by": "fail_closed",
+            "reason": f"unreadable risk override file: {reason}"[:500],
+            "effect": "block_new_entries_allow_reduce_only_exits",
+        }
+        for symbol in job.execution_params.get("symbols") or []
+    }
+
+
+def _journal_corruption_once(store: JobStore, job_id: str, *, reason: str) -> None:
+    path = store.job_dir(job_id) / RISK_OVERRIDES_PATH
+    try:
+        stat = path.stat()
+        fingerprint = f"{stat.st_mtime_ns}:{stat.st_size}"
+    except OSError:
+        fingerprint = reason
+    marker = store.read_json(job_id, RISK_OVERRIDES_CORRUPTION_PATH, default={}) or {}
+    if isinstance(marker, dict) and marker.get("fingerprint") == fingerprint:
+        return
+    store.write_json(
+        job_id,
+        RISK_OVERRIDES_CORRUPTION_PATH,
+        {
+            "fingerprint": fingerprint,
+            "reason": reason,
+            "detected_at": datetime.now(UTC).isoformat(),
+        },
+    )
+    store.append_journal(
+        job_id,
+        {"type": "risk_overrides_unreadable", "reason": reason},
+    )
+
+
+def _require_readable(doc: Mapping[str, Any]) -> None:
+    if doc.get(_UNREADABLE_KEY):
+        raise ValueError("risk override state is unreadable; owner repair is required")
 
 
 def _aware(value: datetime) -> datetime:

--- a/wayfinder_paths/jobs/risk_overrides.py
+++ b/wayfinder_paths/jobs/risk_overrides.py
@@ -1,0 +1,160 @@
+"""Fast, monotone per-symbol entry blocks for regime incidents.
+
+This rail is deliberately separate from strategy promotion.  It can only
+remove risk: new entries and pending entry orders for a named symbol are
+blocked while reduce-only exits continue.  Re-arming is owner-only.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from wayfinder_paths.jobs.compute_lock import job_state_lock
+from wayfinder_paths.jobs.store import JobStore
+
+RISK_OVERRIDES_PATH = "state/risk_overrides.json"
+EVIDENCE_MAX_AGE = timedelta(hours=6)
+
+
+def load_risk_overrides(store: JobStore, job_id: str) -> dict[str, Any]:
+    doc = store.read_json(job_id, RISK_OVERRIDES_PATH, default={}) or {}
+    if not isinstance(doc, dict):
+        doc = {}
+    doc.setdefault("schema_version", "1.0")
+    doc.setdefault("symbols", {})
+    return doc
+
+
+def active_symbol_blocks(store: JobStore, job_id: str) -> dict[str, dict[str, Any]]:
+    return {
+        symbol: dict(block)
+        for symbol, block in load_risk_overrides(store, job_id)["symbols"].items()
+        if isinstance(block, Mapping) and block.get("status") == "blocked"
+    }
+
+
+def risk_block_symbol(
+    store: JobStore,
+    job_id: str,
+    *,
+    symbol: str,
+    reason: str,
+    evidence_refs: list[str],
+    wake_id: str | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Block one configured symbol when fresh regime/attribution evidence exists."""
+    current = _aware(now or datetime.now(UTC))
+    job = store.load(job_id)
+    configured = {str(item) for item in job.execution_params.get("symbols") or []}
+    selected = str(symbol).strip()
+    if selected not in configured:
+        raise ValueError(f"risk override symbol {selected!r} is not configured")
+    verified = _verify_evidence_refs(store.job_dir(job_id), evidence_refs, now=current)
+    if not verified:
+        raise ValueError("risk block requires fresh regime/attribution evidence")
+    wake = str(
+        wake_id
+        or os.environ.get("OPENCODE_SESSION_ID")
+        or os.environ.get("OPENCODE_SESSIONID")
+        or current.replace(minute=0, second=0, microsecond=0).isoformat()
+    )
+    with job_state_lock(store.repo_root, job_id, name="risk_overrides"):
+        doc = load_risk_overrides(store, job_id)
+        existing = doc["symbols"].get(selected) or {}
+        if existing.get("status") == "blocked":
+            return {
+                "status": "duplicate",
+                "symbol": selected,
+                "block_status": existing.get("status"),
+                "blocked_at": existing.get("blocked_at"),
+                "reason": existing.get("reason"),
+            }
+        if doc.get("last_block_wake_id") == wake:
+            raise ValueError("only one newly blocked symbol is allowed per sensor wake")
+        block = {
+            "status": "blocked",
+            "blocked_at": current.isoformat(),
+            "blocked_by": "sensor",
+            "wake_id": wake,
+            "reason": str(reason).strip()[:500],
+            "evidence_refs": verified,
+            "effect": "block_new_entries_allow_reduce_only_exits",
+        }
+        doc["symbols"][selected] = block
+        doc["last_block_wake_id"] = wake
+        store.write_json(job_id, RISK_OVERRIDES_PATH, doc)
+    store.append_journal(
+        job_id,
+        {
+            "type": "risk_symbol_blocked",
+            "symbol": selected,
+            "reason": block["reason"],
+            "evidence_refs": verified,
+            "effective_on": "next_tick",
+        },
+    )
+    return {"symbol": selected, **block}
+
+
+def risk_unblock_symbol(
+    store: JobStore,
+    job_id: str,
+    *,
+    symbol: str,
+    by: str,
+    reason: str | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    if by != "owner":
+        raise ValueError("only the owner can re-arm a symbol risk block")
+    current = _aware(now or datetime.now(UTC))
+    with job_state_lock(store.repo_root, job_id, name="risk_overrides"):
+        doc = load_risk_overrides(store, job_id)
+        block = doc["symbols"].get(symbol)
+        if not isinstance(block, dict) or block.get("status") != "blocked":
+            raise ValueError(f"symbol {symbol!r} is not blocked")
+        block.update(
+            {
+                "status": "cleared",
+                "cleared_at": current.isoformat(),
+                "cleared_by": "owner",
+                "clear_reason": str(reason or "owner re-armed symbol")[:500],
+            }
+        )
+        store.write_json(job_id, RISK_OVERRIDES_PATH, doc)
+    store.append_journal(
+        job_id,
+        {"type": "risk_symbol_unblocked", "symbol": symbol, "by": "owner"},
+    )
+    return {"symbol": symbol, **block}
+
+
+def _verify_evidence_refs(root: Path, refs: list[str], *, now: datetime) -> list[str]:
+    verified: list[str] = []
+    allowed_roots = [
+        (root / "results" / "research").resolve(),
+        (root / "state").resolve(),
+    ]
+    for value in refs:
+        relative = Path(str(value))
+        if relative.is_absolute():
+            continue
+        path = (root / relative).resolve()
+        if not any(path.is_relative_to(allowed) for allowed in allowed_roots):
+            continue
+        try:
+            age = now - datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
+        except OSError:
+            continue
+        if age <= EVIDENCE_MAX_AGE:
+            verified.append(relative.as_posix())
+    return verified
+
+
+def _aware(value: datetime) -> datetime:
+    return value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)

--- a/wayfinder_paths/jobs/sync.py
+++ b/wayfinder_paths/jobs/sync.py
@@ -224,6 +224,12 @@ def snapshot_job(job_id: str, *, store: JobStore | None = None) -> dict[str, Any
         "agent_mode_actual": str(job.agent_loop.mode),
         "agent_mode_source": "job_yaml",
     }
+    from wayfinder_paths.jobs.compute_lock import evolution_compute_budget_status
+    from wayfinder_paths.jobs.risk_overrides import active_symbol_blocks
+
+    scorecard["evolution_compute"] = evolution_compute_budget_status(store.repo_root)
+    blocks = active_symbol_blocks(store, job_id)
+    scorecard["risk_symbol_blocks"] = sorted(blocks)
     dataset_fetch = _dataset_fetch_state(store, job_id)
     if dataset_fetch is not None:
         scorecard = {**scorecard, "dataset_fetch": dataset_fetch}
@@ -257,6 +263,9 @@ def snapshot_job(job_id: str, *, store: JobStore | None = None) -> dict[str, Any
         "runner_links": runner_links,
         "proposals": store.proposals(job_id),
         "probation": store.read_json(job_id, "probation.json", default={"legs": []}),
+        "risk_overrides": store.read_json(
+            job_id, "state/risk_overrides.json", default={"symbols": {}}
+        ),
         "post_apply_shadow": _shadow_topline(store, job_id),
         "regime_health": regime_health,
         "decision_log": _decision_log(store, job_id),

--- a/wayfinder_paths/jobs/wake_economy.py
+++ b/wayfinder_paths/jobs/wake_economy.py
@@ -120,6 +120,21 @@ def saturation_watermark(
             if isinstance(leg, Mapping)
         ]
     )
+    probation_trials = sorted(
+        [
+            (
+                str(trial.get("trial_id")),
+                str(trial.get("status") or ""),
+                str(trial.get("phase") or ""),
+                str((trial.get("promotion") or {}).get("status") or ""),
+            )
+            for trial in load_probation(store, job_id).get("trials") or []
+            if isinstance(trial, Mapping)
+        ]
+    )
+    risk_overrides = (
+        store.read_json(job_id, "state/risk_overrides.json", default={}) or {}
+    )
     remediation = load_remediation(store, job_id) or {}
     remediation_progress = (remediation.get("progress") or {}).get("watermark")
     experiment_watermark = None
@@ -180,6 +195,10 @@ def saturation_watermark(
             "count": len(probation_legs),
             "fingerprint": _fingerprint({"legs": probation_legs}),
         },
+        "probation_trials": {
+            "count": len(probation_trials),
+            "fingerprint": _fingerprint({"trials": probation_trials}),
+        },
         "pending_proposals": sorted(
             str(proposal.get("proposal_id"))
             for proposal in store.proposals(job_id)
@@ -213,6 +232,11 @@ def saturation_watermark(
         else None,
         "evolution_experiment": experiment_watermark,
         "halt": {"source": halt.get("source"), "ts": halt.get("ts")} if halt else None,
+        "risk_symbol_blocks": sorted(
+            symbol
+            for symbol, block in (risk_overrides.get("symbols") or {}).items()
+            if isinstance(block, Mapping) and block.get("status") == "blocked"
+        ),
     }
 
 

--- a/wayfinder_paths/jobs/watchdog.py
+++ b/wayfinder_paths/jobs/watchdog.py
@@ -1804,31 +1804,18 @@ def _run_evolution_campaign_pass(
     }
 
 
-def _run_paper_experiment_pass(
+def _run_probation_pass(
     store: JobStore, job_id: str, now: datetime
 ) -> dict[str, Any] | None:
-    from wayfinder_paths.jobs.paper_experiment import (
-        harvest_hourly_control_candidates,
-        maybe_adjudicate_proposals,
-        maybe_finalize_experiment,
+    from wayfinder_paths.jobs.probation import (
+        ensure_unified_probation,
+        maybe_adjudicate_probation,
     )
 
-    adjudicated = maybe_adjudicate_proposals(store, job_id, now=now)
-    if adjudicated:
-        return {
-            "action": "evolution_proposal_adjudicated",
-            "outcomes": adjudicated,
-        }
-    verdict = maybe_finalize_experiment(store, job_id, now=now)
-    if verdict is not None:
-        return {"action": "evolution_experiment_completed", **verdict}
-    staged = harvest_hourly_control_candidates(store, job_id, now=now)
-    if staged is not None:
-        return {
-            "action": "evolution_control_proposal_staged",
-            "candidate_id": staged.get("candidate_id"),
-            "revision": staged.get("revision"),
-        }
+    ensure_unified_probation(store, job_id, now=now)
+    outcomes = maybe_adjudicate_probation(store, job_id, now=now)
+    if outcomes:
+        return {"action": "probation_adjudicated", "outcomes": outcomes}
     return None
 
 
@@ -2087,9 +2074,9 @@ def recover_stalled_applications(
         if campaign_event is not None:
             recovered.append({"job_id": job.id, **campaign_event})
         try:
-            experiment_event = _run_paper_experiment_pass(store, job.id, now)
+            experiment_event = _run_probation_pass(store, job.id, now)
         except Exception as exc:  # noqa: BLE001
-            errors.append({"job_id": job.id, "error": f"paper_experiment: {exc}"})
+            errors.append({"job_id": job.id, "error": f"probation: {exc}"})
             experiment_event = None
         if experiment_event is not None:
             recovered.append({"job_id": job.id, **experiment_event})

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -4,6 +4,7 @@ import datetime as dt
 import hashlib
 import json
 import os
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -675,17 +676,21 @@ def _build_worker_prompt_sections(
     apply_proposal_id: str | None = None,
     wake_source: str = "scheduled_timer",
     wake_triggers: list[str] | None = None,
+    wake_id: str | None = None,
 ) -> dict[str, str]:
     root = store.job_dir(job_id)
     from wayfinder_paths.jobs.improver.spec import ImproverSpec
 
     improver_spec = ImproverSpec.load(root)
-    evolution_enabled = improver_spec.evolution_enabled_for(job_id)
+    evolution_enabled = improver_spec.evolution_eligibility(root, job_id)["eligible"]
     intervene_scope = (
         "Intervene mode is the sensor/safety lane for this evolution-enabled "
         "job. Ordinary alpha/parameter candidate authoring, signal-family "
         "generation, and paper-probation admission belong exclusively to the "
-        "evolution campaign. This lane may still stage concrete risk reduction, "
+        "evolution campaign. When deterministic research produces executable "
+        "code, submit it as an evolution research seed instead of proposing it "
+        "directly (`wayfinder job evolution-submit-seed`). This lane may still "
+        "stage concrete risk reduction, "
         "revert/kill, operational remediation, exact behavior-equivalence "
         "maintenance, and owner-requested re-stage/application work. This rule "
         "supersedes generic candidate/probation mandates below."
@@ -852,6 +857,7 @@ def _build_worker_prompt_sections(
         "restage_tasks": restage_tasks,
         "search_assignment": search_assignment,
         "wake": {
+            "id": wake_id,
             "source": wake_source,
             "triggers": sorted(set(wake_triggers or [])),
         },
@@ -1058,14 +1064,25 @@ def _build_worker_prompt_sections(
             "to the evolution campaign. The only proposals allowed here are "
             "concrete risk reduction or revert/kill, operational remediation, "
             "exact behavior-equivalence maintenance, and owner-requested "
-            "re-stage work. Forward results adjudicate changes; never fit to "
+            "re-stage work. A reproducible executable hypothesis may be checked "
+            "in only through `core_jobs(action='evolution_submit_seed', "
+            "job_id=..., candidate_dir=..., family=..., hypothesis=..., "
+            "base_revision=..., evidence_refs=[...])`; it receives no inherited "
+            "evidence and must pass the one evolution funnel. Forward results "
+            "adjudicate changes; never fit to "
             "the forward stream.\n"
             "- Regime alarm triage: a standing_checks."
             "portfolio_regime_health warning/critical OVERRIDES ordinary "
             "sensor work: stop routine diagnosis, read the detector's named "
             "signals, then cite the automatically refreshed `attribution` "
             "block before choosing whether to revert, de-risk, gate a regime, "
-            "or re-validate. Never explain away a critical drawdown because "
+            "or re-validate. For a symbol-specific break, immediately call "
+            "`core_jobs(action='risk_block_symbol', job_id=..., symbol=..., "
+            "reason=..., evidence_refs=[...], wake_id=<wake.id>)`: it can only "
+            "block new entries, "
+            "leaves reduce-only exits available, permits one new symbol per "
+            "wake, and only the owner can re-arm. Never explain away a critical "
+            "drawdown because "
             "one entry signal still backtests.\n"
             "- If an allowed propose returns a failed validation, read ALL "
             "failed check names and fix them in ONE follow-up propose; after "
@@ -1472,6 +1489,7 @@ def _build_worker_prompt_sections(
         f"{restage_priority}"
         f"{impasse_directive}"
         f"{ideation_directive}"
+        f"Current wake id (pass verbatim to risk_block_symbol): {wake_id}\n"
         "Current snapshot:\n"
         f"{_canonical_json(dynamic_payload, max_chars=12000)}\n\n"
         "Research agenda (research/agenda.md — cumulative exploration "
@@ -1505,6 +1523,7 @@ def prepare_job_worker_prompt(
     apply_proposal_id: str | None = None,
     wake_source: str = "scheduled_timer",
     wake_triggers: list[str] | None = None,
+    wake_id: str | None = None,
 ) -> dict[str, Any]:
     """Prepare the exact prompt payload used for a job worker wakeup.
 
@@ -1565,6 +1584,7 @@ def prepare_job_worker_prompt(
         apply_proposal_id=apply_proposal_id,
         wake_source=wake_source,
         wake_triggers=wake_triggers,
+        wake_id=wake_id or f"wake-{uuid.uuid4().hex}",
     )
     return {
         **prompt_sections,
@@ -1638,14 +1658,34 @@ def run_job_worker(
     # coherent context without running two LLM sessions against one CPU pool.
     evolution_wake: dict[str, Any] | None = None
     if mode_typed == "intervene" and apply_proposal_id is None:
-        evolution_wake = _queue_evolution_worker(store, job.id)
         from wayfinder_paths.jobs.evolution_campaign import campaign_status
 
-        evolution_status = campaign_status(store, job.id).get("status")
+        campaign = campaign_status(store, job.id)
+        evolution_status = campaign.get("status")
+        risk_preempt = bool(
+            set(wake_triggers or [])
+            & {"risk_halt", "regime_shift", "regime_remediation_due"}
+        )
+        if risk_preempt and evolution_status in {"active", "finalizing"}:
+            retire_evolution_session(
+                store, job.id, str(campaign.get("campaign_id") or "")
+            )
+            store.append_journal(
+                job.id,
+                {
+                    "type": "evolution_paused_for_risk",
+                    "campaign_id": campaign.get("campaign_id"),
+                    "triggers": sorted(set(wake_triggers or [])),
+                },
+            )
+        if not risk_preempt:
+            evolution_wake = _queue_evolution_worker(store, job.id)
         evolution_claimed_lane = bool(
             evolution_wake is not None and not evolution_wake.get("error")
         )
-        if evolution_claimed_lane or evolution_status in {"active", "finalizing"}:
+        if not risk_preempt and (
+            evolution_claimed_lane or evolution_status in {"active", "finalizing"}
+        ):
             session_id = str((evolution_wake or {}).get("session_id") or "") or None
             reason = str((evolution_wake or {}).get("reason") or "").strip()
             return _write_report(
@@ -1793,7 +1833,8 @@ def job_worker_session_busy(job_id: str, mode: str) -> bool:
 def _queue_evolution_worker(store: JobStore, job_id: str) -> dict[str, Any] | None:
     from wayfinder_paths.jobs.improver.spec import ImproverSpec
 
-    if not ImproverSpec.load(store.job_dir(job_id)).evolution_enabled_for(job_id):
+    spec = ImproverSpec.load(store.job_dir(job_id))
+    if not spec.evolution_eligibility(store.job_dir(job_id), job_id)["eligible"]:
         return None
     if not OPENCODE_CLIENT.healthy():
         return None

--- a/wayfinder_paths/mcp/tools/jobs.py
+++ b/wayfinder_paths/mcp/tools/jobs.py
@@ -83,8 +83,10 @@ JobAction = Literal[
     "evolution_start",
     "evolution_status",
     "evolution_prepare",
+    "evolution_submit_seed",
     "evolution_evaluate",
     "evolution_finalize",
+    "risk_block_symbol",
     "forward_experience",
     "promote_params",
     "proposals",
@@ -358,6 +360,10 @@ async def core_jobs(
     candidate_dir: str | None = None,
     candidate_id: str | None = None,
     family: str | None = None,
+    hypothesis: str | None = None,
+    base_revision: str | None = None,
+    evidence_refs: list[str] | None = None,
+    wake_id: str | None = None,
     mutation_kind: Literal["structural", "parameter"] | None = None,
     scenario_plan: dict[str, Any] | None = None,
     improver: dict[str, Any] | None = None,
@@ -907,6 +913,31 @@ async def core_jobs(
             },
         )
 
+    if action == "evolution_submit_seed":
+        if (
+            not job_id
+            or not candidate_dir
+            or not family
+            or not hypothesis
+            or not base_revision
+        ):
+            return err(
+                "invalid_request",
+                "evolution_submit_seed requires job_id, candidate_dir, family, "
+                "hypothesis, and base_revision",
+            )
+        return await _run_job_op(
+            "evolution_submit_seed",
+            {
+                "job_id": job_id,
+                "candidate_root": candidate_dir,
+                "family": family,
+                "hypothesis": hypothesis,
+                "base_revision": base_revision,
+                "evidence_refs": evidence_refs or [],
+            },
+        )
+
     if action == "evolution_evaluate":
         if not job_id or not candidate_id:
             return err(
@@ -928,6 +959,26 @@ async def core_jobs(
                 store, job_id, "evolution_finalize", kwargs
             )
         return await _run_job_op("evolution_finalize", kwargs)
+
+    if action == "risk_block_symbol":
+        if not job_id or not symbol or not reason or not evidence_refs or not wake_id:
+            return err(
+                "invalid_request",
+                "risk_block_symbol requires job_id, symbol, reason, evidence_refs, "
+                "and the current dynamic wake_id",
+            )
+        from wayfinder_paths.jobs.risk_overrides import risk_block_symbol
+
+        return ok(
+            risk_block_symbol(
+                store,
+                job_id,
+                symbol=symbol,
+                reason=reason,
+                evidence_refs=evidence_refs,
+                wake_id=wake_id,
+            )
+        )
 
     if action == "forward_experience":
         if not job_id:

--- a/wayfinder_paths/tests/test_execution_engine.py
+++ b/wayfinder_paths/tests/test_execution_engine.py
@@ -15,6 +15,7 @@ from wayfinder_paths.jobs.execution import (
     OrderIntent,
     PurityViolation,
     RestingOrder,
+    StateSnapshot,
     TradeCapacity,
     VenueCapabilities,
     VenueState,
@@ -182,6 +183,36 @@ async def test_auto_limits_block_oversized_and_off_list_intents() -> None:
     reasons = [event["reason"] for event in result.guard_events]
     assert any("max_notional_per_decision" in reason for reason in reasons)
     assert any("allowed_symbols" in reason for reason in reasons)
+
+
+async def test_symbol_block_and_risk_halt_preserve_semantic_close() -> None:
+    broker = FakeBroker()
+    state = EngineState()
+    state.ledger.positions["SNX"] = PositionRecord(
+        symbol="SNX", side="long", size=1.0, avg_price=10.0
+    )
+    close = OrderIntent(
+        action="CLOSE",
+        venue="hyperliquid",
+        symbol="SNX",
+        side="short",
+        size=1.0,
+        reduce_only=False,
+    )
+
+    result = await _tick(
+        _strategy([close]),
+        _view([10.0, 10.5]),
+        brokers={"hyperliquid": broker},
+        state=state,
+        snapshot=StateSnapshot(status="risk_halt", reason="test"),
+        blocked_entry_symbols={"SNX"},
+        auto_limits={"max_notional_per_decision": 1.0},
+    )
+
+    assert broker.placed == [close]
+    assert result.intents == [close]
+    assert not any(event["kind"] == "intent_rejected" for event in result.guard_events)
 
 
 async def test_daily_notional_cap_accumulates_across_ticks() -> None:

--- a/wayfinder_paths/tests/test_jobs_candidate_shadow.py
+++ b/wayfinder_paths/tests/test_jobs_candidate_shadow.py
@@ -8,10 +8,11 @@ import yaml
 
 from wayfinder_paths.jobs.candidate_shadow import run_candidate_shadows
 from wayfinder_paths.jobs.execution.primitives import CompletedBarsView
+from wayfinder_paths.jobs.gating import compute_workspace_revision
 from wayfinder_paths.jobs.models import WayfinderJob
-from wayfinder_paths.jobs.paper_experiment import (
-    ensure_paper_experiment,
-    stage_paper_proposal,
+from wayfinder_paths.jobs.probation import (
+    load_probation,
+    stage_evolution_probation,
 )
 from wayfinder_paths.jobs.store import JobStore
 
@@ -61,17 +62,15 @@ def test_candidate_shadow_uses_separate_paper_state_and_stream(tmp_path) -> None
         ),
         encoding="utf-8",
     )
-    experiment = ensure_paper_experiment(store, job.id, now=started.to_pydatetime())
-    assert experiment is not None
-    revision = experiment["initial_revision"]
-    stage_paper_proposal(
+    revision = compute_workspace_revision(root)
+    staged = stage_evolution_probation(
         store,
         job.id,
-        arm="evolution",
         candidate_id="candidate-1",
         candidate_root=root,
         revision=revision,
         source="evolution_campaign",
+        family="test-candidate",
         evidence={
             "objective": {"candidate": {"trade_count": 12}},
         },
@@ -99,27 +98,17 @@ def test_candidate_shadow_uses_separate_paper_state_and_stream(tmp_path) -> None
             now=pd.Timestamp("2026-08-25T12:00:00Z"),
         )
     )
-    assert {row["role"] for row in first} == {
-        "proposal_candidate",
-        "proposal_reference",
-    }
-    updated = store.read_json(job.id, "state/evolution_experiment.json")
+    assert {row["role"] for row in first} == {"candidate", "reference"}
+    updated = load_probation(store, job.id)["trials"][0]
+    assert updated["trial_id"] == staged["trial_id"]
     assert updated["status"] == "active"
-    assert updated["admissions"]["evolution"] == 1
-    assert updated["proposals"]["evolution"]["active"] is None
-    assert updated["proposals"]["evolution"]["history"][0]["status"] == "qualified"
-    for role in ("proposal_candidate", "proposal_reference"):
-        assert (
-            root
-            / "state"
-            / "evolution_shadows"
-            / "evolution"
-            / role
-            / revision
-            / "engine_state.json"
-        ).exists()
+    assert updated["burn_in"]["status"] == "passed"
+    assert (
+        len(list((root / "state" / "probation_shadows").rglob("engine_state.json")))
+        >= 2
+    )
     ticks_paths = list(
-        (root / "results" / "forward" / "experiment" / "proposals").rglob("ticks.jsonl")
+        (root / "results" / "forward" / "probation").rglob("ticks.jsonl")
     )
     assert ticks_paths
     # Shadow replays hand candidates the SAME bounded window the simulator and

--- a/wayfinder_paths/tests/test_jobs_compute_lock.py
+++ b/wayfinder_paths/tests/test_jobs_compute_lock.py
@@ -3,16 +3,22 @@ reentrancy, clear busy errors, and heavy entrypoints actually holding it."""
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 import textwrap
+from datetime import UTC, datetime
 
 import pytest
 
 from wayfinder_paths.jobs.compute_lock import (
+    EVOLUTION_BUDGET_RELATIVE,
     ComputeLockBusy,
+    evolution_compute_budget_status,
+    experiment_compute_lock,
     heavy_compute_lock,
 )
+from wayfinder_paths.jobs.store import JobStore
 
 
 def test_reentrant_within_process(tmp_path) -> None:
@@ -135,3 +141,68 @@ def test_wake_monitors_skip_fast_when_lock_held(tmp_path, monkeypatch) -> None:
     finally:
         holder.kill()
         holder.wait()
+
+
+def _write_evolution_usage(tmp_path, *, wall_seconds: float) -> None:
+    path = tmp_path / EVOLUTION_BUDGET_RELATIVE
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "2.0",
+                "window_hours": 12,
+                "soft_duty_fraction": 0.20,
+                "hard_duty_fraction": 0.25,
+                "events": [
+                    {
+                        "ts": datetime.now(UTC).isoformat(),
+                        "job_id": "first-job",
+                        "class": "routine",
+                        "wall_seconds": wall_seconds,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_evolution_completion_has_a_small_machine_wide_priority_reserve(
+    tmp_path,
+) -> None:
+    store = JobStore(repo_root=tmp_path)
+    soft_limit = 0.20 * 12 * 3600
+    _write_evolution_usage(tmp_path, wall_seconds=soft_limit + 1)
+
+    # Usage from another job exhausts routine generation/evaluation globally.
+    with pytest.raises(ComputeLockBusy, match="routine compute duty exhausted"):
+        with experiment_compute_lock(store, "second-job", label="quick-screen"):
+            pass
+
+    # An already-started finalize/gate may use the modest 20%-to-25% reserve.
+    with experiment_compute_lock(
+        store,
+        "second-job",
+        label="finalist-gate",
+        completion_reserve=True,
+    ) as budget:
+        assert budget["soft_limit_seconds"] < budget["hard_limit_seconds"]
+
+    status = evolution_compute_budget_status(tmp_path)
+    assert status["debt_paused"] is True
+    assert status["hard_exhausted"] is False
+
+
+def test_evolution_completion_reserve_stops_at_hard_cap(tmp_path) -> None:
+    store = JobStore(repo_root=tmp_path)
+    hard_limit = 0.25 * 12 * 3600
+    _write_evolution_usage(tmp_path, wall_seconds=hard_limit)
+
+    with pytest.raises(ComputeLockBusy, match="completion compute duty exhausted"):
+        with experiment_compute_lock(
+            store,
+            "second-job",
+            label="finalist-gate",
+            completion_reserve=True,
+        ):
+            pass

--- a/wayfinder_paths/tests/test_jobs_decision_log.py
+++ b/wayfinder_paths/tests/test_jobs_decision_log.py
@@ -339,7 +339,7 @@ def test_active_evolution_campaign_is_one_compact_progress_row(tmp_path) -> None
             "0 reject → full dev 0 pass, 0 reject "
             "(0/4 complete; Optuna 0 complete "
             "(1 eligible, 1 previewed, 0 selected; min 1, budget 2)) "
-            "→ gate 0/1; paper 0"
+            "→ gate 0/1; probation 0"
         ),
         "outcome": "info",
         "actor": "harness",
@@ -378,6 +378,7 @@ def test_active_evolution_campaign_is_one_compact_progress_row(tmp_path) -> None
                     "evaluated": 0,
                     "target": 1,
                     "advanced_to_paper": 0,
+                    "advanced_to_probation": 0,
                     "rejected": 0,
                     "deferred": 0,
                     "running": 0,
@@ -483,6 +484,56 @@ def test_terminal_evolution_campaigns_show_outcomes_without_live_duplicate(
     assert entries[1]["title"] == "Evolution campaign stopped before completion"
     assert entries[1]["kind"] == "recovery"
     assert entries[1]["detail"].endswith("3 finalization attempt(s)")
+
+
+def test_unified_probation_and_fast_risk_events_are_visible_in_activity(
+    tmp_path,
+) -> None:
+    store, job_id = _mk(tmp_path)
+    root = store.job_dir(job_id)
+    journal = [
+        {
+            "ts": _ts(5),
+            "type": "evolution_research_seed_submitted",
+            "seed_id": "seed-1",
+            "family": "regime-break",
+        },
+        {
+            "ts": _ts(4),
+            "type": "evolution_probation_burn_in_started",
+            "trial_id": "trial-1",
+            "candidate_id": "candidate-1",
+        },
+        {
+            "ts": _ts(3),
+            "type": "probation_forward_started",
+            "trial_id": "trial-1",
+        },
+        {
+            "ts": _ts(2),
+            "type": "risk_symbol_blocked",
+            "symbol": "HYPE",
+            "reason": "deterministic regime break",
+        },
+        {
+            "ts": _ts(1),
+            "type": "probation_graduated",
+            "trial_id": "trial-1",
+        },
+    ]
+    (root / "journal.jsonl").write_text(
+        "\n".join(json.dumps(row) for row in journal) + "\n", encoding="utf-8"
+    )
+
+    entries = build_decision_log(store, job_id)["entries"]
+
+    assert any(entry["title"] == "Probation candidate graduated" for entry in entries)
+    blocked = next(
+        entry for entry in entries if "HYPE entries blocked" in entry["title"]
+    )
+    assert blocked["kind"] == "halt"
+    assert blocked["detail"] == "deterministic regime break"
+    assert any("executable evolution seed" in entry["title"] for entry in entries)
 
 
 def test_apply_lifecycle_events(tmp_path) -> None:

--- a/wayfinder_paths/tests/test_jobs_evolution_campaign.py
+++ b/wayfinder_paths/tests/test_jobs_evolution_campaign.py
@@ -108,17 +108,13 @@ def _prepare_campaign_candidates(
 
 def test_rollout_is_gated_and_campaign_context_is_bounded(tmp_path) -> None:
     other_store, other_id = _job(tmp_path / "other", "other-job")
-    # Fleet rollout is eligibility-driven; it is no longer hard-coded to the
-    # original majors canary.
-    assert (
+    with pytest.raises(ValueError, match="disabled_or_excluded"):
         start_campaign(
             other_store,
             other_id,
             now=datetime(2026, 8, 25, 12, tzinfo=UTC),
             force=True,
-        )["status"]
-        == "active"
-    )
+        )
 
     store, job_id = _job(tmp_path / "target", "majors-5m-lab")
     now = datetime(2026, 8, 25, 12, tzinfo=UTC)
@@ -181,6 +177,7 @@ def test_sensor_research_seed_is_frozen_then_consumed_as_real_parent(
         "# sensor hypothesis\ndef decide(ctx):\n    return []\n", encoding="utf-8"
     )
     (seed_root / "job.yaml").write_bytes((root / "job.yaml").read_bytes())
+    store.write_json(job_id, "results/research/regime_health.json", {"ready": True})
     monkeypatch.setattr(
         "wayfinder_paths.jobs.evolution_campaign.validate_execution_job",
         lambda *args, **kwargs: {"checks": []},
@@ -221,6 +218,34 @@ def test_sensor_research_seed_is_frozen_then_consumed_as_real_parent(
     assert seed_state["seeds"][0]["status"] == "consumed"
 
 
+def test_sensor_research_seed_requires_checked_in_research_result(
+    tmp_path, monkeypatch
+) -> None:
+    store, job_id = _job(tmp_path, "majors-5m-lab")
+    root = store.job_dir(job_id)
+    seed_root = root / "research" / "sensor_candidates" / "unsupported"
+    (seed_root / "workspace/src").mkdir(parents=True)
+    (seed_root / "workspace/src/strategy.py").write_text(
+        "# unsupported\ndef decide(ctx):\n    return []\n", encoding="utf-8"
+    )
+    (seed_root / "job.yaml").write_bytes((root / "job.yaml").read_bytes())
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.evolution_campaign.validate_execution_job",
+        lambda *args, **kwargs: {"checks": []},
+    )
+
+    with pytest.raises(ValueError, match="checked-in research result"):
+        submit_research_seed(
+            store,
+            job_id,
+            candidate_root=seed_root,
+            family="unsupported",
+            hypothesis="no evidence",
+            base_revision=compute_workspace_revision(root),
+            evidence_refs=["results/research/missing.json"],
+        )
+
+
 def test_campaign_start_defers_while_intervention_worker_is_busy(
     tmp_path, monkeypatch
 ) -> None:
@@ -241,6 +266,13 @@ def test_campaign_start_defers_while_intervention_worker_is_busy(
 def test_only_one_automatic_campaign_owns_a_machine(tmp_path) -> None:
     store, first = _job(tmp_path, "first-lab")
     _, second = _job(tmp_path, "second-lab")
+    for job_id in (first, second):
+        (store.job_dir(job_id) / "improver.yaml").write_text(
+            yaml.safe_dump(
+                {"evolution": {"allowed_job_ids": ["first-lab", "second-lab"]}}
+            ),
+            encoding="utf-8",
+        )
     now = datetime(2026, 8, 25, 12, tzinfo=UTC)
     start_campaign(store, first, now=now)
 

--- a/wayfinder_paths/tests/test_jobs_evolution_campaign.py
+++ b/wayfinder_paths/tests/test_jobs_evolution_campaign.py
@@ -42,6 +42,7 @@ from wayfinder_paths.jobs.evolution_campaign import (
     recover_lost_candidate_evaluations,
     resolve_candidate_bundle,
     start_campaign,
+    submit_research_seed,
 )
 from wayfinder_paths.jobs.execution.op_process import op_runner_command
 from wayfinder_paths.jobs.execution.primitives import DEFAULT_WARMUP_BARS
@@ -107,7 +108,17 @@ def _prepare_campaign_candidates(
 
 def test_rollout_is_gated_and_campaign_context_is_bounded(tmp_path) -> None:
     other_store, other_id = _job(tmp_path / "other", "other-job")
-    assert maybe_start_campaign(other_store, other_id) is None
+    # Fleet rollout is eligibility-driven; it is no longer hard-coded to the
+    # original majors canary.
+    assert (
+        start_campaign(
+            other_store,
+            other_id,
+            now=datetime(2026, 8, 25, 12, tzinfo=UTC),
+            force=True,
+        )["status"]
+        == "active"
+    )
 
     store, job_id = _job(tmp_path / "target", "majors-5m-lab")
     now = datetime(2026, 8, 25, 12, tzinfo=UTC)
@@ -158,6 +169,58 @@ def test_rollout_is_gated_and_campaign_context_is_bounded(tmp_path) -> None:
     assert len(load_starter_casebook()) > len(block["cases"])
 
 
+def test_sensor_research_seed_is_frozen_then_consumed_as_real_parent(
+    tmp_path, monkeypatch
+) -> None:
+    store, job_id = _job(tmp_path, "majors-5m-lab")
+    root = store.job_dir(job_id)
+    source_revision = compute_workspace_revision(root)
+    seed_root = root / "research" / "sensor_candidates" / "regime-break"
+    (seed_root / "workspace/src").mkdir(parents=True)
+    (seed_root / "workspace/src/strategy.py").write_text(
+        "# sensor hypothesis\ndef decide(ctx):\n    return []\n", encoding="utf-8"
+    )
+    (seed_root / "job.yaml").write_bytes((root / "job.yaml").read_bytes())
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.evolution_campaign.validate_execution_job",
+        lambda *args, **kwargs: {"checks": []},
+    )
+
+    seed = submit_research_seed(
+        store,
+        job_id,
+        candidate_root=seed_root,
+        family="regime-break",
+        hypothesis="remove HYPE entries after a structural regime alarm",
+        base_revision=source_revision,
+        evidence_refs=["results/research/regime_health.json"],
+        now=datetime(2026, 8, 25, 11, tzinfo=UTC),
+    )
+    campaign = start_campaign(
+        store,
+        job_id,
+        now=datetime(2026, 8, 25, 12, tzinfo=UTC),
+        force=True,
+    )
+    manifest = json.loads((root / campaign["manifest"]).read_text(encoding="utf-8"))
+    assert manifest["research_seeds"][0]["seed_id"] == seed["seed_id"]
+    assert manifest["research_seeds"][0]["evidence_reset"] is True
+
+    candidate = prepare_candidate(
+        store,
+        job_id,
+        family="regime-break",
+        summary="materialize the sensor seed",
+        now=datetime(2026, 8, 25, 13, tzinfo=UTC),
+    )
+
+    assert candidate["parent_source"] == "research_seed"
+    assert candidate["research_seed_id"] == seed["seed_id"]
+    assert candidate["evidence_reset"] is True
+    seed_state = store.read_json(job_id, "state/evolution_research_seeds.json")
+    assert seed_state["seeds"][0]["status"] == "consumed"
+
+
 def test_campaign_start_defers_while_intervention_worker_is_busy(
     tmp_path, monkeypatch
 ) -> None:
@@ -172,8 +235,20 @@ def test_campaign_start_defers_while_intervention_worker_is_busy(
 
     with pytest.raises(TransientInfrastructureError, match="intervention worker"):
         start_campaign(store, job_id, now=datetime(2026, 8, 25, 19, tzinfo=UTC))
-
     assert campaign_status(store, job_id) == {}
+
+
+def test_only_one_automatic_campaign_owns_a_machine(tmp_path) -> None:
+    store, first = _job(tmp_path, "first-lab")
+    _, second = _job(tmp_path, "second-lab")
+    now = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    start_campaign(store, first, now=now)
+
+    assert campaign_due(store, second, now=now) is False
+    with pytest.raises(TransientInfrastructureError, match="machine evolution"):
+        start_campaign(store, second, now=now)
+    with pytest.raises(TransientInfrastructureError, match="machine evolution"):
+        start_campaign(store, second, now=now, force=True)
 
 
 def test_runner_command_declares_control_and_heavy_resource_tiers() -> None:
@@ -251,6 +326,9 @@ def test_evolution_enabled_intervention_prompt_is_sensor_and_safety_only(
     assert "exact behavior-equivalence maintenance" in prefix
     assert "EVOLUTION SENSOR CONTRACT" in prompt
     assert "Regime alarm triage" in prompt
+    assert "action='risk_block_symbol'" in prompt
+    assert "wake_id=<wake.id>" in prompt
+    assert "action='evolution_submit_seed'" in prompt
     assert "read ALL failed check names" in prompt
     assert "wayfinder job revalidate <job_id> <proposal_id>" in prompt
     assert "open_paper_probation_leg" not in prompt
@@ -1101,7 +1179,7 @@ def test_finalize_enforces_stage_budgets_and_isolates_candidate_failure(
         "wayfinder_paths.jobs.evolution_campaign._isolated_economic_gate", fake_gate
     )
     monkeypatch.setattr(
-        "wayfinder_paths.jobs.paper_experiment.stage_paper_proposal", fake_stage
+        "wayfinder_paths.jobs.probation.stage_evolution_probation", fake_stage
     )
     result = finalize_campaign(store, job_id)
     assert result["status"] == "complete"

--- a/wayfinder_paths/tests/test_jobs_improver_spec.py
+++ b/wayfinder_paths/tests/test_jobs_improver_spec.py
@@ -45,6 +45,7 @@ def test_defaults_match_legacy_literals(tmp_path) -> None:
     assert spec.probation_max_size_fraction == 0.5
     assert abs(sum(spec.island_weights.values()) - 1.0) < 1e-9
     assert 0 < spec.exploration_floor < 1
+    assert spec.evolution["allowed_job_ids"] == ["majors-5m-lab"]
 
 
 def test_file_override_changes_values_and_revision(tmp_path) -> None:

--- a/wayfinder_paths/tests/test_jobs_unified_probation.py
+++ b/wayfinder_paths/tests/test_jobs_unified_probation.py
@@ -17,6 +17,7 @@ from wayfinder_paths.jobs.execution.primitives import (
     RestingOrder,
 )
 from wayfinder_paths.jobs.gating import compute_workspace_revision
+from wayfinder_paths.jobs.halt import clear_halt, read_halt
 from wayfinder_paths.jobs.models import WayfinderJob
 from wayfinder_paths.jobs.probation import (
     ensure_unified_probation,
@@ -26,6 +27,7 @@ from wayfinder_paths.jobs.probation import (
 )
 from wayfinder_paths.jobs.risk_overrides import (
     active_symbol_blocks,
+    enforced_symbol_blocks,
     risk_block_symbol,
     risk_unblock_symbol,
 )
@@ -148,6 +150,64 @@ def test_active_c03_experiment_migrates_without_resetting_clock_or_cursors(
     assert archived["migrated_to_probation"] == trial["trial_id"]
 
 
+def test_legacy_migration_recovers_between_writes_without_duplicate_trial(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job_id = _job(tmp_path)
+    started = datetime(2026, 8, 30, tzinfo=UTC)
+    experiment = {
+        "experiment_id": "paper-ab-crash-test",
+        "status": "active",
+        "started_at": started.isoformat(),
+        "ends_at": (started + timedelta(days=14)).isoformat(),
+        "arms": {
+            "evolution": {
+                "champion": {
+                    "candidate_id": "c03",
+                    "revision": "candidate-revision",
+                    "source": "evolution_campaign",
+                    "bundle": "research/evolution/experiment/test/evolution/c03",
+                    "stream": "results/forward/experiment/evolution/c03",
+                }
+            },
+            "control": {
+                "champion": {
+                    "candidate_id": "incumbent",
+                    "revision": "incumbent-revision",
+                    "source": "incumbent",
+                    "bundle": "research/evolution/experiment/test/control/incumbent",
+                    "stream": "results/forward/experiment/control/incumbent",
+                }
+            },
+        },
+    }
+    store.write_json(job_id, "state/evolution_experiment.json", experiment)
+    original_write = store.write_json
+
+    def fail_legacy_retirement(job: str, relative: str, data: object) -> Path:
+        if relative == "state/evolution_experiment.json":
+            raise OSError("simulated crash after probation write")
+        return original_write(job, relative, data)
+
+    monkeypatch.setattr(store, "write_json", fail_legacy_retirement)
+    with pytest.raises(OSError, match="simulated crash"):
+        ensure_unified_probation(store, job_id, now=started + timedelta(hours=1))
+    assert len(load_probation(store, job_id)["trials"]) == 1
+    assert (
+        store.read_json(job_id, "state/evolution_experiment.json")["status"] == "active"
+    )
+
+    monkeypatch.setattr(store, "write_json", original_write)
+    ensure_unified_probation(store, job_id, now=started + timedelta(hours=2))
+    doc = ensure_unified_probation(store, job_id, now=started + timedelta(hours=3))
+
+    assert len(doc["trials"]) == 1
+    archived = store.read_json(job_id, "state/evolution_experiment.json")
+    assert archived["status"] == "migrated"
+    journal = (store.job_dir(job_id) / "journal.jsonl").read_text(encoding="utf-8")
+    assert journal.count("evolution_experiment_migrated_to_probation") == 1
+
+
 def test_zero_trade_burn_in_advances_to_forward_on_identical_covered_bars(
     tmp_path: Path,
 ) -> None:
@@ -211,6 +271,64 @@ def test_burn_in_uses_the_jobs_declared_bar_interval(tmp_path: Path) -> None:
     assert updated["burn_in"]["bar_interval_seconds"] == 3600
     assert updated["burn_in"]["coverage"] == 1.0
     assert updated["status"] == "active"
+
+
+def test_burn_in_kills_candidate_execution_error_immediately(tmp_path: Path) -> None:
+    store, job_id = _job(tmp_path)
+    candidate, revision = _candidate(store, job_id, "error")
+    started = datetime(2026, 8, 1, tzinfo=UTC)
+    stage_evolution_probation(
+        store,
+        job_id,
+        candidate_id="error-candidate",
+        candidate_root=candidate,
+        revision=revision,
+        source="evolution_campaign",
+        family="error-family",
+        now=started,
+    )
+    doc = load_probation(store, job_id)
+    doc["trials"][0]["candidate"]["error_count"] = 1
+    store.write_json(job_id, "probation.json", doc)
+
+    outcomes = maybe_adjudicate_probation(
+        store, job_id, now=started + timedelta(minutes=5)
+    )
+
+    updated = load_probation(store, job_id)["trials"][0]
+    assert updated["status"] == "killed"
+    assert updated["verdict_reason"] == "candidate execution error"
+    assert outcomes[0]["action"] == "probation_killed"
+
+
+def test_burn_in_kills_hard_drawdown_breach_immediately(tmp_path: Path) -> None:
+    store, job_id = _job(tmp_path)
+    candidate, revision = _candidate(store, job_id, "breach")
+    started = datetime(2026, 8, 1, tzinfo=UTC)
+    stage_evolution_probation(
+        store,
+        job_id,
+        candidate_id="breach-candidate",
+        candidate_root=candidate,
+        revision=revision,
+        source="evolution_campaign",
+        family="breach-family",
+        now=started,
+    )
+    trial = load_probation(store, job_id)["trials"][0]
+    stream = store.job_dir(job_id) / trial["candidate"]["stream"]
+    stream.mkdir(parents=True, exist_ok=True)
+    _write_trade(stream, started + timedelta(minutes=5), -3_000.0)
+
+    outcomes = maybe_adjudicate_probation(
+        store, job_id, now=started + timedelta(minutes=10)
+    )
+
+    updated = load_probation(store, job_id)["trials"][0]
+    assert updated["status"] == "killed"
+    assert updated["verdict_reason"] == "hard safety breach"
+    assert updated["burn_in"]["hard_constraint_breach"] is True
+    assert outcomes[0]["action"] == "probation_killed"
 
 
 def test_forward_verdicts_only_peek_at_preregistered_day_7_and_14(
@@ -324,6 +442,50 @@ def test_positive_paired_forward_lcb_graduates_to_owner_only_proposal(
     assert any(row["action"] == "probation_promotion_proposed" for row in outcomes)
 
 
+def test_negative_paired_forward_ucb_kills_at_day_seven(tmp_path: Path) -> None:
+    store, job_id = _job(tmp_path)
+    candidate, revision = _candidate(store, job_id, "negative")
+    started = datetime(2026, 8, 1, tzinfo=UTC)
+    stage_evolution_probation(
+        store,
+        job_id,
+        candidate_id="negative-candidate",
+        candidate_root=candidate,
+        revision=revision,
+        source="evolution_campaign",
+        family="negative-family",
+        now=started,
+    )
+    doc = load_probation(store, job_id)
+    trial = doc["trials"][0]
+    trial["status"] = "active"
+    trial["phase"] = "forward"
+    trial["burn_in"]["status"] = "passed"
+    trial["forward"]["started_at"] = started.isoformat()
+    trial["forward"]["deadline_at"] = (started + timedelta(days=14)).isoformat()
+    for role in ("candidate", "reference"):
+        trial[role]["stream"] = (
+            f"results/forward/probation/{trial['trial_id']}/forward/{role}"
+        )
+        stream = store.job_dir(job_id) / trial[role]["stream"]
+        stamps = [started + timedelta(days=offset) for offset in range(8)]
+        _write_ticks(stream, stamps)
+        if role == "candidate":
+            for stamp in stamps:
+                _write_trade(stream, stamp, -10.0)
+    store.write_json(job_id, "probation.json", doc)
+
+    outcomes = maybe_adjudicate_probation(
+        store, job_id, now=started + timedelta(days=8)
+    )
+
+    updated = load_probation(store, job_id)["trials"][0]
+    assert updated["status"] == "killed"
+    assert updated["verdict_reason"] == "paired utility UCB < 0"
+    assert updated["forward"]["metrics"]["ucb"] < 0
+    assert outcomes[0]["action"] == "probation_killed"
+
+
 def test_probation_capacity_is_three_active_and_three_queued(tmp_path: Path) -> None:
     store, job_id = _job(tmp_path)
     statuses = []
@@ -381,7 +543,7 @@ async def test_symbol_block_removes_entries_but_preserves_reduce_only(
         symbol="HYPE",
         side="short",
         size=1.0,
-        reduce_only=True,
+        reduce_only=False,
     )
     state = EngineState(
         pending_intents=[entry, exit_intent],
@@ -427,6 +589,28 @@ async def test_symbol_block_removes_entries_but_preserves_reduce_only(
         store, job_id, symbol="HYPE", by="owner", reason="owner reviewed"
     )
     assert cleared["status"] == "cleared"
+
+
+def test_unreadable_symbol_overrides_fail_closed_and_latch_once(tmp_path: Path) -> None:
+    store, job_id = _job(tmp_path)
+    path = store.job_dir(job_id) / "state/risk_overrides.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not json", encoding="utf-8")
+
+    first = enforced_symbol_blocks(store, job_id)
+    second = enforced_symbol_blocks(store, job_id)
+
+    assert set(first) == {"BTC", "HYPE"}
+    assert second == first
+    halt = read_halt(store.job_dir(job_id))
+    assert halt is not None
+    assert halt["source"] == "symbol_risk_override"
+    with pytest.raises(PermissionError):
+        clear_halt(store, job_id, by="agent")
+    with pytest.raises(ValueError, match="owner repair"):
+        risk_unblock_symbol(store, job_id, symbol="HYPE", by="owner")
+    journal = (store.job_dir(job_id) / "journal.jsonl").read_text(encoding="utf-8")
+    assert journal.count("risk_overrides_unreadable") == 1
 
 
 @pytest.mark.asyncio

--- a/wayfinder_paths/tests/test_jobs_unified_probation.py
+++ b/wayfinder_paths/tests/test_jobs_unified_probation.py
@@ -1,0 +1,477 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from wayfinder_paths.jobs.candidate_shadow import _target_shadow_state_root
+from wayfinder_paths.jobs.execution.driver import _apply_symbol_entry_blocks
+from wayfinder_paths.jobs.execution.engine import EngineState
+from wayfinder_paths.jobs.execution.primitives import (
+    FillEvent,
+    OrderIntent,
+    RestingOrder,
+)
+from wayfinder_paths.jobs.gating import compute_workspace_revision
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.probation import (
+    ensure_unified_probation,
+    load_probation,
+    maybe_adjudicate_probation,
+    stage_evolution_probation,
+)
+from wayfinder_paths.jobs.risk_overrides import (
+    active_symbol_blocks,
+    risk_block_symbol,
+    risk_unblock_symbol,
+)
+from wayfinder_paths.jobs.store import JobStore
+
+
+def _job(tmp_path: Path) -> tuple[JobStore, str]:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        "majors-5m-lab",
+        script="workspace/src/strategy.py",
+        agent_mode="intervene",
+        execution_contract="jobs_v1",
+    )
+    job.execution_params = {"symbols": ["BTC", "HYPE"], "venue": "hyperliquid"}
+    store.save(job)
+    script = store.job_dir(job.id) / "workspace/src/strategy.py"
+    script.parent.mkdir(parents=True, exist_ok=True)
+    script.write_text("def decide(ctx):\n    return []\n", encoding="utf-8")
+    return store, job.id
+
+
+def _candidate(store: JobStore, job_id: str, name: str) -> tuple[Path, str]:
+    root = store.job_dir(job_id)
+    candidate = root / "research" / "candidates" / name
+    (candidate / "workspace/src").mkdir(parents=True)
+    (candidate / "workspace/src/strategy.py").write_text(
+        f"# {name}\ndef decide(ctx):\n    return []\n", encoding="utf-8"
+    )
+    (candidate / "job.yaml").write_bytes((root / "job.yaml").read_bytes())
+    return candidate, compute_workspace_revision(candidate)
+
+
+def _write_ticks(path: Path, stamps: list[datetime]) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "ticks.jsonl").write_text(
+        "".join(json.dumps({"bar_ts": stamp.isoformat()}) + "\n" for stamp in stamps),
+        encoding="utf-8",
+    )
+
+
+def _write_trade(path: Path, stamp: datetime, pnl: float) -> None:
+    with (path / "trades.jsonl").open("a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps({"timestamp": stamp.isoformat(), "net_pnl": pnl}) + "\n"
+        )
+
+
+def test_active_c03_experiment_migrates_without_resetting_clock_or_cursors(
+    tmp_path: Path,
+) -> None:
+    store, job_id = _job(tmp_path)
+    started = datetime(2026, 8, 30, 23, 20, tzinfo=UTC)
+    ends = datetime(2026, 9, 13, 23, 20, tzinfo=UTC)
+    candidate_cursor = datetime(2026, 8, 31, 4, tzinfo=UTC).isoformat()
+    reference_cursor = datetime(2026, 8, 31, 3, 55, tzinfo=UTC).isoformat()
+    experiment = {
+        "experiment_id": "paper-ab-20260830T232000Z",
+        "status": "active",
+        "started_at": started.isoformat(),
+        "ends_at": ends.isoformat(),
+        "confidence": 0.9,
+        "protocol": {"paper_only": True},
+        "arms": {
+            "evolution": {
+                "last_processed_bar": candidate_cursor,
+                "champion": {
+                    "candidate_id": "20260828T160925Z-bbd5e625-c03-30411dca",
+                    "revision": "649eb244b94f",
+                    "source": "evolution_campaign",
+                    "admitted_at": started.isoformat(),
+                    "bundle": (
+                        "research/evolution/experiment/paper-ab-20260830T232000Z/"
+                        "evolution/649eb244b94f"
+                    ),
+                    "stream": ("results/forward/experiment/evolution/649eb244b94f-a1"),
+                },
+            },
+            "control": {
+                "last_processed_bar": reference_cursor,
+                "champion": {
+                    "candidate_id": "incumbent-bbd5e62584fe",
+                    "revision": "bbd5e62584fe",
+                    "source": "incumbent",
+                    "bundle": (
+                        "research/evolution/experiment/paper-ab-20260830T232000Z/"
+                        "control/bbd5e62584fe"
+                    ),
+                    "stream": ("results/forward/experiment/control/bbd5e62584fe-a1"),
+                },
+            },
+        },
+    }
+    store.write_json(job_id, "state/evolution_experiment.json", experiment)
+
+    doc = ensure_unified_probation(
+        store, job_id, now=datetime(2026, 8, 31, 5, tzinfo=UTC)
+    )
+
+    assert len(doc["trials"]) == 1
+    trial = doc["trials"][0]
+    assert trial["candidate_id"] == "20260828T160925Z-bbd5e625-c03-30411dca"
+    assert trial["status"] == "active"
+    assert trial["phase"] == "forward"
+    assert trial["forward"]["started_at"] == started.isoformat()
+    assert trial["forward"]["deadline_at"] == ends.isoformat()
+    assert trial["candidate"]["last_processed_bar"] == candidate_cursor
+    assert trial["reference"]["last_processed_bar"] == reference_cursor
+    root = store.job_dir(job_id)
+    assert (
+        _target_shadow_state_root(root, trial["candidate"])
+        == (root / "state/evolution_shadows/evolution/champion/649eb244b94f").resolve()
+    )
+    assert (
+        _target_shadow_state_root(root, trial["reference"])
+        == (root / "state/evolution_shadows/control/champion/bbd5e62584fe").resolve()
+    )
+    archived = store.read_json(job_id, "state/evolution_experiment.json")
+    assert archived["status"] == "migrated"
+    assert archived["migrated_to_probation"] == trial["trial_id"]
+
+
+def test_zero_trade_burn_in_advances_to_forward_on_identical_covered_bars(
+    tmp_path: Path,
+) -> None:
+    store, job_id = _job(tmp_path)
+    candidate, revision = _candidate(store, job_id, "zero-trade")
+    started = datetime(2026, 8, 1, tzinfo=UTC)
+    staged = stage_evolution_probation(
+        store,
+        job_id,
+        candidate_id="c03",
+        candidate_root=candidate,
+        revision=revision,
+        source="evolution_campaign",
+        family="compression",
+        now=started,
+    )
+    stamps = [started + timedelta(minutes=5 * offset) for offset in range(289)]
+    trial = load_probation(store, job_id)["trials"][0]
+    for role in ("candidate", "reference"):
+        _write_ticks(store.job_dir(job_id) / trial[role]["stream"], stamps)
+
+    outcomes = maybe_adjudicate_probation(
+        store, job_id, now=started + timedelta(hours=24)
+    )
+
+    updated = load_probation(store, job_id)["trials"][0]
+    assert staged["status"] == "burn_in"
+    assert updated["status"] == "active"
+    assert updated["phase"] == "forward"
+    assert updated["burn_in"]["coverage"] == 1.0
+    assert outcomes == [
+        {"action": "probation_forward_started", "trial_id": updated["trial_id"]}
+    ]
+
+
+def test_burn_in_uses_the_jobs_declared_bar_interval(tmp_path: Path) -> None:
+    store, job_id = _job(tmp_path)
+    job = store.load(job_id)
+    job.execution_spec = {"data_contract": {"bar_interval": "1h"}}
+    store.save(job)
+    candidate, revision = _candidate(store, job_id, "hourly")
+    started = datetime(2026, 8, 1, tzinfo=UTC)
+    stage_evolution_probation(
+        store,
+        job_id,
+        candidate_id="hourly-candidate",
+        candidate_root=candidate,
+        revision=revision,
+        source="evolution_campaign",
+        family="hourly-breakout",
+        now=started,
+    )
+    trial = load_probation(store, job_id)["trials"][0]
+    stamps = [started + timedelta(hours=offset) for offset in range(25)]
+    for role in ("candidate", "reference"):
+        _write_ticks(store.job_dir(job_id) / trial[role]["stream"], stamps)
+
+    maybe_adjudicate_probation(store, job_id, now=started + timedelta(hours=24))
+
+    updated = load_probation(store, job_id)["trials"][0]
+    assert updated["burn_in"]["bar_interval_seconds"] == 3600
+    assert updated["burn_in"]["coverage"] == 1.0
+    assert updated["status"] == "active"
+
+
+def test_forward_verdicts_only_peek_at_preregistered_day_7_and_14(
+    tmp_path: Path,
+) -> None:
+    store, job_id = _job(tmp_path)
+    candidate, revision = _candidate(store, job_id, "checkpoints")
+    started = datetime(2026, 8, 1, tzinfo=UTC)
+    stage_evolution_probation(
+        store,
+        job_id,
+        candidate_id="checkpoint-candidate",
+        candidate_root=candidate,
+        revision=revision,
+        source="evolution_campaign",
+        family="checkpoint-family",
+        now=started,
+    )
+    doc = load_probation(store, job_id)
+    trial = doc["trials"][0]
+    trial["status"] = "active"
+    trial["phase"] = "forward"
+    trial["burn_in"]["status"] = "passed"
+    trial["forward"]["started_at"] = started.isoformat()
+    trial["forward"]["deadline_at"] = (started + timedelta(days=14)).isoformat()
+    for role in ("candidate", "reference"):
+        trial[role]["stream"] = (
+            f"results/forward/probation/{trial['trial_id']}/forward/{role}"
+        )
+    store.write_json(job_id, "probation.json", doc)
+
+    for count, current in ((8, 8), (9, 9), (14, 14)):
+        stamps = [started + timedelta(days=offset) for offset in range(count)]
+        for role in ("candidate", "reference"):
+            _write_ticks(store.job_dir(job_id) / trial[role]["stream"], stamps)
+        outcomes = maybe_adjudicate_probation(
+            store, job_id, now=started + timedelta(days=current)
+        )
+        if current == 8:
+            assert [row["action"] for row in outcomes] == [
+                "probation_checkpoint_inconclusive"
+            ]
+            assert (
+                load_probation(store, job_id)["trials"][0]["forward"][
+                    "last_decision_day"
+                ]
+                == 7
+            )
+        elif current == 9:
+            assert outcomes == []
+
+    updated = load_probation(store, job_id)["trials"][0]
+    assert updated["status"] == "inconclusive"
+    assert updated["verdict_reason"] == "14-day endpoint inconclusive"
+
+
+def test_positive_paired_forward_lcb_graduates_to_owner_only_proposal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, job_id = _job(tmp_path)
+    candidate, revision = _candidate(store, job_id, "positive")
+    started = datetime(2026, 8, 1, tzinfo=UTC)
+    stage_evolution_probation(
+        store,
+        job_id,
+        candidate_id="positive-candidate",
+        candidate_root=candidate,
+        revision=revision,
+        source="evolution_campaign",
+        family="breakout",
+        now=started,
+    )
+    doc = load_probation(store, job_id)
+    trial = doc["trials"][0]
+    trial["status"] = "active"
+    trial["phase"] = "forward"
+    trial["burn_in"]["status"] = "passed"
+    trial["forward"]["started_at"] = started.isoformat()
+    trial["forward"]["deadline_at"] = (started + timedelta(days=14)).isoformat()
+    for role in ("candidate", "reference"):
+        trial[role]["stream"] = (
+            f"results/forward/probation/{trial['trial_id']}/forward/{role}"
+        )
+    store.write_json(job_id, "probation.json", doc)
+    stamps = [started + timedelta(days=offset) for offset in range(8)]
+    for role in ("candidate", "reference"):
+        stream = store.job_dir(job_id) / trial[role]["stream"]
+        _write_ticks(stream, stamps)
+        if role == "candidate":
+            for stamp in stamps:
+                _write_trade(stream, stamp, 10.0)
+
+    captured: dict = {}
+
+    def fake_propose(*args, **kwargs):
+        captured.update(kwargs)
+        return {"proposal_id": kwargs["proposal_id"]}
+
+    monkeypatch.setattr("wayfinder_paths.jobs.proposals.propose_change", fake_propose)
+
+    outcomes = maybe_adjudicate_probation(
+        store, job_id, now=started + timedelta(days=8)
+    )
+
+    updated = load_probation(store, job_id)["trials"][0]
+    assert updated["status"] == "graduated"
+    assert updated["forward"]["metrics"]["paired_days"] >= 7
+    assert updated["forward"]["metrics"]["lcb"] > 0
+    assert updated["promotion"]["status"] == "owner_review"
+    assert captured["allow_auto_apply"] is False
+    assert any(row["action"] == "probation_promotion_proposed" for row in outcomes)
+
+
+def test_probation_capacity_is_three_active_and_three_queued(tmp_path: Path) -> None:
+    store, job_id = _job(tmp_path)
+    statuses = []
+    for index in range(7):
+        candidate, revision = _candidate(store, job_id, f"capacity-{index}")
+        statuses.append(
+            stage_evolution_probation(
+                store,
+                job_id,
+                candidate_id=f"candidate-{index}",
+                candidate_root=candidate,
+                revision=revision,
+                source="evolution_campaign",
+                family=f"family-{index}",
+                now=datetime(2026, 8, 1, tzinfo=UTC),
+            )["status"]
+        )
+
+    assert statuses == ["burn_in"] * 3 + ["queued"] * 3 + ["deferred"]
+
+
+@pytest.mark.asyncio
+async def test_symbol_block_removes_entries_but_preserves_reduce_only(
+    tmp_path: Path,
+) -> None:
+    store, job_id = _job(tmp_path)
+    evidence = store.job_dir(job_id) / "results/research/regime_break.json"
+    evidence.parent.mkdir(parents=True, exist_ok=True)
+    evidence.write_text('{"regime":"break"}\n', encoding="utf-8")
+    now = datetime.now(UTC)
+    os.utime(evidence, (now.timestamp(), now.timestamp()))
+
+    block = risk_block_symbol(
+        store,
+        job_id,
+        symbol="HYPE",
+        reason="deterministic regime break",
+        evidence_refs=["results/research/regime_break.json"],
+        wake_id="wake-1",
+        now=now,
+    )
+    with pytest.raises(ValueError, match="only the owner"):
+        risk_unblock_symbol(store, job_id, symbol="HYPE", by="sensor")
+
+    entry = OrderIntent(
+        action="OPEN",
+        venue="hyperliquid",
+        symbol="HYPE",
+        side="long",
+        size=1.0,
+    )
+    exit_intent = OrderIntent(
+        action="CLOSE",
+        venue="hyperliquid",
+        symbol="HYPE",
+        side="short",
+        size=1.0,
+        reduce_only=True,
+    )
+    state = EngineState(
+        pending_intents=[entry, exit_intent],
+        resting_orders={
+            "entry-order": RestingOrder(entry, now.isoformat()),
+            "exit-order": RestingOrder(exit_intent, now.isoformat()),
+        },
+        mode="live",
+    )
+
+    class Broker:
+        canceled: list[str] = []
+
+        async def cancel_resting_order(self, order: RestingOrder):
+            client_order_id = str(order.intent.client_order_id or "entry-order")
+            self.canceled.append(client_order_id)
+            return FillEvent(
+                status="filled",
+                venue="hyperliquid",
+                symbol=order.intent.symbol,
+                side=order.intent.side,
+                client_order_id=client_order_id,
+            )
+
+    broker = Broker()
+    events = await _apply_symbol_entry_blocks(
+        state=state,
+        brokers={"hyperliquid": broker},
+        blocked_symbols={"HYPE"},
+        now=pd.Timestamp(now),
+    )
+
+    assert block["status"] == "blocked"
+    assert set(active_symbol_blocks(store, job_id)) == {"HYPE"}
+    assert state.pending_intents == [exit_intent]
+    assert set(state.resting_orders) == {"exit-order"}
+    assert broker.canceled == ["entry-order"]
+    assert {row["kind"] for row in events} == {
+        "pending_entry_canceled_by_symbol_block",
+        "resting_entry_canceled_by_symbol_block",
+    }
+    cleared = risk_unblock_symbol(
+        store, job_id, symbol="HYPE", by="owner", reason="owner reviewed"
+    )
+    assert cleared["status"] == "cleared"
+
+
+@pytest.mark.asyncio
+async def test_live_symbol_block_preserves_unconfirmed_resting_entry() -> None:
+    now = pd.Timestamp("2026-08-30T12:00:00Z")
+    entry = OrderIntent(
+        action="OPEN",
+        venue="hyperliquid",
+        symbol="HYPE",
+        side="long",
+        size=1.0,
+        client_order_id="entry-order",
+    )
+    state = EngineState(
+        resting_orders={
+            "entry-order": RestingOrder(entry, now.isoformat(), order_id="42")
+        },
+        mode="live",
+    )
+
+    class Broker:
+        async def cancel_resting_order(self, order: RestingOrder) -> FillEvent:
+            return FillEvent(
+                status="ambiguous",
+                venue="hyperliquid",
+                symbol=order.intent.symbol,
+                side=order.intent.side,
+                client_order_id=order.intent.client_order_id,
+                error="venue timeout",
+            )
+
+    events = await _apply_symbol_entry_blocks(
+        state=state,
+        brokers={"hyperliquid": Broker()},
+        blocked_symbols={"HYPE"},
+        now=now,
+    )
+
+    assert set(state.resting_orders) == {"entry-order"}
+    assert events == [
+        {
+            "kind": "resting_entry_cancel_failed_by_symbol_block",
+            "symbol": "HYPE",
+            "client_order_id": "entry-order",
+            "timestamp": now.isoformat(),
+            "cancel_error": "venue timeout",
+        }
+    ]


### PR DESCRIPTION
## Summary
- make evolution the fleet candidate factory while intervention becomes the deterministic sensor and falsification lane
- replace the temporary paper experiment with immutable 24h burn-in and paired 7/14-day probation, preserving the active c03 test in place
- enforce one campaign per box and a shared 20% compute budget with a 25% finalize/staging completion reserve
- add executable research seeds, permanent parentage, owner-only promotion proposals, and visible funnel/activity receipts
- add evidence-backed per-symbol entry blocks that preserve reduce-only exits and confirm live resting-order cancellation

## Safety
- probation never auto-applies; graduation creates an owner-review proposal
- only the owner can re-arm a blocked symbol
- forced starts cannot bypass the machine campaign slot
- live cancel ambiguity preserves local order state and halts the job

## Validation
- 335 focused integration tests passed
- 132 post-quality-pass evolution/probation tests passed
- full suite: 3181 passed, 10 skipped; remaining failures are pre-existing unauthenticated live-token tests, the sports step-count assertion, and an unrelated eval fixture missing close-time metadata
- Ruff, compileall, and isolated mypy checks passed