### PR TITLE
Sync fail-closed risk override state

### DIFF
--- a/wayfinder_paths/jobs/risk_overrides.py
+++ b/wayfinder_paths/jobs/risk_overrides.py
@@ -54,6 +54,20 @@ def active_symbol_blocks(store: JobStore, job_id: str) -> dict[str, dict[str, An
     return _active_blocks_from_doc(doc)
 
 
+def risk_overrides_snapshot(store: JobStore, job_id: str) -> dict[str, Any]:
+    """Return the same fail-closed override state enforced by execution."""
+    doc = load_risk_overrides(store, job_id)
+    if not doc.get(_UNREADABLE_KEY):
+        return doc
+    reason = str(doc.get("reason") or "unreadable risk override file")
+    return {
+        "schema_version": "1.0",
+        "symbols": _fail_closed_blocks(store, job_id, reason=reason),
+        "unreadable": True,
+        "reason": reason,
+    }
+
+
 def enforced_symbol_blocks(store: JobStore, job_id: str) -> dict[str, dict[str, Any]]:
     """Resolve blocks for execution and latch unreadable state as a halt."""
     doc = load_risk_overrides(store, job_id)

--- a/wayfinder_paths/jobs/sync.py
+++ b/wayfinder_paths/jobs/sync.py
@@ -225,7 +225,10 @@ def snapshot_job(job_id: str, *, store: JobStore | None = None) -> dict[str, Any
         "agent_mode_source": "job_yaml",
     }
     from wayfinder_paths.jobs.compute_lock import evolution_compute_budget_status
-    from wayfinder_paths.jobs.risk_overrides import active_symbol_blocks
+    from wayfinder_paths.jobs.risk_overrides import (
+        active_symbol_blocks,
+        risk_overrides_snapshot,
+    )
 
     scorecard["evolution_compute"] = evolution_compute_budget_status(store.repo_root)
     blocks = active_symbol_blocks(store, job_id)
@@ -263,9 +266,7 @@ def snapshot_job(job_id: str, *, store: JobStore | None = None) -> dict[str, Any
         "runner_links": runner_links,
         "proposals": store.proposals(job_id),
         "probation": store.read_json(job_id, "probation.json", default={"legs": []}),
-        "risk_overrides": store.read_json(
-            job_id, "state/risk_overrides.json", default={"symbols": {}}
-        ),
+        "risk_overrides": risk_overrides_snapshot(store, job_id),
         "post_apply_shadow": _shadow_topline(store, job_id),
         "regime_health": regime_health,
         "decision_log": _decision_log(store, job_id),

--- a/wayfinder_paths/tests/test_jobs_unified_probation.py
+++ b/wayfinder_paths/tests/test_jobs_unified_probation.py
@@ -32,6 +32,7 @@ from wayfinder_paths.jobs.risk_overrides import (
     risk_unblock_symbol,
 )
 from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.jobs.sync import snapshot_job
 
 
 def _job(tmp_path: Path) -> tuple[JobStore, str]:
@@ -611,6 +612,23 @@ def test_unreadable_symbol_overrides_fail_closed_and_latch_once(tmp_path: Path) 
         risk_unblock_symbol(store, job_id, symbol="HYPE", by="owner")
     journal = (store.job_dir(job_id) / "journal.jsonl").read_text(encoding="utf-8")
     assert journal.count("risk_overrides_unreadable") == 1
+
+
+def test_unreadable_symbol_overrides_sync_as_fail_closed(tmp_path: Path) -> None:
+    store, job_id = _job(tmp_path)
+    path = store.job_dir(job_id) / "state/risk_overrides.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not json", encoding="utf-8")
+
+    snapshot = snapshot_job(job_id, store=store)["risk_overrides"]
+
+    assert snapshot["unreadable"] is True
+    assert "JSONDecodeError" in snapshot["reason"]
+    assert set(snapshot["symbols"]) == {"BTC", "HYPE"}
+    assert all(
+        block["status"] == "blocked" and block["blocked_by"] == "fail_closed"
+        for block in snapshot["symbols"].values()
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- make job snapshots use the same risk-override loader as execution
- synthesize blocked entries for every configured symbol when override state is unreadable
- expose an explicit unreadable marker and repair reason for authenticated reporting
- prevent the frontend from showing no blocks while execution is fail-closed

Follow-up to #758; frontend reporting is in WayfinderFoundation/vault-frontend#2193.

## Validation
- `pytest wayfinder_paths/tests/test_jobs_unified_probation.py -q --no-cov` (14 passed)
- focused Ruff checks passed
- diff whitespace check passed