### PR TITLE
Fix live protection recovery and forward accounting

### DIFF
--- a/wayfinder_paths/jobs/decision_gates.py
+++ b/wayfinder_paths/jobs/decision_gates.py
@@ -107,7 +107,12 @@ def evaluate_gate_criteria(
 ) -> tuple[bool, dict[str, Any]]:
     trades = forward_summary.get("trades") or {}
     runs = forward_summary.get("runs") or {}
-    closed_trades = int(trades.get("closed_count") or 0)
+    strategy_closed = trades.get("strategy_closed_count")
+    closed_trades = int(
+        strategy_closed
+        if strategy_closed is not None
+        else (trades.get("closed_count") or 0)
+    )
     win_rate = trades.get("win_rate")
     net_pnl = float(trades.get("net_pnl") or 0.0)
     run_count = int(runs.get("count") or 0)

--- a/wayfinder_paths/jobs/execution/driver.py
+++ b/wayfinder_paths/jobs/execution/driver.py
@@ -15,7 +15,9 @@ from wayfinder_paths.jobs.execution.engine import (
     EngineState,
     TickResult,
     flatten_positions,
+    resolve_fill_bracket,
     run_tick,
+    sync_native_protection,
 )
 from wayfinder_paths.jobs.execution.features import (
     apply_precompute,
@@ -44,12 +46,17 @@ from wayfinder_paths.jobs.execution.venues import (
     VenueState,
     build_adapter,
 )
-from wayfinder_paths.jobs.forward import ForwardRecorder
+from wayfinder_paths.jobs.forward import ForwardRecorder, forward_exit_category
 from wayfinder_paths.jobs.gating import clamp_leverage, governance_hard_constraints
 from wayfinder_paths.jobs.halt import read_halt, request_halt
-from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.models import (
+    DEFAULT_FORWARD_FILLS,
+    DEFAULT_FORWARD_TICKS,
+    WayfinderJob,
+)
 from wayfinder_paths.jobs.store import JobStore
 from wayfinder_paths.jobs.triggers import fire_triggers
+from wayfinder_paths.runner.monitor_state import atomic_write_json
 
 ENGINE_STATE_PATH = "state/engine_state.json"
 SIZE_TOLERANCE = 1e-6
@@ -358,6 +365,28 @@ async def tick_job(
         venue_state_sink=venue_states,
     )
 
+    protection_recovery_notes: list[dict[str, Any]] = []
+    if mode == "live" and snapshot.status == "valid":
+        for recovery in _recover_missing_native_brackets(root, state):
+            sync_result = TickResult()
+            installed = await sync_native_protection(
+                brokers=brokers,
+                state=state,
+                symbol=str(recovery["symbol"]),
+                venue=str(recovery["venue"]),
+                result=sync_result,
+            )
+            recovery["installed"] = installed
+            protection_recovery_notes.extend(sync_result.guard_events)
+            protection_recovery_notes.append(recovery)
+            if installed:
+                protection = state.native_protections[str(recovery["symbol"])]
+                venue_state = venue_states.get(str(recovery["venue"]))
+                if venue_state is not None:
+                    venue_state.open_orders.append(
+                        {"cloid": protection["client_order_id"]}
+                    )
+
     (
         protection_notes,
         protection_fills,
@@ -528,6 +557,7 @@ async def tick_job(
     tick.guard_events.extend(mode_notes)
     tick.guard_events.extend(leverage_notes)
     tick.guard_events.extend(reconcile_notes)
+    tick.guard_events.extend(protection_recovery_notes)
     tick.guard_events.extend(protection_notes)
     tick.guard_events.extend(symbol_block_notes)
     tick.guard_events.extend(risk_notes)
@@ -797,6 +827,135 @@ _FUNDING_STATE_PATH = "state/funding_state.json"
 _EQUITY_RECON_PATH = "state/equity_recon.json"
 
 
+def _recover_missing_native_brackets(
+    root: Path, state: EngineState
+) -> list[dict[str, Any]]:
+    """Rebuild a lost bracket only from a matching, successfully filled intent."""
+    missing = {
+        symbol: position
+        for symbol, position in state.ledger.positions.items()
+        if symbol not in state.brackets and symbol not in state.native_protections
+    }
+    if not missing:
+        return []
+
+    entry_cloids: dict[str, str] = {}
+    fills_path = root / DEFAULT_FORWARD_FILLS
+    if not fills_path.exists():
+        return []
+    with fills_path.open(encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            try:
+                fill = json.loads(line)
+            except ValueError:
+                continue
+            symbol = str(fill.get("symbol") or "")
+            position = missing.get(symbol)
+            if (
+                position is None
+                or fill.get("mode") != "live"
+                or fill.get("status") != "filled"
+                or fill.get("reduce_only")
+                or str(fill.get("timestamp") or "") != str(position.opened_at or "")
+                or not fill.get("client_order_id")
+            ):
+                continue
+            entry_cloids[symbol] = str(fill["client_order_id"])
+    if not entry_cloids:
+        return []
+
+    intents_by_cloid: dict[str, dict[str, Any]] = {}
+    ticks_path = root / DEFAULT_FORWARD_TICKS
+    if not ticks_path.exists():
+        return []
+    wanted_cloids = set(entry_cloids.values())
+    with ticks_path.open(encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            try:
+                tick = json.loads(line)
+            except ValueError:
+                continue
+            if tick.get("mode") != "live":
+                continue
+            for intent in tick.get("intents") or []:
+                cloid = str(intent.get("client_order_id") or "")
+                if cloid in wanted_cloids:
+                    intents_by_cloid[cloid] = intent
+
+    recovered: list[dict[str, Any]] = []
+    for symbol, cloid in entry_cloids.items():
+        intent = intents_by_cloid.get(cloid) or {}
+        policy = intent.get("bracket") or {}
+        position = missing[symbol]
+        if intent.get("action") != "OPEN" or not policy.get("native_required"):
+            continue
+        venue = str(intent.get("venue") or "")
+        if not venue:
+            continue
+        state.brackets[symbol] = resolve_fill_bracket(
+            policy,
+            position.side,
+            position.avg_price,
+            venue,
+            cloid,
+        )
+        recovered.append(
+            {
+                "kind": "native_protection_contract_recovered",
+                "symbol": symbol,
+                "venue": venue,
+                "entry_client_order_id": cloid,
+            }
+        )
+    return recovered
+
+
+def _first_positive_live_equity_seed(
+    root: Path, *, not_before: str | None = None
+) -> dict[str, Any] | None:
+    """Recover the funded inception snapshot for a legacy zero seed.
+
+    Early live ticks can validly report a zero balance while the user is still
+    funding the wallet. Older code made that provisional zero permanent. The
+    recorded tick stream is the authoritative migration source and lets us
+    repair an existing job without rebasing it at today's already-drawn-down
+    equity.
+    """
+    path = root / DEFAULT_FORWARD_TICKS
+    if not path.exists():
+        return None
+    with path.open(encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            try:
+                row = json.loads(line)
+            except ValueError:
+                continue
+            if not isinstance(row, dict) or row.get("mode") != "live":
+                continue
+            row_ts = str(row.get("ts") or "")
+            if not_before and row_ts and row_ts < not_before:
+                continue
+            snapshot = row.get("snapshot") or {}
+            data = snapshot.get("data") or {}
+            raw_account_value = data.get("account_value")
+            if raw_account_value is None:
+                continue
+            try:
+                account_value = float(raw_account_value)
+            except (TypeError, ValueError):
+                continue
+            if account_value <= 0:
+                continue
+            ledger = row.get("ledger") or {}
+            return {
+                "venue_equity_start": account_value,
+                "ledger_realized_at_seed": float(ledger.get("realized_pnl") or 0.0),
+                "seeded_at": row_ts or pd.Timestamp.now(tz="UTC").isoformat(),
+                "seed_source": "first_positive_live_tick",
+            }
+    return None
+
+
 async def _collect_funding(
     brokers: Mapping[str, Any],
     root: Path,
@@ -872,16 +1031,36 @@ def _reconciliation_block(
             seed = json.loads(recon_path.read_text(encoding="utf-8"))
         except (OSError, ValueError):
             seed = {}
-        if reset_fired or "venue_equity_start" not in seed:
+        if reset_fired:
+            seed = {}
+        try:
+            seeded_equity = float(seed.get("venue_equity_start"))
+        except (TypeError, ValueError):
+            seeded_equity = 0.0
+        if seeded_equity <= 0:
+            # Zero before funding is provisional, not a useful inception
+            # baseline. Wait for capital rather than pinning a permanent
+            # +deposit-sized drift. Existing zero-seeded jobs recover the
+            # first funded snapshot from their durable tick history.
+            if float(account_value) <= 0:
+                return None
+            recovered = (
+                None
+                if reset_fired
+                else _first_positive_live_equity_seed(
+                    root, not_before=str(seed.get("seeded_at") or "") or None
+                )
+            )
             # Mode flips archive the engine state — the realized baseline
             # restarts with it.
-            seed = {
+            seed = recovered or {
                 "venue_equity_start": float(account_value),
                 "ledger_realized_at_seed": realized,
                 "seeded_at": pd.Timestamp.now(tz="UTC").isoformat(),
+                "seed_source": "current_positive_live_tick",
             }
             recon_path.parent.mkdir(parents=True, exist_ok=True)
-            recon_path.write_text(json.dumps(seed), encoding="utf-8")
+            atomic_write_json(recon_path, seed)
 
         unrealized = 0.0
         for symbol, position in (ledger.get("positions") or {}).items():
@@ -1033,6 +1212,7 @@ def _trade_close_payload(
         "exit_reason": exit_reason,
         "effective_leverage": params.get("leverage") or 1.0,
     }
+    payload["exit_category"] = forward_exit_category(payload)
     if action == "STOP_LOSS":
         payload.update(
             {

--- a/wayfinder_paths/jobs/execution/engine.py
+++ b/wayfinder_paths/jobs/execution/engine.py
@@ -840,7 +840,7 @@ def _record_fill(
         position = state.ledger.positions.get(fill.symbol)
         if intent is not None and intent.bracket and not intent.reduce_only:
             if position is not None:
-                state.brackets[fill.symbol] = _resolve_fill_bracket(
+                state.brackets[fill.symbol] = resolve_fill_bracket(
                     intent.bracket,
                     position.side,
                     position.avg_price,
@@ -883,7 +883,7 @@ async def _record_fill_and_protect(
         return
 
     if intent.reduce_only:
-        await _sync_native_protection(
+        await sync_native_protection(
             brokers=brokers,
             state=state,
             symbol=fill.symbol,
@@ -895,7 +895,7 @@ async def _record_fill_and_protect(
     bracket = state.brackets.get(fill.symbol) or {}
     if not bracket.get("native_required"):
         return
-    installed = await _sync_native_protection(
+    installed = await sync_native_protection(
         brokers=brokers,
         state=state,
         symbol=fill.symbol,
@@ -935,10 +935,16 @@ async def _record_fill_and_protect(
                 trace=trace,
                 result=result,
             )
-    if previous_bracket is None:
-        state.brackets.pop(fill.symbol, None)
-    else:
+    # Restore the pre-entry contract only after the new risk is actually gone.
+    # If the fail-closed unwind is rejected or ambiguous, keep the resolved
+    # bracket: monitor_native_protection uses it as the durable invariant that
+    # catches and retries an unprotected position on the next monitor tick.
+    # Dropping it unconditionally made a failed unwind permanently invisible.
+    remaining_position = state.ledger.positions.get(fill.symbol)
+    if previous_bracket is not None:
         state.brackets[fill.symbol] = previous_bracket
+    elif remaining_position is None:
+        state.brackets.pop(fill.symbol, None)
     result.guard_events.append(
         {
             "kind": "native_protection_failed",
@@ -952,7 +958,7 @@ async def _record_fill_and_protect(
     )
 
 
-def _resolve_fill_bracket(
+def resolve_fill_bracket(
     policy: Mapping[str, Any],
     side: str,
     entry_price: float,
@@ -974,7 +980,7 @@ def _resolve_fill_bracket(
     return resolved
 
 
-async def _sync_native_protection(
+async def sync_native_protection(
     *,
     brokers: Mapping[str, Broker],
     state: EngineState,

--- a/wayfinder_paths/jobs/forward.py
+++ b/wayfinder_paths/jobs/forward.py
@@ -20,6 +20,10 @@ from wayfinder_paths.jobs.models import (
 from wayfinder_paths.runner.monitor_state import atomic_write_json
 
 FORWARD_SCHEMA_VERSION = "0.1"
+TRADE_METRICS_VERSION = 2
+OPERATIONAL_SAFETY_EXIT_REASONS = frozenset(
+    {"native_protection_unconfirmed", "native_protection_breach"}
+)
 FORWARD_FILES = {
     "run": DEFAULT_FORWARD_RUNS,
     "trade": DEFAULT_FORWARD_TRADES,
@@ -28,6 +32,160 @@ FORWARD_FILES = {
     "funding": DEFAULT_FORWARD_FUNDING,
     "tick": DEFAULT_FORWARD_TICKS,
 }
+
+
+def forward_exit_category(row: Mapping[str, Any]) -> str:
+    """Separate execution containment from strategy-authored exits.
+
+    Operational closes remain in total net PnL because they cost real money,
+    but they must not manufacture strategy losses, loss streaks, or evidence
+    that a strategy completed another intentional trade.
+    """
+    explicit = str(row.get("exit_category") or "")
+    if explicit:
+        return explicit
+    reason = str(row.get("exit_reason") or "")
+    if not reason:
+        raw = row.get("raw") or {}
+        metadata = raw.get("intent_metadata") or {}
+        reason = str(metadata.get("exit_reason") or "")
+    return (
+        "operational_safety"
+        if reason in OPERATIONAL_SAFETY_EXIT_REASONS
+        else "strategy"
+    )
+
+
+def _new_trade_summary() -> dict[str, Any]:
+    return {
+        "trade_metrics_version": TRADE_METRICS_VERSION,
+        "closed_count": 0,
+        "strategy_closed_count": 0,
+        "operational_closed_count": 0,
+        "wins": 0,
+        "losses": 0,
+        "win_rate": None,
+        "net_pnl": 0,
+        "operational_net_pnl": 0,
+        "current_loss_streak": 0,
+    }
+
+
+def _trade_net_pnl(row: Mapping[str, Any]) -> float | None:
+    match row.get("pnl"):
+        case Mapping() as pnl:
+            raw_pnl = pnl.get("net_usd")
+            if raw_pnl is None:
+                raw_pnl = pnl.get("net")
+        case other:
+            raw_pnl = other
+    if raw_pnl is None:
+        raw_pnl = row.get("net_pnl")
+    return float(raw_pnl) if raw_pnl is not None else None
+
+
+def _apply_trade_summary_row(trades: dict[str, Any], row: Mapping[str, Any]) -> None:
+    trades["closed_count"] = int(trades.get("closed_count") or 0) + 1
+    net_pnl = _trade_net_pnl(row)
+    if net_pnl is not None:
+        trades["net_pnl"] = float(trades.get("net_pnl") or 0) + net_pnl
+
+    if forward_exit_category(row) == "operational_safety":
+        trades["operational_closed_count"] = (
+            int(trades.get("operational_closed_count") or 0) + 1
+        )
+        if net_pnl is not None:
+            trades["operational_net_pnl"] = (
+                float(trades.get("operational_net_pnl") or 0) + net_pnl
+            )
+    else:
+        trades["strategy_closed_count"] = (
+            int(trades.get("strategy_closed_count") or 0) + 1
+        )
+        if net_pnl is not None:
+            if net_pnl >= 0:
+                trades["wins"] = int(trades.get("wins") or 0) + 1
+                trades["current_loss_streak"] = 0
+            else:
+                trades["losses"] = int(trades.get("losses") or 0) + 1
+                trades["current_loss_streak"] = (
+                    int(trades.get("current_loss_streak") or 0) + 1
+                )
+        strategy_closed = int(trades.get("strategy_closed_count") or 0)
+        trades["win_rate"] = (
+            int(trades.get("wins") or 0) / strategy_closed if strategy_closed else None
+        )
+    trades["last_trade_at"] = row.get("closed_at") or row.get("ts")
+
+
+def _legacy_safety_unwind_keys(forward_dir: Path) -> set[tuple[str, str]]:
+    """Recover pre-reason safety exits from their durable guard events."""
+    path = forward_dir / Path(DEFAULT_FORWARD_TICKS).name
+    keys: set[tuple[str, str]] = set()
+    if not path.exists():
+        return keys
+    with path.open(encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            try:
+                tick = json.loads(line)
+            except ValueError:
+                continue
+            for event in tick.get("guard_events") or []:
+                if (
+                    event.get("kind") == "native_protection_failed"
+                    and event.get("unwind_status") == "filled"
+                    and event.get("symbol")
+                    and event.get("timestamp")
+                ):
+                    keys.add((str(event["symbol"]), str(event["timestamp"])))
+    return keys
+
+
+def _upgrade_trade_summary(summary: dict[str, Any], trades_path: Path) -> bool:
+    """Rebuild legacy counters once so existing jobs gain honest categories."""
+    current = summary.setdefault("trades", {})
+    if current.get("trade_metrics_version") == TRADE_METRICS_VERSION:
+        return False
+    rebuilt = _new_trade_summary()
+    rebuilt_from_rows = False
+    legacy_safety_unwinds = _legacy_safety_unwind_keys(trades_path.parent)
+    if trades_path.exists():
+        with trades_path.open(encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                try:
+                    row = json.loads(line)
+                except ValueError:
+                    continue
+                if isinstance(row, dict):
+                    key = (
+                        str(row.get("symbol") or ""),
+                        str(row.get("closed_at") or row.get("timestamp") or ""),
+                    )
+                    if (
+                        forward_exit_category(row) == "strategy"
+                        and key in legacy_safety_unwinds
+                    ):
+                        row["exit_category"] = "operational_safety"
+                    _apply_trade_summary_row(rebuilt, row)
+                    rebuilt_from_rows = True
+    if not rebuilt_from_rows:
+        # Compatibility for callers that persisted only summary.json before
+        # the recorder owned detailed rows: absent evidence of an operational
+        # close, preserve the old counters as strategy outcomes.
+        rebuilt.update(
+            {
+                "closed_count": int(current.get("closed_count") or 0),
+                "strategy_closed_count": int(current.get("closed_count") or 0),
+                "wins": int(current.get("wins") or 0),
+                "losses": int(current.get("losses") or 0),
+                "win_rate": current.get("win_rate"),
+                "net_pnl": float(current.get("net_pnl") or 0),
+                "current_loss_streak": int(current.get("current_loss_streak") or 0),
+                "last_trade_at": current.get("last_trade_at"),
+            }
+        )
+    summary["trades"] = {**current, **rebuilt}
+    return True
 
 
 def default_forward_summary(
@@ -46,14 +204,7 @@ def default_forward_summary(
             "last_reason": None,
             "error_count": 0,
         },
-        "trades": {
-            "closed_count": 0,
-            "wins": 0,
-            "losses": 0,
-            "win_rate": None,
-            "net_pnl": 0,
-            "current_loss_streak": 0,
-        },
+        "trades": _new_trade_summary(),
         "orders": {"count": 0, "last_order_at": None, "pending_count": 0},
         "fills": {"count": 0, "last_fill_at": None, "fees_total": 0.0},
         # Signed usd funding payments (negative = paid) — real PnL that never
@@ -103,11 +254,33 @@ def render_forward_recap(summary: dict[str, Any] | None) -> str:
     wins = int(trades.get("wins") or 0)
     losses = int(trades.get("losses") or 0)
     # Stored win_rate is a fraction (wins/closed); render as a whole percent.
+    operational = int(trades.get("operational_closed_count") or 0)
+    raw_strategy_closed = trades.get("strategy_closed_count")
+    strategy_closed = (
+        int(raw_strategy_closed) if raw_strategy_closed is not None else closed
+    )
     win_rate = trades.get("win_rate")
+    win_rate_denominator = strategy_closed if operational else closed
     win_rate_pct = (
-        (float(win_rate) * 100.0) if win_rate is not None else (wins / closed * 100.0)
+        (float(win_rate) * 100.0)
+        if win_rate is not None
+        else (wins / win_rate_denominator * 100.0)
+        if win_rate_denominator
+        else 0.0
     )
     net_pnl = float(trades.get("net_pnl") or 0.0)
+    if operational:
+        safety_label = "safety exit" if operational == 1 else "safety exits"
+        if strategy_closed <= 0:
+            return (
+                f"Forward: 0 strategy closed · {operational} {safety_label} · "
+                f"{net_pnl:+g} total net"
+            )
+        return (
+            f"Forward: {strategy_closed} strategy closed · {wins}W/{losses}L · "
+            f"{win_rate_pct:.0f}% WR · {operational} {safety_label} · "
+            f"{net_pnl:+g} total net"
+        )
     return (
         f"Forward: {closed} closed · {wins}W/{losses}L · "
         f"{win_rate_pct:.0f}% WR · {net_pnl:+g} net"
@@ -280,6 +453,9 @@ class ForwardRecorder:
         )
         summary["job_id"] = summary.get("job_id") or self.job_id
         summary["updated_at"] = utc_now_iso()
+        trade_summary_rebuilt = _upgrade_trade_summary(
+            summary, self.forward_dir / Path(DEFAULT_FORWARD_TRADES).name
+        )
         if kind == "run":
             runs = summary.setdefault("runs", {})
             runs["count"] = int(runs.get("count") or 0) + 1
@@ -296,34 +472,10 @@ class ForwardRecorder:
                 runs["error_count"] = int(runs.get("error_count") or 0) + 1
         elif kind == "trade":
             trades = summary.setdefault("trades", {})
-            trades["closed_count"] = int(trades.get("closed_count") or 0) + 1
-            match row.get("pnl"):
-                case Mapping() as pnl:
-                    raw_pnl = pnl.get("net_usd")
-                    if raw_pnl is None:
-                        raw_pnl = pnl.get("net")
-                case other:
-                    raw_pnl = other
-            if raw_pnl is None:
-                raw_pnl = row.get("net_pnl")
-            net_pnl = float(raw_pnl) if raw_pnl is not None else None
-            if net_pnl is not None:
-                trades["net_pnl"] = float(trades.get("net_pnl") or 0) + net_pnl
-                if net_pnl >= 0:
-                    trades["wins"] = int(trades.get("wins") or 0) + 1
-                    trades["current_loss_streak"] = 0
-                else:
-                    trades["losses"] = int(trades.get("losses") or 0) + 1
-                    trades["current_loss_streak"] = (
-                        int(trades.get("current_loss_streak") or 0) + 1
-                    )
-                closed_count = int(trades.get("closed_count") or 0)
-                trades["win_rate"] = (
-                    int(trades.get("wins") or 0) / closed_count
-                    if closed_count
-                    else None
-                )
-            trades["last_trade_at"] = row.get("closed_at") or row.get("ts")
+            # A legacy rebuild reads the row that append() just wrote, so do
+            # not count it a second time.
+            if not trade_summary_rebuilt:
+                _apply_trade_summary_row(trades, row)
         elif kind == "order":
             orders = summary.setdefault("orders", {})
             orders["count"] = int(orders.get("count") or 0) + 1

--- a/wayfinder_paths/tests/test_execution_engine.py
+++ b/wayfinder_paths/tests/test_execution_engine.py
@@ -697,6 +697,57 @@ async def test_unconfirmed_live_stop_unwinds_new_risk_and_requests_halt() -> Non
     assert failure["halt_required"] is True
 
 
+async def test_failed_unwind_preserves_required_protection_contract() -> None:
+    class RejectingUnwindBroker(FakeNativeBroker):
+        async def place(
+            self, intent: OrderIntent, *, timestamp: str, price: float | None = None
+        ) -> FillEvent:
+            if intent.reduce_only:
+                self.placed.append(intent)
+                return FillEvent(
+                    status="rejected",
+                    venue=intent.venue,
+                    symbol=intent.symbol,
+                    side=intent.side,
+                    reduce_only=True,
+                    error="reduce_only_no_position",
+                    raw={
+                        "intent_action": intent.action,
+                        "intent_metadata": intent.metadata,
+                    },
+                    timestamp=timestamp,
+                )
+            return await super().place(intent, timestamp=timestamp, price=price)
+
+    broker = RejectingUnwindBroker(confirm=False)
+    state = EngineState(mode="live")
+    intent = OrderIntent(
+        action="OPEN",
+        venue="hyperliquid",
+        symbol="SNX",
+        side="long",
+        size=1.0,
+        bracket={"stop_loss_pct": 0.05, "native_required": True},
+    )
+
+    result = await _tick(
+        _strategy([intent]),
+        _view([10.0, 10.5]),
+        state=state,
+        brokers={"hyperliquid": broker},
+    )
+
+    assert "SNX" in state.ledger.positions
+    assert state.brackets["SNX"]["native_required"] is True
+    assert state.brackets["SNX"]["stop_loss"] == pytest.approx(9.975)
+    failure = next(
+        event
+        for event in result.guard_events
+        if event["kind"] == "native_protection_failed"
+    )
+    assert failure["unwind_status"] == "rejected"
+
+
 async def test_unconfirmed_replaced_stop_cancel_requests_halt() -> None:
     broker = FakeNativeBroker(cancel_confirm=False)
     state = EngineState(mode="live")

--- a/wayfinder_paths/tests/test_job_forward_results.py
+++ b/wayfinder_paths/tests/test_job_forward_results.py
@@ -149,6 +149,95 @@ def test_forward_recorder_uses_env_and_preserves_loose_rows(
     assert summary["trades"]["losses"] == 1
 
 
+def test_operational_safety_exit_does_not_manufacture_strategy_loss(
+    tmp_path: Path,
+) -> None:
+    recorder = ForwardRecorder(job_id="safety-job", job_dir=tmp_path, mode="live")
+    recorder.record_trade_close(
+        net_pnl=-0.23,
+        exit_reason="native_protection_unconfirmed",
+    )
+
+    summary = recorder.summary()
+    trades = summary["trades"]
+    assert trades["closed_count"] == 1
+    assert trades["strategy_closed_count"] == 0
+    assert trades["operational_closed_count"] == 1
+    assert trades["losses"] == 0
+    assert trades["current_loss_streak"] == 0
+    assert trades["net_pnl"] == -0.23
+    assert trades["operational_net_pnl"] == -0.23
+    assert (
+        render_forward_recap(summary)
+        == "Forward: 0 strategy closed · 1 safety exit · -0.23 total net"
+    )
+
+
+def test_legacy_summary_rebuilds_operational_exit_categories(tmp_path: Path) -> None:
+    forward_dir = tmp_path / "results" / "forward"
+    forward_dir.mkdir(parents=True)
+    (forward_dir / "trades.jsonl").write_text(
+        "\n".join(
+            json.dumps(row)
+            for row in (
+                {
+                    "ts": "2026-08-25T18:00:00+00:00",
+                    "closed_at": "2026-08-25T18:00:00+00:00",
+                    "symbol": "BTC",
+                    "net_pnl": -0.23,
+                },
+                {
+                    "ts": "2026-08-26T18:00:00+00:00",
+                    "closed_at": "2026-08-26T18:00:00+00:00",
+                    "symbol": "BTC",
+                    "net_pnl": -0.5,
+                    "exit_reason": "signal_rebalance",
+                },
+            )
+        )
+        + "\n"
+    )
+    (forward_dir / "ticks.jsonl").write_text(
+        json.dumps(
+            {
+                "guard_events": [
+                    {
+                        "kind": "native_protection_failed",
+                        "symbol": "BTC",
+                        "timestamp": "2026-08-25T18:00:00+00:00",
+                        "unwind_status": "filled",
+                    }
+                ]
+            }
+        )
+        + "\n"
+    )
+    (forward_dir / "summary.json").write_text(
+        json.dumps(
+            {
+                "trades": {
+                    "closed_count": 2,
+                    "wins": 0,
+                    "losses": 2,
+                    "net_pnl": -0.73,
+                    "current_loss_streak": 2,
+                }
+            }
+        )
+    )
+
+    recorder = ForwardRecorder(job_id="legacy-job", job_dir=tmp_path, mode="live")
+    recorder.record_run(decision="hold")
+    trades = recorder.summary()["trades"]
+
+    assert trades["closed_count"] == 2
+    assert trades["strategy_closed_count"] == 1
+    assert trades["operational_closed_count"] == 1
+    assert trades["losses"] == 1
+    assert trades["current_loss_streak"] == 1
+    assert trades["net_pnl"] == -0.73
+
+
 def test_forward_snapshot_is_capped_and_accepts_missing_files(tmp_path: Path) -> None:
     store = JobStore(repo_root=tmp_path)
     job = WayfinderJob.new(

--- a/wayfinder_paths/tests/test_jobs_decision_gates.py
+++ b/wayfinder_paths/tests/test_jobs_decision_gates.py
@@ -124,6 +124,22 @@ def test_criteria_need_the_full_evidence_window(tmp_path: Path) -> None:
     )
     assert met is False
 
+    # Fail-closed execution churn costs real PnL but is not evidence that the
+    # strategy intentionally completed the pre-registered trade window.
+    met, measured = evaluate_gate_criteria(
+        CRITERIA,
+        {
+            "trades": {
+                "closed_count": 25,
+                "strategy_closed_count": 5,
+                "operational_closed_count": 20,
+                "win_rate": 0.0,
+                "net_pnl": -50.0,
+            }
+        },
+    )
+    assert met is False and measured["closed_trades"] == 5
+
 
 # ── paper auto-resolution ────────────────────────────────────────────────
 

--- a/wayfinder_paths/tests/test_jobs_live_driver.py
+++ b/wayfinder_paths/tests/test_jobs_live_driver.py
@@ -5,12 +5,14 @@ from pathlib import Path
 from typing import Any
 
 import pandas as pd
+import pytest
 
 from wayfinder_paths.jobs.compiler import JobCompiler
 from wayfinder_paths.jobs.execution import (
     CompletedBarsView,
     ExecutionSpec,
     FillEvent,
+    NativeProtectionResult,
     OrderIntent,
     PositionLedger,
     TradeCapacity,
@@ -134,6 +136,27 @@ class FakeLiveBroker:
 
     async def cancel(self, client_order_id: str) -> FillEvent:
         return FillEvent(status="rejected", venue="fake", symbol="", side="")
+
+
+class FakeNativeLiveBroker(FakeLiveBroker):
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.stops: list[dict[str, Any]] = []
+
+    async def place_stop_loss(self, **kwargs: Any) -> NativeProtectionResult:
+        self.stops.append(kwargs)
+        return NativeProtectionResult(
+            status="confirmed",
+            symbol=str(kwargs["symbol"]),
+            client_order_id=str(kwargs["client_order_id"]),
+        )
+
+    async def cancel_stop_loss(self, **kwargs: Any) -> NativeProtectionResult:
+        return NativeProtectionResult(
+            status="confirmed",
+            symbol=str(kwargs["symbol"]),
+            client_order_id=str(kwargs["client_order_id"]),
+        )
 
 
 class FakeFeed:
@@ -942,6 +965,82 @@ async def test_mode_flip_archives_state_and_adopts_venue(tmp_path: Path) -> None
     assert restored.mode == "live"
     assert restored.ledger.positions["SNX"].metadata.get("adopted_from_venue")
     assert restored.strategy_state == {}
+
+
+async def test_live_tick_recovers_and_installs_legacy_missing_stop(
+    tmp_path: Path,
+) -> None:
+    store, job, root = _make_job(tmp_path, mode="live")
+    position = PositionRecord(
+        symbol="SNX",
+        side="long",
+        size=2.0,
+        avg_price=9.5,
+        opened_at="2026-01-01T00:00:00+00:00",
+    )
+    state = EngineState(mode="live")
+    state.ledger.positions["SNX"] = position
+    state.save(root / "state" / "engine_state.json")
+
+    forward = root / "results" / "forward"
+    (forward / "fills.jsonl").write_text(
+        json.dumps(
+            {
+                "mode": "live",
+                "status": "filled",
+                "symbol": "SNX",
+                "timestamp": position.opened_at,
+                "filled_size": 2.0,
+                "reduce_only": False,
+                "client_order_id": "entry-snx",
+            }
+        )
+        + "\n"
+    )
+    (forward / "ticks.jsonl").write_text(
+        json.dumps(
+            {
+                "mode": "live",
+                "intents": [
+                    {
+                        "action": "OPEN",
+                        "venue": "hyperliquid",
+                        "symbol": "SNX",
+                        "client_order_id": "entry-snx",
+                        "bracket": {
+                            "stop_loss_pct": 0.05,
+                            "native_required": True,
+                        },
+                    }
+                ],
+            }
+        )
+        + "\n"
+    )
+    broker = FakeNativeLiveBroker(
+        venue_positions={"SNX": position}, account_value=100.0
+    )
+    view = _view(2)
+
+    result = await tick_job(
+        job,
+        root,
+        "live",
+        store=store,
+        adapters={"hyperliquid": FakeAdapter(view, broker)},
+        now=_now(view),
+    )
+
+    recovered = next(
+        event
+        for event in result["guard_events"]
+        if event.get("kind") == "native_protection_contract_recovered"
+    )
+    assert recovered["installed"] is True
+    assert broker.stops[0]["trigger_price"] == pytest.approx(9.025)
+    restored = EngineState.load(root / "state" / "engine_state.json")
+    assert "SNX" in restored.native_protections
+    assert "SNX" in restored.ledger.positions
 
 
 async def test_legacy_state_without_mode_is_stamped_not_archived(

--- a/wayfinder_paths/tests/test_jobs_live_fees.py
+++ b/wayfinder_paths/tests/test_jobs_live_fees.py
@@ -265,6 +265,85 @@ def test_reconciliation_block_identity(tmp_path) -> None:
     )
 
 
+def test_reconciliation_recovers_first_funded_tick_from_zero_seed(tmp_path) -> None:
+    from wayfinder_paths.jobs.execution.driver import _reconciliation_block
+
+    recorder = ForwardRecorder(job_id="j", job_dir=tmp_path, mode="live")
+    recon_path = tmp_path / "state" / "equity_recon.json"
+    recon_path.parent.mkdir(parents=True)
+    recon_path.write_text(
+        json.dumps(
+            {
+                "venue_equity_start": 0.0,
+                "ledger_realized_at_seed": 0.0,
+                "seeded_at": "2026-08-25T14:35:00+00:00",
+            }
+        )
+    )
+    ticks_path = tmp_path / "results" / "forward" / "ticks.jsonl"
+    ticks_path.parent.mkdir(parents=True, exist_ok=True)
+    ticks_path.write_text(
+        "\n".join(
+            json.dumps(row)
+            for row in (
+                {
+                    "mode": "live",
+                    "ts": "2026-08-25T14:35:00+00:00",
+                    "snapshot": {"data": {"account_value": 0.0}},
+                    "ledger": {"realized_pnl": 0.0},
+                },
+                {
+                    "mode": "live",
+                    "ts": "2026-08-25T16:39:00+00:00",
+                    "snapshot": {"data": {"account_value": 52.8}},
+                    "ledger": {"realized_pnl": 0.0},
+                },
+            )
+        )
+        + "\n"
+    )
+
+    tick = SimpleNamespace(
+        snapshot=SimpleNamespace(data={"account_value": 50.8}),
+        ledger_snapshot={"realized_pnl": -2.0, "positions": {}},
+        guard_events=[],
+    )
+    block = _reconciliation_block(
+        tick,
+        root=tmp_path,
+        recorder=recorder,
+        mode="live",
+        view=SimpleNamespace(latest=lambda _symbol: None),
+    )
+
+    assert block["venue_equity_start"] == 52.8
+    assert block["expected_equity"] == 50.8
+    assert block["drift"] == 0.0
+    recovered = json.loads(recon_path.read_text())
+    assert recovered["seed_source"] == "first_positive_live_tick"
+
+
+def test_reconciliation_does_not_pin_provisional_zero_equity(tmp_path) -> None:
+    from wayfinder_paths.jobs.execution.driver import _reconciliation_block
+
+    recorder = ForwardRecorder(job_id="j", job_dir=tmp_path, mode="live")
+    tick = SimpleNamespace(
+        snapshot=SimpleNamespace(data={"account_value": 0.0}),
+        ledger_snapshot={"realized_pnl": 0.0, "positions": {}},
+        guard_events=[],
+    )
+    block = _reconciliation_block(
+        tick,
+        root=tmp_path,
+        recorder=recorder,
+        mode="live",
+        view=SimpleNamespace(latest=lambda _symbol: None),
+    )
+
+    assert block is None
+    assert not (tmp_path / "state" / "equity_recon.json").exists()
+
+
 def test_risk_equity_includes_funding(tmp_path) -> None:
     import wayfinder_paths.jobs.execution.risk as risk_module
 


### PR DESCRIPTION
## Summary

- preserve the resolved native-protection contract when a fail-closed unwind is rejected or ambiguous, so the next monitor tick can still contain the position
- recover legacy missing protection only from a matching successful live entry fill and its recorded native-required intent, then install the stop through the existing broker price-normalization path
- treat zero pre-funding equity as provisional and migrate legacy zero seeds from the first positive live account snapshot
- separate operational safety exits from strategy closes in forward summaries and decision-gate evidence while retaining their real PnL in total net performance

## Safety behavior

Recovery never invents a bracket from the current position alone. It requires the durable fill/intent pair that created the position. A recovered stop must be venue-confirmed; otherwise the existing native-protection monitor immediately takes the fail-closed path for the job-attributed position.

The trigger-price quantization fix from #730 is already present on the target branch and remains the single price-normalization path used by both new and recovered stops.

## Compatibility

The forward-summary schema is additive. Existing `closed_count` and total `net_pnl` semantics remain intact; new strategy/operational counters are migrated once from durable trade and guard-event records. Legacy summaries without detailed rows retain their former counters as strategy outcomes.

## Validation

- `ruff check` — passed
- `mypy` on the four changed production modules — passed
- focused execution/forward/gate suite — 88 passed
- adjacent risk/reconciliation suite — 107 passed
- compatibility suite — 142 passed, with the existing `test_wayfinder_jobs_eval_validates_hard_execution_backtest` fixture failure reproduced unchanged on the clean base

## Canary expectation

On the affected job, the first healthy live tick should reconstruct the recorded TSLA bracket and submit its stop through the normal broker adapter. Its seven historical native-protection unwinds should migrate to safety exits, leaving zero strategy closes for gate evidence.
