### PR TITLE
Paths - SDK Runtime Reliability

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -220,7 +220,7 @@ version = "0.7.0"
 description = "Reusable constraint types to use with typing.Annotated"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
     {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
@@ -232,7 +232,7 @@ version = "4.13.0"
 description = "High-level concurrency and networking framework on top of asyncio or Trio"
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708"},
     {file = "anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc"},
@@ -251,7 +251,7 @@ version = "26.1.0"
 description = "Classes Without Boilerplate"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309"},
     {file = "attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32"},
@@ -528,7 +528,7 @@ files = [
     {file = "cffi-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9"},
     {file = "cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"},
 ]
-markers = {dev = "platform_python_implementation != \"PyPy\""}
+markers = {dev = "platform_machine != \"ppc64le\" and platform_machine != \"s390x\" and sys_platform == \"linux\" and platform_python_implementation != \"PyPy\""}
 
 [package.dependencies]
 pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
@@ -1152,6 +1152,7 @@ files = [
     {file = "cryptography-46.0.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:8456928655f856c6e1533ff59d5be76578a7157224dbd9ce6872f25055ab9ab7"},
     {file = "cryptography-46.0.5.tar.gz", hash = "sha256:abace499247268e3757271b2f1e244b36b06f8515cf27c4d49468fc9eb16e93d"},
 ]
+markers = {dev = "platform_machine != \"ppc64le\" and platform_machine != \"s390x\" and sys_platform == \"linux\""}
 
 [package.dependencies]
 cffi = {version = ">=2.0.0", markers = "python_full_version >= \"3.9.0\" and platform_python_implementation != \"PyPy\""}
@@ -1824,7 +1825,7 @@ version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
     {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
@@ -1881,7 +1882,7 @@ version = "1.0.9"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
     {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
@@ -1925,7 +1926,7 @@ version = "0.28.1"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
     {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
@@ -1951,7 +1952,7 @@ version = "0.4.3"
 description = "Consume Server-Sent Event (SSE) messages with HTTPX."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc"},
     {file = "httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d"},
@@ -2181,7 +2182,7 @@ version = "4.26.0"
 description = "An implementation of JSON Schema validation for Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce"},
     {file = "jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326"},
@@ -2203,7 +2204,7 @@ version = "2025.9.1"
 description = "The JSON Schema meta-schemas and vocabularies, exposed as a Registry"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe"},
     {file = "jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d"},
@@ -2714,7 +2715,7 @@ version = "1.26.0"
 description = "Model Context Protocol SDK"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca"},
     {file = "mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66"},
@@ -3741,7 +3742,7 @@ files = [
     {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
     {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
 ]
-markers = {main = "implementation_name != \"PyPy\"", dev = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""}
+markers = {main = "implementation_name != \"PyPy\"", dev = "platform_machine != \"ppc64le\" and platform_machine != \"s390x\" and sys_platform == \"linux\" and platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""}
 
 [[package]]
 name = "pycryptodome"
@@ -3800,7 +3801,7 @@ version = "2.13.4"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba"},
     {file = "pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6"},
@@ -3822,7 +3823,7 @@ version = "2.46.4"
 description = "Core functionality for Pydantic validation and serialization"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "pydantic_core-2.46.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a396dcc17e5a0b164dbe026896245a4fa9ff402edca1dff0be3d53a517f74de4"},
     {file = "pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da4b951fe36dc7c3a1ccb4e3cd1747c3542b8c9ceede8fc86cae054e764485f5"},
@@ -3955,7 +3956,7 @@ version = "2.13.1"
 description = "Settings management using Pydantic"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237"},
     {file = "pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025"},
@@ -3994,7 +3995,7 @@ version = "2.12.1"
 description = "JSON Web Token implementation in Python"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c"},
     {file = "pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b"},
@@ -4198,7 +4199,7 @@ version = "1.2.2"
 description = "Read key-value pairs from a .env file and set them as environment variables"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a"},
     {file = "python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3"},
@@ -4213,7 +4214,7 @@ version = "0.0.22"
 description = "A streaming multipart parser for Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155"},
     {file = "python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58"},
@@ -4249,7 +4250,8 @@ version = "311"
 description = "Python for Window Extensions"
 optional = false
 python-versions = "*"
-groups = ["main", "dev"]
+groups = ["main"]
+markers = "platform_system == \"Windows\" or sys_platform == \"win32\""
 files = [
     {file = "pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3"},
     {file = "pywin32-311-cp310-cp310-win_amd64.whl", hash = "sha256:797c2772017851984b97180b0bebe4b620bb86328e8a884bb626156295a63b3b"},
@@ -4272,7 +4274,6 @@ files = [
     {file = "pywin32-311-cp39-cp39-win_amd64.whl", hash = "sha256:e0c4cfb0621281fe40387df582097fd796e80430597cb9944f0ae70447bacd91"},
     {file = "pywin32-311-cp39-cp39-win_arm64.whl", hash = "sha256:62ea666235135fee79bb154e695f3ff67370afefd71bd7fea7512fc70ef31e3d"},
 ]
-markers = {main = "platform_system == \"Windows\"", dev = "sys_platform == \"win32\""}
 
 [[package]]
 name = "pywin32-ctypes"
@@ -4396,7 +4397,7 @@ version = "0.37.0"
 description = "JSON Referencing + Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231"},
     {file = "referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8"},
@@ -4630,7 +4631,7 @@ version = "0.30.0"
 description = "Python bindings to Rust's persistent data structures (rpds)"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "rpds_py-0.30.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288"},
     {file = "rpds_py-0.30.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00"},
@@ -4920,7 +4921,7 @@ version = "3.3.3"
 description = "SSE plugin for Starlette"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "sse_starlette-3.3.3-py3-none-any.whl", hash = "sha256:c5abb5082a1cc1c6294d89c5290c46b5f67808cfdb612b7ec27e8ba061c22e8d"},
     {file = "sse_starlette-3.3.3.tar.gz", hash = "sha256:72a95d7575fd5129bd0ae15275ac6432bb35ac542fdebb82889c24bb9f3f4049"},
@@ -4942,7 +4943,7 @@ version = "1.0.0"
 description = "The little ASGI library that shines."
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b"},
     {file = "starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149"},
@@ -5051,7 +5052,7 @@ version = "0.4.2"
 description = "Runtime typing introspection tools"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7"},
     {file = "typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464"},
@@ -5096,7 +5097,7 @@ version = "0.42.0"
 description = "The lightning-fast ASGI server."
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main"]
 markers = "sys_platform != \"emscripten\""
 files = [
     {file = "uvicorn-0.42.0-py3-none-any.whl", hash = "sha256:96c30f5c7abe6f74ae8900a70e92b85ad6613b745d4879eb9b16ccad15645359"},
@@ -5414,4 +5415,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "404973b525727ff449fe3dd73bbbaf45181cfe31a531ea0b58b0b86b8a53a045"
+content-hash = "99f3e600206c123b4d25ec3a6542b8dbf104a23975f635459441219c4fa71dd8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ py-order-utils = "0.3.2"
 packaging = "^25.0"
 py-clob-client-v2-felix = "1.0.2"
 croniter = "^6.0.0"
+mcp = "^1.10.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.4.2"
@@ -47,7 +48,6 @@ ruff = "^0.13.2"
 bandit = "^1.7.5"
 safety = "^2.3.5"
 twine = "^6.2.0"
-mcp = "^1.10.1"
 vulture = "^2.14"
 mypy = "^1.19.1"
 

--- a/wayfinder_paths/conftest.py
+++ b/wayfinder_paths/conftest.py
@@ -3,11 +3,29 @@ from pathlib import Path
 
 import pytest
 
+from wayfinder_paths.paths.runtime_registry import (
+    PublishedPackage,
+    installed_runtime_package_version,
+)
+
 pytest_plugins = ["wayfinder_paths.testing.gorlami"]
 
 # Add repo root to path so tests.test_utils can be imported
 _repo_root = Path(__file__).parent.parent
 _repo_root_str = str(_repo_root)
+
+
+@pytest.fixture
+def published_installed_runtime(monkeypatch) -> None:
+    """Treat the checked-out SDK as published in tests of unrelated path flows."""
+    version = installed_runtime_package_version()
+    monkeypatch.setattr(
+        "wayfinder_paths.paths.doctor.published_package",
+        lambda package: PublishedPackage(
+            latest=version,
+            versions=frozenset({version}),
+        ),
+    )
 
 
 def pytest_configure(config):

--- a/wayfinder_paths/core/clients/GorlamiTestnetClient.py
+++ b/wayfinder_paths/core/clients/GorlamiTestnetClient.py
@@ -160,4 +160,4 @@ class GorlamiTestnetClient(WayfinderClient):
         return True
 
     async def close(self) -> None:
-        await self.client.aclose()
+        await self.aclose()

--- a/wayfinder_paths/core/clients/MerklClient.py
+++ b/wayfinder_paths/core/clients/MerklClient.py
@@ -4,15 +4,19 @@ from typing import Any
 
 import httpx
 
+from wayfinder_paths.core.clients.WayfinderClient import AsyncClientOwner
 from wayfinder_paths.core.constants.base import DEFAULT_HTTP_TIMEOUT
 
 MERKL_API_BASE_URL = "https://api.merkl.xyz"
 
 
-class MerklClient:
+class MerklClient(AsyncClientOwner):
     def __init__(self, *, base_url: str = MERKL_API_BASE_URL) -> None:
+        super().__init__()
         self.base_url = str(base_url).rstrip("/")
-        self.client = httpx.AsyncClient(timeout=httpx.Timeout(DEFAULT_HTTP_TIMEOUT))
+
+    def _create_client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(timeout=httpx.Timeout(DEFAULT_HTTP_TIMEOUT))
 
     async def get_user_rewards(
         self,

--- a/wayfinder_paths/core/clients/MorphoClient.py
+++ b/wayfinder_paths/core/clients/MorphoClient.py
@@ -8,6 +8,7 @@ from typing import Any, Required, TypedDict
 import httpx
 from loguru import logger
 
+from wayfinder_paths.core.clients.WayfinderClient import AsyncClientOwner
 from wayfinder_paths.core.constants.base import DEFAULT_HTTP_TIMEOUT
 
 MORPHO_GRAPHQL_URL = "https://api.morpho.org/graphql"
@@ -28,27 +29,32 @@ class PublicAllocatorItem(TypedDict):
     morphoBlue: Required[MorphoBlueDeployment]
 
 
-class MorphoClient:
+class MorphoClient(AsyncClientOwner):
     def __init__(self, *, graphql_url: str = MORPHO_GRAPHQL_URL) -> None:
+        super().__init__()
         self.graphql_url = str(graphql_url)
         self._timeout = httpx.Timeout(DEFAULT_HTTP_TIMEOUT)
-        self.client = httpx.AsyncClient(timeout=self._timeout)
         self.headers = {"Content-Type": "application/json"}
         self._client_loop: asyncio.AbstractEventLoop | None = None
 
+    def _create_client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(timeout=self._timeout)
+
+    async def aclose(self) -> None:
+        self._client_loop = None
+        await super().aclose()
+
     async def _reset_client(self) -> None:
-        try:
-            await self.client.aclose()
-        except Exception:  # noqa: BLE001
-            pass
-        self.client = httpx.AsyncClient(timeout=self._timeout)
+        await self.aclose()
 
     async def _ensure_client(self) -> None:
         loop = asyncio.get_running_loop()
         if self._client_loop is None:
             self._client_loop = loop
             return
-        if self._client_loop is not loop or getattr(self.client, "is_closed", False):
+        if self._client_loop is not loop or (
+            self._client is not None and self._client.is_closed is True
+        ):
             await self._reset_client()
             self._client_loop = loop
 

--- a/wayfinder_paths/core/clients/MorphoRewardsClient.py
+++ b/wayfinder_paths/core/clients/MorphoRewardsClient.py
@@ -4,15 +4,19 @@ from typing import Any
 
 import httpx
 
+from wayfinder_paths.core.clients.WayfinderClient import AsyncClientOwner
 from wayfinder_paths.core.constants.base import DEFAULT_HTTP_TIMEOUT
 
 MORPHO_REWARDS_API_BASE_URL = "https://rewards.morpho.org"
 
 
-class MorphoRewardsClient:
+class MorphoRewardsClient(AsyncClientOwner):
     def __init__(self, *, base_url: str = MORPHO_REWARDS_API_BASE_URL) -> None:
+        super().__init__()
         self.base_url = str(base_url).rstrip("/")
-        self.client = httpx.AsyncClient(timeout=httpx.Timeout(DEFAULT_HTTP_TIMEOUT))
+
+    def _create_client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(timeout=httpx.Timeout(DEFAULT_HTTP_TIMEOUT))
 
     async def _get_json(
         self, *, path: str, params: dict[str, Any] | None = None

--- a/wayfinder_paths/core/clients/WayfinderClient.py
+++ b/wayfinder_paths/core/clients/WayfinderClient.py
@@ -1,5 +1,9 @@
+from __future__ import annotations
+
 import time
-from typing import Any
+from collections.abc import Awaitable
+from typing import Any, Self
+from weakref import WeakSet
 
 import httpx
 from loguru import logger
@@ -8,13 +12,63 @@ from wayfinder_paths.core.config import get_api_key
 from wayfinder_paths.core.constants.base import DEFAULT_HTTP_TIMEOUT
 
 
-class WayfinderClient:
-    def __init__(self):
+class AsyncClientOwner:
+    def __init__(self) -> None:
+        self._client: httpx.AsyncClient | None = None
+        _CLIENT_OWNERS.add(self)
+
+    def _create_client(self) -> httpx.AsyncClient:
+        raise NotImplementedError
+
+    @property
+    def client(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed is True:
+            self._client = self._create_client()
+        return self._client
+
+    @client.setter
+    def client(self, value: httpx.AsyncClient) -> None:
+        self._client = value
+
+    async def aclose(self) -> None:
+        client, self._client = self._client, None
+        if client is not None and client.is_closed is not True:
+            await client.aclose()
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        await self.aclose()
+
+
+_CLIENT_OWNERS: WeakSet[AsyncClientOwner] = WeakSet()
+
+
+async def close_async_clients() -> None:
+    for owner in list(_CLIENT_OWNERS):
+        await owner.aclose()
+
+
+async def with_async_client_cleanup[ResultT](
+    awaitable: Awaitable[ResultT],
+) -> ResultT:
+    try:
+        return await awaitable
+    finally:
+        await close_async_clients()
+
+
+class WayfinderClient(AsyncClientOwner):
+    def __init__(self) -> None:
+        super().__init__()
         self.headers = {
             "Content-Type": "application/json",
         }
         self._ensure_api_key_header()
-        self.client = httpx.AsyncClient(
+
+    def _create_client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
             timeout=httpx.Timeout(DEFAULT_HTTP_TIMEOUT),
             follow_redirects=True,
             headers=self.headers,

--- a/wayfinder_paths/mcp/cli_builder.py
+++ b/wayfinder_paths/mcp/cli_builder.py
@@ -13,6 +13,8 @@ from typing import Any, Protocol
 
 import click
 
+from wayfinder_paths.core.clients.WayfinderClient import with_async_client_cleanup
+
 TYPE_MAP = {"string": str, "integer": int, "number": float, "boolean": bool}
 
 
@@ -144,7 +146,9 @@ def build_tool_command(tool, mcp: MCPInterface) -> click.Command:
                 for k, v in kwargs.items()
                 if v is not None
             }
-            result = asyncio.run(mcp.call_tool(tool_name, args))
+            result = asyncio.run(
+                with_async_client_cleanup(mcp.call_tool(tool_name, args))
+            )
             echo_result(result)
 
         return callback

--- a/wayfinder_paths/mcp/server.py
+++ b/wayfinder_paths/mcp/server.py
@@ -30,11 +30,13 @@ from __future__ import annotations
 import argparse
 import asyncio
 import os
-from collections.abc import Sequence
-from typing import Literal
+from collections.abc import AsyncIterator, Sequence
+from contextlib import asynccontextmanager
+from typing import Any, Literal
 
 from mcp.server.fastmcp import FastMCP
 
+from wayfinder_paths.core.clients.WayfinderClient import close_async_clients
 from wayfinder_paths.core.config import is_opencode_instance
 from wayfinder_paths.mcp.tools.alpha_lab import (
     research_get_alpha_types,
@@ -149,12 +151,20 @@ from wayfinder_paths.paths.heartbeat import maybe_heartbeat_installed_paths
 MCPTransport = Literal["stdio", "sse", "streamable-http"]
 
 
+@asynccontextmanager
+async def _client_lifespan(_mcp: FastMCP) -> AsyncIterator[dict[str, Any]]:
+    try:
+        yield {}
+    finally:
+        await close_async_clients()
+
+
 def build_mcp(
     *,
     host: str = "127.0.0.1",
     port: int = 8000,
 ) -> FastMCP:
-    mcp = FastMCP("wayfinder", host=host, port=port)
+    mcp = FastMCP("wayfinder", host=host, port=port, lifespan=_client_lifespan)
 
     # ─── contracts_* ───────────────────────────────────────────────────
     mcp.tool()(contracts_list)

--- a/wayfinder_paths/paths/doctor.py
+++ b/wayfinder_paths/paths/doctor.py
@@ -23,6 +23,7 @@ from wayfinder_paths.paths.pipeline import (
     validate_pipeline_graph,
 )
 from wayfinder_paths.paths.renderer import PathSkillRenderError, render_skill_exports
+from wayfinder_paths.paths.runtime_registry import published_package
 from wayfinder_paths.paths.scaffold import slugify
 
 _ROOT_ASSET_RE = re.compile(r"""(?:src|href)=["']/(assets|_next)/""")
@@ -439,6 +440,31 @@ def _validate_runtime_skill_contract(
             path=path_dir / "wfpath.yaml",
         )
         return
+
+    explicit_runtime_version = skill.runtime.version if skill.runtime else None
+    if runtime.package and explicit_runtime_version:
+        published = published_package(runtime.package)
+        if published is None:
+            _record_issue(
+                warnings,
+                level="warning",
+                message=(
+                    "Could not verify the skill runtime against the package index; "
+                    "check the package and version before publishing"
+                ),
+                path=path_dir / "wfpath.yaml",
+            )
+        elif explicit_runtime_version not in published.versions:
+            _record_issue(
+                errors,
+                level="error",
+                message=(
+                    "Unpublished skill runtime: "
+                    f"{runtime.package}=={explicit_runtime_version}. "
+                    f"Latest published version is {published.latest}"
+                ),
+                path=path_dir / "wfpath.yaml",
+            )
 
     if skill.uses_portable_alias:
         _record_issue(

--- a/wayfinder_paths/paths/manifest.py
+++ b/wayfinder_paths/paths/manifest.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from importlib import metadata as importlib_metadata
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +13,7 @@ from wayfinder_paths.paths.pipeline import (
     DEFAULT_PRIMARY_HOSTS,
     get_pipeline_archetype,
 )
+from wayfinder_paths.paths.runtime_registry import installed_runtime_package_version
 
 
 class PathManifestError(Exception):
@@ -841,13 +841,6 @@ class PathManifest:
         )
 
 
-def _package_version_or_default(package: str) -> str:
-    try:
-        return importlib_metadata.version(package)
-    except importlib_metadata.PackageNotFoundError:
-        return "0.0.0"
-
-
 def resolve_skill_runtime(manifest: PathManifest) -> PathSkillRuntimeConfig:
     skill = manifest.skill
     runtime = skill.runtime if skill else None
@@ -859,7 +852,7 @@ def resolve_skill_runtime(manifest: PathManifest) -> PathSkillRuntimeConfig:
         package=package,
         version=runtime.version
         if runtime and runtime.version
-        else _package_version_or_default(package),
+        else installed_runtime_package_version(package),
         python=runtime.python
         if runtime and runtime.python
         else _DEFAULT_RUNTIME_PYTHON,

--- a/wayfinder_paths/paths/runtime_registry.py
+++ b/wayfinder_paths/paths/runtime_registry.py
@@ -9,7 +9,6 @@ from urllib import error, parse, request
 
 _PYPI_PROJECT_URL = "https://pypi.org/pypi/{package}/json"
 _PYPI_TIMEOUT_SECONDS = 2.0
-_KNOWN_PUBLISHED_VERSIONS = {"wayfinder-paths": "0.11.0"}
 
 
 @dataclass(frozen=True)
@@ -55,17 +54,3 @@ def installed_package_version(package: str) -> str | None:
 
 def installed_runtime_package_version(package: str = "wayfinder-paths") -> str:
     return installed_package_version(package) or "0.0.0"
-
-
-def published_runtime_package_version(package: str = "wayfinder-paths") -> str:
-    installed = installed_package_version(package)
-    published = published_package(package)
-    if published is not None:
-        if installed in published.versions:
-            return installed
-        return published.latest
-
-    known_published = _KNOWN_PUBLISHED_VERSIONS.get(package)
-    if known_published is not None:
-        return known_published
-    return installed or "0.0.0"

--- a/wayfinder_paths/paths/runtime_registry.py
+++ b/wayfinder_paths/paths/runtime_registry.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from functools import cache
+from importlib import metadata as importlib_metadata
+from typing import Any
+from urllib import error, parse, request
+
+_PYPI_PROJECT_URL = "https://pypi.org/pypi/{package}/json"
+_PYPI_TIMEOUT_SECONDS = 2.0
+_KNOWN_PUBLISHED_VERSIONS = {"wayfinder-paths": "0.11.0"}
+
+
+@dataclass(frozen=True)
+class PublishedPackage:
+    latest: str
+    versions: frozenset[str]
+
+
+@cache
+def published_package(package: str) -> PublishedPackage | None:
+    url = _PYPI_PROJECT_URL.format(package=parse.quote(package, safe=""))
+    req = request.Request(url, headers={"User-Agent": "wayfinder-paths/doctor"})
+    try:
+        with request.urlopen(req, timeout=_PYPI_TIMEOUT_SECONDS) as response:
+            payload: Any = json.load(response)
+    except (error.URLError, TimeoutError, json.JSONDecodeError, OSError):
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+    info = payload.get("info")
+    releases = payload.get("releases")
+    if not isinstance(info, dict) or not isinstance(releases, dict):
+        return None
+
+    latest = str(info.get("version") or "").strip()
+    versions = frozenset(
+        str(version)
+        for version, files in releases.items()
+        if str(version).strip() and isinstance(files, list) and files
+    )
+    if not latest or latest not in versions:
+        return None
+    return PublishedPackage(latest=latest, versions=versions)
+
+
+def installed_package_version(package: str) -> str | None:
+    try:
+        return importlib_metadata.version(package)
+    except importlib_metadata.PackageNotFoundError:
+        return None
+
+
+def installed_runtime_package_version(package: str = "wayfinder-paths") -> str:
+    return installed_package_version(package) or "0.0.0"
+
+
+def published_runtime_package_version(package: str = "wayfinder-paths") -> str:
+    installed = installed_package_version(package)
+    published = published_package(package)
+    if published is not None:
+        if installed in published.versions:
+            return installed
+        return published.latest
+
+    known_published = _KNOWN_PUBLISHED_VERSIONS.get(package)
+    if known_published is not None:
+        return known_published
+    return installed or "0.0.0"

--- a/wayfinder_paths/paths/scaffold.py
+++ b/wayfinder_paths/paths/scaffold.py
@@ -16,7 +16,7 @@ from wayfinder_paths.paths.pipeline import (
     default_pipeline_graph,
     get_pipeline_archetype,
 )
-from wayfinder_paths.paths.runtime_registry import published_runtime_package_version
+from wayfinder_paths.paths.runtime_registry import installed_runtime_package_version
 
 
 class PathScaffoldError(Exception):
@@ -128,7 +128,7 @@ def _build_wfpath_yaml(
         lines.append("  runtime:")
         lines.append("    mode: thin")
         lines.append('    package: "wayfinder-paths"')
-        lines.append(f'    version: "{published_runtime_package_version()}"')
+        lines.append(f'    version: "{installed_runtime_package_version()}"')
         lines.append('    python: ">=3.12,<3.13"')
         lines.append('    component: "main"')
         lines.append("    bootstrap: uv")

--- a/wayfinder_paths/paths/scaffold.py
+++ b/wayfinder_paths/paths/scaffold.py
@@ -4,7 +4,6 @@ import json
 import re
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from importlib import metadata as importlib_metadata
 from importlib import resources
 from pathlib import Path
 from typing import Any
@@ -17,6 +16,7 @@ from wayfinder_paths.paths.pipeline import (
     default_pipeline_graph,
     get_pipeline_archetype,
 )
+from wayfinder_paths.paths.runtime_registry import published_runtime_package_version
 
 
 class PathScaffoldError(Exception):
@@ -55,13 +55,6 @@ def _read_template(relative_path: str) -> str:
     root = resources.files("wayfinder_paths.paths")
     template_path = root.joinpath("templates").joinpath(relative_path)
     return template_path.read_text(encoding="utf-8")
-
-
-def _runtime_package_version(package: str = "wayfinder-paths") -> str:
-    try:
-        return importlib_metadata.version(package)
-    except importlib_metadata.PackageNotFoundError:
-        return "0.0.0"
 
 
 @dataclass(frozen=True)
@@ -135,7 +128,7 @@ def _build_wfpath_yaml(
         lines.append("  runtime:")
         lines.append("    mode: thin")
         lines.append('    package: "wayfinder-paths"')
-        lines.append(f'    version: "{_runtime_package_version()}"')
+        lines.append(f'    version: "{published_runtime_package_version()}"')
         lines.append('    python: ">=3.12,<3.13"')
         lines.append('    component: "main"')
         lines.append("    bootstrap: uv")

--- a/wayfinder_paths/run_strategy.py
+++ b/wayfinder_paths/run_strategy.py
@@ -17,6 +17,7 @@ from typing import Any
 from loguru import logger
 
 from wayfinder_paths.core.clients.TokenClient import TOKEN_CLIENT
+from wayfinder_paths.core.clients.WayfinderClient import with_async_client_cleanup
 from wayfinder_paths.core.config import CONFIG, load_config
 from wayfinder_paths.core.engine.strategy_loader import load_strategy_module
 from wayfinder_paths.core.strategies.Strategy import Strategy
@@ -410,23 +411,25 @@ def main():
         raise SystemExit(str(exc)) from exc
 
     asyncio.run(
-        run_strategy(
-            str(strategy_name),
-            args.action,
-            amount=args.amount,
-            main_token_amount=args.main_token_amount,
-            gas_token_amount=args.gas_token_amount,
-            interval=args.interval,
-            max_wait_s=args.max_wait_s,
-            poll_interval_s=args.poll_interval_s,
-            wallet_id=args.wallet_id,
-            wallet_label=args.wallet_label,
-            main_wallet_label=args.main_wallet_label,
-            gorlami=args.gorlami,
-            gorlami_chain_id=args.gorlami_chain_id,
-            gorlami_fund_native_eth=args.gorlami_fund_native_eth,
-            gorlami_fund_erc20=args.gorlami_fund_erc20,
-            gorlami_no_default_gas=args.gorlami_no_default_gas,
+        with_async_client_cleanup(
+            run_strategy(
+                str(strategy_name),
+                args.action,
+                amount=args.amount,
+                main_token_amount=args.main_token_amount,
+                gas_token_amount=args.gas_token_amount,
+                interval=args.interval,
+                max_wait_s=args.max_wait_s,
+                poll_interval_s=args.poll_interval_s,
+                wallet_id=args.wallet_id,
+                wallet_label=args.wallet_label,
+                main_wallet_label=args.main_wallet_label,
+                gorlami=args.gorlami,
+                gorlami_chain_id=args.gorlami_chain_id,
+                gorlami_fund_native_eth=args.gorlami_fund_native_eth,
+                gorlami_fund_erc20=args.gorlami_fund_erc20,
+                gorlami_no_default_gas=args.gorlami_no_default_gas,
+            )
         )
     )
 

--- a/wayfinder_paths/tests/test_async_client_lifecycle.py
+++ b/wayfinder_paths/tests/test_async_client_lifecycle.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from wayfinder_paths.core.clients.MerklClient import MerklClient
+from wayfinder_paths.core.clients.MorphoClient import MorphoClient
+from wayfinder_paths.core.clients.MorphoRewardsClient import MorphoRewardsClient
+from wayfinder_paths.core.clients.WayfinderClient import (
+    WayfinderClient,
+    close_async_clients,
+    with_async_client_cleanup,
+)
+
+
+def test_async_clients_are_created_lazily() -> None:
+    assert WayfinderClient()._client is None
+    assert MerklClient()._client is None
+    assert MorphoClient()._client is None
+    assert MorphoRewardsClient()._client is None
+
+
+@pytest.mark.asyncio
+async def test_wayfinder_client_aclose_releases_and_recreates_client() -> None:
+    client = WayfinderClient()
+    first = client.client
+
+    await client.aclose()
+
+    assert first.is_closed
+    assert client._client is None
+    second = client.client
+    assert second is not first
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_wayfinder_client_async_context_manager_closes_client() -> None:
+    async with WayfinderClient() as client:
+        transport = httpx.MockTransport(lambda request: httpx.Response(200))
+        client.client = httpx.AsyncClient(transport=transport)
+        response = await client.client.get("https://example.test")
+        owned_client = client.client
+
+    assert response.status_code == 200
+    assert owned_client.is_closed
+    assert client._client is None
+
+
+@pytest.mark.asyncio
+async def test_registered_clients_close_at_process_boundary() -> None:
+    client = WayfinderClient()
+    owned_client = client.client
+
+    await close_async_clients()
+
+    assert owned_client.is_closed
+    assert client._client is None
+
+
+@pytest.mark.asyncio
+async def test_client_cleanup_runs_when_operation_fails() -> None:
+    client = WayfinderClient()
+    owned_client = client.client
+
+    async def fail() -> None:
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await with_async_client_cleanup(fail())
+
+    assert owned_client.is_closed
+    assert client._client is None

--- a/wayfinder_paths/tests/test_paths_publish_install.py
+++ b/wayfinder_paths/tests/test_paths_publish_install.py
@@ -18,6 +18,8 @@ from wayfinder_paths.paths.client import PathsApiClient
 from wayfinder_paths.paths.doctor import DoctorIssue, PathDoctorReport
 from wayfinder_paths.paths.scaffold import init_path
 
+pytestmark = pytest.mark.usefixtures("published_installed_runtime")
+
 
 def test_path_publish_uploads_rendered_skill_exports_and_bond_metadata(
     tmp_path: Path, monkeypatch

--- a/wayfinder_paths/tests/test_paths_scaffold.py
+++ b/wayfinder_paths/tests/test_paths_scaffold.py
@@ -13,9 +13,10 @@ from wayfinder_paths.paths.builder import PathBuilder
 from wayfinder_paths.paths.doctor import run_doctor
 from wayfinder_paths.paths.evaluator import run_path_eval
 from wayfinder_paths.paths.hooks import install_path_hooks
-from wayfinder_paths.paths.manifest import PathManifest
+from wayfinder_paths.paths.manifest import PathManifest, resolve_skill_runtime
 from wayfinder_paths.paths.preview import inspect_preview_path
 from wayfinder_paths.paths.renderer import render_skill_exports
+from wayfinder_paths.paths.runtime_registry import PublishedPackage
 from wayfinder_paths.paths.scaffold import init_path
 
 
@@ -53,6 +54,21 @@ def test_path_init_creates_expected_files(tmp_path: Path):
     assert manifest.skill.runtime is not None
     assert manifest.skill.runtime.mode == "thin"
     assert manifest.skill.runtime.component == "main"
+
+
+def test_path_init_pins_a_published_runtime(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "wayfinder_paths.paths.scaffold.published_runtime_package_version",
+        lambda: "0.11.0",
+    )
+    path_dir = tmp_path / "published-runtime"
+
+    init_path(path_dir=path_dir, slug="published-runtime", with_applet=False)
+
+    manifest = PathManifest.load(path_dir / "wfpath.yaml")
+    assert manifest.skill is not None
+    assert manifest.skill.runtime is not None
+    assert manifest.skill.runtime.version == "0.11.0"
 
 
 def test_path_init_defaults_to_applet(tmp_path: Path):
@@ -162,6 +178,65 @@ def test_path_doctor_ok_on_pipeline_path(tmp_path: Path):
     )
 
     report = run_doctor(path_dir=path_dir, fix=False)
+    assert report.ok is True
+
+
+def test_path_doctor_rejects_unpublished_runtime(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "wayfinder_paths.paths.scaffold.published_runtime_package_version",
+        lambda: "0.11.0",
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.paths.doctor.published_package",
+        lambda package: PublishedPackage(
+            latest="0.11.0", versions=frozenset({"0.11.0"})
+        ),
+    )
+    path_dir = tmp_path / "unpublished-runtime"
+    init_path(path_dir=path_dir, slug="unpublished-runtime", with_applet=False)
+    manifest_path = path_dir / "wfpath.yaml"
+    manifest_path.write_text(
+        manifest_path.read_text(encoding="utf-8").replace(
+            '    version: "0.11.0"', '    version: "0.11.1"'
+        ),
+        encoding="utf-8",
+    )
+
+    report = run_doctor(path_dir=path_dir)
+
+    assert report.ok is False
+    assert any("Unpublished skill runtime" in issue.message for issue in report.errors)
+
+
+def test_versionless_historical_runtime_keeps_installed_sdk(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "wayfinder_paths.paths.scaffold.published_runtime_package_version",
+        lambda: "0.11.0",
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.paths.manifest.installed_runtime_package_version",
+        lambda package: "0.11.1",
+    )
+    path_dir = tmp_path / "historical-runtime"
+    init_path(path_dir=path_dir, slug="historical-runtime", with_applet=False)
+    manifest_path = path_dir / "wfpath.yaml"
+    manifest_path.write_text(
+        manifest_path.read_text(encoding="utf-8").replace(
+            '    version: "0.11.0"\n', ""
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.paths.doctor.published_package",
+        lambda package: pytest.fail("versionless runtimes must not query the index"),
+    )
+
+    manifest = PathManifest.load(manifest_path)
+    report = run_doctor(path_dir=path_dir)
+
+    assert resolve_skill_runtime(manifest).version == "0.11.1"
     assert report.ok is True
 
 

--- a/wayfinder_paths/tests/test_paths_scaffold.py
+++ b/wayfinder_paths/tests/test_paths_scaffold.py
@@ -19,6 +19,8 @@ from wayfinder_paths.paths.renderer import render_skill_exports
 from wayfinder_paths.paths.runtime_registry import PublishedPackage
 from wayfinder_paths.paths.scaffold import init_path
 
+pytestmark = pytest.mark.usefixtures("published_installed_runtime")
+
 
 @pytest.mark.smoke
 def test_path_init_creates_expected_files(tmp_path: Path):
@@ -56,10 +58,10 @@ def test_path_init_creates_expected_files(tmp_path: Path):
     assert manifest.skill.runtime.component == "main"
 
 
-def test_path_init_pins_a_published_runtime(tmp_path: Path, monkeypatch) -> None:
+def test_path_init_pins_the_installed_runtime(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(
-        "wayfinder_paths.paths.scaffold.published_runtime_package_version",
-        lambda: "0.11.0",
+        "wayfinder_paths.paths.scaffold.installed_runtime_package_version",
+        lambda: "0.11.1",
     )
     path_dir = tmp_path / "published-runtime"
 
@@ -68,7 +70,7 @@ def test_path_init_pins_a_published_runtime(tmp_path: Path, monkeypatch) -> None
     manifest = PathManifest.load(path_dir / "wfpath.yaml")
     assert manifest.skill is not None
     assert manifest.skill.runtime is not None
-    assert manifest.skill.runtime.version == "0.11.0"
+    assert manifest.skill.runtime.version == "0.11.1"
 
 
 def test_path_init_defaults_to_applet(tmp_path: Path):
@@ -183,7 +185,7 @@ def test_path_doctor_ok_on_pipeline_path(tmp_path: Path):
 
 def test_path_doctor_rejects_unpublished_runtime(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(
-        "wayfinder_paths.paths.scaffold.published_runtime_package_version",
+        "wayfinder_paths.paths.scaffold.installed_runtime_package_version",
         lambda: "0.11.0",
     )
     monkeypatch.setattr(
@@ -212,7 +214,7 @@ def test_versionless_historical_runtime_keeps_installed_sdk(
     tmp_path: Path, monkeypatch
 ) -> None:
     monkeypatch.setattr(
-        "wayfinder_paths.paths.scaffold.published_runtime_package_version",
+        "wayfinder_paths.paths.scaffold.installed_runtime_package_version",
         lambda: "0.11.0",
     )
     monkeypatch.setattr(

--- a/wayfinder_paths/tests/test_runtime_registry.py
+++ b/wayfinder_paths/tests/test_runtime_registry.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from wayfinder_paths.paths import runtime_registry
+from wayfinder_paths.paths.runtime_registry import PublishedPackage
+
+
+def test_runtime_version_uses_installed_version_when_published(monkeypatch) -> None:
+    monkeypatch.setattr(
+        runtime_registry, "installed_package_version", lambda package: "0.11.1"
+    )
+    monkeypatch.setattr(
+        runtime_registry,
+        "published_package",
+        lambda package: PublishedPackage(
+            latest="0.11.1", versions=frozenset({"0.11.0", "0.11.1"})
+        ),
+    )
+
+    assert runtime_registry.published_runtime_package_version() == "0.11.1"
+
+
+def test_runtime_version_replaces_unpublished_installed_version(monkeypatch) -> None:
+    monkeypatch.setattr(
+        runtime_registry, "installed_package_version", lambda package: "0.11.1"
+    )
+    monkeypatch.setattr(
+        runtime_registry,
+        "published_package",
+        lambda package: PublishedPackage(
+            latest="0.11.0", versions=frozenset({"0.11.0"})
+        ),
+    )
+
+    assert runtime_registry.published_runtime_package_version() == "0.11.0"
+
+
+def test_runtime_version_uses_known_release_when_registry_is_unavailable(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        runtime_registry, "installed_package_version", lambda package: "0.11.1"
+    )
+    monkeypatch.setattr(runtime_registry, "published_package", lambda package: None)
+
+    assert runtime_registry.published_runtime_package_version() == "0.11.0"
+
+
+def test_versionless_runtime_keeps_installed_version(monkeypatch) -> None:
+    monkeypatch.setattr(
+        runtime_registry, "installed_package_version", lambda package: "0.11.1"
+    )
+
+    assert runtime_registry.installed_runtime_package_version() == "0.11.1"

--- a/wayfinder_paths/tests/test_runtime_registry.py
+++ b/wayfinder_paths/tests/test_runtime_registry.py
@@ -1,53 +1,69 @@
 from __future__ import annotations
 
+import io
+import json
+
 from wayfinder_paths.paths import runtime_registry
 from wayfinder_paths.paths.runtime_registry import PublishedPackage
 
 
-def test_runtime_version_uses_installed_version_when_published(monkeypatch) -> None:
+def test_published_package_reads_available_release_versions(monkeypatch) -> None:
+    payload = {
+        "info": {"version": "0.11.1"},
+        "releases": {
+            "0.11.0": [{"filename": "wayfinder_paths-0.11.0.whl"}],
+            "0.11.1": [{"filename": "wayfinder_paths-0.11.1.whl"}],
+            "0.12.0": [],
+        },
+    }
     monkeypatch.setattr(
-        runtime_registry, "installed_package_version", lambda package: "0.11.1"
+        runtime_registry.request,
+        "urlopen",
+        lambda request, timeout: io.BytesIO(json.dumps(payload).encode()),
     )
-    monkeypatch.setattr(
-        runtime_registry,
-        "published_package",
-        lambda package: PublishedPackage(
-            latest="0.11.1", versions=frozenset({"0.11.0", "0.11.1"})
-        ),
-    )
+    runtime_registry.published_package.cache_clear()
 
-    assert runtime_registry.published_runtime_package_version() == "0.11.1"
+    try:
+        package = runtime_registry.published_package("wayfinder-paths")
+    finally:
+        runtime_registry.published_package.cache_clear()
 
-
-def test_runtime_version_replaces_unpublished_installed_version(monkeypatch) -> None:
-    monkeypatch.setattr(
-        runtime_registry, "installed_package_version", lambda package: "0.11.1"
-    )
-    monkeypatch.setattr(
-        runtime_registry,
-        "published_package",
-        lambda package: PublishedPackage(
-            latest="0.11.0", versions=frozenset({"0.11.0"})
-        ),
+    assert package == PublishedPackage(
+        latest="0.11.1",
+        versions=frozenset({"0.11.0", "0.11.1"}),
     )
 
-    assert runtime_registry.published_runtime_package_version() == "0.11.0"
 
-
-def test_runtime_version_uses_known_release_when_registry_is_unavailable(
+def test_published_package_returns_none_when_registry_is_unavailable(
     monkeypatch,
 ) -> None:
-    monkeypatch.setattr(
-        runtime_registry, "installed_package_version", lambda package: "0.11.1"
-    )
-    monkeypatch.setattr(runtime_registry, "published_package", lambda package: None)
+    def unavailable(*args, **kwargs):
+        raise runtime_registry.error.URLError("offline")
 
-    assert runtime_registry.published_runtime_package_version() == "0.11.0"
+    monkeypatch.setattr(runtime_registry.request, "urlopen", unavailable)
+    runtime_registry.published_package.cache_clear()
+
+    try:
+        package = runtime_registry.published_package("wayfinder-paths")
+    finally:
+        runtime_registry.published_package.cache_clear()
+
+    assert package is None
 
 
-def test_versionless_runtime_keeps_installed_version(monkeypatch) -> None:
+def test_runtime_version_uses_installed_version(monkeypatch) -> None:
     monkeypatch.setattr(
         runtime_registry, "installed_package_version", lambda package: "0.11.1"
     )
 
     assert runtime_registry.installed_runtime_package_version() == "0.11.1"
+
+
+def test_runtime_version_has_a_deterministic_missing_package_fallback(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        runtime_registry, "installed_package_version", lambda package: None
+    )
+
+    assert runtime_registry.installed_runtime_package_version() == "0.0.0"


### PR DESCRIPTION
### Summary

- Lazily create and explicitly close shared async HTTP clients across CLI, strategy, and MCP process boundaries.
- Keep new paths pinned to the SDK they were built against and block unpublished explicit pins during doctor checks without changing historical manifests.
- Package MCP as a runtime dependency and add regression coverage for lifecycle, package-index, and runtime validation behavior.