### PR TITLE
jobs: decision gates — plain-language owner summaries, executable acknowledgments, idempotent resolution

### DIFF
--- a/wayfinder_paths/jobs/cli.py
+++ b/wayfinder_paths/jobs/cli.py
@@ -2326,7 +2326,8 @@ def decision_gate_register_cmd(
 @decision_gate_group.command(
     name="resolve",
     help="Owner resolution of a tripped/armed gate; --execute runs the same "
-    "bounded retire flow the paper auto path uses.",
+    "bounded retire flow the paper auto path uses (also on a gate previously "
+    "resolved as acknowledge-only). Retries of a settled gate are a no-op.",
 )
 @click.argument("job_id")
 @click.argument("gate_id")
@@ -2343,13 +2344,14 @@ def decision_gate_resolve_cmd(
         )
     except ValueError as exc:
         raise click.ClickException(str(exc)) from exc
-    _echo_json({"ok": True, "result": gate})
+    _echo_json({"ok": True, "noop": bool(gate.pop("noop", False)), "result": gate})
 
 
 @decision_gate_group.command(
     name="reopen",
     help="Undo an auto-resolution (re-enables the script loop) or dismiss a "
-    "trip. The gate stays reopened until explicitly re-registered.",
+    "trip. The gate stays reopened until explicitly re-registered; reopening "
+    "an already-reopened gate is a no-op.",
 )
 @click.argument("job_id")
 @click.argument("gate_id")
@@ -2360,7 +2362,7 @@ def decision_gate_reopen_cmd(job_id: str, gate_id: str, reopened_by: str) -> Non
         gate = reopen_decision_gate(store, job_id, gate_id, by=reopened_by)
     except ValueError as exc:
         raise click.ClickException(str(exc)) from exc
-    _echo_json({"ok": True, "result": gate})
+    _echo_json({"ok": True, "noop": bool(gate.pop("noop", False)), "result": gate})
 
 
 @decision_gate_group.command(name="list", help="List registered decision gates.")

--- a/wayfinder_paths/jobs/decision_gates.py
+++ b/wayfinder_paths/jobs/decision_gates.py
@@ -250,18 +250,45 @@ def resolve_decision_gate(
     execute: bool = False,
 ) -> dict[str, Any]:
     """Manual resolution — the owner acting on a tripped (or armed) gate.
-    ``execute=True`` runs the same bounded retire flow the paper path uses."""
+    ``execute=True`` runs the same bounded retire flow the paper path uses.
+
+    Acknowledge-only is completable: ``execute=True`` on a gate already
+    resolved as ``acknowledged`` runs the pre-registered response now (an FE
+    resolve click that landed without execute must not strand the gate).
+    Anything else that is already settled — executed, acknowledged again
+    without execute, or reopened — returns the gate with ``noop=True`` and
+    changes nothing: double-clicks and timeout retries read as "already
+    done", never as failure."""
     doc = load_decision_gates(store, job_id)
     gate = _find_gate(doc, gate_id)
-    if gate.get("status") not in {"armed", "tripped_needs_owner"}:
-        raise ValueError(f"gate {gate_id} is {gate.get('status')}; nothing to resolve")
+    status = str(gate.get("status"))
+    resolution = gate.get("resolution") or {}
+    acknowledged_only = (
+        status == "resolved" and resolution.get("action") == "acknowledged"
+    )
+    if status not in {"armed", "tripped_needs_owner"} and not (
+        acknowledged_only and execute
+    ):
+        return dict(gate, noop=True)
     if execute:
+        prior_ack = (
+            {
+                "by": resolution.get("by"),
+                "note": resolution.get("note"),
+                "at": gate.get("resolved_at"),
+            }
+            if acknowledged_only
+            else None
+        )
         job = store.load(job_id)
         summary = store.read_json(job_id, "results/forward/summary.json") or {}
         _, measured = evaluate_gate_criteria(gate.get("criteria") or {}, summary)
         event = _auto_resolve(store, job, gate, measured, dt.datetime.now(dt.UTC))
         event["resolved_by"] = by
         gate["resolution"]["by"] = by
+        if prior_ack is not None:
+            event["type"] = "decision_gate_executed"
+            gate["resolution"]["acknowledged"] = prior_ack
     else:
         gate.update(
             {
@@ -287,10 +314,13 @@ def reopen_decision_gate(
     """Undo: reverse an auto-resolution (re-enable the script loop; the active
     workspace was never destroyed) or dismiss a trip. The gate lands in
     ``reopened`` — terminal until explicitly re-registered, so it cannot
-    re-trip on the very next watchdog pass."""
+    re-trip on the very next watchdog pass. Reopening an already-reopened
+    gate is a retry, not a failure: it returns the gate with ``noop=True``."""
     doc = load_decision_gates(store, job_id)
     gate = _find_gate(doc, gate_id)
     status = str(gate.get("status"))
+    if status == "reopened":
+        return dict(gate, noop=True)
     if status not in {"resolved", "tripped_needs_owner"}:
         raise ValueError(f"gate {gate_id} is {status}; nothing to reopen")
     was_retired = (gate.get("resolution") or {}).get("action") == "retire_and_pivot"

--- a/wayfinder_paths/jobs/owner_attention.py
+++ b/wayfinder_paths/jobs/owner_attention.py
@@ -167,7 +167,7 @@ def _needs_you(
 
     items.extend(_unauditable_claims(store, job_id, now))
     items.extend(_owner_review_markers(job_id, journal, proposals_by_id, now))
-    items.extend(_tripped_gates(store, job_id))
+    items.extend(_tripped_gates(store, job_id, job))
 
     halt = read_halt(store.job_dir(job_id))
     if halt and str(halt.get("source") or "") in RISK_LATCH_SOURCES:
@@ -178,8 +178,9 @@ def _needs_you(
                 job_id=job_id,
                 ref_id=source,
                 summary=(
-                    f"risk-latched halt ({source}): {halt.get('reason')} — "
-                    "clearing requires the owner (wayfinder job resume-from-halt)"
+                    f"Trading is halted by a safety latch "
+                    f"({source.replace('_', ' ')}): {halt.get('reason')}. "
+                    "It stays paused until you clear it."
                 )[:300],
                 evidence_ref="state/halt.json",
                 since_ts=halt.get("ts"),
@@ -278,7 +279,9 @@ def _owner_review_markers(
     return items
 
 
-def _tripped_gates(store: JobStore, job_id: str) -> list[dict[str, Any]]:
+def _tripped_gates(
+    store: JobStore, job_id: str, job: WayfinderJob
+) -> list[dict[str, Any]]:
     from wayfinder_paths.jobs.decision_gates import (
         DECISION_GATES_PATH,
         load_decision_gates,
@@ -288,23 +291,63 @@ def _tripped_gates(store: JobStore, job_id: str) -> list[dict[str, Any]]:
     for gate in load_decision_gates(store, job_id).get("gates") or []:
         if gate.get("status") != "tripped_needs_owner":
             continue
-        gate_id = str(gate.get("gate_id"))
-        items.append(
-            _item(
-                kind="decision_gate_tripped",
-                job_id=job_id,
-                ref_id=gate_id,
-                summary=(
-                    f"decision gate {gate_id} criteria met on a live-capable "
-                    "job — pre-registered response is "
-                    f"{gate.get('on_met')}; owner resolves or re-arms "
-                    "(wayfinder job decision-gate resolve/reopen)"
-                )[:300],
-                evidence_ref=DECISION_GATES_PATH,
-                since_ts=gate.get("tripped_at"),
-            )
+        item = _item(
+            kind="decision_gate_tripped",
+            job_id=job_id,
+            ref_id=str(gate.get("gate_id")),
+            summary=_tripped_gate_summary(job, gate),
+            evidence_ref=DECISION_GATES_PATH,
+            since_ts=gate.get("tripped_at"),
         )
+        # Machine detail rides structured fields; the summary stays prose.
+        item.update(
+            {
+                "criteria": gate.get("criteria"),
+                "measured": gate.get("measured"),
+                "successor_ref": gate.get("successor_ref"),
+                "on_met": gate.get("on_met"),
+            }
+        )
+        items.append(item)
     return items
+
+
+def _tripped_gate_summary(job: WayfinderJob, gate: dict[str, Any]) -> str:
+    """Owner prose for a tripped gate: what happened, what the pre-registered
+    plan says, and the choice. No gate ids, no CLI commands, no policy tokens
+    — those live in the item's structured fields, not in the sentence the
+    owner reads."""
+    title = str(job.name or job.id).replace("_", " ")
+    measured = gate.get("measured") or {}
+    performance = ""
+    if measured.get("closed_trades") is not None:
+        net_pnl = float(measured.get("net_pnl") or 0.0)
+        direction = "down" if net_pnl < 0 else "up"
+        win_rate = measured.get("win_rate")
+        win_clause = (
+            f"winning {round(float(win_rate) * 100)}% and "
+            if win_rate is not None
+            else ""
+        )
+        performance = (
+            f": after {int(measured['closed_trades'])} trades it's "
+            f"{win_clause}{direction} ${abs(net_pnl):,.2f}"
+        )
+    head = f"{title} hit its pre-agreed checkpoint{performance}. "
+    registered = str(gate.get("pre_registered_ts") or "")[:10]
+    plan = f"The plan registered {registered}" if registered else "The registered plan"
+    closing = ". Choose: retire and pivot, or keep it running."
+    pivot = " ".join(str(gate.get("successor_ref") or "").split())
+    if pivot:
+        middle = f"{plan} calls for retiring this strategy and pivoting research to: "
+        budget = 300 - len(head) - len(middle) - len(closing)
+        summary = f"{head}{middle}{pivot[: max(budget, 0)]}{closing}"
+    else:
+        summary = (
+            f"{head}{plan} calls for retiring this strategy and pivoting "
+            f"research{closing}"
+        )
+    return summary[:300]
 
 
 def _decided_autonomously(

--- a/wayfinder_paths/tests/test_jobs_decision_gates.py
+++ b/wayfinder_paths/tests/test_jobs_decision_gates.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -201,7 +202,21 @@ def test_live_capable_job_trips_to_needs_you(
     assert gate["status"] == "tripped_needs_owner"
     needs_you = build_owner_attention(store, job.id)["needs_you"]
     assert [item["kind"] for item in needs_you] == ["decision_gate_tripped"]
-    assert needs_you[0]["ref_id"] == "gate-imx"
+    item = needs_you[0]
+    assert item["ref_id"] == "gate-imx"
+    # The owner reads prose with the measured numbers — the machine detail
+    # (id, criteria, measured, successor, response) rides structured fields.
+    summary = item["summary"]
+    assert "20 trades" in summary
+    assert "winning 30%" in summary
+    assert "down $12.50" in summary
+    assert "gate-imx" not in summary
+    assert "retire_and_pivot" not in summary
+    assert "wayfinder" not in summary
+    assert item["measured"]["closed_trades"] == 20
+    assert item["criteria"] == CRITERIA
+    assert item["successor_ref"] == "lane-b"
+    assert item["on_met"] == "retire_and_pivot"
     # A tripped gate does not re-trip on the next watchdog pass.
     assert evaluate_decision_gates(store, job) == []
 
@@ -246,6 +261,128 @@ def test_owner_resolves_a_tripped_gate(tmp_path: Path, compiled: list[str]) -> N
     # Acknowledged, not executed: the loop keeps running.
     assert store.load(job.id).script_loop.enabled is True
     assert compiled == []
+
+
+def test_execute_after_acknowledge_runs_the_retirement(
+    tmp_path: Path, compiled: list[str]
+) -> None:
+    """The incident path: an FE resolve click that landed acknowledge-only
+    must not strand the gate — a later --execute runs the pre-registered
+    response and records both the acknowledgment and the execution."""
+    store, job = _store(tmp_path, wallet_label="main")
+    register_decision_gate(
+        store, job.id, criteria=CRITERIA, successor_ref="lane-b", gate_id="gate-imx"
+    )
+    store.write_json(job.id, "results/forward/summary.json", FAILING_SUMMARY)
+    evaluate_decision_gates(store, job)
+    resolve_decision_gate(store, job.id, "gate-imx", by="owner", note="agreed")
+    assert store.load(job.id).script_loop.enabled is True
+    # A second acknowledge-only click reads as already done, not failure.
+    retry = resolve_decision_gate(store, job.id, "gate-imx", by="owner")
+    assert retry["noop"] is True
+
+    gate = resolve_decision_gate(store, job.id, "gate-imx", by="owner", execute=True)
+
+    assert "noop" not in gate
+    assert gate["status"] == "resolved"
+    resolution = gate["resolution"]
+    assert resolution["action"] == "retire_and_pivot"
+    assert resolution["by"] == "owner"
+    # The earlier acknowledgment is evidence, recorded beside the execution.
+    assert resolution["acknowledged"]["by"] == "owner"
+    assert resolution["acknowledged"]["note"] == "agreed"
+    assert resolution["acknowledged"]["at"]
+    # The retirement actually ran: loop disabled + recompiled, workspace kept.
+    assert store.load(job.id).script_loop.enabled is False
+    assert compiled == [job.id]
+    archived = store.job_dir(job.id) / resolution["archived_workspace"] / "workspace"
+    assert (archived / "src" / "strategy.py").exists()
+    assert "decision_gate_executed" in _journal_types(store, job.id)
+    persisted = load_decision_gates(store, job.id)["gates"][0]
+    assert persisted["resolution"]["acknowledged"]["note"] == "agreed"
+    # Reopen still reverses the executed retirement.
+    reopen_decision_gate(store, job.id, "gate-imx", by="owner")
+    assert store.load(job.id).script_loop.enabled is True
+
+
+def test_settled_gate_retries_read_as_already_done(
+    tmp_path: Path, compiled: list[str]
+) -> None:
+    store, job = _store(tmp_path)
+    register_decision_gate(
+        store, job.id, criteria=CRITERIA, successor_ref="lane-b", gate_id="gate-imx"
+    )
+    store.write_json(job.id, "results/forward/summary.json", FAILING_SUMMARY)
+    evaluate_decision_gates(store, job)  # paper: retirement already executed
+    journal_before = _journal_types(store, job.id)
+
+    for execute in (False, True):
+        gate = resolve_decision_gate(
+            store, job.id, "gate-imx", by="owner", execute=execute
+        )
+        assert gate["noop"] is True
+        assert gate["status"] == "resolved"
+        assert gate["resolution"]["action"] == "retire_and_pivot"
+    # No journal spam, no re-run, and the marker is response-only.
+    assert _journal_types(store, job.id) == journal_before
+    assert compiled == [job.id]
+    assert "noop" not in load_decision_gates(store, job.id)["gates"][0]
+
+    reopen_decision_gate(store, job.id, "gate-imx", by="owner")
+    again = reopen_decision_gate(store, job.id, "gate-imx", by="owner")
+    assert again["noop"] is True
+    assert compiled == [job.id, job.id]  # reopen recompiled once, retry did not
+    assert _journal_types(store, job.id).count("decision_gate_reopened") == 1
+    # A reopened gate is settled by the owner's undo — resolve is a no-op too.
+    gate = resolve_decision_gate(store, job.id, "gate-imx", by="owner", execute=True)
+    assert gate["noop"] is True
+    assert store.load(job.id).script_loop.enabled is True
+
+
+def test_cli_resolve_and_reopen_retries_exit_zero_with_noop(
+    tmp_path: Path, compiled: list[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from click.testing import CliRunner
+
+    from wayfinder_paths.jobs import cli as cli_module
+
+    store, job = _store(tmp_path, wallet_label="main")
+    register_decision_gate(
+        store, job.id, criteria=CRITERIA, successor_ref="lane-b", gate_id="gate-imx"
+    )
+    store.write_json(job.id, "results/forward/summary.json", FAILING_SUMMARY)
+    evaluate_decision_gates(store, job)
+    monkeypatch.setattr(cli_module, "JobStore", lambda: store)
+    runner = CliRunner()
+
+    first = runner.invoke(
+        cli_module.job_cli,
+        ["decision-gate", "resolve", job.id, "gate-imx", "--execute"],
+    )
+    assert first.exit_code == 0, first.output
+    body = json.loads(first.output)
+    assert body["ok"] is True and body["noop"] is False
+    assert body["result"]["resolution"]["action"] == "retire_and_pivot"
+
+    retry = runner.invoke(
+        cli_module.job_cli,
+        ["decision-gate", "resolve", job.id, "gate-imx", "--execute"],
+    )
+    assert retry.exit_code == 0, retry.output
+    body = json.loads(retry.output)
+    assert body["ok"] is True and body["noop"] is True
+    assert "noop" not in body["result"]
+
+    reopened = runner.invoke(
+        cli_module.job_cli, ["decision-gate", "reopen", job.id, "gate-imx"]
+    )
+    assert reopened.exit_code == 0, reopened.output
+    assert json.loads(reopened.output)["noop"] is False
+    again = runner.invoke(
+        cli_module.job_cli, ["decision-gate", "reopen", job.id, "gate-imx"]
+    )
+    assert again.exit_code == 0, again.output
+    assert json.loads(again.output)["noop"] is True
 
 
 # ── watchdog integration ─────────────────────────────────────────────────

--- a/wayfinder_paths/tests/test_jobs_owner_attention.py
+++ b/wayfinder_paths/tests/test_jobs_owner_attention.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime as dt
 import json
+import re
 from pathlib import Path
 
 from wayfinder_paths.jobs import sync as sync_mod
@@ -89,6 +90,40 @@ def _kinds(items: list[dict]) -> list[str]:
     return [item["kind"] for item in items]
 
 
+# Tone lint: a needs_you summary is a sentence for the owner, not machine
+# text (the imx-short incident shipped "decision gate gate-31f22e28 ...
+# pre-registered response is retire_and_pivot ... (wayfinder job
+# decision-gate resolve/reopen)" and the owner clicked wrong). Machine detail
+# belongs in structured item fields; prose must carry none of: CLI
+# invocations, flag syntax, machine gate ids, snake_case policy tokens.
+_BANNED_SUMMARY_PATTERNS = (
+    re.compile(r"\bwayfinder\s"),
+    re.compile(r"(?:^|\s)--[A-Za-z]"),
+    re.compile(r"\bgate-[0-9a-f]{6,}\b"),
+    re.compile(r"\b[a-z][a-z0-9]*(?:_[a-z0-9]+)+\b"),
+)
+
+
+def assert_owner_readable(items: list[dict]) -> None:
+    for item in items:
+        summary = str(item["summary"])
+        assert len(summary) <= 300, (item["kind"], len(summary))
+        for pattern in _BANNED_SUMMARY_PATTERNS:
+            assert not pattern.search(summary), (
+                item["kind"],
+                pattern.pattern,
+                summary,
+            )
+
+
+def _needs_you(store: JobStore, job_id: str) -> list[dict]:
+    """Every needs_you read in these tests goes through the tone lint, so a
+    future kind (or a reworded summary) inherits the rule automatically."""
+    items = build_owner_attention(store, job_id)["needs_you"]
+    assert_owner_readable(items)
+    return items
+
+
 # ── needs_you routing ────────────────────────────────────────────────────
 
 
@@ -108,9 +143,8 @@ def test_pending_proposal_on_live_capable_job_needs_owner(tmp_path: Path) -> Non
     _write_pending_proposal(store, job_id, "prop-live")
     _journal(store, job_id, {"type": "proposal_created", "proposal_id": "prop-live"})
 
-    attention = build_owner_attention(store, job_id)
+    items = _needs_you(store, job_id)
 
-    items = attention["needs_you"]
     assert _kinds(items) == ["live_proposal_approval"]
     assert items[0]["ref_id"] == "prop-live"
     assert items[0]["evidence_ref"] == "proposals/prop-live.json"
@@ -121,21 +155,23 @@ def test_pending_proposal_on_pure_paper_job_is_mechanical(tmp_path: Path) -> Non
     store, job_id = _store(tmp_path)  # paper, no wallet
     _write_pending_proposal(store, job_id, "prop-paper")
 
-    attention = build_owner_attention(store, job_id)
-
-    assert attention["needs_you"] == []
+    assert _needs_you(store, job_id) == []
 
 
 def test_risk_latched_halt_needs_owner_but_manual_does_not(tmp_path: Path) -> None:
     store, job_id = _store(tmp_path)
     request_halt(store, job_id, reason="dd breach", source="risk_limits")
-    items = build_owner_attention(store, job_id)["needs_you"]
+    items = _needs_you(store, job_id)
     assert _kinds(items) == ["halt_awaiting_owner_clear"]
     assert items[0]["ref_id"] == "risk_limits"
+    # Prose, not machine text: the latch source reads as words and the
+    # summary carries no CLI hint (ref_id keeps the machine token).
+    assert "risk limits" in items[0]["summary"]
+    assert "dd breach" in items[0]["summary"]
 
     store2, job2 = _store(tmp_path / "b", job_id="attn-manual")
     request_halt(store2, job2, reason="pause please", source="manual")
-    assert build_owner_attention(store2, job2)["needs_you"] == []
+    assert _needs_you(store2, job2) == []
 
 
 def test_owner_review_markers_surface_and_resolve(tmp_path: Path) -> None:
@@ -172,14 +208,14 @@ def test_owner_review_markers_surface_and_resolve(tmp_path: Path) -> None:
         },
     )
 
-    kinds = _kinds(build_owner_attention(store, job_id)["needs_you"])
+    kinds = _kinds(_needs_you(store, job_id))
     assert sorted(kinds) == ["proposal_reject_refused", "successor_abandoned"]
 
     # Once the restage flag clears, the reject-refusal marker resolves.
     proposal = store.load_proposal(job_id, "prop-stuck")
     proposal["application"]["restage_requested"] = False
     store.write_proposal(job_id, proposal)
-    kinds = _kinds(build_owner_attention(store, job_id)["needs_you"])
+    kinds = _kinds(_needs_you(store, job_id))
     assert kinds == ["successor_abandoned"]
 
 
@@ -221,7 +257,7 @@ def test_pending_claims_emit_one_item_per_claim(tmp_path: Path) -> None:
         },
     )
 
-    items = build_owner_attention(store, job_id)["needs_you"]
+    items = _needs_you(store, job_id)
 
     assert _kinds(items) == ["exhaustion_claim_unauditable"] * 3
     by_ref = {item["ref_id"]: item for item in items}
@@ -316,7 +352,7 @@ def test_every_emitted_needs_you_kind_is_in_the_fe_union(tmp_path: Path) -> None
         },
     )
 
-    kinds = set(_kinds(build_owner_attention(store, job_id)["needs_you"]))
+    kinds = set(_kinds(_needs_you(store, job_id)))
 
     assert kinds == WAYFINDER_NEEDS_YOU_KINDS
 
@@ -348,7 +384,7 @@ def test_unauditable_pending_claim_needs_owner(tmp_path: Path) -> None:
             {"claim_id": claim_id, **claim},
         )
 
-    items = build_owner_attention(store, job_id)["needs_you"]
+    items = _needs_you(store, job_id)
     assert _kinds(items) == ["exhaustion_claim_unauditable"]
     assert items[0]["ref_id"] == "claim-stuck"
 
@@ -361,9 +397,18 @@ def test_tripped_decision_gate_needs_owner(tmp_path: Path) -> None:
         {
             "gates": [
                 {
-                    "gate_id": "gate-imx",
+                    "gate_id": "gate-31f22e28",
                     "status": "tripped_needs_owner",
                     "on_met": "retire_and_pivot",
+                    "criteria": {"min_trades": 20, "max_win_rate": 0.4},
+                    "measured": {
+                        "closed_trades": 23,
+                        "win_rate": 0.26,
+                        "net_pnl": -41.07,
+                        "runs": 90,
+                    },
+                    "successor_ref": "explore the funding-skew entry on HYPE",
+                    "pre_registered_ts": "2026-08-10T09:00:00+00:00",
                     "tripped_at": "2026-08-24T00:00:00+00:00",
                 },
                 {"gate_id": "gate-armed", "status": "armed"},
@@ -371,9 +416,64 @@ def test_tripped_decision_gate_needs_owner(tmp_path: Path) -> None:
         },
     )
 
-    items = build_owner_attention(store, job_id)["needs_you"]
+    items = _needs_you(store, job_id)
+
     assert _kinds(items) == ["decision_gate_tripped"]
-    assert items[0]["ref_id"] == "gate-imx"
+    item = items[0]
+    assert item["ref_id"] == "gate-31f22e28"
+    # Plain language carrying the measured numbers, the pre-registered plan,
+    # and the choice...
+    summary = item["summary"]
+    assert "Attn Demo hit its pre-agreed checkpoint" in summary
+    assert "after 23 trades" in summary
+    assert "winning 26%" in summary
+    assert "down $41.07" in summary
+    assert "registered 2026-08-10" in summary
+    assert "funding-skew" in summary
+    assert summary.endswith("Choose: retire and pivot, or keep it running.")
+    # ...and none of the machine text the incident summary leaked (the tone
+    # lint in _needs_you enforces the classes; pin the incident offenders).
+    assert "gate-31f22e28" not in summary
+    assert "retire_and_pivot" not in summary
+    assert "wayfinder" not in summary
+    # Machine detail rides structured fields for the FE.
+    assert item["measured"]["closed_trades"] == 23
+    assert item["criteria"] == {"min_trades": 20, "max_win_rate": 0.4}
+    assert item["successor_ref"] == "explore the funding-skew entry on HYPE"
+    assert item["on_met"] == "retire_and_pivot"
+
+
+def test_tripped_gate_summary_trims_long_successor_to_budget(
+    tmp_path: Path,
+) -> None:
+    store, job_id = _store(tmp_path, wallet_label="main")
+    store.write_json(
+        job_id,
+        "research/decision_gates.json",
+        {
+            "gates": [
+                {
+                    "gate_id": "gate-long",
+                    "status": "tripped_needs_owner",
+                    "on_met": "retire_and_pivot",
+                    "measured": {
+                        "closed_trades": 20,
+                        "win_rate": 0.3,
+                        "net_pnl": -12.5,
+                        "runs": 40,
+                    },
+                    "successor_ref": "a very long successor description " * 20,
+                    "pre_registered_ts": "2026-08-10T09:00:00+00:00",
+                }
+            ]
+        },
+    )
+
+    summary = _needs_you(store, job_id)[0]["summary"]
+
+    assert len(summary) <= 300  # trimmed gracefully, not chopped mid-choice
+    assert summary.endswith("Choose: retire and pivot, or keep it running.")
+    assert "after 20 trades" in summary
 
 
 # ── decided_autonomously feed ────────────────────────────────────────────
@@ -543,6 +643,7 @@ def test_snapshot_ships_owner_attention_top_level(tmp_path: Path, monkeypatch) -
 
     attention = snapshot["owner_attention"]
     assert _kinds(attention["needs_you"]) == ["live_proposal_approval"]
+    assert_owner_readable(attention["needs_you"])
     assert attention["decided_autonomously"] == []
 
 


### PR DESCRIPTION
## Incident

A decision gate tripped on `imx-short`. The needs_you summary was machine text ("decision gate gate-31f22e28 criteria met … pre-registered response is retire_and_pivot … (wayfinder job decision-gate resolve/reopen)"). The owner's FE resolve click landed acknowledge-only (no `--execute`, so the pre-registered retirement never ran), the second click errored "gate … is resolved; nothing to resolve", and the gate was stranded with no path to execute the retirement.

## Changes

1. **Executable acknowledgments** (`decision_gates.py`): `resolve --execute` on a gate previously resolved as acknowledge-only now runs the bounded retire flow (loop disabled + recompiled, workspace archived), records the earlier acknowledgment beside the execution in `resolution`, and journals `decision_gate_executed`. Un-strands acknowledged gates.
2. **Idempotent resolution**: retries against settled gates (executed, acknowledged again without execute, or reopened) return the gate with `"noop": true` in the CLI envelope and exit 0 for both `resolve` and `reopen` — double-clicks and timeout retries read as "already done", never failure. No journal spam, no re-runs.
3. **Plain-language owner summaries** (`owner_attention.py`): the `decision_gate_tripped` summary is now prose — job title, measured trades / win rate / dollar drawdown, plan registration date, pivot phrase, and the choice — with no gate ids, CLI commands, or policy tokens, trimmed gracefully to the 300-char budget. Machine detail (`criteria`, `measured`, `successor_ref`, `on_met`) rides structured item fields for the FE. The risk-halt summary also drops its CLI hint. A tone-lint helper in the owner-attention tests bans CLI strings, flag syntax, machine gate ids, and snake_case policy tokens across every needs_you kind, so future kinds inherit the rule.

## Tests

- Execute-after-acknowledge runs the retirement (loop disabled, workspace archived, `decision_gate_executed` journaled, prior ack preserved); reopen still reverses it.
- Settled-gate retries are no-ops for both verbs (function level and CLI envelope/exit-code level).
- Humanized summary carries the numbers and none of the banned tokens; long successor refs trim within budget; structured fields asserted.
- Tone lint wired through every needs_you read in the owner-attention tests.
- `pytest -q -k "jobs or runner or mcp"`: 1424 passed, 9 skipped (excluding the known pre-existing `test_eval_wayfinder_jobs` hard-execution failure). Ruff clean; scoped mypy adds no new errors.