### PR TITLE
jobs: probation trials carry the strategy's real identity; no degenerate early intervals

### DIFF
--- a/wayfinder_paths/jobs/archive.py
+++ b/wayfinder_paths/jobs/archive.py
@@ -94,6 +94,15 @@ def load_archive(store: JobStore, job_id: str) -> dict[str, Any]:
     return doc
 
 
+def find_candidate(
+    store: JobStore, job_id: str, candidate_id: str
+) -> dict[str, Any] | None:
+    """Resolve an archive entry by content id, proposal UUID, or revision."""
+    if not candidate_id:
+        return None
+    return _resolve(load_archive(store, job_id), candidate_id)
+
+
 def record_candidate(
     store: JobStore,
     job_id: str,

--- a/wayfinder_paths/jobs/evolution_campaign.py
+++ b/wayfinder_paths/jobs/evolution_campaign.py
@@ -1834,7 +1834,8 @@ def _finalize_campaign(store: JobStore, job_id: str) -> dict[str, Any]:
                         candidate_root=candidate_root,
                         revision=str(candidate.get("revision") or ""),
                         source="evolution_campaign",
-                        family=str(candidate.get("family") or "evolution"),
+                        family=str(candidate.get("family") or ""),
+                        summary=str(candidate.get("summary") or "") or None,
                         campaign_id=campaign_id,
                         evidence=economic,
                     )

--- a/wayfinder_paths/jobs/probation.py
+++ b/wayfinder_paths/jobs/probation.py
@@ -17,6 +17,7 @@ from typing import Any
 
 import pandas as pd
 
+from wayfinder_paths.jobs.archive import find_candidate
 from wayfinder_paths.jobs.bundles import copy_job_bundle
 from wayfinder_paths.jobs.compute_lock import job_state_lock
 from wayfinder_paths.jobs.economics import block_bootstrap_lcb
@@ -38,6 +39,15 @@ TRIAL_ACTIVE_STATUSES = frozenset({"burn_in", "active"})
 TRIAL_TERMINAL_STATUSES = frozenset(
     {"graduated", "killed", "inconclusive", "superseded"}
 )
+# Owner-facing trial identity: a trial card names the STRATEGY, not the
+# plumbing that delivered it. "evolution" is the pipeline, never a family.
+GENERIC_TRIAL_FAMILY = "unknown-strategy"
+TRIAL_SUMMARY_MAX_CHARS = 200
+PLACEHOLDER_TRIAL_FAMILIES = frozenset({"", "evolution", GENERIC_TRIAL_FAMILY})
+# Circular moving-block bootstrap block length for paired forward deltas.
+# Below this many paired days every resample is the full (rotated) sample, so
+# the "interval" collapses to the point estimate — report no bounds instead.
+FORWARD_BOOTSTRAP_BLOCK_LEN = 5
 
 
 def load_probation(store: JobStore, job_id: str) -> dict[str, Any]:
@@ -402,11 +412,21 @@ def ensure_unified_probation(
                     None,
                 )
                 if migrated_trial is None:
+                    family, summary = _resolve_trial_identity(
+                        store,
+                        job_id,
+                        candidate_id=str(
+                            candidate.get("candidate_id") or candidate["revision"]
+                        ),
+                        fallback_family=None,
+                        fallback_summary=None,
+                    )
                     trial = {
                         "trial_id": trial_id,
                         "candidate_id": candidate.get("candidate_id"),
                         "candidate_revision": candidate.get("revision"),
-                        "family": "evolution",
+                        "family": family,
+                        "summary": summary,
                         "source": candidate.get("source") or "evolution_campaign",
                         "status": "active",
                         "phase": "forward",
@@ -482,6 +502,70 @@ def ensure_unified_probation(
         return doc
 
 
+def _resolve_trial_identity(
+    store: JobStore,
+    job_id: str,
+    *,
+    candidate_id: str,
+    fallback_family: str | None,
+    fallback_summary: str | None,
+) -> tuple[str, str | None]:
+    """The candidate's real strategy identity for the owner-facing trial card.
+
+    Archive entry first (authoritative family + hypothesis summary), then the
+    campaign candidate record, then an honest generic placeholder — never the
+    literal pipeline name "evolution"."""
+    entry = find_candidate(store, job_id, candidate_id) or {}
+    archive_family = str(entry.get("family") or "").strip()
+    archive_summary = str(entry.get("summary") or "").strip()
+    family = next(
+        (
+            value
+            for value in (archive_family, str(fallback_family or "").strip())
+            if value.lower() not in PLACEHOLDER_TRIAL_FAMILIES
+        ),
+        GENERIC_TRIAL_FAMILY,
+    )
+    summary = (archive_summary or str(fallback_summary or "").strip())[
+        :TRIAL_SUMMARY_MAX_CHARS
+    ]
+    return family, summary or None
+
+
+def _repair_trial_identity(
+    store: JobStore, job_id: str, trial: dict[str, Any]
+) -> dict[str, Any] | None:
+    """Patch a legacy placeholder identity in place once the archive knows the
+    candidate — live trials get fixed on the next adjudication pass, no manual
+    migration."""
+    if str(trial.get("family") or "").strip().lower() not in (
+        PLACEHOLDER_TRIAL_FAMILIES
+    ):
+        return None
+    entry = (
+        find_candidate(
+            store,
+            job_id,
+            str(trial.get("candidate_id") or trial.get("candidate_revision") or ""),
+        )
+        or {}
+    )
+    family = str(entry.get("family") or "").strip()
+    if family.lower() in PLACEHOLDER_TRIAL_FAMILIES:
+        return None
+    trial["family"] = family
+    summary = str(entry.get("summary") or "").strip()[:TRIAL_SUMMARY_MAX_CHARS]
+    if summary:
+        trial["summary"] = summary
+    trial["updated_at"] = utc_now_iso()
+    return {
+        "action": "probation_trial_identity_repaired",
+        "trial_id": trial.get("trial_id"),
+        "candidate_id": trial.get("candidate_id"),
+        "family": family,
+    }
+
+
 def stage_evolution_probation(
     store: JobStore,
     job_id: str,
@@ -491,12 +575,20 @@ def stage_evolution_probation(
     revision: str,
     source: str,
     family: str,
+    summary: str | None = None,
     campaign_id: str | None = None,
     evidence: dict[str, Any] | None = None,
     now: datetime | None = None,
 ) -> dict[str, Any]:
     """Freeze a gate-green candidate into the permanent paper probation rail."""
     current = _aware(now or datetime.now(UTC))
+    family, summary = _resolve_trial_identity(
+        store,
+        job_id,
+        candidate_id=candidate_id,
+        fallback_family=family,
+        fallback_summary=summary,
+    )
     spec = ImproverSpec.load(store.job_dir(job_id))
     policy = spec.evolution.get("probation") or {}
     max_active = int(policy.get("max_active") or 3)
@@ -557,6 +649,7 @@ def stage_evolution_probation(
             "reference_revision": reference_revision,
             "campaign_id": campaign_id,
             "family": family,
+            "summary": summary,
             "source": source,
             "status": status,
             "phase": "burn_in" if status == "burn_in" else "queued",
@@ -737,6 +830,9 @@ def maybe_adjudicate_probation(
     with job_state_lock(store.repo_root, job_id, name="probation"):
         doc = load_probation(store, job_id)
         for trial in doc.get("trials") or []:
+            repair = _repair_trial_identity(store, job_id, trial)
+            if repair:
+                outcomes.append(repair)
             if trial.get("status") == "burn_in":
                 outcome = _adjudicate_burn_in(store, job_id, trial, current=current)
             elif trial.get("status") == "active":
@@ -942,13 +1038,29 @@ def _paired_forward_metrics(
         if candidate[day] > -capital and reference[day] > -capital
     ]
     confidence = float(trial["forward"].get("confidence") or 0.90)
-    lcb = block_bootstrap_lcb(
-        deltas, block_len=5, iterations=500, confidence=confidence
-    )
-    reverse = block_bootstrap_lcb(
-        [-value for value in deltas], block_len=5, iterations=500, confidence=confidence
-    )
-    ucb = -reverse if reverse is not None else None
+    lcb: float | None
+    ucb: float | None
+    if len(deltas) < FORWARD_BOOTSTRAP_BLOCK_LEN:
+        # Degenerate bootstrap: fewer paired days than one block makes every
+        # resample identical, rendering lcb == ucb == estimate as false
+        # precision. Decision checkpoints are unaffected — the day-7/14
+        # peeks have >= block-length days, and verdicts null-guard the bounds.
+        lcb = None
+        ucb = None
+    else:
+        lcb = block_bootstrap_lcb(
+            deltas,
+            block_len=FORWARD_BOOTSTRAP_BLOCK_LEN,
+            iterations=500,
+            confidence=confidence,
+        )
+        reverse = block_bootstrap_lcb(
+            [-value for value in deltas],
+            block_len=FORWARD_BOOTSTRAP_BLOCK_LEN,
+            iterations=500,
+            confidence=confidence,
+        )
+        ucb = -reverse if reverse is not None else None
     safety = _hard_constraint_metrics(store, job_id, candidate)
     return {
         "paired_days": len(deltas),

--- a/wayfinder_paths/tests/test_jobs_unified_probation.py
+++ b/wayfinder_paths/tests/test_jobs_unified_probation.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
+from wayfinder_paths.jobs.archive import record_candidate
 from wayfinder_paths.jobs.candidate_shadow import _target_shadow_state_root
 from wayfinder_paths.jobs.execution.driver import _apply_symbol_entry_blocks
 from wayfinder_paths.jobs.execution.engine import EngineState
@@ -20,6 +21,7 @@ from wayfinder_paths.jobs.gating import compute_workspace_revision
 from wayfinder_paths.jobs.halt import clear_halt, read_halt
 from wayfinder_paths.jobs.models import WayfinderJob
 from wayfinder_paths.jobs.probation import (
+    GENERIC_TRIAL_FAMILY,
     ensure_unified_probation,
     load_probation,
     maybe_adjudicate_probation,
@@ -131,6 +133,11 @@ def test_active_c03_experiment_migrates_without_resetting_clock_or_cursors(
     assert len(doc["trials"]) == 1
     trial = doc["trials"][0]
     assert trial["candidate_id"] == "20260828T160925Z-bbd5e625-c03-30411dca"
+    # No archive entry in this fixture: the trial gets an honest generic
+    # identity, never the pipeline name "evolution".
+    assert trial["family"] == GENERIC_TRIAL_FAMILY
+    assert trial["summary"] is None
+    assert trial["source"] == "evolution_campaign"
     assert trial["status"] == "active"
     assert trial["phase"] == "forward"
     assert trial["forward"]["started_at"] == started.isoformat()
@@ -207,6 +214,185 @@ def test_legacy_migration_recovers_between_writes_without_duplicate_trial(
     assert archived["status"] == "migrated"
     journal = (store.job_dir(job_id) / "journal.jsonl").read_text(encoding="utf-8")
     assert journal.count("evolution_experiment_migrated_to_probation") == 1
+
+
+def test_staged_trial_carries_the_candidates_real_archive_identity(
+    tmp_path: Path,
+) -> None:
+    store, job_id = _job(tmp_path)
+    candidate, revision = _candidate(store, job_id, "identity")
+    record_candidate(
+        store,
+        job_id,
+        candidate_id="20260828T160925Z-bbd5e625-c03-30411dca",
+        family="momentum-alignment-entry-gate",
+        summary=(
+            "Gate new entries on bounded-window momentum alignment: open long "
+            "legs only when short-window realized return is positive and short "
+            "legs only when negative."
+        ),
+        status="dev_frontier",
+        objective=None,
+    )
+
+    staged = stage_evolution_probation(
+        store,
+        job_id,
+        candidate_id="20260828T160925Z-bbd5e625-c03-30411dca",
+        candidate_root=candidate,
+        revision=revision,
+        source="evolution_campaign",
+        family="evolution",
+        now=datetime(2026, 8, 1, tzinfo=UTC),
+    )
+
+    assert staged["family"] == "momentum-alignment-entry-gate"
+    assert staged["summary"].startswith(
+        "Gate new entries on bounded-window momentum alignment"
+    )
+    assert len(staged["summary"]) <= 200
+    assert staged["source"] == "evolution_campaign"
+
+
+def test_trial_identity_falls_back_to_campaign_record_then_generic(
+    tmp_path: Path,
+) -> None:
+    store, job_id = _job(tmp_path)
+    campaign_backed, campaign_revision = _candidate(store, job_id, "campaign-backed")
+    staged = stage_evolution_probation(
+        store,
+        job_id,
+        candidate_id="no-archive-entry",
+        candidate_root=campaign_backed,
+        revision=campaign_revision,
+        source="evolution_campaign",
+        family="short-window-momentum",
+        summary="Campaign candidate record summary line.",
+        now=datetime(2026, 8, 1, tzinfo=UTC),
+    )
+    assert staged["family"] == "short-window-momentum"
+    assert staged["summary"] == "Campaign candidate record summary line."
+
+    orphan, orphan_revision = _candidate(store, job_id, "orphan")
+    generic = stage_evolution_probation(
+        store,
+        job_id,
+        candidate_id="no-identity-anywhere",
+        candidate_root=orphan,
+        revision=orphan_revision,
+        source="evolution_campaign",
+        family="evolution",
+        now=datetime(2026, 8, 1, tzinfo=UTC),
+    )
+    assert generic["family"] == GENERIC_TRIAL_FAMILY
+    assert generic["family"] != "evolution"
+    assert generic["summary"] is None
+
+
+def test_lazy_repair_patches_placeholder_trial_identity_once(tmp_path: Path) -> None:
+    store, job_id = _job(tmp_path)
+    candidate, revision = _candidate(store, job_id, "repair")
+    started = datetime(2026, 8, 1, tzinfo=UTC)
+    stage_evolution_probation(
+        store,
+        job_id,
+        candidate_id="c03-repair",
+        candidate_root=candidate,
+        revision=revision,
+        source="evolution_campaign",
+        family="staged-family",
+        now=started,
+    )
+    doc = load_probation(store, job_id)
+    doc["trials"][0]["family"] = "evolution"  # legacy placeholder on disk
+    doc["trials"][0].pop("summary", None)
+    store.write_json(job_id, "probation.json", doc)
+    record_candidate(
+        store,
+        job_id,
+        candidate_id="c03-repair",
+        family="momentum-alignment-entry-gate",
+        summary="Gate new entries on bounded-window momentum alignment.",
+        status="dev_frontier",
+        objective=None,
+    )
+
+    outcomes = maybe_adjudicate_probation(
+        store, job_id, now=started + timedelta(minutes=5)
+    )
+    repeat = maybe_adjudicate_probation(
+        store, job_id, now=started + timedelta(minutes=10)
+    )
+
+    updated = load_probation(store, job_id)["trials"][0]
+    assert updated["family"] == "momentum-alignment-entry-gate"
+    assert (
+        updated["summary"] == "Gate new entries on bounded-window momentum alignment."
+    )
+    assert [row["action"] for row in outcomes] == ["probation_trial_identity_repaired"]
+    assert repeat == []
+    repaired_rows = [
+        row
+        for row in store.read_jsonl(job_id, "journal.jsonl")
+        if row.get("type") == "probation_trial_identity_repaired"
+    ]
+    assert len(repaired_rows) == 1
+    assert repaired_rows[0]["family"] == "momentum-alignment-entry-gate"
+
+
+def test_two_paired_days_emit_no_interval_bounds_but_keep_estimate(
+    tmp_path: Path,
+) -> None:
+    store, job_id = _job(tmp_path)
+    candidate, revision = _candidate(store, job_id, "degenerate")
+    started = datetime(2026, 8, 1, tzinfo=UTC)
+    stage_evolution_probation(
+        store,
+        job_id,
+        candidate_id="degenerate-candidate",
+        candidate_root=candidate,
+        revision=revision,
+        source="evolution_campaign",
+        family="degenerate-family",
+        now=started,
+    )
+    doc = load_probation(store, job_id)
+    trial = doc["trials"][0]
+    trial["status"] = "active"
+    trial["phase"] = "forward"
+    trial["burn_in"]["status"] = "passed"
+    trial["forward"]["started_at"] = started.isoformat()
+    trial["forward"]["deadline_at"] = (started + timedelta(days=14)).isoformat()
+    for role in ("candidate", "reference"):
+        trial[role]["stream"] = (
+            f"results/forward/probation/{trial['trial_id']}/forward/{role}"
+        )
+    store.write_json(job_id, "probation.json", doc)
+    stamps = [started + timedelta(days=offset) for offset in range(3)]
+    for role in ("candidate", "reference"):
+        stream = store.job_dir(job_id) / trial[role]["stream"]
+        _write_ticks(stream, stamps)
+        if role == "candidate":
+            for stamp in stamps:
+                _write_trade(stream, stamp, 5.0)
+
+    outcomes = maybe_adjudicate_probation(
+        store, job_id, now=started + timedelta(days=2, hours=6)
+    )
+
+    updated = load_probation(store, job_id)["trials"][0]
+    metrics = updated["forward"]["metrics"]
+    assert outcomes == []
+    assert updated["status"] == "active"
+    assert metrics["paired_days"] == 2
+    assert metrics["lcb"] is None
+    assert metrics["ucb"] is None
+    assert metrics["estimate"] > 0
+    assert metrics["candidate_net_pnl"] == 15.0
+    assert metrics["reference_net_pnl"] == 0.0
+    synced = snapshot_job(job_id, store=store)["probation"]["trials"][0]
+    assert synced["forward"]["metrics"]["lcb"] is None
+    assert synced["forward"]["metrics"]["ucb"] is None
 
 
 def test_zero_trade_burn_in_advances_to_forward_on_identical_covered_bars(
@@ -435,9 +621,12 @@ def test_positive_paired_forward_lcb_graduates_to_owner_only_proposal(
     )
 
     updated = load_probation(store, job_id)["trials"][0]
+    metrics = updated["forward"]["metrics"]
     assert updated["status"] == "graduated"
-    assert updated["forward"]["metrics"]["paired_days"] >= 7
-    assert updated["forward"]["metrics"]["lcb"] > 0
+    assert metrics["paired_days"] >= 7
+    # Day-7 checkpoint always has >= block-length paired days: real bounds.
+    assert metrics["lcb"] is not None and metrics["lcb"] > 0
+    assert metrics["ucb"] is not None and metrics["ucb"] >= metrics["lcb"]
     assert updated["promotion"]["status"] == "owner_review"
     assert captured["allow_auto_apply"] is False
     assert any(row["action"] == "probation_promotion_proposed" for row in outcomes)


### PR DESCRIPTION
## Incident (verified live on the majors box)

The unified probation trial for `20260828T160925Z-bbd5e625-c03-30411dca` showed `family: "evolution"` — the pipeline's name, not the strategy's. The candidate's real identity (family `momentum-alignment-entry-gate` + hypothesis summary) was sitting in the archive the whole time. Separately, at 2 paired days the forward metrics emitted `lcb == ucb == estimate` exactly: with fewer paired days than the bootstrap block length (5), every circular block resample is the full sample, so the "interval" collapses to the point estimate and renders as false precision.

## Changes

- **Truthful trial identity** — `stage_evolution_probation` and the legacy-experiment migration now resolve the candidate's real `family` + `summary` (200-char cap): archive entry first, campaign candidate record second, an honest generic placeholder (`unknown-strategy`) last — never the literal string `evolution`. `source: "evolution_campaign"` stays as provenance.
- **Lazy repair for existing trials** — the adjudication pass patches placeholder families (`evolution`/empty/generic) in place once the archive knows the candidate, journaling `probation_trial_identity_repaired` exactly once. The live c03 trial gets fixed on the first watchdog pass after roll; no manual migration.
- **Interval honesty** — `_paired_forward_metrics` emits `lcb: null` / `ucb: null` when `paired_days < FORWARD_BOOTSTRAP_BLOCK_LEN` (5); `estimate` and the PnL fields stay. Day-7/14 decision checkpoints always have ≥ block-length days (test asserts real bounds at the day-7 peek), and `_adjudicate_forward` already null-guards the bounds. `sync.py` ships `probation.json` raw, so the nulls pass through.

## Tests

- Staged trial carries the archive family + summary; fallback chain archive → campaign record → generic (never `evolution`).
- Lazy repair patches a placeholder trial once — idempotent, single journal row.
- 2 paired days → null bounds, real estimate/PnL, nulls survive `snapshot_job`; day-7 graduation asserts non-null bounds with `ucb >= lcb`.
- Full `pytest -q -k "jobs or runner or mcp"`: 1442 passed; only the known pre-existing `test_eval_wayfinder_jobs` hard-execution failure (plus one `test_runner_view_server` timing flake that passes in isolation). ruff clean; scoped mypy identical to baseline (no new errors).