### PR TITLE
feat(jobs): add isolated evolution A/B and bounded work orders

### DIFF
--- a/examples/bench/README.md
+++ b/examples/bench/README.md
@@ -89,6 +89,11 @@ report. If runtime identity differs outside the declared model/variant fields or
 token cost differs by more than the registered ratio, the result is invalid—not
 a win for either arm.
 
+Isolation is audited from persisted tool-call state. A successful access outside
+the private arm (or to the protected world/holdout roots) invalidates the run.
+A policy-denied attempt transfers no data, remains valid, and is reported as the
+secondary `policy_denied_attempts` process metric.
+
 If a campaign stages no candidate, that run keeps the incumbent and contributes
 an exact zero candidate-minus-incumbent endpoint. A staged but invalid holdout
 (including the 10-trade participation floor or invariance failure) invalidates

--- a/examples/bench/README.md
+++ b/examples/bench/README.md
@@ -26,9 +26,12 @@ wayfinder-bench prepare-world \
   --world-id majors-losing
 ```
 
-`world.json`, `bars.json`, the incumbent bundle, and truncated feature stores
-are agent-visible. The holdout bytes remain only in the owner-supplied sealed
-directory; `world.json` contains their commitment, never their path or values.
+`world.json`, `bars.json`, the incumbent bundle, a one-time incumbent baseline
+on that exact development prefix, and truncated feature stores are
+agent-visible. The baseline is hash-pinned in the world manifest and installed
+into every arm; it never includes holdout rows. The holdout bytes remain only
+in the owner-supplied sealed directory; `world.json` contains their commitment,
+never their path or values.
 
 ## 2. Get a fast side-by-side bundle scorecard
 
@@ -65,6 +68,16 @@ The first arm is `wayfinder/deepseek-v4-pro`. “DeepSeek Flash Max” is expres
 using model `wayfinder/deepseek-v4-flash` with OpenCode variant `max`; both
 interfaces are preflighted before campaign work starts. Four repeats per
 arm/world are mandatory for a decision-grade aggregate.
+
+Set `max_parallel_arms` to a bounded value (1–8) to run isolated arm processes
+concurrently. This changes wall time, not the registered runs or their output
+ordering; each arm retains its own MCP server, OpenCode data directory, and job
+store.
+
+An arm may override campaign policy under its own `campaign` mapping. These
+parameters are hash-pinned and must be declared through `arm_parameters` in
+`allowed_identity_differences`, which supports process A/Bs such as a
+default-off parameter behavior preview versus an explicit enabled treatment.
 
 Each race stores copied bundles beside a `results/` directory containing both
 full side outputs, `compare.json`, and `report.txt`.

--- a/examples/bench/README.md
+++ b/examples/bench/README.md
@@ -1,0 +1,88 @@
+# Evolution A/B harness
+
+This harness answers two different questions without changing production gates:
+
+- `race` compares two already-built strategy bundles on one frozen holdout.
+- `run` compares two complete self-improvement processes. Each arm gets its own
+  SDK workspace, OpenCode data directory, campaign state, and lifecycle-only MCP
+  server. The model sees only the chronological development prefix; the runner
+  replays the sealed tail through the production paper probation controller.
+
+Nothing in this package applies, approves, trades, or bypasses the economic or
+owner promotion gates.
+
+## 1. Freeze a real world
+
+Choose a generation cutoff and a 14–21 day holdout. Keep the sealed directory
+outside the world directory and outside every arm workspace.
+
+```bash
+wayfinder-bench prepare-world \
+  /path/to/.wayfinder/jobs/majors-5m-lab \
+  --out .wayfinder_runs/bench/worlds/majors-losing \
+  --sealed .wayfinder_runs/bench/sealed/majors-losing \
+  --generation-cutoff 2026-08-10T00:00:00Z \
+  --holdout-end 2026-08-31T00:00:00Z \
+  --world-id majors-losing
+```
+
+`world.json`, `bars.json`, the incumbent bundle, and truncated feature stores
+are agent-visible. The holdout bytes remain only in the owner-supplied sealed
+directory; `world.json` contains their commitment, never their path or values.
+
+## 2. Get a fast side-by-side bundle scorecard
+
+```bash
+wayfinder-bench race /path/to/candidate \
+  --world .wayfinder_runs/bench/worlds/majors-losing \
+  --sealed .wayfinder_runs/bench/sealed/majors-losing \
+  --out .wayfinder_runs/bench/races/candidate-v-incumbent
+```
+
+The B arm defaults to the world's frozen incumbent. `race.json` is written
+before either simulation. Re-run the exact registered question with:
+
+```bash
+wayfinder-bench race rerun \
+  .wayfinder_runs/bench/races/candidate-v-incumbent
+```
+
+The verdict is fixed: A wins only when the 90% paired daily utility-delta LCB is
+positive, both sides meet the 10-trade floor, and A's maximum drawdown is no
+more than 1.25 times B's.
+
+## 3. Run the first full-loop model experiment
+
+Copy and edit
+[`deepseek-v4-pro-vs-flash-max.json`](deepseek-v4-pro-vs-flash-max.json), then:
+
+```bash
+wayfinder-bench run \
+  examples/bench/deepseek-v4-pro-vs-flash-max.json
+```
+
+The first arm is `wayfinder/deepseek-v4-pro`. “DeepSeek Flash Max” is expressed
+using model `wayfinder/deepseek-v4-flash` with OpenCode variant `max`; both
+interfaces are preflighted before campaign work starts. Four repeats per
+arm/world are mandatory for a decision-grade aggregate.
+
+Each race stores copied bundles beside a `results/` directory containing both
+full side outputs, `compare.json`, and `report.txt`.
+
+The experiment directory contains the frozen experiment question, one scorecard
+per arm/world/seed, prompt and runtime identity hashes, token/tool accounting,
+identity and cost-parity checks, the pooled paired-LCB endpoint, and a plain-text
+report. If runtime identity differs outside the declared model/variant fields or
+token cost differs by more than the registered ratio, the result is invalid—not
+a win for either arm.
+
+If a campaign stages no candidate, that run keeps the incumbent and contributes
+an exact zero candidate-minus-incumbent endpoint. A staged but invalid holdout
+(including the 10-trade participation floor or invariance failure) invalidates
+the run instead of being silently scored as zero.
+
+An arm may set its own `sdk_root`. The controller is launched from a private
+copy of that SDK, with only the neutral `jobs/bench` adapter overlaid, so prompt
+or process comparisons actually execute the named worktree. Any SDK, prompt,
+agent, or temperature difference must also be pre-registered in
+`allowed_identity_differences`; undeclared drift invalidates the experiment.

--- a/examples/bench/deepseek-v4-flash-behavior-preview.json
+++ b/examples/bench/deepseek-v4-flash-behavior-preview.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": "1.0",
+  "output_dir": "../../.wayfinder_runs/bench/deepseek-v4-flash-behavior-preview",
+  "sdk_root": "../..",
+  "runtime_opencode_config": "{env:WAYFINDER_BENCH_OPENCODE_CONFIG}",
+  "wayfinder_base_url": "https://llm-dev.wayfinder.ai/v1",
+  "allowed_identity_differences": ["arm_parameters"],
+  "arms": [
+    {
+      "name": "behavior-preview-off",
+      "model": "wayfinder/deepseek-v4-flash",
+      "variant": "max",
+      "campaign": {
+        "behavior_preview_enabled": false
+      }
+    },
+    {
+      "name": "behavior-preview-on",
+      "model": "wayfinder/deepseek-v4-flash",
+      "variant": "max",
+      "campaign": {
+        "behavior_preview_enabled": true
+      }
+    }
+  ],
+  "worlds": [
+    {
+      "world_dir": "../../.wayfinder_runs/bench/worlds/majors-losing-grounded",
+      "sealed_dir": "../../.wayfinder_runs/bench/sealed/majors-losing-grounded"
+    }
+  ],
+  "seeds": [101, 202, 303, 404],
+  "max_parallel_arms": 8,
+  "campaign": {
+    "generated_programs": 8,
+    "full_dev_survivors": 3,
+    "finalist_gate_candidates": 1,
+    "investigation_design_enabled": true,
+    "wildcard_slots": 2
+  },
+  "interface_smoke": true,
+  "max_turns": 40,
+  "turn_timeout_seconds": 1800,
+  "settle_timeout_seconds": 3600,
+  "confidence": 0.9,
+  "max_cost_ratio": 1.25
+}

--- a/examples/bench/deepseek-v4-pro-vs-flash-max-pilot.json
+++ b/examples/bench/deepseek-v4-pro-vs-flash-max-pilot.json
@@ -19,11 +19,12 @@
   ],
   "worlds": [
     {
-      "world_dir": "../../.wayfinder_runs/bench/worlds/majors-losing",
-      "sealed_dir": "../../.wayfinder_runs/bench/sealed/majors-losing"
+      "world_dir": "../../.wayfinder_runs/bench/worlds/majors-losing-grounded",
+      "sealed_dir": "../../.wayfinder_runs/bench/sealed/majors-losing-grounded"
     }
   ],
   "seeds": [101],
+  "max_parallel_arms": 2,
   "campaign": {
     "generated_programs": 4,
     "full_dev_survivors": 1,

--- a/examples/bench/deepseek-v4-pro-vs-flash-max-pilot.json
+++ b/examples/bench/deepseek-v4-pro-vs-flash-max-pilot.json
@@ -1,6 +1,7 @@
 {
   "schema_version": "1.0",
-  "output_dir": "../../.wayfinder_runs/bench/deepseek-v4-pro-vs-flash-max",
+  "pilot": true,
+  "output_dir": "../../.wayfinder_runs/bench/deepseek-v4-pro-vs-flash-max-pilot",
   "sdk_root": "../..",
   "runtime_opencode_config": "{env:WAYFINDER_BENCH_OPENCODE_CONFIG}",
   "wayfinder_base_url": "https://llm-dev.wayfinder.ai/v1",
@@ -22,18 +23,18 @@
       "sealed_dir": "../../.wayfinder_runs/bench/sealed/majors-losing"
     }
   ],
-  "seeds": [101, 202, 303, 404],
+  "seeds": [101],
   "campaign": {
-    "generated_programs": 8,
-    "full_dev_survivors": 3,
+    "generated_programs": 4,
+    "full_dev_survivors": 1,
     "finalist_gate_candidates": 1,
     "investigation_design_enabled": true,
-    "wildcard_slots": 2
+    "wildcard_slots": 1
   },
   "interface_smoke": true,
-  "max_turns": 40,
-  "turn_timeout_seconds": 1800,
-  "settle_timeout_seconds": 3600,
+  "max_turns": 16,
+  "turn_timeout_seconds": 1200,
+  "settle_timeout_seconds": 1800,
   "confidence": 0.9,
   "max_cost_ratio": 1.25
 }

--- a/examples/bench/deepseek-v4-pro-vs-flash-max.json
+++ b/examples/bench/deepseek-v4-pro-vs-flash-max.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "1.0",
+  "output_dir": "../../.wayfinder_runs/bench/deepseek-v4-pro-vs-flash-max",
+  "sdk_root": "../..",
+  "allowed_identity_differences": ["model", "variant"],
+  "arms": [
+    {
+      "name": "deepseek-v4-pro",
+      "model": "wayfinder/deepseek-v4-pro"
+    },
+    {
+      "name": "deepseek-v4-flash-max",
+      "model": "wayfinder/deepseek-v4-flash",
+      "variant": "max"
+    }
+  ],
+  "worlds": [
+    {
+      "world_dir": "../../.wayfinder_runs/bench/worlds/majors-losing",
+      "sealed_dir": "../../.wayfinder_runs/bench/sealed/majors-losing"
+    }
+  ],
+  "seeds": [101, 202, 303, 404],
+  "campaign": {
+    "generated_programs": 8,
+    "full_dev_survivors": 3,
+    "finalist_gate_candidates": 1,
+    "investigation_design_enabled": true,
+    "wildcard_slots": 2
+  },
+  "interface_smoke": true,
+  "max_turns": 40,
+  "turn_timeout_seconds": 1800,
+  "settle_timeout_seconds": 3600,
+  "confidence": 0.9,
+  "max_cost_ratio": 1.25
+}

--- a/examples/bench/deepseek-v4-pro-vs-flash-max.json
+++ b/examples/bench/deepseek-v4-pro-vs-flash-max.json
@@ -23,6 +23,7 @@
     }
   ],
   "seeds": [101, 202, 303, 404],
+  "max_parallel_arms": 4,
   "campaign": {
     "generated_programs": 8,
     "full_dev_survivors": 3,

--- a/examples/bench/deepseek-v4-pro-vs-flash-max.json
+++ b/examples/bench/deepseek-v4-pro-vs-flash-max.json
@@ -18,8 +18,8 @@
   ],
   "worlds": [
     {
-      "world_dir": "../../.wayfinder_runs/bench/worlds/majors-losing",
-      "sealed_dir": "../../.wayfinder_runs/bench/sealed/majors-losing"
+      "world_dir": "../../.wayfinder_runs/bench/worlds/majors-losing-grounded",
+      "sealed_dir": "../../.wayfinder_runs/bench/sealed/majors-losing-grounded"
     }
   ],
   "seeds": [101, 202, 303, 404],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ mypy = "^1.19.1"
 
 [tool.poetry.scripts]
 wayfinder = "wayfinder_paths.mcp.cli:main"
+wayfinder-bench = "wayfinder_paths.jobs.bench.cli:main"
 
 [tool.ruff]
 target-version = "py312"

--- a/scripts/bench_ab.py
+++ b/scripts/bench_ab.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# ruff: noqa: E402
+"""Run the Wayfinder strategy/evolution A/B harness."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from wayfinder_paths.jobs.bench.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/scripts/eval_wayfinder_jobs.py
+++ b/scripts/eval_wayfinder_jobs.py
@@ -565,7 +565,11 @@ def build_strategy(params: dict) -> Strategy:
         encoding="utf-8",
     )
     write_json(
-        root / "results" / "backtest" / "input_bars.json", execution_backtest_bars()
+        root / "results" / "backtest" / "input_bars.json",
+        {
+            "metadata": {"label_convention": "close_time"},
+            "bars": execution_backtest_bars(),
+        },
     )
     grid_path = root / "workspace" / "config" / "grid.json"
     write_json(grid_path, {"threshold": [10.4, 99.0], "initial_capital": [1000]})

--- a/wayfinder_paths/jobs/bench/__init__.py
+++ b/wayfinder_paths/jobs/bench/__init__.py
@@ -1,0 +1,6 @@
+"""Isolated A/B harness for strategy races and evolution campaigns.
+
+Keep package import deliberately light: the benchmark MCP entry point is loaded
+as ``wayfinder_paths.jobs.bench.mcp_server`` inside every arm, and must not
+eagerly import the controller that launches that server.
+"""

--- a/wayfinder_paths/jobs/bench/aggregate.py
+++ b/wayfinder_paths/jobs/bench/aggregate.py
@@ -16,6 +16,7 @@ def aggregate_experiment(
     output_dir: Path | None = None,
     confidence: float = 0.90,
     max_cost_ratio: float = 1.25,
+    pilot: bool = False,
 ) -> dict[str, Any]:
     if len(arm_order) != 2:
         raise ValueError("campaign A/B aggregation requires exactly two arms")
@@ -76,6 +77,8 @@ def aggregate_experiment(
         decision = "b_wins"
     else:
         decision = "no_significant_difference"
+    if pilot and not decision.startswith("invalid_"):
+        decision = "pilot_directional_only"
     report = {
         "schema_version": "1.0",
         "arms": arm_order,
@@ -84,10 +87,18 @@ def aggregate_experiment(
             "confidence": confidence,
             "cost_ratio_max": max_cost_ratio,
             "decision": (
-                "winner only when the paired interval excludes zero and token "
-                "cost ratio is within the pre-registered bound"
+                (
+                    "pilot reports direction and process metrics only; it cannot "
+                    "declare a winner"
+                )
+                if pilot
+                else (
+                    "winner only when the paired interval excludes zero and token "
+                    "cost ratio is within the pre-registered bound"
+                )
             ),
         },
+        "pilot": pilot,
         "primary": {
             "pairs": len(paired),
             "estimate": round(estimate, 8),
@@ -166,16 +177,43 @@ def _arm_stats(rows: list[dict[str, Any]]) -> dict[str, Any]:
         },
         "process": {
             key: sum(int((row.get("process") or {}).get(key) or 0) for row in rows)
-            for key in ("fact_citations", "wildcards_used", "postmortems_consumed")
+            for key in (
+                "fact_citations",
+                "wildcards_used",
+                "postmortems_consumed",
+                "behavior_changed_attempts",
+                "behavior_unchanged_attempts",
+            )
         },
         "tokens_total": tokens,
         "tokens_per_staged_candidate": round(tokens / staged, 2) if staged else None,
         "tool_calls": sum(
             int((row.get("cost") or {}).get("tool_calls") or 0) for row in rows
         ),
+        "tool_output_bytes": sum(
+            int((row.get("cost") or {}).get("tool_output_bytes") or 0) for row in rows
+        ),
         "wall_seconds": round(
             sum(
                 float((row.get("cost") or {}).get("wall_seconds") or 0) for row in rows
+            ),
+            3,
+        ),
+        "model_seconds": round(
+            sum(
+                float((row.get("cost") or {}).get("model_seconds") or 0) for row in rows
+            ),
+            3,
+        ),
+        "tool_seconds": round(
+            sum(
+                float((row.get("cost") or {}).get("tool_seconds") or 0) for row in rows
+            ),
+            3,
+        ),
+        "other_seconds": round(
+            sum(
+                float((row.get("cost") or {}).get("other_seconds") or 0) for row in rows
             ),
             3,
         ),

--- a/wayfinder_paths/jobs/bench/aggregate.py
+++ b/wayfinder_paths/jobs/bench/aggregate.py
@@ -161,6 +161,22 @@ def _arm_stats(rows: list[dict[str, Any]]) -> dict[str, Any]:
         float((row.get("diversity") or {}).get("mean_elite_trade_count") or 0.0)
         for row in rows
     ]
+    process = {
+        key: sum(int((row.get("process") or {}).get(key) or 0) for row in rows)
+        for key in (
+            "fact_citations",
+            "wildcards_used",
+            "postmortems_consumed",
+            "behavior_changed_attempts",
+            "behavior_unchanged_attempts",
+            "quick_simulations",
+            "behavior_preview_rejections",
+            "behavior_preview_ticks",
+        )
+    }
+    process["policy_denied_attempts"] = sum(
+        len((row.get("isolation") or {}).get("denied_attempts") or []) for row in rows
+    )
     return {
         "runs": len(rows),
         "invalid_runs": sum(bool(row.get("invalid_reason")) for row in rows),
@@ -175,19 +191,7 @@ def _arm_stats(rows: list[dict[str, Any]]) -> dict[str, Any]:
                 round(sum(elite_counts) / len(elite_counts), 3) if elite_counts else 0.0
             ),
         },
-        "process": {
-            key: sum(int((row.get("process") or {}).get(key) or 0) for row in rows)
-            for key in (
-                "fact_citations",
-                "wildcards_used",
-                "postmortems_consumed",
-                "behavior_changed_attempts",
-                "behavior_unchanged_attempts",
-                "quick_simulations",
-                "behavior_preview_rejections",
-                "behavior_preview_ticks",
-            )
-        },
+        "process": process,
         "tokens_total": tokens,
         "tokens_per_staged_candidate": round(tokens / staged, 2) if staged else None,
         "tool_calls": sum(

--- a/wayfinder_paths/jobs/bench/aggregate.py
+++ b/wayfinder_paths/jobs/bench/aggregate.py
@@ -183,6 +183,9 @@ def _arm_stats(rows: list[dict[str, Any]]) -> dict[str, Any]:
                 "postmortems_consumed",
                 "behavior_changed_attempts",
                 "behavior_unchanged_attempts",
+                "quick_simulations",
+                "behavior_preview_rejections",
+                "behavior_preview_ticks",
             )
         },
         "tokens_total": tokens,

--- a/wayfinder_paths/jobs/bench/aggregate.py
+++ b/wayfinder_paths/jobs/bench/aggregate.py
@@ -1,0 +1,194 @@
+"""Pre-registered aggregation for repeated campaign A/B runs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from wayfinder_paths.jobs.bench.env import atomic_json
+from wayfinder_paths.jobs.economics import block_bootstrap_lcb
+
+
+def aggregate_experiment(
+    rows: list[dict[str, Any]],
+    *,
+    arm_order: list[str],
+    output_dir: Path | None = None,
+    confidence: float = 0.90,
+    max_cost_ratio: float = 1.25,
+) -> dict[str, Any]:
+    if len(arm_order) != 2:
+        raise ValueError("campaign A/B aggregation requires exactly two arms")
+    invalid_rows = [row for row in rows if row.get("invalid_reason")]
+    by_key = {
+        (str(row["world_id"]), int(row["seed"]), str(row["arm"])): row
+        for row in rows
+        if not row.get("invalid_reason")
+    }
+    paired: list[dict[str, Any]] = []
+    for world_id, seed in sorted({(key[0], key[1]) for key in by_key}):
+        left = by_key.get((world_id, seed, arm_order[0]))
+        right = by_key.get((world_id, seed, arm_order[1]))
+        if not left or not right:
+            continue
+        left_delta = _holdout_estimate(left)
+        right_delta = _holdout_estimate(right)
+        paired.append(
+            {
+                "world_id": world_id,
+                "seed": seed,
+                "a": left_delta,
+                "b": right_delta,
+                "delta": left_delta - right_delta,
+            }
+        )
+    values = [row["delta"] for row in paired]
+    estimate = sum(values) / len(values) if values else 0.0
+    lcb = block_bootstrap_lcb(
+        values, block_len=1, iterations=1_000, confidence=confidence
+    )
+    reverse = block_bootstrap_lcb(
+        [-value for value in values],
+        block_len=1,
+        iterations=1_000,
+        confidence=confidence,
+    )
+    ucb = -reverse if reverse is not None else None
+    arm_rows = {
+        arm: [row for row in rows if row.get("arm") == arm] for arm in arm_order
+    }
+    arm_stats = {arm: _arm_stats(items) for arm, items in arm_rows.items()}
+    a_cost = arm_stats[arm_order[0]]["tokens_total"]
+    b_cost = arm_stats[arm_order[1]]["tokens_total"]
+    cost_ratio = (
+        max(a_cost, b_cost) / min(a_cost, b_cost) if min(a_cost, b_cost) > 0 else None
+    )
+    cost_matched = cost_ratio is not None and cost_ratio <= max_cost_ratio
+    if invalid_rows:
+        decision = "invalid_arm_runs"
+    elif not paired:
+        decision = "invalid_unpaired"
+    elif not cost_matched:
+        decision = "invalid_cost_mismatch"
+    elif lcb is not None and lcb > 0:
+        decision = "a_wins"
+    elif ucb is not None and ucb < 0:
+        decision = "b_wins"
+    else:
+        decision = "no_significant_difference"
+    report = {
+        "schema_version": "1.0",
+        "arms": arm_order,
+        "pre_registered_rule": {
+            "primary": "paired LCB of holdout utility delta across world/seed",
+            "confidence": confidence,
+            "cost_ratio_max": max_cost_ratio,
+            "decision": (
+                "winner only when the paired interval excludes zero and token "
+                "cost ratio is within the pre-registered bound"
+            ),
+        },
+        "primary": {
+            "pairs": len(paired),
+            "estimate": round(estimate, 8),
+            "lcb": lcb,
+            "ucb": ucb,
+            "rows": paired,
+        },
+        "by_arm": arm_stats,
+        "invalid_runs": [
+            {
+                "arm": row.get("arm"),
+                "world_id": row.get("world_id"),
+                "seed": row.get("seed"),
+                "reason": row.get("invalid_reason"),
+            }
+            for row in invalid_rows
+        ],
+        "cost_parity": {"ratio": cost_ratio, "matched": cost_matched},
+        "decision": decision,
+    }
+    if output_dir is not None:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        atomic_json(output_dir / "aggregate.json", report)
+        (output_dir / "report.txt").write_text(_format_report(report), encoding="utf-8")
+    return report
+
+
+def _holdout_estimate(row: dict[str, Any]) -> float:
+    holdout = row.get("holdout") or {}
+    paired = holdout.get("paired_daily_utility_delta") or {}
+    return float(paired.get("estimate") or 0.0)
+
+
+def _arm_stats(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    funnel_keys = (
+        "candidates_generated",
+        "attempts",
+        "screen_positive",
+        "full_dev",
+        "gate_passed",
+        "staged",
+    )
+    funnel = {
+        key: sum(int((row.get("funnel") or {}).get(key) or 0) for row in rows)
+        for key in funnel_keys
+    }
+    verdicts = {
+        status: sum(
+            1 for row in rows if str((row.get("forward") or {}).get("status")) == status
+        )
+        for status in ("burn_in", "active", "graduated", "killed", "inconclusive")
+    }
+    tokens = sum(
+        int((row.get("cost") or {}).get(key) or 0)
+        for row in rows
+        for key in ("tokens_in", "tokens_out", "tokens_reasoning")
+    )
+    staged = funnel["staged"]
+    elite_counts = [
+        float((row.get("diversity") or {}).get("mean_elite_trade_count") or 0.0)
+        for row in rows
+    ]
+    return {
+        "runs": len(rows),
+        "invalid_runs": sum(bool(row.get("invalid_reason")) for row in rows),
+        "funnel": funnel,
+        "verdicts": verdicts,
+        "diversity": {
+            "qd_cells_occupied": sum(
+                int((row.get("diversity") or {}).get("qd_cells_occupied") or 0)
+                for row in rows
+            ),
+            "mean_elite_trade_count": (
+                round(sum(elite_counts) / len(elite_counts), 3) if elite_counts else 0.0
+            ),
+        },
+        "process": {
+            key: sum(int((row.get("process") or {}).get(key) or 0) for row in rows)
+            for key in ("fact_citations", "wildcards_used", "postmortems_consumed")
+        },
+        "tokens_total": tokens,
+        "tokens_per_staged_candidate": round(tokens / staged, 2) if staged else None,
+        "tool_calls": sum(
+            int((row.get("cost") or {}).get("tool_calls") or 0) for row in rows
+        ),
+        "wall_seconds": round(
+            sum(
+                float((row.get("cost") or {}).get("wall_seconds") or 0) for row in rows
+            ),
+            3,
+        ),
+    }
+
+
+def _format_report(report: dict[str, Any]) -> str:
+    primary = report["primary"]
+    return (
+        f"Campaign A/B decision: {report['decision']}\n"
+        f"Arms: {report['arms'][0]} vs {report['arms'][1]}\n"
+        f"Paired runs: {primary['pairs']}\n"
+        f"Mean paired utility delta: {primary['estimate']}\n"
+        f"90% interval: [{primary['lcb']}, {primary['ucb']}]\n"
+        f"Cost parity: {report['cost_parity']}\n"
+    )

--- a/wayfinder_paths/jobs/bench/arm_entry.py
+++ b/wayfinder_paths/jobs/bench/arm_entry.py
@@ -1,0 +1,30 @@
+"""Private subprocess entry point for one declared-SDK benchmark arm."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from wayfinder_paths.jobs.bench.env import atomic_json, load_json
+from wayfinder_paths.jobs.bench.runner import run_arm
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit(
+            "usage: python -m wayfinder_paths.jobs.bench.arm_entry REQUEST"
+        )
+    request = load_json(Path(sys.argv[1]))
+    result = run_arm(
+        config=dict(request["config"]),
+        arm=dict(request["arm"]),
+        seed=int(request["seed"]),
+        world_dir=Path(request["world_dir"]),
+        sealed_dir=Path(request["sealed_dir"]),
+        output_dir=Path(request["output_dir"]),
+    )
+    atomic_json(Path(request["result_path"]), result)
+
+
+if __name__ == "__main__":
+    main()

--- a/wayfinder_paths/jobs/bench/cli.py
+++ b/wayfinder_paths/jobs/bench/cli.py
@@ -1,0 +1,139 @@
+"""CLI for frozen bundle races and full campaign A/B experiments."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from wayfinder_paths.jobs.bench.env import atomic_json, git_sha, sha256_file
+from wayfinder_paths.jobs.bench.forward_replay import race_bundles
+from wayfinder_paths.jobs.bench.runner import run_experiment
+from wayfinder_paths.jobs.bench.world import prepare_world
+from wayfinder_paths.jobs.bundles import copy_job_bundle
+from wayfinder_paths.jobs.gating import compute_workspace_revision
+
+
+def main(argv: list[str] | None = None) -> None:
+    resolved_argv = list(sys.argv[1:] if argv is None else argv)
+    if resolved_argv[:2] == ["race", "rerun"]:
+        resolved_argv[:2] = ["race-rerun"]
+    parser = argparse.ArgumentParser(prog="wayfinder-bench")
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    world = commands.add_parser("prepare-world")
+    world.add_argument("source_job", type=Path)
+    world.add_argument("--out", required=True, type=Path)
+    world.add_argument("--sealed", required=True, type=Path)
+    world.add_argument("--generation-cutoff", required=True)
+    world.add_argument("--holdout-end", required=True)
+    world.add_argument("--world-id")
+
+    race = commands.add_parser("race")
+    race.add_argument("a_bundle", type=Path)
+    race.add_argument("b_bundle", type=Path, nargs="?")
+    race.add_argument("--world", required=True, type=Path)
+    race.add_argument("--sealed", required=True, type=Path)
+    race.add_argument("--out", required=True, type=Path)
+
+    rerun = commands.add_parser("race-rerun")
+    rerun.add_argument("race_dir", type=Path)
+
+    experiment = commands.add_parser("run")
+    experiment.add_argument("config", type=Path)
+
+    args = parser.parse_args(resolved_argv)
+    if args.command == "prepare-world":
+        result = prepare_world(
+            args.source_job,
+            args.out,
+            generation_cutoff=_parse(args.generation_cutoff),
+            holdout_end=_parse(args.holdout_end),
+            sealed_dir=args.sealed,
+            world_id=args.world_id,
+        )
+    elif args.command == "race":
+        result = _run_race(
+            args.a_bundle,
+            args.b_bundle,
+            world=args.world,
+            sealed=args.sealed,
+            output=args.out,
+        )
+    elif args.command == "race-rerun":
+        result = _rerun_race(args.race_dir)
+    else:
+        result = run_experiment(args.config)
+    print(json.dumps(result, indent=2, sort_keys=True, default=str))
+
+
+def _run_race(
+    a_bundle: Path,
+    b_bundle: Path | None,
+    *,
+    world: Path,
+    sealed: Path,
+    output: Path,
+) -> dict[str, Any]:
+    world = world.resolve()
+    sealed = sealed.resolve()
+    b_source = b_bundle or (world / "incumbent")
+    output = output.resolve()
+    output.mkdir(parents=True, exist_ok=False)
+    copy_job_bundle(a_bundle.resolve(), output / "a")
+    copy_job_bundle(b_source.resolve(), output / "b")
+    manifest = {
+        "schema_version": "1.0",
+        "world": str(world),
+        "sealed": str(sealed),
+        "a_revision": compute_workspace_revision(output / "a"),
+        "b_revision": compute_workspace_revision(output / "b"),
+        "world_sha256": sha256_file(world / "world.json"),
+        "sdk_ref": git_sha(Path(__file__).resolve().parents[3]),
+        "rules": {
+            "paired_lcb_confidence": 0.90,
+            "participation_floor": 10,
+            "max_drawdown_ratio": 1.25,
+            "bootstrap_seed": 7,
+        },
+    }
+    # Pre-register the complete race identity and verdict before simulating.
+    atomic_json(output / "race.json", manifest)
+    return race_bundles(
+        output / "a",
+        output / "b",
+        world_dir=world,
+        sealed_dir=sealed,
+        output_dir=output,
+    )
+
+
+def _rerun_race(race_dir: Path) -> dict[str, Any]:
+    race_dir = race_dir.resolve()
+    manifest = json.loads((race_dir / "race.json").read_text(encoding="utf-8"))
+    if compute_workspace_revision(race_dir / "a") != manifest["a_revision"]:
+        raise ValueError("race A bundle changed after registration")
+    if compute_workspace_revision(race_dir / "b") != manifest["b_revision"]:
+        raise ValueError("race B bundle changed after registration")
+    if sha256_file(Path(manifest["world"]) / "world.json") != manifest["world_sha256"]:
+        raise ValueError("race world changed after registration")
+    if git_sha(Path(__file__).resolve().parents[3]) != manifest["sdk_ref"]:
+        raise ValueError("race SDK changed after registration")
+    return race_bundles(
+        race_dir / "a",
+        race_dir / "b",
+        world_dir=Path(manifest["world"]),
+        sealed_dir=Path(manifest["sealed"]),
+        output_dir=race_dir,
+    )
+
+
+def _parse(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+if __name__ == "__main__":
+    main()

--- a/wayfinder_paths/jobs/bench/env.py
+++ b/wayfinder_paths/jobs/bench/env.py
@@ -1,0 +1,60 @@
+"""Small deterministic filesystem/runtime helpers for benchmark runs."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import socket
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from wayfinder_paths.runner.monitor_state import atomic_write_json
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_json(value: Any) -> str:
+    return sha256_bytes(canonical_json(value).encode())
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def atomic_json(path: Path, value: Any) -> None:
+    atomic_write_json(path, value, default=str)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    loaded = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise ValueError(f"expected a JSON object: {path}")
+    return loaded
+
+
+def git_sha(root: Path) -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout.strip() if result.returncode == 0 else "unknown"
+
+
+def free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])

--- a/wayfinder_paths/jobs/bench/env.py
+++ b/wayfinder_paths/jobs/bench/env.py
@@ -43,6 +43,19 @@ def load_json(path: Path) -> dict[str, Any]:
     return loaded
 
 
+def sandbox_relative(value: Any, *, root: Path) -> Any:
+    """Rewrite sandbox-absolute paths to the production-style relative form."""
+    resolved = str(root.resolve())
+    prefix = f"{resolved}/"
+    if isinstance(value, dict):
+        return {key: sandbox_relative(child, root=root) for key, child in value.items()}
+    if isinstance(value, list):
+        return [sandbox_relative(child, root=root) for child in value]
+    if isinstance(value, str):
+        return value.replace(prefix, "").replace(resolved, ".")
+    return value
+
+
 def git_sha(root: Path) -> str:
     result = subprocess.run(
         ["git", "rev-parse", "HEAD"],

--- a/wayfinder_paths/jobs/bench/forward_replay.py
+++ b/wayfinder_paths/jobs/bench/forward_replay.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import math
 from collections import defaultdict
+from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -132,7 +133,7 @@ def race_bundles(
 def evaluate_bundle(
     bundle: Path,
     *,
-    rows: list[dict[str, Any]],
+    rows: Sequence[Mapping[str, Any]],
     cutoff: datetime,
     environment: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
@@ -150,7 +151,7 @@ def evaluate_bundle(
     params.update(dict(environment.get("params") or {}))
     script = resolve_bundle_script_entrypoint(bundle, job_data)
     dataset = PreparedExecutionDataset.from_rows(
-        rows, {"source": "sealed_benchmark_world"}
+        list(rows), {"source": "sealed_benchmark_world"}
     )
     probe = window_invariance_probe(script, dataset.bars, spec, params)
     result = simulate_execution(script, dataset, spec, params)
@@ -212,7 +213,7 @@ def replay_probation(
     warmup_rows = [
         row for row in development_rows if _row_timestamp(row) <= pd.Timestamp(cutoff)
     ][-2_000:]
-    replay_rows = [*warmup_rows, *holdout_rows]
+    replay_rows: list[Mapping[str, Any]] = [*warmup_rows, *holdout_rows]
     view = CompletedBarsView.from_rows(replay_rows)
     end = max(view.timestamps)
     asyncio.run(run_candidate_shadows(store, job_id, view=view, now=end))

--- a/wayfinder_paths/jobs/bench/forward_replay.py
+++ b/wayfinder_paths/jobs/bench/forward_replay.py
@@ -13,6 +13,7 @@ import pandas as pd
 
 from wayfinder_paths.jobs.bench.env import atomic_json, git_sha, sha256_json
 from wayfinder_paths.jobs.bench.world import load_world
+from wayfinder_paths.jobs.bundles import resolve_bundle_script_entrypoint
 from wayfinder_paths.jobs.candidate_shadow import run_candidate_shadows
 from wayfinder_paths.jobs.economics import block_bootstrap_lcb
 from wayfinder_paths.jobs.execution.job import _load_job_yaml
@@ -147,7 +148,7 @@ def evaluate_bundle(
     expected_spec = environment.get("spec_sha256")
     spec_matches = not expected_spec or sha256_json(spec.to_dict()) == expected_spec
     params.update(dict(environment.get("params") or {}))
-    script = _bundle_script(bundle, job_data)
+    script = resolve_bundle_script_entrypoint(bundle, job_data)
     dataset = PreparedExecutionDataset.from_rows(
         rows, {"source": "sealed_benchmark_world"}
     )
@@ -260,20 +261,6 @@ def _rebase_trial(trial: dict[str, Any], *, cutoff: datetime) -> None:
     for role in ("candidate", "reference"):
         trial[role]["last_processed_bar"] = cutoff.isoformat()
         trial[role]["error_count"] = 0
-
-
-def _bundle_script(bundle: Path, job_data: dict[str, Any]) -> Path:
-    raw = str((job_data.get("script_loop") or {}).get("entrypoint") or "")
-    if not raw:
-        raise FileNotFoundError("bundle script_loop.entrypoint is missing")
-    path = Path(raw)
-    if not path.is_absolute():
-        return bundle / path
-    parts = path.parts
-    if "workspace" in parts:
-        index = parts.index("workspace")
-        return bundle / "workspace" / Path(*parts[index + 1 :])
-    raise ValueError("absolute bundle entrypoint is outside workspace")
 
 
 def _daily_pnl(

--- a/wayfinder_paths/jobs/bench/forward_replay.py
+++ b/wayfinder_paths/jobs/bench/forward_replay.py
@@ -1,0 +1,385 @@
+"""Production-engine bundle races and compressed probation replay."""
+
+from __future__ import annotations
+
+import asyncio
+import math
+from collections import defaultdict
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from wayfinder_paths.jobs.bench.env import atomic_json, git_sha, sha256_json
+from wayfinder_paths.jobs.bench.world import load_world
+from wayfinder_paths.jobs.candidate_shadow import run_candidate_shadows
+from wayfinder_paths.jobs.economics import block_bootstrap_lcb
+from wayfinder_paths.jobs.execution.job import _load_job_yaml
+from wayfinder_paths.jobs.execution.primitives import (
+    CompletedBarsView,
+    ExecutionSpec,
+)
+from wayfinder_paths.jobs.execution.simulator import (
+    PreparedExecutionDataset,
+    simulate_execution,
+)
+from wayfinder_paths.jobs.execution.validation import (
+    resolve_execution_spec,
+    window_invariance_probe,
+)
+from wayfinder_paths.jobs.execution.walk_forward import _test_window_stats
+from wayfinder_paths.jobs.gating import compute_workspace_revision
+from wayfinder_paths.jobs.probation import load_probation, maybe_adjudicate_probation
+from wayfinder_paths.jobs.store import JobStore
+
+PARTICIPATION_FLOOR = 10
+CONFIDENCE = 0.90
+
+
+def race_bundles(
+    a_bundle: Path,
+    b_bundle: Path,
+    *,
+    world_dir: Path,
+    sealed_dir: Path,
+    output_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Evaluate A and B on identical frozen rows and pre-written rules."""
+    world = load_world(world_dir, sealed_dir)
+    cutoff = _parse(world["manifest"]["generation_cutoff"])
+    rows = [
+        *(world["development"].get("bars") or []),
+        *(world["holdout"].get("bars") or []),
+    ]
+    environment = dict(world["manifest"].get("execution_environment") or {})
+    a = evaluate_bundle(a_bundle, rows=rows, cutoff=cutoff, environment=environment)
+    b = evaluate_bundle(b_bundle, rows=rows, cutoff=cutoff, environment=environment)
+    days = sorted(set(a["daily_pnl"]) & set(b["daily_pnl"]))
+    deltas = [
+        math.log1p(a["daily_pnl"][day] / 10_000.0)
+        - math.log1p(b["daily_pnl"][day] / 10_000.0)
+        for day in days
+        if a["daily_pnl"][day] > -10_000 and b["daily_pnl"][day] > -10_000
+    ]
+    estimate = sum(deltas)
+    lcb = block_bootstrap_lcb(
+        deltas, block_len=5, iterations=500, confidence=CONFIDENCE
+    )
+    a_participates = int(a["stats"].get("trade_count") or 0) >= PARTICIPATION_FLOOR
+    b_participates = int(b["stats"].get("trade_count") or 0) >= PARTICIPATION_FLOOR
+    a_drawdown = abs(float(a["stats"].get("max_drawdown_pct") or 0.0))
+    b_drawdown = abs(float(b["stats"].get("max_drawdown_pct") or 0.0))
+    drawdown_ok = a_drawdown <= max(0.000001, 1.25 * b_drawdown)
+    valid = bool(
+        a["valid"] and b["valid"] and days and a_participates and b_participates
+    )
+    if not valid:
+        verdict = "invalid"
+    elif lcb is not None and lcb > 0 and drawdown_ok:
+        verdict = "a_beats_b"
+    else:
+        verdict = "no_significant_difference"
+    compare = {
+        "schema_version": "1.0",
+        "world_id": world["manifest"]["world_id"],
+        "sdk_ref": git_sha(Path(__file__).resolve().parents[3]),
+        "dataset_sha256": world["manifest"]["dataset"].get(
+            "benchmark_rows_sha256",
+            world["manifest"]["dataset"]["full_rows_sha256"],
+        ),
+        "generation_cutoff": cutoff.isoformat(),
+        "rules": {
+            "confidence": CONFIDENCE,
+            "participation_floor": PARTICIPATION_FLOOR,
+            "max_drawdown_ratio": 1.25,
+            "verdict": (
+                "A beats B iff paired LCB > 0, both sides meet the participation "
+                "floor, and A drawdown is no more than 1.25x B"
+            ),
+        },
+        "paired_daily_utility_delta": {
+            "days": len(deltas),
+            "estimate": round(estimate, 8),
+            "lcb": lcb,
+            "values": [round(value, 10) for value in deltas],
+        },
+        "participation": {
+            "a": a_participates,
+            "b": b_participates,
+        },
+        "drawdown_check": {
+            "a": a_drawdown,
+            "b": b_drawdown,
+            "passed": drawdown_ok,
+        },
+        "behavior_distance": _behavior_distance(a["trades"], b["trades"]),
+        "a": _public_side(a),
+        "b": _public_side(b),
+        "verdict": verdict,
+    }
+    if output_dir is not None:
+        results = output_dir / "results"
+        results.mkdir(parents=True, exist_ok=True)
+        _write_side(results / "a", a)
+        _write_side(results / "b", b)
+        atomic_json(results / "compare.json", compare)
+        (results / "report.txt").write_text(_race_report(compare), encoding="utf-8")
+    return compare
+
+
+def evaluate_bundle(
+    bundle: Path,
+    *,
+    rows: list[dict[str, Any]],
+    cutoff: datetime,
+    environment: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    bundle = bundle.resolve()
+    before = compute_workspace_revision(bundle)
+    job_data = _load_job_yaml(bundle)
+    spec_data, _ = resolve_execution_spec(bundle, job_data)
+    if not spec_data:
+        raise FileNotFoundError(f"bundle has no execution_spec: {bundle}")
+    spec = ExecutionSpec.from_dict(spec_data)
+    params = dict(job_data.get("execution_params") or {})
+    environment = environment or {}
+    expected_spec = environment.get("spec_sha256")
+    spec_matches = not expected_spec or sha256_json(spec.to_dict()) == expected_spec
+    params.update(dict(environment.get("params") or {}))
+    script = _bundle_script(bundle, job_data)
+    dataset = PreparedExecutionDataset.from_rows(
+        rows, {"source": "sealed_benchmark_world"}
+    )
+    probe = window_invariance_probe(script, dataset.bars, spec, params)
+    result = simulate_execution(script, dataset, spec, params)
+    stats = _test_window_stats(result, pd.Timestamp(cutoff), spec, params)
+    trades = [
+        trade
+        for trade in result.trades
+        if _trade_timestamp(trade) > pd.Timestamp(cutoff)
+    ]
+    after = compute_workspace_revision(bundle)
+    return {
+        "revision_before": before,
+        "revision_after": after,
+        "valid": bool(
+            before == after
+            and spec_matches
+            and probe.get("status") == "passed"
+            and result.validation.get("execution_valid") is True
+        ),
+        "spec_matches_world": spec_matches,
+        "window_invariance": {
+            key: value for key, value in probe.items() if not key.endswith("_intents")
+        },
+        "validation": result.validation,
+        "stats": stats,
+        "daily_pnl": _daily_pnl(result.equity_curve, cutoff=cutoff),
+        "trades": trades,
+        "per_symbol_direction": _per_symbol_direction(trades),
+        "profile": result.profile,
+        "equity_curve": result.equity_curve,
+    }
+
+
+def replay_probation(
+    store: JobStore,
+    job_id: str,
+    *,
+    development_rows: list[dict[str, Any]],
+    holdout_rows: list[dict[str, Any]],
+    generation_cutoff: datetime,
+) -> dict[str, Any]:
+    """Replay a staged trial through the real burn-in/day-7/day-14 code."""
+    cutoff = _aware(generation_cutoff)
+    doc = load_probation(store, job_id)
+    runnable = [
+        trial
+        for trial in doc.get("trials") or []
+        if trial.get("status") in {"queued", "burn_in", "active"}
+    ]
+    if not runnable:
+        return {
+            "available": False,
+            "reason": "campaign staged no probation candidate",
+            "paired_daily_delta": [],
+        }
+    trial = runnable[0]
+    _rebase_trial(trial, cutoff=cutoff)
+    store.write_json(job_id, "probation.json", doc)
+    warmup_rows = [
+        row for row in development_rows if _row_timestamp(row) <= pd.Timestamp(cutoff)
+    ][-2_000:]
+    replay_rows = [*warmup_rows, *holdout_rows]
+    view = CompletedBarsView.from_rows(replay_rows)
+    end = max(view.timestamps)
+    asyncio.run(run_candidate_shadows(store, job_id, view=view, now=end))
+    maybe_adjudicate_probation(store, job_id, now=end.to_pydatetime())
+    updated = next(
+        row
+        for row in load_probation(store, job_id)["trials"]
+        if row["trial_id"] == trial["trial_id"]
+    )
+    metrics = (updated.get("forward") or {}).get("metrics") or {}
+    return {
+        "available": True,
+        "trial_id": updated["trial_id"],
+        "candidate_id": updated.get("candidate_id"),
+        "status": updated.get("status"),
+        "phase": updated.get("phase"),
+        "burn_in": updated.get("burn_in"),
+        "forward": updated.get("forward"),
+        "paired_daily_delta": metrics.get("daily_deltas") or [],
+    }
+
+
+def _rebase_trial(trial: dict[str, Any], *, cutoff: datetime) -> None:
+    trial["status"] = "burn_in"
+    trial["phase"] = "burn_in"
+    trial["burn_in"].update(
+        {
+            "status": "running",
+            "started_at": cutoff.isoformat(),
+            "expires_at": (
+                cutoff
+                + timedelta(
+                    hours=float(trial["burn_in"].get("duration_hours") or 24) + 12
+                )
+            ).isoformat(),
+        }
+    )
+    trial["forward"].update(
+        {
+            "started_at": None,
+            "deadline_at": None,
+            "last_decision_day": 0,
+            "metrics": None,
+        }
+    )
+    for role in ("candidate", "reference"):
+        trial[role]["last_processed_bar"] = cutoff.isoformat()
+        trial[role]["error_count"] = 0
+
+
+def _bundle_script(bundle: Path, job_data: dict[str, Any]) -> Path:
+    raw = str((job_data.get("script_loop") or {}).get("entrypoint") or "")
+    if not raw:
+        raise FileNotFoundError("bundle script_loop.entrypoint is missing")
+    path = Path(raw)
+    if not path.is_absolute():
+        return bundle / path
+    parts = path.parts
+    if "workspace" in parts:
+        index = parts.index("workspace")
+        return bundle / "workspace" / Path(*parts[index + 1 :])
+    raise ValueError("absolute bundle entrypoint is outside workspace")
+
+
+def _daily_pnl(
+    equity_curve: list[dict[str, Any]], *, cutoff: datetime
+) -> dict[str, float]:
+    cutoff_stamp = pd.Timestamp(cutoff)
+    prior = [
+        row for row in equity_curve if pd.Timestamp(row["timestamp"]) <= cutoff_stamp
+    ]
+    anchor = float(prior[-1]["equity"]) if prior else 10_000.0
+    last_by_day: dict[str, float] = {}
+    for row in equity_curve:
+        stamp = pd.Timestamp(row["timestamp"])
+        if stamp <= cutoff_stamp:
+            continue
+        last_by_day[stamp.date().isoformat()] = float(row["equity"])
+    daily: dict[str, float] = {}
+    for day, value in sorted(last_by_day.items()):
+        daily[day] = value - anchor
+        anchor = value
+    return daily
+
+
+def _trade_timestamp(trade: dict[str, Any]) -> pd.Timestamp:
+    return pd.Timestamp(trade.get("timestamp") or trade.get("filled_at"))
+
+
+def _per_symbol_direction(trades: list[dict[str, Any]]) -> dict[str, Any]:
+    grouped: dict[str, dict[str, float]] = defaultdict(
+        lambda: {"fills": 0, "fees": 0.0, "realized_pnl": 0.0}
+    )
+    for trade in trades:
+        symbol = str(trade.get("symbol") or "unknown")
+        side = str(trade.get("side") or trade.get("action") or "unknown").lower()
+        key = f"{symbol}:{side}"
+        grouped[key]["fills"] += 1
+        grouped[key]["fees"] += float(trade.get("fee") or 0.0)
+        grouped[key]["realized_pnl"] += float(trade.get("realized_pnl_delta") or 0.0)
+    return dict(grouped)
+
+
+def _behavior_distance(
+    a: list[dict[str, Any]], b: list[dict[str, Any]]
+) -> dict[str, Any]:
+    def signatures(rows: list[dict[str, Any]]) -> set[tuple[str, str, str]]:
+        return {
+            (
+                str(row.get("timestamp") or row.get("filled_at")),
+                str(row.get("symbol")),
+                str(row.get("side") or row.get("action")),
+            )
+            for row in rows
+        }
+
+    left, right = signatures(a), signatures(b)
+    union = left | right
+    return {
+        "changed_decisions": len(left ^ right),
+        "jaccard_distance": round(len(left ^ right) / len(union), 6) if union else 0.0,
+    }
+
+
+def _public_side(side: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: side[key]
+        for key in (
+            "revision_before",
+            "revision_after",
+            "valid",
+            "validation",
+            "spec_matches_world",
+            "window_invariance",
+            "stats",
+            "daily_pnl",
+            "per_symbol_direction",
+            "profile",
+        )
+    }
+
+
+def _write_side(root: Path, side: dict[str, Any]) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    atomic_json(root / "summary.json", _public_side(side))
+    atomic_json(root / "trades.json", side["trades"])
+    atomic_json(root / "equity.json", side["equity_curve"])
+
+
+def _race_report(compare: dict[str, Any]) -> str:
+    paired = compare["paired_daily_utility_delta"]
+    return (
+        f"Race verdict: {compare['verdict']}\n"
+        f"World: {compare['world_id']}\n"
+        f"Paired days: {paired['days']}\n"
+        f"Utility delta estimate: {paired['estimate']}\n"
+        f"90% LCB: {paired['lcb']}\n"
+    )
+
+
+def _row_timestamp(row: dict[str, Any]) -> pd.Timestamp:
+    stamp = pd.Timestamp(row.get("timestamp", row.get("t")))
+    return stamp.tz_localize("UTC") if stamp.tzinfo is None else stamp.tz_convert("UTC")
+
+
+def _parse(value: Any) -> datetime:
+    return _aware(datetime.fromisoformat(str(value).replace("Z", "+00:00")))
+
+
+def _aware(value: datetime) -> datetime:
+    return value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)

--- a/wayfinder_paths/jobs/bench/identity.py
+++ b/wayfinder_paths/jobs/bench/identity.py
@@ -55,6 +55,7 @@ def runtime_identity(
     world_manifest: dict[str, Any],
     prompt_hashes: list[str],
     declared_differences: list[str],
+    arm_parameters: dict[str, Any],
     opencode: Path,
 ) -> dict[str, Any]:
     agents = sandbox / ".opencode" / "agents"
@@ -84,6 +85,7 @@ def runtime_identity(
         },
         "prompt_hashes": list(prompt_hashes),
         "initial_prompt_sha256": prompt_hashes[0] if prompt_hashes else None,
+        "arm_parameters": dict(arm_parameters),
         "declared_differences": sorted(set(declared_differences)),
     }
 

--- a/wayfinder_paths/jobs/bench/identity.py
+++ b/wayfinder_paths/jobs/bench/identity.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import yaml  # type: ignore[import-untyped]
 
-from wayfinder_paths.jobs.bench.env import git_sha, sha256_file, sha256_json
+from wayfinder_paths.jobs.bench.env import sha256_file, sha256_json
 
 IDENTITY_SCHEMA_VERSION = "1.0"
 
@@ -47,7 +47,7 @@ def ensure_model_declared(config_path: Path, model: str) -> bool:
 
 def runtime_identity(
     *,
-    sdk_root: Path,
+    sdk_ref: str,
     sandbox: Path,
     model: str,
     variant: str | None,
@@ -68,7 +68,7 @@ def runtime_identity(
     )
     return {
         "schema_version": IDENTITY_SCHEMA_VERSION,
-        "sdk_ref": git_sha(sdk_root),
+        "sdk_ref": sdk_ref,
         "world_id": world_manifest["world_id"],
         "data": dict(world_manifest["dataset"]),
         "source_revision": world_manifest["source_revision"],

--- a/wayfinder_paths/jobs/bench/identity.py
+++ b/wayfinder_paths/jobs/bench/identity.py
@@ -1,0 +1,124 @@
+"""Runtime identity pins and preflight checks for comparable A/B arms."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import yaml  # type: ignore[import-untyped]
+
+from wayfinder_paths.jobs.bench.env import git_sha, sha256_file, sha256_json
+
+IDENTITY_SCHEMA_VERSION = "1.0"
+
+
+def ensure_model_declared(config_path: Path, model: str) -> bool:
+    """Declare an API model in an isolated config; return whether it was added.
+
+    OpenCode requires models to be present in its provider catalog even when
+    the compatible upstream endpoint already serves them. The benchmark never
+    mutates the source checkout's config.
+    """
+    provider_id, separator, model_id = model.partition("/")
+    if not separator or not provider_id or not model_id:
+        raise ValueError(f"model must be provider/model, got {model!r}")
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    provider = (config.get("provider") or {}).get(provider_id)
+    if not isinstance(provider, dict):
+        raise ValueError(f"provider {provider_id!r} is not configured")
+    models = provider.setdefault("models", {})
+    if model_id in models:
+        return False
+    template: dict[str, Any] = next(iter(models.values()), {})
+    models[model_id] = {
+        "name": model_id.replace("-", " ").title(),
+        **({"limit": template["limit"]} if template.get("limit") else {}),
+        **(
+            {"interleaved": template["interleaved"]}
+            if template.get("interleaved")
+            else {}
+        ),
+    }
+    config_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    return True
+
+
+def runtime_identity(
+    *,
+    sdk_root: Path,
+    sandbox: Path,
+    model: str,
+    variant: str | None,
+    repeat_seed: int,
+    world_manifest: dict[str, Any],
+    prompt_hashes: list[str],
+    declared_differences: list[str],
+    opencode: Path,
+) -> dict[str, Any]:
+    agents = sandbox / ".opencode" / "agents"
+    config = sandbox / ".opencode" / "opencode.json"
+    version = subprocess.run(
+        [str(opencode), "--version"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return {
+        "schema_version": IDENTITY_SCHEMA_VERSION,
+        "sdk_ref": git_sha(sdk_root),
+        "world_id": world_manifest["world_id"],
+        "data": dict(world_manifest["dataset"]),
+        "source_revision": world_manifest["source_revision"],
+        "model": model,
+        "variant": variant,
+        "repeat_seed": repeat_seed,
+        "agent_temperatures": {
+            path.name: _agent_temperature(path) for path in sorted(agents.glob("*.md"))
+        },
+        "opencode_version": version.stdout.strip() or version.stderr.strip(),
+        "opencode_config_sha256": sha256_file(config),
+        "agent_hashes": {
+            path.name: sha256_file(path) for path in sorted(agents.glob("*.md"))
+        },
+        "prompt_hashes": list(prompt_hashes),
+        "initial_prompt_sha256": prompt_hashes[0] if prompt_hashes else None,
+        "declared_differences": sorted(set(declared_differences)),
+    }
+
+
+def _agent_temperature(path: Path) -> float | None:
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---\n"):
+        return None
+    _, separator, remainder = text.partition("---\n")
+    frontmatter, closing, _ = remainder.partition("\n---\n")
+    if not separator or not closing:
+        return None
+    parsed = yaml.safe_load(frontmatter) or {}
+    temperature = parsed.get("temperature")
+    return float(temperature) if temperature is not None else None
+
+
+def compare_identities(
+    left: dict[str, Any], right: dict[str, Any], *, allowed: set[str]
+) -> dict[str, Any]:
+    """Fail closed when arms differ outside their pre-registered fields."""
+    ignored = {"declared_differences", *allowed}
+    keys = set(left) | set(right)
+    differences = {
+        key: {"left": left.get(key), "right": right.get(key)}
+        for key in sorted(keys - ignored)
+        if sha256_json(left.get(key)) != sha256_json(right.get(key))
+    }
+    return {"comparable": not differences, "differences": differences}
+
+
+def assert_isolation(*, sandbox: Path, sealed_dir: Path) -> None:
+    sandbox = sandbox.resolve()
+    sealed_dir = sealed_dir.resolve()
+    if sealed_dir == sandbox or sealed_dir.is_relative_to(sandbox):
+        raise ValueError("sealed holdout must be outside the arm sandbox")
+    if sandbox.is_relative_to(sealed_dir):
+        raise ValueError("arm sandbox must not be nested under the sealed holdout")

--- a/wayfinder_paths/jobs/bench/mcp_server.py
+++ b/wayfinder_paths/jobs/bench/mcp_server.py
@@ -1,0 +1,79 @@
+"""Benchmark MCP surface: campaign lifecycle only, no market-data tools."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any, Literal
+
+from mcp.server.fastmcp import FastMCP
+
+from wayfinder_paths.mcp.tools.jobs import core_jobs as _production_core_jobs
+
+BenchAction = Literal[
+    "evolution_status",
+    "evolution_design",
+    "evolution_prepare",
+    "evolution_submit_seed",
+    "evolution_evaluate",
+    "evolution_finalize",
+]
+_ALLOWED_ACTIONS = {
+    "evolution_status",
+    "evolution_design",
+    "evolution_prepare",
+    "evolution_submit_seed",
+    "evolution_evaluate",
+    "evolution_finalize",
+}
+
+
+async def core_jobs(
+    action: BenchAction,
+    *,
+    job_id: str,
+    campaign_design: dict[str, Any] | None = None,
+    family: str | None = None,
+    summary: str | None = None,
+    mutation_kind: Literal["structural", "parameter"] | None = None,
+    candidate_dir: str | None = None,
+    candidate_id: str | None = None,
+    hypothesis: str | None = None,
+    base_revision: str | None = None,
+    evidence_refs: list[str] | None = None,
+    background: bool | None = None,
+) -> dict[str, Any]:
+    """Production evolution lifecycle with all data/live actions absent."""
+    if action not in _ALLOWED_ACTIONS:
+        raise ValueError(f"action {action!r} is unavailable in benchmark mode")
+    return await _production_core_jobs(
+        action,
+        job_id=job_id,
+        campaign_design=campaign_design,
+        family=family,
+        summary=summary,
+        mutation_kind=mutation_kind,
+        candidate_dir=candidate_dir,
+        candidate_id=candidate_id,
+        hypothesis=hypothesis,
+        base_revision=base_revision,
+        evidence_refs=evidence_refs,
+        background=background,
+    )
+
+
+def build_bench_mcp(*, host: str, port: int) -> FastMCP:
+    server = FastMCP("wayfinder-bench", host=host, port=port)
+    server.tool()(core_jobs)
+    return server
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", required=True, type=int)
+    args = parser.parse_args()
+    build_bench_mcp(host=args.host, port=args.port).run(transport="streamable-http")
+
+
+if __name__ == "__main__":
+    main()

--- a/wayfinder_paths/jobs/bench/mcp_server.py
+++ b/wayfinder_paths/jobs/bench/mcp_server.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import argparse
+from pathlib import Path
 from typing import Any, Literal
 
 from mcp.server.fastmcp import FastMCP
 
+from wayfinder_paths.jobs.bench.env import sandbox_relative
 from wayfinder_paths.mcp.tools.jobs import core_jobs as _production_core_jobs
 
 BenchAction = Literal[
@@ -45,7 +47,11 @@ async def core_jobs(
     """Production evolution lifecycle with all data/live actions absent."""
     if action not in _ALLOWED_ACTIONS:
         raise ValueError(f"action {action!r} is unavailable in benchmark mode")
-    return await _production_core_jobs(
+    # Design validation is lightweight. Keep it inline so a malformed design
+    # returns its exact validator error to the same model turn instead of
+    # depending on a future scheduler wake to discover a detached failure.
+    effective_background = False if action == "evolution_design" else background
+    result = await _production_core_jobs(
         action,
         job_id=job_id,
         campaign_design=campaign_design,
@@ -57,8 +63,9 @@ async def core_jobs(
         hypothesis=hypothesis,
         base_revision=base_revision,
         evidence_refs=evidence_refs,
-        background=background,
+        background=effective_background,
     )
+    return sandbox_relative(result, root=Path.cwd())
 
 
 def build_bench_mcp(*, host: str, port: int) -> FastMCP:

--- a/wayfinder_paths/jobs/bench/runner.py
+++ b/wayfinder_paths/jobs/bench/runner.py
@@ -26,6 +26,7 @@ from wayfinder_paths.jobs.bench.env import (
     load_json,
     sandbox_relative,
     sha256_file,
+    sha256_json,
 )
 from wayfinder_paths.jobs.bench.forward_replay import race_bundles, replay_probation
 from wayfinder_paths.jobs.bench.identity import (
@@ -225,10 +226,11 @@ def run_arm(
     if base_url := str(config.get("wayfinder_base_url") or "").strip():
         _set_provider_base_url(config_path, provider="wayfinder", base_url=base_url)
     ensure_model_declared(config_path, model)
+    arm_campaign = dict(arm.get("campaign") or {})
     store, job_id = _install_job(
         run_root,
         world_dir=world_dir,
-        policy=dict(config.get("campaign") or {}),
+        policy={**dict(config.get("campaign") or {}), **arm_campaign},
         # The stores are physically isolated, so arms can share the same job
         # id. This keeps the production prompt bytes identical across a pair.
         job_id_override=f"bench-{_safe_name(world['manifest']['world_id'])}-s{seed}",
@@ -395,6 +397,7 @@ def run_arm(
         declared_differences=list(
             config.get("allowed_identity_differences") or ["model", "variant"]
         ),
+        arm_parameters={"campaign": arm_campaign},
         opencode=opencode,
     )
     return {
@@ -909,6 +912,7 @@ def _validate_config(config: dict[str, Any]) -> None:
         "agent_hashes",
         "agent_temperatures",
         "initial_prompt_sha256",
+        "arm_parameters",
     }
     unsupported = allowed_identity - supported_identity
     if unsupported:
@@ -989,6 +993,7 @@ def _runtime_pins(config_path: Path, config: dict[str, Any]) -> dict[str, Any]:
             "name": str(arm["name"]),
             "sdk_root": str(_resolve_sdk_root(runtime, arm)),
             "sdk_ref": git_sha(_resolve_sdk_root(runtime, arm)),
+            "campaign_sha256": sha256_json(dict(arm.get("campaign") or {})),
         }
         for arm in config["arms"]
     ]
@@ -1022,6 +1027,8 @@ def _verify_runtime_pins(
     )
     if not arm_pin or arm_pin.get("sdk_ref") != git_sha(sdk_root):
         raise ValueError("arm SDK changed after experiment registration")
+    if arm_pin.get("campaign_sha256") != sha256_json(dict(arm.get("campaign") or {})):
+        raise ValueError("arm campaign parameters changed after registration")
     world_pin = next(
         (
             row

--- a/wayfinder_paths/jobs/bench/runner.py
+++ b/wayfinder_paths/jobs/bench/runner.py
@@ -243,9 +243,13 @@ def run_arm(
     invalid_reason: str | None = None
     try:
         if bool(config.get("interface_smoke", True)):
+            smoke_path = (store.job_dir(job_id) / "job.yaml").resolve()
             smoke = run_agent_prompt(
                 sandbox=run_root,
-                prompt="Reply with exactly BENCH_READY and do not call tools.",
+                prompt=(
+                    f"Read exactly `{smoke_path}` with the read tool, then reply "
+                    "with exactly BENCH_READY. Do not call any other tool."
+                ),
                 model=model,
                 variant=variant,
                 title=f"bench-smoke-{_safe_name(run_id)}",

--- a/wayfinder_paths/jobs/bench/runner.py
+++ b/wayfinder_paths/jobs/bench/runner.py
@@ -1,0 +1,963 @@
+"""Synchronous, isolated driver for full self-improvement campaign A/Bs."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import socket
+import sqlite3
+import subprocess
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml  # type: ignore[import-untyped]
+
+from wayfinder_paths.jobs.archive import behavior_cell
+from wayfinder_paths.jobs.bench.aggregate import aggregate_experiment
+from wayfinder_paths.jobs.bench.env import (
+    atomic_json,
+    free_port,
+    git_sha,
+    load_json,
+    sha256_file,
+)
+from wayfinder_paths.jobs.bench.forward_replay import race_bundles, replay_probation
+from wayfinder_paths.jobs.bench.identity import (
+    assert_isolation,
+    compare_identities,
+    ensure_model_declared,
+    runtime_identity,
+)
+from wayfinder_paths.jobs.bench.world import install_development_world, load_world
+from wayfinder_paths.jobs.benchmarks.agent_adapter import (
+    DEFAULT_OPENCODE,
+    install_agent_workspace,
+    meter_session_ids,
+    run_agent_prompt,
+)
+from wayfinder_paths.jobs.bundles import copy_job_bundle
+from wayfinder_paths.jobs.evolution_campaign import (
+    campaign_prompt_block,
+    campaign_status,
+    start_campaign,
+)
+from wayfinder_paths.jobs.evolution_funnel import summarize_evolution_funnel
+from wayfinder_paths.jobs.execution.op_process import terminate_campaign_ops
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.probation import load_probation, resolve_probation_bundle
+from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.jobs.worker import build_evolution_stage_prompt
+
+EXPERIMENT_SCHEMA_VERSION = "1.0"
+
+
+def run_experiment(config_path: Path) -> dict[str, Any]:
+    config_path = config_path.resolve()
+    config = load_json(config_path)
+    _validate_config(config)
+    output_dir = _from_config(config_path, config["output_dir"])
+    output_dir.mkdir(parents=True, exist_ok=False)
+    # Freeze the question before the first model call.
+    pins = _runtime_pins(config_path, config)
+    frozen_config = {
+        **config,
+        "config_sha256": sha256_file(config_path),
+        "runtime_pins": pins,
+    }
+    atomic_json(output_dir / "experiment.json", frozen_config)
+    runtime_config = {
+        **config,
+        "_config_dir": str(config_path.parent),
+        "_runtime_pins": pins,
+    }
+    rows: list[dict[str, Any]] = []
+    identities: dict[tuple[str, int, str], dict[str, Any]] = {}
+    for world_config in config["worlds"]:
+        world_dir = _from_config(config_path, world_config["world_dir"])
+        sealed_dir = _from_config(config_path, world_config["sealed_dir"])
+        for seed in config["seeds"]:
+            for arm in config["arms"]:
+                row = _run_arm_in_declared_sdk(
+                    config=runtime_config,
+                    arm=arm,
+                    seed=int(seed),
+                    world_dir=world_dir,
+                    sealed_dir=sealed_dir,
+                    output_dir=output_dir,
+                )
+                rows.append(row)
+                identities[(row["world_id"], row["seed"], row["arm"])] = row["identity"]
+                atomic_json(output_dir / "runs" / f"{row['run_id']}.json", row)
+    parity = _identity_parity(config, identities)
+    atomic_json(output_dir / "identity_parity.json", parity)
+    if not parity["comparable"]:
+        report = {
+            "schema_version": EXPERIMENT_SCHEMA_VERSION,
+            "decision": "invalid_identity_mismatch",
+            "identity": parity,
+            "runs": len(rows),
+        }
+        atomic_json(output_dir / "aggregate.json", report)
+        return report
+    return aggregate_experiment(
+        rows,
+        arm_order=[str(arm["name"]) for arm in config["arms"]],
+        output_dir=output_dir,
+        confidence=float(config.get("confidence") or 0.90),
+        max_cost_ratio=float(config.get("max_cost_ratio") or 1.25),
+    )
+
+
+def _run_arm_in_declared_sdk(
+    *,
+    config: dict[str, Any],
+    arm: dict[str, Any],
+    seed: int,
+    world_dir: Path,
+    sealed_dir: Path,
+    output_dir: Path,
+) -> dict[str, Any]:
+    """Run the controller under the arm's SDK, not the launcher's imports.
+
+    The neutral benchmark package is overlaid onto a private copy of the arm
+    SDK. Everything it calls (campaign state, prompts, screens, gates, and
+    probation) therefore resolves from that arm's declared checkout.
+    """
+    world_id = str(load_json(world_dir / "world.json")["world_id"])
+    run_id = f"{world_id}-{seed}-{arm['name']}"
+    controller = output_dir / "controllers" / _safe_name(run_id)
+    if controller.exists():
+        raise FileExistsError(f"arm controller already exists: {controller}")
+    sdk_root = _resolve_sdk_root(config, arm)
+    source_package = sdk_root / "wayfinder_paths"
+    if not source_package.is_dir():
+        raise FileNotFoundError(f"arm SDK package is missing: {source_package}")
+    shutil.copytree(
+        source_package,
+        controller / "wayfinder_paths",
+        ignore=shutil.ignore_patterns("__pycache__", "*.pyc", "tests"),
+    )
+    _overlay_bench_package(controller)
+    request = {
+        "config": config,
+        "arm": arm,
+        "seed": seed,
+        "world_dir": str(world_dir),
+        "sealed_dir": str(sealed_dir),
+        "output_dir": str(output_dir),
+        "result_path": str(controller / "result.json"),
+    }
+    atomic_json(controller / "request.json", request)
+    python = sdk_root / ".venv" / "bin" / "python"
+    command = [
+        str(python if python.exists() else Path(sys.executable)),
+        "-m",
+        "wayfinder_paths.jobs.bench.arm_entry",
+        str(controller / "request.json"),
+    ]
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(controller)
+    log_path = controller / "controller.log"
+    with log_path.open("w", encoding="utf-8") as log:
+        completed = subprocess.run(
+            command,
+            cwd=controller,
+            env=env,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            check=False,
+            timeout=float(config.get("arm_timeout_seconds") or 43_200),
+        )
+    if completed.returncode != 0:
+        tail = log_path.read_text(encoding="utf-8", errors="replace")[-2_000:]
+        raise RuntimeError(
+            f"benchmark arm {run_id} exited {completed.returncode}: {tail}"
+        )
+    return load_json(controller / "result.json")
+
+
+def run_arm(
+    *,
+    config: dict[str, Any],
+    arm: dict[str, Any],
+    seed: int,
+    world_dir: Path,
+    sealed_dir: Path,
+    output_dir: Path,
+) -> dict[str, Any]:
+    world = load_world(world_dir, sealed_dir)
+    run_id = f"{world['manifest']['world_id']}-{seed}-{arm['name']}"
+    run_root = output_dir / "workspaces" / _safe_name(run_id)
+    if run_root.exists():
+        raise FileExistsError(f"run workspace already exists: {run_root}")
+    _assert_bench_root(run_root)
+    assert_isolation(sandbox=run_root, sealed_dir=sealed_dir)
+    assert_isolation(sandbox=run_root, sealed_dir=world_dir)
+    sdk_root = _resolve_sdk_root(config, arm)
+    _verify_runtime_pins(
+        config,
+        arm=arm,
+        sdk_root=sdk_root,
+        world_dir=world_dir,
+        sealed_dir=sealed_dir,
+    )
+    model = str(arm["model"])
+    variant = str(arm.get("variant") or "") or None
+    opencode = Path(config.get("opencode") or DEFAULT_OPENCODE).expanduser()
+    port = free_port()
+    install_agent_workspace(
+        sandbox=run_root,
+        repo_root=sdk_root,
+        mcp_url=f"http://127.0.0.1:{port}/mcp",
+    )
+    _overlay_bench_package(run_root)
+    config_path = run_root / ".opencode" / "opencode.json"
+    ensure_model_declared(config_path, model)
+    store, job_id = _install_job(
+        run_root,
+        world_dir=world_dir,
+        policy=dict(config.get("campaign") or {}),
+        # The stores are physically isolated, so arms can share the same job
+        # id. This keeps the production prompt bytes identical across a pair.
+        job_id_override=f"bench-{_safe_name(world['manifest']['world_id'])}-s{seed}",
+    )
+    generation_cutoff = _parse(world["manifest"]["generation_cutoff"])
+    prompt_hashes: list[str] = []
+    sessions: list[dict[str, Any]] = []
+    stage_sessions: dict[str, str] = {}
+    env = _arm_env(run_root)
+    server = _start_mcp(run_root, port=port, env=env)
+    started = time.monotonic()
+    invalid_reason: str | None = None
+    try:
+        if bool(config.get("interface_smoke", True)):
+            smoke = run_agent_prompt(
+                sandbox=run_root,
+                prompt="Reply with exactly BENCH_READY and do not call tools.",
+                model=model,
+                variant=variant,
+                title=f"bench-smoke-{_safe_name(run_id)}",
+                opencode=opencode,
+                agent="wayfinder-evolution-designer",
+                timeout_s=int(config.get("turn_timeout_seconds") or 1_800),
+                env=env,
+            )
+            sessions.append({"stage": "interface-smoke", **smoke})
+            if smoke["exit_code"] != 0 or "BENCH_READY" not in smoke["stdout_tail"]:
+                invalid_reason = "model interface smoke failed"
+        if invalid_reason is None:
+            start_campaign(store, job_id, now=generation_cutoff, force=True)
+            invalid_reason = _drive_campaign(
+                store=store,
+                job_id=job_id,
+                model=model,
+                variant=variant,
+                opencode=opencode,
+                sandbox=run_root,
+                env=env,
+                virtual_now=generation_cutoff,
+                repeat_seed=seed,
+                max_turns=int(config.get("max_turns") or 40),
+                timeout_s=int(config.get("turn_timeout_seconds") or 1_800),
+                settle_timeout_s=int(config.get("settle_timeout_seconds") or 3_600),
+                prompt_hashes=prompt_hashes,
+                sessions=sessions,
+                stage_sessions=stage_sessions,
+            )
+    finally:
+        server.terminate()
+        try:
+            server.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            server.kill()
+
+    development = list(world["development"].get("bars") or [])
+    holdout_rows = list(world["holdout"].get("bars") or [])
+    forward: dict[str, Any]
+    holdout: dict[str, Any]
+    if invalid_reason is not None:
+        state = campaign_status(store, job_id)
+        campaign_id = str(state.get("campaign_id") or "")
+        if campaign_id:
+            terminate_campaign_ops(store, job_id, campaign_id)
+        forward = {
+            "available": False,
+            "status": "invalid",
+            "reason": invalid_reason,
+        }
+        holdout = {"verdict": "invalid", "reason": invalid_reason}
+    else:
+        forward = replay_probation(
+            store,
+            job_id,
+            development_rows=development,
+            holdout_rows=holdout_rows,
+            generation_cutoff=generation_cutoff,
+        )
+        probation = load_probation(store, job_id)
+        trial = next(iter(probation.get("trials") or []), None)
+        if trial:
+            candidate_bundle = resolve_probation_bundle(
+                store, job_id, trial["candidate"]
+            )
+            reference_bundle = resolve_probation_bundle(
+                store, job_id, trial["reference"]
+            )
+            holdout = race_bundles(
+                candidate_bundle,
+                reference_bundle,
+                world_dir=world_dir,
+                sealed_dir=sealed_dir,
+                output_dir=run_root / "results" / "holdout",
+            )
+            if holdout.get("verdict") == "invalid":
+                invalid_reason = "holdout_race_invalid"
+        else:
+            # No survivor means the process retained the incumbent. Its
+            # candidate-minus-incumbent endpoint is exactly zero; do not run
+            # a fake incumbent-vs-itself race just to manufacture activity.
+            holdout = {
+                "verdict": "no_candidate",
+                "paired_daily_utility_delta": {
+                    "days": 0,
+                    "estimate": 0.0,
+                    "lcb": None,
+                    "values": [],
+                },
+            }
+    session_db = _session_db(run_root)
+    session_ids = []
+    missing_transcripts = []
+    for row in sessions:
+        session_id = row.get("session_id") or _lookup_session_id(
+            session_db, row["title"]
+        )
+        if session_id:
+            session_ids.append(str(session_id))
+        else:
+            missing_transcripts.append(str(row["title"]))
+    cost = meter_session_ids(session_ids, session_db=session_db)
+    cost["wall_seconds"] = round(time.monotonic() - started, 3)
+    isolation = _audit_session_isolation(
+        session_ids,
+        session_db=session_db,
+        sandbox=run_root,
+        protected_roots=[world_dir, sealed_dir],
+        missing_transcripts=missing_transcripts,
+    )
+    if not isolation["passed"] and invalid_reason is None:
+        invalid_reason = "isolation_breach"
+    state = campaign_status(store, job_id)
+    funnel = summarize_evolution_funnel(state)
+    scorecard = _scorecard(
+        state=state,
+        funnel=funnel,
+        forward=forward,
+        holdout=holdout,
+        sessions=sessions,
+        cost=cost,
+    )
+    identity = runtime_identity(
+        sdk_root=sdk_root,
+        sandbox=run_root,
+        model=model,
+        variant=variant,
+        repeat_seed=seed,
+        world_manifest=world["manifest"],
+        prompt_hashes=prompt_hashes,
+        declared_differences=list(
+            config.get("allowed_identity_differences") or ["model", "variant"]
+        ),
+        opencode=opencode,
+    )
+    return {
+        "schema_version": EXPERIMENT_SCHEMA_VERSION,
+        "run_id": run_id,
+        "arm": str(arm["name"]),
+        "world_id": world["manifest"]["world_id"],
+        "seed": seed,
+        "model": model,
+        "variant": variant,
+        "invalid_reason": invalid_reason,
+        "funnel": scorecard["funnel"],
+        "verdicts": scorecard["verdicts"],
+        "forward": forward,
+        "holdout": holdout,
+        "diversity": scorecard["diversity"],
+        "process": scorecard["process"],
+        "cost": cost,
+        "isolation": isolation,
+        "identity": identity,
+        "workspace": str(run_root),
+    }
+
+
+def _install_job(
+    sandbox: Path,
+    *,
+    world_dir: Path,
+    policy: dict[str, Any],
+    job_id_override: str | None = None,
+) -> tuple[JobStore, str]:
+    world_manifest = load_json(world_dir / "world.json")
+    source = world_dir / str(world_manifest["incumbent"]["path"])
+    job_id = job_id_override or str(world_manifest["source_job"])
+    store = JobStore(repo_root=sandbox)
+    destination = store.job_dir(job_id)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    copy_job_bundle(source, destination)
+    job_yaml_path = destination / "job.yaml"
+    job_yaml = yaml.safe_load(job_yaml_path.read_text(encoding="utf-8")) or {}
+    job_yaml.update(
+        {
+            "id": job_id,
+            "name": str(job_yaml.get("name") or job_id),
+            "execution_contract": "jobs_v1",
+        }
+    )
+    job_yaml["script_loop"] = {
+        **dict(job_yaml.get("script_loop") or {}),
+        "enabled": True,
+        "mode": "paper",
+    }
+    job_yaml["agent_loop"] = {
+        **dict(job_yaml.get("agent_loop") or {}),
+        "enabled": True,
+        "mode": "intervene",
+    }
+    execution_params = dict(job_yaml.get("execution_params") or {})
+    execution_params.pop("wallet_label", None)
+    job_yaml["execution_params"] = execution_params
+    job_yaml_path.write_text(
+        yaml.safe_dump(job_yaml, sort_keys=False), encoding="utf-8"
+    )
+    job = WayfinderJob.from_dict(job_yaml)
+    store.init_layout(job)
+    install_development_world(world_dir, destination_job=destination)
+    evolution = {
+        "enabled": True,
+        "allowed_job_ids": [job_id],
+        "excluded_job_ids": [],
+        "pricing_schedule": {"blocked_windows_utc": []},
+        **policy,
+    }
+    (destination / "improver.yaml").write_text(
+        yaml.safe_dump({"evolution": evolution}, sort_keys=False), encoding="utf-8"
+    )
+    return store, job_id
+
+
+def _drive_campaign(
+    *,
+    store: JobStore,
+    job_id: str,
+    model: str,
+    variant: str | None,
+    opencode: Path,
+    sandbox: Path,
+    env: dict[str, str],
+    virtual_now: datetime,
+    repeat_seed: int,
+    max_turns: int,
+    timeout_s: int,
+    settle_timeout_s: int,
+    prompt_hashes: list[str],
+    sessions: list[dict[str, Any]],
+    stage_sessions: dict[str, str],
+) -> str | None:
+    prior_handoff: dict[str, Any] | None = None
+    for turn in range(max_turns):
+        state = campaign_status(store, job_id)
+        if state.get("status") in {"complete", "failed", "expired"}:
+            return (
+                None if state.get("status") == "complete" else str(state.get("status"))
+            )
+        block = campaign_prompt_block(store, job_id, now=virtual_now)
+        if block is None:
+            return "campaign prompt disappeared before completion"
+        if block.get("status") == "blocked":
+            if not _wait_for_settle(store, job_id, timeout_s=settle_timeout_s):
+                return str(block.get("reason") or "campaign remained blocked")
+            continue
+        rendered = build_evolution_stage_prompt(
+            job_id, block, prior_handoff=prior_handoff
+        )
+        prompt = (
+            f"{rendered['prompt']}\n\n"
+            f"BENCHMARK REPETITION TOKEN: {repeat_seed}. This token distinguishes "
+            "stochastic repeats; it does not change evaluation rules or data."
+        )
+        prompt_hashes.append(hashlib.sha256(prompt.encode()).hexdigest())
+        stage = rendered["session_stage"]
+        title = f"{rendered['title']}/seed-turn-{turn:02d}"
+        existing_session = stage_sessions.get(stage)
+        result = run_agent_prompt(
+            sandbox=sandbox,
+            prompt=prompt,
+            model=model,
+            variant=variant,
+            title=title,
+            session_id=existing_session,
+            opencode=opencode,
+            agent=rendered["agent_name"],
+            timeout_s=timeout_s,
+            env=env,
+        )
+        result.update({"stage": stage, "turn": turn})
+        sessions.append(result)
+        if result["exit_code"] != 0:
+            return f"OpenCode stage {stage} exited {result['exit_code']}"
+        session_db = _session_db(sandbox)
+        session_id = existing_session or _lookup_session_id(session_db, title)
+        if session_id:
+            stage_sessions[stage] = session_id
+            result["session_id"] = session_id
+        prior_handoff = {
+            "from_stage": stage,
+            "final_summary": result["stdout_tail"][-1_200:],
+        }
+        if not _wait_for_settle(store, job_id, timeout_s=settle_timeout_s):
+            return f"campaign stage {stage} did not settle"
+    return f"campaign exceeded max_turns={max_turns}"
+
+
+def _wait_for_settle(store: JobStore, job_id: str, *, timeout_s: int) -> bool:
+    deadline = time.monotonic() + timeout_s
+    prior = ""
+    stable = 0
+    time.sleep(0.5)
+    while time.monotonic() < deadline:
+        state = campaign_status(store, job_id)
+        encoded = json.dumps(state, sort_keys=True, default=str)
+        running = state.get("status") == "finalizing" or any(
+            str(candidate.get("status") or "").endswith("_running")
+            for candidate in state.get("candidates") or []
+        )
+        if encoded == prior and not running:
+            stable += 1
+            if stable >= 3:
+                return True
+        else:
+            stable = 0
+        prior = encoded
+        time.sleep(1.0)
+    return False
+
+
+def _start_mcp(sandbox: Path, *, port: int, env: dict[str, str]) -> subprocess.Popen:
+    python = sandbox / ".venv" / "bin" / "python"
+    command = [
+        str(python if python.exists() else Path(sys.executable)),
+        "-m",
+        "wayfinder_paths.jobs.bench.mcp_server",
+        "--port",
+        str(port),
+    ]
+    log = (sandbox / "mcp.log").open("w", encoding="utf-8")
+    process = subprocess.Popen(
+        command,
+        cwd=sandbox,
+        env=env,
+        stdout=log,
+        stderr=subprocess.STDOUT,
+    )
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError("benchmark MCP server exited during startup")
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.25):
+                return process
+        except OSError:
+            time.sleep(0.25)
+    process.terminate()
+    raise TimeoutError("benchmark MCP server did not start")
+
+
+def _arm_env(sandbox: Path) -> dict[str, str]:
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(sandbox)
+    env["XDG_DATA_HOME"] = str(sandbox / ".bench-data")
+    env["XDG_CACHE_HOME"] = str(sandbox / ".bench-cache")
+    env["WAYFINDER_BENCHMARK"] = "1"
+    env["WAYFINDER_BURST_STATE_PATH"] = str(
+        sandbox / ".bench-state" / "burst-governor.json"
+    )
+    return env
+
+
+def _session_db(sandbox: Path) -> Path:
+    root = sandbox / ".bench-data"
+    matches = sorted(root.rglob("opencode.db")) if root.exists() else []
+    return matches[0] if matches else root / "opencode" / "opencode.db"
+
+
+def _lookup_session_id(database: Path, title: str) -> str | None:
+    if not database.exists():
+        return None
+    connection = sqlite3.connect(str(database))
+    try:
+        row = connection.execute(
+            "SELECT id FROM session WHERE title=? ORDER BY time_updated DESC LIMIT 1",
+            (title,),
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return None
+    finally:
+        connection.close()
+    return str(row[0]) if row else None
+
+
+def _audit_session_isolation(
+    session_ids: list[str],
+    *,
+    session_db: Path,
+    sandbox: Path,
+    protected_roots: list[Path],
+    missing_transcripts: list[str],
+) -> dict[str, Any]:
+    """Detect future/sibling/network access in persisted tool inputs."""
+    breaches: list[dict[str, Any]] = [
+        {"type": "missing_transcript", "title": title} for title in missing_transcripts
+    ]
+    if not session_db.exists():
+        if session_ids:
+            breaches.append({"type": "missing_session_database"})
+        return {"passed": not breaches, "breaches": breaches}
+    sandbox = sandbox.resolve()
+    protected = [path.resolve() for path in protected_roots]
+    connection = sqlite3.connect(str(session_db))
+    try:
+        for session_id in dict.fromkeys(session_ids):
+            try:
+                rows = connection.execute(
+                    "SELECT json_extract(data,'$.tool'), "
+                    "json_extract(data,'$.state.input') FROM part "
+                    "WHERE session_id=? AND json_extract(data,'$.type')='tool'",
+                    (session_id,),
+                )
+            except sqlite3.OperationalError:
+                breaches.append(
+                    {"type": "unreadable_transcript", "session_id": session_id}
+                )
+                continue
+            for tool, raw_input in rows:
+                tool_name = str(tool or "unknown")
+                lowered = tool_name.lower()
+                if any(
+                    marker in lowered
+                    for marker in ("bash", "shell", "fetch", "http", "browser", "web")
+                ):
+                    breaches.append(
+                        {
+                            "type": "network_or_shell_tool",
+                            "session_id": session_id,
+                            "tool": tool_name,
+                        }
+                    )
+                    continue
+                try:
+                    tool_input = json.loads(raw_input) if raw_input else {}
+                except (TypeError, ValueError):
+                    tool_input = {}
+                if tool_name == "core_jobs":
+                    continue
+                for key, value in _input_strings(tool_input):
+                    if not any(
+                        marker in key.lower()
+                        for marker in ("path", "file", "directory", "root")
+                    ):
+                        continue
+                    candidate = Path(value).expanduser()
+                    resolved = (
+                        candidate.resolve()
+                        if candidate.is_absolute()
+                        else (sandbox / candidate).resolve()
+                    )
+                    outside = not resolved.is_relative_to(sandbox)
+                    protected_access = any(
+                        resolved == root or resolved.is_relative_to(root)
+                        for root in protected
+                        if root != sandbox
+                    )
+                    if outside or protected_access:
+                        breaches.append(
+                            {
+                                "type": "filesystem_escape",
+                                "session_id": session_id,
+                                "tool": tool_name,
+                                "path": value[:300],
+                            }
+                        )
+    finally:
+        connection.close()
+    return {"passed": not breaches, "breaches": breaches}
+
+
+def _input_strings(value: Any, key: str = "") -> list[tuple[str, str]]:
+    if isinstance(value, dict):
+        return [
+            pair
+            for child_key, child in value.items()
+            for pair in _input_strings(child, str(child_key))
+        ]
+    if isinstance(value, list):
+        return [pair for child in value for pair in _input_strings(child, key)]
+    return [(key, value)] if isinstance(value, str) else []
+
+
+def _scorecard(
+    *,
+    state: dict[str, Any],
+    funnel: dict[str, Any],
+    forward: dict[str, Any],
+    holdout: dict[str, Any],
+    sessions: list[dict[str, Any]],
+    cost: dict[str, Any],
+) -> dict[str, Any]:
+    candidates = list(state.get("candidates") or [])
+    funnel_counts = state.get("counts") or {}
+    quick = funnel.get("quick_screen") or {}
+    full_development = funnel.get("full_development") or {}
+    finalist = funnel.get("finalist_gate") or {}
+    elites = [row for row in candidates if row.get("elite_eligible") is True]
+    elite_trades = [
+        int((row.get("elite_activity") or {}).get("validation_trades") or 0)
+        for row in elites
+    ]
+    cells = {
+        cell
+        for row in elites
+        if (cell := behavior_cell(row.get("behavior"))) is not None
+    }
+    return {
+        "funnel": {
+            "candidates_generated": int(funnel_counts.get("generated") or 0),
+            "attempts": int(
+                funnel_counts.get("quick_attempts")
+                or funnel_counts.get("quick_evaluated")
+                or 0
+            ),
+            "screen_positive": int(quick.get("passed") or 0),
+            "full_dev": int(full_development.get("evaluated") or 0),
+            "gate_passed": int(
+                finalist.get("advanced_to_probation")
+                or finalist.get("advanced_to_paper")
+                or 0
+            ),
+            "staged": 1 if forward.get("available") else 0,
+            "production_summary": funnel,
+        },
+        "verdicts": {
+            "burn_in_admitted": bool(
+                (forward.get("burn_in") or {}).get("status") == "passed"
+            ),
+            "graduated": forward.get("status") == "graduated",
+            "killed": forward.get("status") == "killed",
+            "inconclusive": forward.get("status") == "inconclusive",
+        },
+        "diversity": {
+            "qd_cells_occupied": len(cells),
+            "distinct_families": len(
+                {str(row.get("family")) for row in candidates if row.get("family")}
+            ),
+            "mean_elite_trade_count": (
+                round(sum(elite_trades) / len(elite_trades), 3) if elite_trades else 0.0
+            ),
+            "parent_sources": sorted(
+                {
+                    str(row.get("parent_source"))
+                    for row in candidates
+                    if row.get("parent_source")
+                }
+            ),
+        },
+        "process": {
+            "turns": len(
+                [row for row in sessions if row.get("stage") != "interface-smoke"]
+            ),
+            "failed_turns": sum(1 for row in sessions if row.get("exit_code") != 0),
+            "fact_citations": sum(
+                len(row.get("evidence_refs") or []) for row in candidates
+            ),
+            "wildcards_used": sum(bool(row.get("wildcard")) for row in candidates),
+            "postmortems_consumed": sum(
+                max(int(row.get("attempt_count") or 0) - 1, 0) for row in candidates
+            ),
+            "holdout_verdict": holdout.get("verdict"),
+        },
+        "cost": cost,
+    }
+
+
+def _identity_parity(
+    config: dict[str, Any],
+    identities: dict[tuple[str, int, str], dict[str, Any]],
+) -> dict[str, Any]:
+    arms = [str(arm["name"]) for arm in config["arms"]]
+    checks = []
+    for world_id, seed in sorted({(key[0], key[1]) for key in identities}):
+        left = identities[(world_id, seed, arms[0])]
+        right = identities[(world_id, seed, arms[1])]
+        check = compare_identities(
+            left,
+            right,
+            allowed={
+                *(config.get("allowed_identity_differences") or ["model", "variant"]),
+                "opencode_config_sha256",
+                "prompt_hashes",
+            },
+        )
+        checks.append({"world_id": world_id, "seed": seed, **check})
+    return {
+        "comparable": bool(checks) and all(row["comparable"] for row in checks),
+        "checks": checks,
+    }
+
+
+def _validate_config(config: dict[str, Any]) -> None:
+    if config.get("schema_version") != EXPERIMENT_SCHEMA_VERSION:
+        raise ValueError(f"schema_version must be {EXPERIMENT_SCHEMA_VERSION}")
+    if len(config.get("arms") or []) != 2:
+        raise ValueError("experiments require exactly two arms")
+    if not config.get("worlds") or not config.get("seeds"):
+        raise ValueError("experiments require worlds and seeds")
+    if len(config["seeds"]) < 4:
+        raise ValueError("experiments require at least four seeds per arm/world")
+    names = [str(arm.get("name") or "") for arm in config["arms"]]
+    if not all(names) or len(set(names)) != 2:
+        raise ValueError("arm names must be non-empty and unique")
+    allowed_identity = set(
+        config.get("allowed_identity_differences") or ["model", "variant"]
+    )
+    supported_identity = {
+        "model",
+        "variant",
+        "sdk_ref",
+        "agent_hashes",
+        "agent_temperatures",
+        "initial_prompt_sha256",
+    }
+    unsupported = allowed_identity - supported_identity
+    if unsupported:
+        raise ValueError(
+            f"unsupported allowed_identity_differences: {sorted(unsupported)}"
+        )
+
+
+def _from_config(config_path: Path, raw: str) -> Path:
+    path = Path(raw).expanduser()
+    return (
+        path.resolve() if path.is_absolute() else (config_path.parent / path).resolve()
+    )
+
+
+def _resolve_sdk_root(config: dict[str, Any], arm: dict[str, Any]) -> Path:
+    config_dir = Path(str(config.get("_config_dir") or Path.cwd()))
+    value = Path(arm.get("sdk_root") or config.get("sdk_root") or ".").expanduser()
+    return value.resolve() if value.is_absolute() else (config_dir / value).resolve()
+
+
+def _runtime_pins(config_path: Path, config: dict[str, Any]) -> dict[str, Any]:
+    runtime = {**config, "_config_dir": str(config_path.parent)}
+    worlds = []
+    for item in config["worlds"]:
+        world_dir = _from_config(config_path, item["world_dir"])
+        sealed_dir = _from_config(config_path, item["sealed_dir"])
+        loaded = load_world(world_dir, sealed_dir)
+        worlds.append(
+            {
+                "world_dir": str(world_dir),
+                "sealed_dir": str(sealed_dir),
+                "world_sha256": sha256_file(world_dir / "world.json"),
+                "development_sha256": loaded["manifest"]["dataset"][
+                    "development_sha256"
+                ],
+                "holdout_commitment": loaded["manifest"]["dataset"][
+                    "holdout_commitment"
+                ],
+            }
+        )
+    arms = [
+        {
+            "name": str(arm["name"]),
+            "sdk_root": str(_resolve_sdk_root(runtime, arm)),
+            "sdk_ref": git_sha(_resolve_sdk_root(runtime, arm)),
+        }
+        for arm in config["arms"]
+    ]
+    return {"worlds": worlds, "arms": arms}
+
+
+def _verify_runtime_pins(
+    config: dict[str, Any],
+    *,
+    arm: dict[str, Any],
+    sdk_root: Path,
+    world_dir: Path,
+    sealed_dir: Path,
+) -> None:
+    pins = dict(config.get("_runtime_pins") or {})
+    arm_pin = next(
+        (row for row in pins.get("arms") or [] if row.get("name") == arm.get("name")),
+        None,
+    )
+    if not arm_pin or arm_pin.get("sdk_ref") != git_sha(sdk_root):
+        raise ValueError("arm SDK changed after experiment registration")
+    world_pin = next(
+        (
+            row
+            for row in pins.get("worlds") or []
+            if row.get("world_dir") == str(world_dir.resolve())
+            and row.get("sealed_dir") == str(sealed_dir.resolve())
+        ),
+        None,
+    )
+    if not world_pin or world_pin.get("world_sha256") != sha256_file(
+        world_dir / "world.json"
+    ):
+        raise ValueError("benchmark world changed after experiment registration")
+    loaded = load_world(world_dir, sealed_dir)
+    dataset = loaded["manifest"]["dataset"]
+    if world_pin.get("development_sha256") != dataset.get(
+        "development_sha256"
+    ) or world_pin.get("holdout_commitment") != dataset.get("holdout_commitment"):
+        raise ValueError("benchmark data commitments changed after registration")
+
+
+def _overlay_bench_package(root: Path) -> None:
+    source = Path(__file__).resolve().parent
+    destination = root / "wayfinder_paths" / "jobs" / "bench"
+    if destination.exists():
+        shutil.rmtree(destination)
+    shutil.copytree(
+        source,
+        destination,
+        ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
+    )
+
+
+def _safe_name(value: str) -> str:
+    return "".join(char if char.isalnum() or char in "-_" else "-" for char in value)
+
+
+def _assert_bench_root(path: Path) -> None:
+    resolved = path.resolve()
+    parts = resolved.parts
+    if any(
+        parts[index : index + 2] == (".wayfinder", "jobs")
+        for index in range(len(parts) - 1)
+    ):
+        raise ValueError("benchmark workspaces cannot live inside .wayfinder/jobs")
+
+
+def _parse(value: Any) -> datetime:
+    parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    return (
+        parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed.astimezone(UTC)
+    )

--- a/wayfinder_paths/jobs/bench/runner.py
+++ b/wayfinder_paths/jobs/bench/runner.py
@@ -24,6 +24,7 @@ from wayfinder_paths.jobs.bench.env import (
     free_port,
     git_sha,
     load_json,
+    sandbox_relative,
     sha256_file,
 )
 from wayfinder_paths.jobs.bench.forward_replay import race_bundles, replay_probation
@@ -110,6 +111,7 @@ def run_experiment(config_path: Path) -> dict[str, Any]:
         output_dir=output_dir,
         confidence=float(config.get("confidence") or 0.90),
         max_cost_ratio=float(config.get("max_cost_ratio") or 1.25),
+        pilot=bool(config.get("pilot")),
     )
 
 
@@ -199,12 +201,14 @@ def run_arm(
     assert_isolation(sandbox=run_root, sealed_dir=sealed_dir)
     assert_isolation(sandbox=run_root, sealed_dir=world_dir)
     sdk_root = _resolve_sdk_root(config, arm)
+    runtime_opencode_config = _resolve_runtime_opencode_config(config)
     _verify_runtime_pins(
         config,
         arm=arm,
         sdk_root=sdk_root,
         world_dir=world_dir,
         sealed_dir=sealed_dir,
+        runtime_opencode_config=runtime_opencode_config,
     )
     model = str(arm["model"])
     variant = str(arm.get("variant") or "") or None
@@ -214,9 +218,12 @@ def run_arm(
         sandbox=run_root,
         repo_root=sdk_root,
         mcp_url=f"http://127.0.0.1:{port}/mcp",
+        runtime_config=runtime_opencode_config,
     )
     _overlay_bench_package(run_root)
     config_path = run_root / ".opencode" / "opencode.json"
+    if base_url := str(config.get("wayfinder_base_url") or "").strip():
+        _set_provider_base_url(config_path, provider="wayfinder", base_url=base_url)
     ensure_model_declared(config_path, model)
     store, job_id = _install_job(
         run_root,
@@ -230,7 +237,7 @@ def run_arm(
     prompt_hashes: list[str] = []
     sessions: list[dict[str, Any]] = []
     stage_sessions: dict[str, str] = {}
-    env = _arm_env(run_root)
+    env = _arm_env(run_root, virtual_now=generation_cutoff)
     server = _start_mcp(run_root, port=port, env=env)
     started = time.monotonic()
     invalid_reason: str | None = None
@@ -342,7 +349,18 @@ def run_arm(
         else:
             missing_transcripts.append(str(row["title"]))
     cost = meter_session_ids(session_ids, session_db=session_db)
-    cost["wall_seconds"] = round(time.monotonic() - started, 3)
+    elapsed_seconds = round(time.monotonic() - started, 3)
+    cost["agent_wall_seconds"] = cost["wall_seconds"]
+    cost["wall_seconds"] = elapsed_seconds
+    cost["other_seconds"] = round(
+        max(
+            elapsed_seconds
+            - float(cost.get("model_seconds") or 0)
+            - float(cost.get("tool_seconds") or 0),
+            0,
+        ),
+        3,
+    )
     isolation = _audit_session_isolation(
         session_ids,
         session_db=session_db,
@@ -391,6 +409,23 @@ def run_arm(
         "diversity": scorecard["diversity"],
         "process": scorecard["process"],
         "cost": cost,
+        "session_diagnostics": [
+            {
+                key: row.get(key)
+                for key in (
+                    "stage",
+                    "artifact_key",
+                    "turn",
+                    "title",
+                    "session_id",
+                    "exit_code",
+                    "stdout_tail",
+                    "stderr_tail",
+                )
+                if row.get(key) is not None
+            }
+            for row in sessions
+        ],
         "isolation": isolation,
         "identity": identity,
         "workspace": str(run_root),
@@ -484,6 +519,7 @@ def _drive_campaign(
             if not _wait_for_settle(store, job_id, timeout_s=settle_timeout_s):
                 return str(block.get("reason") or "campaign remained blocked")
             continue
+        block = sandbox_relative(block, root=sandbox)
         rendered = build_evolution_stage_prompt(
             job_id, block, prior_handoff=prior_handoff
         )
@@ -494,8 +530,9 @@ def _drive_campaign(
         )
         prompt_hashes.append(hashlib.sha256(prompt.encode()).hexdigest())
         stage = rendered["session_stage"]
+        artifact_key = rendered["artifact_key"]
         title = f"{rendered['title']}/seed-turn-{turn:02d}"
-        existing_session = stage_sessions.get(stage)
+        existing_session = stage_sessions.get(artifact_key)
         result = run_agent_prompt(
             sandbox=sandbox,
             prompt=prompt,
@@ -508,18 +545,20 @@ def _drive_campaign(
             timeout_s=timeout_s,
             env=env,
         )
-        result.update({"stage": stage, "turn": turn})
+        result.update({"stage": stage, "artifact_key": artifact_key, "turn": turn})
         sessions.append(result)
         if result["exit_code"] != 0:
             return f"OpenCode stage {stage} exited {result['exit_code']}"
         session_db = _session_db(sandbox)
         session_id = existing_session or _lookup_session_id(session_db, title)
         if session_id:
-            stage_sessions[stage] = session_id
+            stage_sessions[artifact_key] = session_id
             result["session_id"] = session_id
         prior_handoff = {
             "from_stage": stage,
-            "final_summary": result["stdout_tail"][-1_200:],
+            "final_summary": sandbox_relative(
+                result["stdout_tail"][-1_200:], root=sandbox
+            ),
         }
         if not _wait_for_settle(store, job_id, timeout_s=settle_timeout_s):
             return f"campaign stage {stage} did not settle"
@@ -579,16 +618,25 @@ def _start_mcp(sandbox: Path, *, port: int, env: dict[str, str]) -> subprocess.P
     raise TimeoutError("benchmark MCP server did not start")
 
 
-def _arm_env(sandbox: Path) -> dict[str, str]:
+def _arm_env(sandbox: Path, *, virtual_now: datetime | None = None) -> dict[str, str]:
     env = dict(os.environ)
+    isolated_home = sandbox / ".bench-home"
+    isolated_home.mkdir(parents=True, exist_ok=True)
+    env["HOME"] = str(isolated_home)
     env["PYTHONPATH"] = str(sandbox)
     env["XDG_DATA_HOME"] = str(sandbox / ".bench-data")
     env["XDG_CACHE_HOME"] = str(sandbox / ".bench-cache")
     env["WAYFINDER_BENCHMARK"] = "1"
+    if virtual_now is not None:
+        env["WAYFINDER_BENCHMARK_NOW"] = _aware_utc(virtual_now).isoformat()
     env["WAYFINDER_BURST_STATE_PATH"] = str(
         sandbox / ".bench-state" / "burst-governor.json"
     )
     return env
+
+
+def _aware_utc(value: datetime) -> datetime:
+    return value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)
 
 
 def _session_db(sandbox: Path) -> Path:
@@ -735,6 +783,17 @@ def _scorecard(
         for row in elites
         if (cell := behavior_cell(row.get("behavior"))) is not None
     }
+    behavior_flags = [
+        value
+        for row in candidates
+        for attempt in row.get("attempts") or []
+        if isinstance(
+            value := ((attempt.get("postmortem") or {}).get("behavior_diff") or {}).get(
+                "material_change"
+            ),
+            bool,
+        )
+    ]
     return {
         "funnel": {
             "candidates_generated": int(funnel_counts.get("generated") or 0),
@@ -789,6 +848,10 @@ def _scorecard(
             "postmortems_consumed": sum(
                 max(int(row.get("attempt_count") or 0) - 1, 0) for row in candidates
             ),
+            "behavior_changed_attempts": sum(value is True for value in behavior_flags),
+            "behavior_unchanged_attempts": sum(
+                value is False for value in behavior_flags
+            ),
             "holdout_verdict": holdout.get("verdict"),
         },
         "cost": cost,
@@ -827,7 +890,7 @@ def _validate_config(config: dict[str, Any]) -> None:
         raise ValueError("experiments require exactly two arms")
     if not config.get("worlds") or not config.get("seeds"):
         raise ValueError("experiments require worlds and seeds")
-    if len(config["seeds"]) < 4:
+    if not config.get("pilot") and len(config["seeds"]) < 4:
         raise ValueError("experiments require at least four seeds per arm/world")
     names = [str(arm.get("name") or "") for arm in config["arms"]]
     if not all(names) or len(set(names)) != 2:
@@ -863,8 +926,42 @@ def _resolve_sdk_root(config: dict[str, Any], arm: dict[str, Any]) -> Path:
     return value.resolve() if value.is_absolute() else (config_dir / value).resolve()
 
 
+def _resolve_runtime_opencode_config(config: dict[str, Any]) -> Path | None:
+    raw = str(config.get("runtime_opencode_config") or "").strip()
+    if not raw:
+        return None
+    if raw.startswith("{env:") and raw.endswith("}"):
+        variable = raw[5:-1].strip()
+        if not variable:
+            raise ValueError("runtime_opencode_config has an empty env variable")
+        raw = str(os.environ.get(variable) or "").strip()
+        if not raw:
+            raise ValueError(
+                f"runtime_opencode_config requires environment variable {variable}"
+            )
+    config_dir = Path(str(config.get("_config_dir") or Path.cwd()))
+    path = Path(raw).expanduser()
+    resolved = path.resolve() if path.is_absolute() else (config_dir / path).resolve()
+    if not resolved.is_file():
+        raise FileNotFoundError(f"OpenCode runtime config is missing: {resolved}")
+    return resolved
+
+
+def _set_provider_base_url(config_path: Path, *, provider: str, base_url: str) -> None:
+    config = load_json(config_path)
+    provider_config = (config.get("provider") or {}).get(provider)
+    if not isinstance(provider_config, dict):
+        raise ValueError(f"provider {provider!r} is not configured")
+    options = provider_config.setdefault("options", {})
+    if not isinstance(options, dict):
+        raise ValueError(f"provider {provider!r} options must be an object")
+    options["baseURL"] = base_url.rstrip("/")
+    atomic_json(config_path, config)
+
+
 def _runtime_pins(config_path: Path, config: dict[str, Any]) -> dict[str, Any]:
     runtime = {**config, "_config_dir": str(config_path.parent)}
+    runtime_opencode_config = _resolve_runtime_opencode_config(runtime)
     worlds = []
     for item in config["worlds"]:
         world_dir = _from_config(config_path, item["world_dir"])
@@ -891,7 +988,18 @@ def _runtime_pins(config_path: Path, config: dict[str, Any]) -> dict[str, Any]:
         }
         for arm in config["arms"]
     ]
-    return {"worlds": worlds, "arms": arms}
+    return {
+        "worlds": worlds,
+        "arms": arms,
+        "runtime_opencode_config": (
+            {
+                "path": str(runtime_opencode_config),
+                "sha256": sha256_file(runtime_opencode_config),
+            }
+            if runtime_opencode_config is not None
+            else None
+        ),
+    }
 
 
 def _verify_runtime_pins(
@@ -901,6 +1009,7 @@ def _verify_runtime_pins(
     sdk_root: Path,
     world_dir: Path,
     sealed_dir: Path,
+    runtime_opencode_config: Path | None,
 ) -> None:
     pins = dict(config.get("_runtime_pins") or {})
     arm_pin = next(
@@ -928,6 +1037,16 @@ def _verify_runtime_pins(
         "development_sha256"
     ) or world_pin.get("holdout_commitment") != dataset.get("holdout_commitment"):
         raise ValueError("benchmark data commitments changed after registration")
+    config_pin = pins.get("runtime_opencode_config")
+    if runtime_opencode_config is None:
+        if config_pin is not None:
+            raise ValueError("OpenCode runtime config changed after registration")
+    elif (
+        not isinstance(config_pin, dict)
+        or config_pin.get("path") != str(runtime_opencode_config)
+        or config_pin.get("sha256") != sha256_file(runtime_opencode_config)
+    ):
+        raise ValueError("OpenCode runtime config changed after registration")
 
 
 def _overlay_bench_package(root: Path) -> None:

--- a/wayfinder_paths/jobs/bench/runner.py
+++ b/wayfinder_paths/jobs/bench/runner.py
@@ -818,6 +818,11 @@ def _scorecard(
             bool,
         )
     ]
+    attempt_outcomes = [
+        attempt.get("outcome") or {}
+        for row in candidates
+        for attempt in row.get("attempts") or []
+    ]
     return {
         "funnel": {
             "candidates_generated": int(funnel_counts.get("generated") or 0),
@@ -875,6 +880,18 @@ def _scorecard(
             "behavior_changed_attempts": sum(value is True for value in behavior_flags),
             "behavior_unchanged_attempts": sum(
                 value is False for value in behavior_flags
+            ),
+            "quick_simulations": sum(
+                outcome.get("quick_simulation_ran") is True
+                for outcome in attempt_outcomes
+            ),
+            "behavior_preview_rejections": sum(
+                ((outcome.get("behavior_preview") or {}).get("status") == "unchanged")
+                for outcome in attempt_outcomes
+            ),
+            "behavior_preview_ticks": sum(
+                int((outcome.get("behavior_preview") or {}).get("ticks_evaluated") or 0)
+                for outcome in attempt_outcomes
             ),
             "holdout_verdict": holdout.get("verdict"),
         },

--- a/wayfinder_paths/jobs/bench/runner.py
+++ b/wayfinder_paths/jobs/bench/runner.py
@@ -693,23 +693,30 @@ def _audit_session_isolation(
     protected_roots: list[Path],
     missing_transcripts: list[str],
 ) -> dict[str, Any]:
-    """Detect future/sibling/network access in persisted tool inputs."""
+    """Detect successful future/sibling/network access in persisted tool calls."""
     breaches: list[dict[str, Any]] = [
         {"type": "missing_transcript", "title": title} for title in missing_transcripts
     ]
     if not session_db.exists():
         if session_ids:
             breaches.append({"type": "missing_session_database"})
-        return {"passed": not breaches, "breaches": breaches}
+        return {
+            "passed": not breaches,
+            "breaches": breaches,
+            "denied_attempts": [],
+        }
     sandbox = sandbox.resolve()
     protected = [path.resolve() for path in protected_roots]
+    denied_attempts: list[dict[str, Any]] = []
     connection = sqlite3.connect(str(session_db))
     try:
         for session_id in dict.fromkeys(session_ids):
             try:
                 rows = connection.execute(
                     "SELECT json_extract(data,'$.tool'), "
-                    "json_extract(data,'$.state.input') FROM part "
+                    "json_extract(data,'$.state.input'), "
+                    "json_extract(data,'$.state.status'), "
+                    "json_extract(data,'$.state.error') FROM part "
                     "WHERE session_id=? AND json_extract(data,'$.type')='tool'",
                     (session_id,),
                 )
@@ -718,16 +725,28 @@ def _audit_session_isolation(
                     {"type": "unreadable_transcript", "session_id": session_id}
                 )
                 continue
-            for tool, raw_input in rows:
+            for tool, raw_input, status, raw_error in rows:
                 tool_name = str(tool or "unknown")
                 lowered = tool_name.lower()
+                policy_denied = str(status or "") == "error" and any(
+                    marker in str(raw_error or "").lower()
+                    for marker in (
+                        "prevents you from using this specific tool call",
+                        "permission denied",
+                    )
+                )
                 if any(
                     marker in lowered
                     for marker in ("bash", "shell", "fetch", "http", "browser", "web")
                 ):
-                    breaches.append(
+                    target = denied_attempts if policy_denied else breaches
+                    target.append(
                         {
-                            "type": "network_or_shell_tool",
+                            "type": (
+                                "denied_network_or_shell_tool"
+                                if policy_denied
+                                else "network_or_shell_tool"
+                            ),
                             "session_id": session_id,
                             "tool": tool_name,
                         }
@@ -758,9 +777,14 @@ def _audit_session_isolation(
                         if root != sandbox
                     )
                     if outside or protected_access:
-                        breaches.append(
+                        target = denied_attempts if policy_denied else breaches
+                        target.append(
                             {
-                                "type": "filesystem_escape",
+                                "type": (
+                                    "denied_filesystem_escape"
+                                    if policy_denied
+                                    else "filesystem_escape"
+                                ),
                                 "session_id": session_id,
                                 "tool": tool_name,
                                 "path": value[:300],
@@ -768,7 +792,11 @@ def _audit_session_isolation(
                         )
     finally:
         connection.close()
-    return {"passed": not breaches, "breaches": breaches}
+    return {
+        "passed": not breaches,
+        "breaches": breaches,
+        "denied_attempts": denied_attempts,
+    }
 
 
 def _input_strings(value: Any, key: str = "") -> list[tuple[str, str]]:

--- a/wayfinder_paths/jobs/bench/runner.py
+++ b/wayfinder_paths/jobs/bench/runner.py
@@ -11,6 +11,7 @@ import sqlite3
 import subprocess
 import sys
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -77,24 +78,40 @@ def run_experiment(config_path: Path) -> dict[str, Any]:
         "_config_dir": str(config_path.parent),
         "_runtime_pins": pins,
     }
-    rows: list[dict[str, Any]] = []
+    registered_runs = [
+        (
+            _from_config(config_path, world_config["world_dir"]),
+            _from_config(config_path, world_config["sealed_dir"]),
+            int(seed),
+            arm,
+        )
+        for world_config in config["worlds"]
+        for seed in config["seeds"]
+        for arm in config["arms"]
+    ]
+    ordered_rows: list[dict[str, Any] | None] = [None] * len(registered_runs)
     identities: dict[tuple[str, int, str], dict[str, Any]] = {}
-    for world_config in config["worlds"]:
-        world_dir = _from_config(config_path, world_config["world_dir"])
-        sealed_dir = _from_config(config_path, world_config["sealed_dir"])
-        for seed in config["seeds"]:
-            for arm in config["arms"]:
-                row = _run_arm_in_declared_sdk(
-                    config=runtime_config,
-                    arm=arm,
-                    seed=int(seed),
-                    world_dir=world_dir,
-                    sealed_dir=sealed_dir,
-                    output_dir=output_dir,
-                )
-                rows.append(row)
-                identities[(row["world_id"], row["seed"], row["arm"])] = row["identity"]
-                atomic_json(output_dir / "runs" / f"{row['run_id']}.json", row)
+    max_parallel = int(config.get("max_parallel_arms") or 1)
+    with ThreadPoolExecutor(max_workers=max_parallel) as pool:
+        futures = {
+            pool.submit(
+                _run_arm_in_declared_sdk,
+                config=runtime_config,
+                arm=arm,
+                seed=seed,
+                world_dir=world_dir,
+                sealed_dir=sealed_dir,
+                output_dir=output_dir,
+            ): index
+            for index, (world_dir, sealed_dir, seed, arm) in enumerate(registered_runs)
+        }
+        for future in as_completed(futures):
+            index = futures[future]
+            row = future.result()
+            ordered_rows[index] = row
+            identities[(row["world_id"], row["seed"], row["arm"])] = row["identity"]
+            atomic_json(output_dir / "runs" / f"{row['run_id']}.json", row)
+    rows = [row for row in ordered_rows if row is not None]
     parity = _identity_parity(config, identities)
     atomic_json(output_dir / "identity_parity.json", parity)
     if not parity["comparable"]:
@@ -899,6 +916,9 @@ def _validate_config(config: dict[str, Any]) -> None:
         raise ValueError("experiments require worlds and seeds")
     if not config.get("pilot") and len(config["seeds"]) < 4:
         raise ValueError("experiments require at least four seeds per arm/world")
+    max_parallel = int(config.get("max_parallel_arms") or 1)
+    if not 1 <= max_parallel <= 8:
+        raise ValueError("max_parallel_arms must be between 1 and 8")
     names = [str(arm.get("name") or "") for arm in config["arms"]]
     if not all(names) or len(set(names)) != 2:
         raise ValueError("arm names must be non-empty and unique")

--- a/wayfinder_paths/jobs/bench/runner.py
+++ b/wayfinder_paths/jobs/bench/runner.py
@@ -404,7 +404,7 @@ def run_arm(
         cost=cost,
     )
     identity = runtime_identity(
-        sdk_root=sdk_root,
+        sdk_ref=_arm_runtime_pin(config, arm)["sdk_ref"],
         sandbox=run_root,
         model=model,
         variant=variant,
@@ -1087,11 +1087,8 @@ def _verify_runtime_pins(
     runtime_opencode_config: Path | None,
 ) -> None:
     pins = dict(config.get("_runtime_pins") or {})
-    arm_pin = next(
-        (row for row in pins.get("arms") or [] if row.get("name") == arm.get("name")),
-        None,
-    )
-    if not arm_pin or arm_pin.get("sdk_ref") != git_sha(sdk_root):
+    arm_pin = _arm_runtime_pin(config, arm)
+    if arm_pin.get("sdk_ref") != git_sha(sdk_root):
         raise ValueError("arm SDK changed after experiment registration")
     if arm_pin.get("campaign_sha256") != sha256_json(dict(arm.get("campaign") or {})):
         raise ValueError("arm campaign parameters changed after registration")
@@ -1124,6 +1121,17 @@ def _verify_runtime_pins(
         or config_pin.get("sha256") != sha256_file(runtime_opencode_config)
     ):
         raise ValueError("OpenCode runtime config changed after registration")
+
+
+def _arm_runtime_pin(config: dict[str, Any], arm: dict[str, Any]) -> dict[str, Any]:
+    pins = dict(config.get("_runtime_pins") or {})
+    arm_pin = next(
+        (row for row in pins.get("arms") or [] if row.get("name") == arm.get("name")),
+        None,
+    )
+    if not isinstance(arm_pin, dict) or not arm_pin.get("sdk_ref"):
+        raise ValueError("arm SDK runtime pin is missing")
+    return arm_pin
 
 
 def _overlay_bench_package(root: Path) -> None:

--- a/wayfinder_paths/jobs/bench/runner.py
+++ b/wayfinder_paths/jobs/bench/runner.py
@@ -733,6 +733,7 @@ def _audit_session_isolation(
                     for marker in (
                         "prevents you from using this specific tool call",
                         "permission denied",
+                        "url must start with http:// or https://",
                     )
                 )
                 if any(

--- a/wayfinder_paths/jobs/bench/world.py
+++ b/wayfinder_paths/jobs/bench/world.py
@@ -14,7 +14,14 @@ from wayfinder_paths.jobs.bundles import copy_job_bundle
 from wayfinder_paths.jobs.execution.features import parse_feature_specs
 from wayfinder_paths.jobs.execution.job import _load_dataset, _load_job_yaml
 from wayfinder_paths.jobs.execution.primitives import ExecutionSpec
-from wayfinder_paths.jobs.execution.validation import resolve_execution_spec
+from wayfinder_paths.jobs.execution.simulator import (
+    PreparedExecutionDataset,
+    simulate_execution,
+)
+from wayfinder_paths.jobs.execution.validation import (
+    resolve_execution_spec,
+    window_invariance_probe,
+)
 from wayfinder_paths.jobs.gating import compute_workspace_revision
 
 WORLD_SCHEMA_VERSION = "1.0"
@@ -98,6 +105,13 @@ def prepare_world(
     }
     atomic_json(world_dir / "bars.json", development_payload)
     atomic_json(sealed_dir / "holdout.json", holdout_payload)
+    baseline = _freeze_development_baseline(
+        incumbent,
+        development_payload=development_payload,
+        spec=spec,
+        params=execution_params,
+        world_id=resolved_world_id,
+    )
     features = _freeze_feature_prefixes(
         source_job,
         world_dir=world_dir,
@@ -132,6 +146,7 @@ def prepare_world(
             "path": "incumbent",
             "revision": compute_workspace_revision(incumbent),
         },
+        "baseline": baseline,
         "features": features,
         # The runner receives sealed_dir separately. No owner path or holdout
         # bytes are written into the agent-visible world.
@@ -149,6 +164,11 @@ def load_world(world_dir: Path, sealed_dir: Path) -> dict[str, Any]:
         raise ValueError("development world bytes changed after freeze")
     if sha256_json(holdout) != manifest["dataset"]["holdout_commitment"]:
         raise ValueError("sealed holdout bytes do not match the commitment")
+    baseline = manifest.get("baseline")
+    if baseline:
+        baseline_path = world_dir / str(baseline["path"])
+        if sha256_file(baseline_path) != baseline["sha256"]:
+            raise ValueError("development baseline bytes changed after freeze")
     return {"manifest": manifest, "development": development, "holdout": holdout}
 
 
@@ -162,6 +182,14 @@ def install_development_world(
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_bytes(payload)
     manifest = json.loads((world_dir / "world.json").read_text(encoding="utf-8"))
+    baseline = manifest.get("baseline")
+    if baseline:
+        source = world_dir / str(baseline["path"])
+        if sha256_file(source) != baseline["sha256"]:
+            raise ValueError("development baseline bytes changed after freeze")
+        destination = destination_job / "results" / "backtest" / "baseline.json"
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(source.read_bytes())
     for feature in manifest.get("features") or []:
         source = world_dir / str(feature["path"])
         if sha256_file(source) != feature["sha256"]:
@@ -172,6 +200,67 @@ def install_development_world(
         destination = destination_job / relative
         destination.parent.mkdir(parents=True, exist_ok=True)
         destination.write_bytes(source.read_bytes())
+
+
+def _freeze_development_baseline(
+    incumbent: Path,
+    *,
+    development_payload: dict[str, Any],
+    spec: ExecutionSpec,
+    params: dict[str, Any],
+    world_id: str,
+) -> dict[str, Any]:
+    """Run the incumbent once on the exact agent-visible development prefix."""
+    job_data = _load_job_yaml(incumbent)
+    script = _bundle_script(incumbent, job_data)
+    rows = list(development_payload.get("bars") or [])
+    metadata = dict(development_payload.get("metadata") or {})
+    dataset = PreparedExecutionDataset.from_rows(rows, metadata)
+    probe = window_invariance_probe(script, dataset.bars, spec, params)
+    result = simulate_execution(script, dataset, spec, params)
+    timestamps = dataset.bars.timestamps
+    scope: dict[str, Any] = {
+        "partition": "development",
+        "bars": len(timestamps),
+        "start": timestamps[0].isoformat() if timestamps else None,
+        "end": timestamps[-1].isoformat() if timestamps else None,
+    }
+    payload: dict[str, Any] = {
+        "schema_version": "1.0",
+        "world_id": world_id,
+        "scope": scope,
+        "result": {
+            "params": result.params,
+            "stats": result.stats,
+            "validation": result.validation,
+            "window_invariance": {
+                key: value
+                for key, value in probe.items()
+                if not key.endswith("_intents")
+            },
+        },
+    }
+    path = incumbent.parent / "baseline.json"
+    atomic_json(path, payload)
+    return {
+        "path": str(path.relative_to(incumbent.parent)),
+        "sha256": sha256_file(path),
+        "revision": compute_workspace_revision(incumbent),
+        **scope,
+    }
+
+
+def _bundle_script(bundle: Path, job_data: dict[str, Any]) -> Path:
+    raw = str((job_data.get("script_loop") or {}).get("entrypoint") or "")
+    if not raw:
+        raise FileNotFoundError("bundle script_loop.entrypoint is missing")
+    path = Path(raw)
+    if not path.is_absolute():
+        return bundle / path
+    if "workspace" in path.parts:
+        index = path.parts.index("workspace")
+        return bundle / "workspace" / Path(*path.parts[index + 1 :])
+    raise ValueError("absolute bundle entrypoint is outside workspace")
 
 
 def _row_timestamp(row: dict[str, Any]) -> datetime:

--- a/wayfinder_paths/jobs/bench/world.py
+++ b/wayfinder_paths/jobs/bench/world.py
@@ -1,0 +1,251 @@
+"""Frozen benchmark worlds with a physically sealed chronological holdout."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from wayfinder_paths.jobs.bench.env import atomic_json, sha256_file, sha256_json
+from wayfinder_paths.jobs.bundles import copy_job_bundle
+from wayfinder_paths.jobs.execution.features import parse_feature_specs
+from wayfinder_paths.jobs.execution.job import _load_dataset, _load_job_yaml
+from wayfinder_paths.jobs.execution.primitives import ExecutionSpec
+from wayfinder_paths.jobs.execution.validation import resolve_execution_spec
+from wayfinder_paths.jobs.gating import compute_workspace_revision
+
+WORLD_SCHEMA_VERSION = "1.0"
+
+
+def prepare_world(
+    source_job: Path,
+    world_dir: Path,
+    *,
+    generation_cutoff: datetime,
+    holdout_end: datetime,
+    sealed_dir: Path,
+    world_id: str | None = None,
+) -> dict[str, Any]:
+    """Freeze one real job into an agent-visible prefix and owner-only tail."""
+    source_job = source_job.resolve()
+    world_dir = world_dir.resolve()
+    sealed_dir = sealed_dir.resolve()
+    if world_dir.exists() and any(world_dir.iterdir()):
+        raise FileExistsError(f"world directory is not empty: {world_dir}")
+    if sealed_dir.exists() and any(sealed_dir.iterdir()):
+        raise FileExistsError(f"sealed directory is not empty: {sealed_dir}")
+    cutoff = _aware(generation_cutoff)
+    end = _aware(holdout_end)
+    if end <= cutoff:
+        raise ValueError("holdout_end must be after generation_cutoff")
+    holdout_days = (end - cutoff).total_seconds() / 86_400
+    if not 14 <= holdout_days <= 21:
+        raise ValueError("benchmark holdout must span 14 to 21 days")
+    if (
+        world_dir == sealed_dir
+        or world_dir.is_relative_to(sealed_dir)
+        or sealed_dir.is_relative_to(world_dir)
+    ):
+        raise ValueError("sealed holdout must be physically outside the world")
+
+    job_data = _load_job_yaml(source_job)
+    spec_data, _ = resolve_execution_spec(source_job, job_data)
+    if not spec_data:
+        raise FileNotFoundError("source job has no execution_spec")
+    spec = ExecutionSpec.from_dict(spec_data)
+    execution_params = dict(job_data.get("execution_params") or {})
+    dataset = _load_dataset(
+        source_job,
+        spec,
+        job_data,
+        feature_roots=(source_job,),
+        include_store_features=True,
+    )
+    rows = dataset.bars.to_rows()
+    development = [row for row in rows if _row_timestamp(row) <= cutoff]
+    holdout = [row for row in rows if cutoff < _row_timestamp(row) <= end]
+    if not development or not holdout:
+        raise ValueError("world needs non-empty development and holdout bar sets")
+
+    resolved_world_id = world_id or (
+        f"{source_job.name}-{cutoff.strftime('%Y%m%dT%H%M%SZ')}"
+    )
+    world_dir.mkdir(parents=True, exist_ok=True)
+    sealed_dir.mkdir(parents=True, exist_ok=True)
+    incumbent = world_dir / "incumbent"
+    copy_job_bundle(source_job, incumbent)
+    development_payload = {
+        "bars": development,
+        "metadata": {
+            **dict(dataset.metadata),
+            "world_id": resolved_world_id,
+            "partition": "development",
+            "generation_cutoff": cutoff.isoformat(),
+        },
+    }
+    holdout_payload = {
+        "bars": holdout,
+        "metadata": {
+            **dict(dataset.metadata),
+            "world_id": resolved_world_id,
+            "partition": "holdout",
+            "generation_cutoff": cutoff.isoformat(),
+            "holdout_end": end.isoformat(),
+        },
+    }
+    atomic_json(world_dir / "bars.json", development_payload)
+    atomic_json(sealed_dir / "holdout.json", holdout_payload)
+    features = _freeze_feature_prefixes(
+        source_job,
+        world_dir=world_dir,
+        cutoff=cutoff,
+        spec=spec,
+    )
+
+    source_bars = source_job / "results" / "backtest" / "input_bars.json"
+    manifest = {
+        "schema_version": WORLD_SCHEMA_VERSION,
+        "world_id": resolved_world_id,
+        "created_at": datetime.now(UTC).isoformat(),
+        "source_job": source_job.name,
+        "source_revision": compute_workspace_revision(source_job),
+        "generation_cutoff": cutoff.isoformat(),
+        "holdout_end": end.isoformat(),
+        "development_bars": len(development),
+        "holdout_bars": len(holdout),
+        "dataset": {
+            "source_bytes_sha256": sha256_file(source_bars),
+            "full_rows_sha256": sha256_json(rows),
+            "benchmark_rows_sha256": sha256_json([*development, *holdout]),
+            "development_sha256": sha256_json(development_payload),
+            "holdout_commitment": sha256_json(holdout_payload),
+        },
+        "execution_environment": {
+            "spec_sha256": sha256_json(spec.to_dict()),
+            "data_contract": dict(spec.data_contract),
+            "params": _frozen_execution_params(execution_params, spec),
+        },
+        "incumbent": {
+            "path": "incumbent",
+            "revision": compute_workspace_revision(incumbent),
+        },
+        "features": features,
+        # The runner receives sealed_dir separately. No owner path or holdout
+        # bytes are written into the agent-visible world.
+        "holdout_locator": "owner-supplied",
+    }
+    atomic_json(world_dir / "world.json", manifest)
+    return manifest
+
+
+def load_world(world_dir: Path, sealed_dir: Path) -> dict[str, Any]:
+    manifest = json.loads((world_dir / "world.json").read_text(encoding="utf-8"))
+    development = json.loads((world_dir / "bars.json").read_text(encoding="utf-8"))
+    holdout = json.loads((sealed_dir / "holdout.json").read_text(encoding="utf-8"))
+    if sha256_json(development) != manifest["dataset"]["development_sha256"]:
+        raise ValueError("development world bytes changed after freeze")
+    if sha256_json(holdout) != manifest["dataset"]["holdout_commitment"]:
+        raise ValueError("sealed holdout bytes do not match the commitment")
+    return {"manifest": manifest, "development": development, "holdout": holdout}
+
+
+def install_development_world(
+    world_dir: Path,
+    *,
+    destination_job: Path,
+) -> None:
+    payload = (world_dir / "bars.json").read_bytes()
+    target = destination_job / "results" / "backtest" / "input_bars.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(payload)
+    manifest = json.loads((world_dir / "world.json").read_text(encoding="utf-8"))
+    for feature in manifest.get("features") or []:
+        source = world_dir / str(feature["path"])
+        if sha256_file(source) != feature["sha256"]:
+            raise ValueError("development feature bytes changed after freeze")
+        relative = Path(str(feature["target_path"]))
+        if relative.is_absolute() or ".." in relative.parts:
+            raise ValueError("feature target must remain inside the job root")
+        destination = destination_job / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(source.read_bytes())
+
+
+def _row_timestamp(row: dict[str, Any]) -> datetime:
+    raw = row.get("timestamp", row.get("t"))
+    stamp = pd.Timestamp(raw)
+    if stamp.tzinfo is None:
+        stamp = stamp.tz_localize("UTC")
+    return stamp.tz_convert("UTC").to_pydatetime()
+
+
+def _freeze_feature_prefixes(
+    source_job: Path,
+    *,
+    world_dir: Path,
+    cutoff: datetime,
+    spec: ExecutionSpec,
+) -> list[dict[str, Any]]:
+    frozen: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for feature in parse_feature_specs(spec):
+        if feature.path in seen:
+            continue
+        seen.add(feature.path)
+        relative = Path(feature.path)
+        if relative.is_absolute() or ".." in relative.parts:
+            raise ValueError("benchmark feature paths must stay inside the job root")
+        source = source_job / relative
+        if not source.exists():
+            raise FileNotFoundError(f"declared feature file is missing: {source}")
+        lines: list[str] = []
+        with source.open(encoding="utf-8") as handle:
+            for raw in handle:
+                try:
+                    row = json.loads(raw)
+                    timestamp = _row_timestamp(row)
+                except (TypeError, ValueError):
+                    continue
+                if timestamp <= cutoff:
+                    lines.append(json.dumps(row, sort_keys=True, default=str))
+        target = world_dir / "features" / f"feature-{len(frozen):02d}.jsonl"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+        frozen.append(
+            {
+                "target_path": feature.path,
+                "path": str(target.relative_to(world_dir)),
+                "sha256": sha256_file(target),
+                "rows": len(lines),
+            }
+        )
+    return frozen
+
+
+def _aware(value: datetime) -> datetime:
+    return value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)
+
+
+def _frozen_execution_params(
+    params: dict[str, Any], spec: ExecutionSpec
+) -> dict[str, Any]:
+    symbols = params.get("symbols") or spec.data_contract.get("symbols") or []
+    return {
+        "symbols": list(symbols),
+        "venue": params.get("venue"),
+        "initial_capital": float(params.get("initial_capital") or 10_000.0),
+        # A missing estimate must not turn the holdout into a zero-cost world.
+        "fee_bps": float(
+            params["fee_bps"] if params.get("fee_bps") is not None else 7.0
+        ),
+        "maker_fee_bps": float(
+            params["maker_fee_bps"] if params.get("maker_fee_bps") is not None else 1.5
+        ),
+        "slippage_bps": float(params.get("slippage_bps") or 0.0),
+        "stop_market_slippage_bps": float(
+            params.get("stop_market_slippage_bps") or 0.0
+        ),
+    }

--- a/wayfinder_paths/jobs/bench/world.py
+++ b/wayfinder_paths/jobs/bench/world.py
@@ -10,7 +10,10 @@ from typing import Any
 import pandas as pd
 
 from wayfinder_paths.jobs.bench.env import atomic_json, sha256_file, sha256_json
-from wayfinder_paths.jobs.bundles import copy_job_bundle
+from wayfinder_paths.jobs.bundles import (
+    copy_job_bundle,
+    resolve_bundle_script_entrypoint,
+)
 from wayfinder_paths.jobs.execution.features import parse_feature_specs
 from wayfinder_paths.jobs.execution.job import _load_dataset, _load_job_yaml
 from wayfinder_paths.jobs.execution.primitives import ExecutionSpec
@@ -212,7 +215,7 @@ def _freeze_development_baseline(
 ) -> dict[str, Any]:
     """Run the incumbent once on the exact agent-visible development prefix."""
     job_data = _load_job_yaml(incumbent)
-    script = _bundle_script(incumbent, job_data)
+    script = resolve_bundle_script_entrypoint(incumbent, job_data)
     rows = list(development_payload.get("bars") or [])
     metadata = dict(development_payload.get("metadata") or {})
     dataset = PreparedExecutionDataset.from_rows(rows, metadata)
@@ -248,19 +251,6 @@ def _freeze_development_baseline(
         "revision": compute_workspace_revision(incumbent),
         **scope,
     }
-
-
-def _bundle_script(bundle: Path, job_data: dict[str, Any]) -> Path:
-    raw = str((job_data.get("script_loop") or {}).get("entrypoint") or "")
-    if not raw:
-        raise FileNotFoundError("bundle script_loop.entrypoint is missing")
-    path = Path(raw)
-    if not path.is_absolute():
-        return bundle / path
-    if "workspace" in path.parts:
-        index = path.parts.index("workspace")
-        return bundle / "workspace" / Path(*path.parts[index + 1 :])
-    raise ValueError("absolute bundle entrypoint is outside workspace")
 
 
 def _row_timestamp(row: dict[str, Any]) -> datetime:

--- a/wayfinder_paths/jobs/benchmarks/agent_adapter.py
+++ b/wayfinder_paths/jobs/benchmarks/agent_adapter.py
@@ -148,9 +148,25 @@ def install_agent_workspace(
     repo_root: Path,
     disable_mcp: bool = False,
     mcp_url: str | None = None,
+    runtime_config: Path | None = None,
 ) -> None:
     """Make an isolated directory runnable by the real OpenCode agents."""
     sandbox.mkdir(parents=True, exist_ok=True)
+    # OpenCode resolves relative tool paths from the discovered project root.
+    # Benchmark outputs commonly live below the SDK checkout, so give every
+    # arm its own boundary instead of leaking resolution into the parent repo.
+    if not (sandbox / ".git").exists():
+        initialized = subprocess.run(
+            ["git", "init", "--quiet"],
+            cwd=sandbox,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if initialized.returncode != 0:
+            raise RuntimeError(
+                f"failed to isolate benchmark project root: {initialized.stderr}"
+            )
     config_source = _config_source(repo_root)
     target = sandbox / ".opencode"
     if not target.exists():
@@ -165,10 +181,17 @@ def install_agent_workspace(
             ignore=shutil.ignore_patterns("node_modules"),
             symlinks=False,
         )
-    # opencode.json carries local provider credentials/settings and is
-    # intentionally untracked. Only this file falls back to the primary
-    # checkout; agents and plugins stay pinned to the declared SDK ref.
-    if not (target / "opencode.json").exists():
+    # The benchmark may pin the exact Shells runtime config. Otherwise the
+    # untracked local provider config falls back to the primary checkout;
+    # agents and plugins still stay pinned to the declared SDK ref.
+    if runtime_config is not None:
+        runtime_config = runtime_config.resolve()
+        if not runtime_config.is_file():
+            raise FileNotFoundError(
+                f"OpenCode runtime config is missing: {runtime_config}"
+            )
+        shutil.copy(runtime_config, target / "opencode.json")
+    elif not (target / "opencode.json").exists():
         shutil.copy(config_source / ".opencode" / "opencode.json", target)
     opencode_json = target / "opencode.json"
     if opencode_json.exists():
@@ -350,6 +373,12 @@ def meter_session_ids(
         "tool_calls": 0,
         "tool_result_bytes": 0,
         "tool_result_bytes_by_tool": {},
+        "tool_output_bytes": 0,
+        "tool_output_bytes_by_tool": {},
+        "wall_seconds": 0.0,
+        "model_seconds": 0.0,
+        "tool_seconds": 0.0,
+        "other_seconds": 0.0,
     }
     if not session_ids or (connection is None and not session_db.exists()):
         return totals
@@ -371,12 +400,19 @@ def meter_session_ids(
             if not found:
                 continue
             totals["sessions"] += 1
+            starts: list[int] = []
+            ends: list[int] = []
+            model_intervals: list[tuple[int, int]] = []
+            tool_intervals: list[tuple[int, int]] = []
             query = (
                 "SELECT json_extract(data,'$.tokens.input'), "
                 "json_extract(data,'$.tokens.output'), "
                 "json_extract(data,'$.tokens.reasoning'), "
                 "json_extract(data,'$.tokens.cache.read'), "
-                "json_extract(data,'$.tokens.cache.write') FROM message "
+                "json_extract(data,'$.tokens.cache.write'), "
+                "json_extract(data,'$.role'), "
+                "json_extract(data,'$.time.created'), "
+                "json_extract(data,'$.time.completed'), time_created FROM message "
                 "WHERE session_id=?"
             )
             params: tuple[Any, ...] = (session_id,)
@@ -389,6 +425,10 @@ def meter_session_ids(
                 tokens_reasoning,
                 tokens_cache_read,
                 tokens_cache_write,
+                role,
+                message_started,
+                message_completed,
+                row_created,
             ) in db.execute(query, params):
                 totals["messages"] += 1
                 totals["tokens_in"] += int(tokens_in or 0)
@@ -396,8 +436,20 @@ def meter_session_ids(
                 totals["tokens_reasoning"] += int(tokens_reasoning or 0)
                 totals["tokens_cache_read"] += int(tokens_cache_read or 0)
                 totals["tokens_cache_write"] += int(tokens_cache_write or 0)
+                started = int(message_started or row_created or 0)
+                completed = int(message_completed or 0)
+                if started:
+                    starts.append(max(started, int(since_ms or started)))
+                if completed:
+                    ends.append(completed)
+                    if str(role or "") == "assistant" and completed >= started:
+                        model_intervals.append((started, completed))
             part_query = (
-                "SELECT json_extract(data,'$.tool'), length(data) FROM part "
+                "SELECT json_extract(data,'$.tool'), length(data), "
+                "json_extract(data,'$.state.output'), "
+                "json_extract(data,'$.state.error'), "
+                "json_extract(data,'$.state.time.start'), "
+                "json_extract(data,'$.state.time.end'), time_created FROM part "
                 "WHERE session_id=? AND json_extract(data,'$.type')='tool'"
             )
             part_params: tuple[Any, ...] = (session_id,)
@@ -405,16 +457,95 @@ def meter_session_ids(
                 part_query += " AND time_created>=?"
                 part_params = (session_id, int(since_ms))
             by_tool = totals["tool_result_bytes_by_tool"]
-            for tool, byte_count in db.execute(part_query, part_params):
+            output_by_tool = totals["tool_output_bytes_by_tool"]
+            for (
+                tool,
+                byte_count,
+                output,
+                error,
+                tool_started,
+                tool_completed,
+                part_created,
+            ) in db.execute(part_query, part_params):
                 tool_name = str(tool or "unknown")
                 size = int(byte_count or 0)
+                output_size = sum(
+                    len(str(value).encode("utf-8"))
+                    for value in (output, error)
+                    if value is not None
+                )
                 totals["tool_calls"] += 1
                 totals["tool_result_bytes"] += size
+                totals["tool_output_bytes"] += output_size
                 by_tool[tool_name] = int(by_tool.get(tool_name) or 0) + size
+                output_by_tool[tool_name] = (
+                    int(output_by_tool.get(tool_name) or 0) + output_size
+                )
+                started = int(tool_started or part_created or 0)
+                completed = int(tool_completed or 0)
+                if started:
+                    starts.append(max(started, int(since_ms or started)))
+                if completed:
+                    ends.append(completed)
+                    if completed >= started:
+                        tool_intervals.append((started, completed))
+            merged_tools = _merge_intervals(tool_intervals)
+            session_tool_ms = sum(end - start for start, end in merged_tools)
+            session_model_ms = sum(
+                end - start
+                for start, end in _subtract_intervals(
+                    _merge_intervals(model_intervals), merged_tools
+                )
+            )
+            if starts and ends:
+                session_wall_ms = max(max(ends) - min(starts), 0)
+            else:
+                session_wall_ms = session_model_ms + session_tool_ms
+            totals["wall_seconds"] += session_wall_ms / 1000
+            totals["model_seconds"] += session_model_ms / 1000
+            totals["tool_seconds"] += session_tool_ms / 1000
+            totals["other_seconds"] += (
+                max(session_wall_ms - session_model_ms - session_tool_ms, 0) / 1000
+            )
     finally:
         if owned:
             db.close()
+    for key in ("wall_seconds", "model_seconds", "tool_seconds", "other_seconds"):
+        totals[key] = round(float(totals[key]), 3)
     return totals
+
+
+def _merge_intervals(intervals: list[tuple[int, int]]) -> list[tuple[int, int]]:
+    merged: list[tuple[int, int]] = []
+    for start, end in sorted(intervals):
+        if end < start:
+            continue
+        if not merged or start > merged[-1][1]:
+            merged.append((start, end))
+        else:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+    return merged
+
+
+def _subtract_intervals(
+    intervals: list[tuple[int, int]], exclusions: list[tuple[int, int]]
+) -> list[tuple[int, int]]:
+    remaining: list[tuple[int, int]] = []
+    for start, end in intervals:
+        cursor = start
+        for blocked_start, blocked_end in exclusions:
+            if blocked_end <= cursor:
+                continue
+            if blocked_start >= end:
+                break
+            if blocked_start > cursor:
+                remaining.append((cursor, min(blocked_start, end)))
+            cursor = max(cursor, blocked_end)
+            if cursor >= end:
+                break
+        if cursor < end:
+            remaining.append((cursor, end))
+    return remaining
 
 
 def session_diagnostic_summary(

--- a/wayfinder_paths/jobs/benchmarks/agent_adapter.py
+++ b/wayfinder_paths/jobs/benchmarks/agent_adapter.py
@@ -142,6 +142,34 @@ def build_world_bundle(
     return job.id
 
 
+def _allow_benchmark_job_paths(opencode_root: Path) -> None:
+    """Keep production job permissions valid after local path normalization.
+
+    OpenCode's read result echoes a project-relative input as an absolute path.
+    A later model turn may reuse that exact path, so benchmark copies of the
+    evolution agents need an equivalent recursive job-path rule. The rule is
+    confined to ``.wayfinder/jobs`` and never changes the source agent files.
+    """
+    relative_rule = '    ".wayfinder/jobs/**": allow\n'
+    normalized_rule = '    "**/.wayfinder/jobs/**": allow\n'
+    for name in (
+        "wayfinder-evolution-designer.md",
+        "wayfinder-evolution-worker.md",
+    ):
+        path = opencode_root / "agents" / name
+        if not path.is_file():
+            continue
+        content = path.read_text(encoding="utf-8")
+        if normalized_rule in content:
+            continue
+        if relative_rule not in content:
+            raise ValueError(f"benchmark agent is missing job-path permission: {path}")
+        path.write_text(
+            content.replace(relative_rule, relative_rule + normalized_rule),
+            encoding="utf-8",
+        )
+
+
 def install_agent_workspace(
     *,
     sandbox: Path,
@@ -181,6 +209,7 @@ def install_agent_workspace(
             ignore=shutil.ignore_patterns("node_modules"),
             symlinks=False,
         )
+    _allow_benchmark_job_paths(target)
     # The benchmark may pin the exact Shells runtime config. Otherwise the
     # untracked local provider config falls back to the primary checkout;
     # agents and plugins still stay pinned to the declared SDK ref.

--- a/wayfinder_paths/jobs/benchmarks/agent_adapter.py
+++ b/wayfinder_paths/jobs/benchmarks/agent_adapter.py
@@ -48,15 +48,29 @@ DEFAULT_AGENT = "wayfinder-job-worker"
 _DIAGNOSTIC_TOOL_LIMIT = 25
 _DIAGNOSTIC_ERROR_LIMIT = 300
 _DIAGNOSTIC_TEXT_LIMIT = 1_500
-# opencode.json (provider config) is untracked; worktrees lack it. Fall back
-# to the primary checkout when the given repo_root is a bare worktree.
-PRIMARY_CHECKOUT = Path("/Users/adrianhaldenby/Documents/wayfinder-paths-sdk")
 
 
 def _config_source(repo_root: Path) -> Path:
     if (repo_root / ".opencode" / "opencode.json").exists():
         return repo_root
-    return PRIMARY_CHECKOUT
+    override = os.environ.get("WAYFINDER_OPENCODE_CONFIG_ROOT")
+    candidates = [Path(override).expanduser()] if override else []
+    common = subprocess.run(
+        ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if common.returncode == 0:
+        candidates.append(Path(common.stdout.strip()).resolve().parent)
+    for candidate in candidates:
+        if (candidate / ".opencode" / "opencode.json").exists():
+            return candidate
+    raise FileNotFoundError(
+        "opencode.json is untracked and was not found in the SDK checkout, "
+        "its primary worktree, or WAYFINDER_OPENCODE_CONFIG_ROOT"
+    )
 
 
 def build_world_bundle(
@@ -72,44 +86,9 @@ def build_world_bundle(
     from wayfinder_paths.jobs.models import WayfinderJob
     from wayfinder_paths.jobs.store import JobStore
 
-    sandbox.mkdir(parents=True, exist_ok=True)
-    # The sandbox must BE an opencode-able SDK workspace: agent definitions
-    # + provider config (opencode.json is UNTRACKED — source it from a real
-    # checkout, not a bare worktree), the venv + package symlinked so the
-    # `wayfinder job` CLI works, and MCP servers disabled (file-based
-    # worlds; the worker falls back to the CLI — eval-harness pattern).
-    config_source = _config_source(repo_root)
-    target = sandbox / ".opencode"
-    if not target.exists():
-        shutil.copytree(
-            config_source / ".opencode", target,
-            ignore=shutil.ignore_patterns("node_modules"),
-            symlinks=False,
-        )
-    opencode_json = target / "opencode.json"
-    if opencode_json.exists():
-        config = json.loads(opencode_json.read_text())
-        for server in (config.get("mcp") or {}).values():
-            if isinstance(server, dict):
-                server["enabled"] = False
-        opencode_json.write_text(json.dumps(config, indent=2) + "\n")
-    # Code must be INSIDE the sandbox (symlinks trip opencode's
-    # external_directory permission wall — found live on pilot wake 0);
-    # the venv stays a symlink, agents execute it but rarely read it.
-    for name in ("pyproject.toml", "poetry.lock"):
-        source = config_source / name
-        if source.exists() and not (sandbox / name).exists():
-            shutil.copy(source, sandbox / name)
-    package = sandbox / "wayfinder_paths"
-    if not package.exists():
-        shutil.copytree(
-            config_source / "wayfinder_paths", package,
-            ignore=shutil.ignore_patterns("__pycache__", "*.pyc", "tests"),
-        )
-    venv_source = config_source / ".venv"
-    if venv_source.exists() and not (sandbox / ".venv").exists():
-        (sandbox / ".venv").symlink_to(venv_source)
-
+    install_agent_workspace(sandbox=sandbox, repo_root=repo_root, disable_mcp=True)
+    # The file-based WOB worker falls back to the CLI, so MCP stays disabled.
+    # Campaign A/B uses the same helper with a lifecycle-only MCP URL.
     store = JobStore(repo_root=sandbox)
     job = WayfinderJob.new(
         f"wob-{world.world_id}",
@@ -130,7 +109,7 @@ def build_world_bundle(
     interpreter = write_interpreter(src_dir)
     interpreter.rename(src_dir / "strategy.py")
 
-    import yaml
+    import yaml  # type: ignore[import-untyped]
 
     job_yaml_path = root / "job.yaml"
     job_yaml = yaml.safe_load(job_yaml_path.read_text()) or {}
@@ -138,7 +117,10 @@ def build_world_bundle(
         "genome_spec": initial_genome.to_dict(),
         "fee_bps": world.mechanism.fee_bps,
     }
-    job_yaml["script_loop"] = {"enabled": True, "entrypoint": "workspace/src/strategy.py"}
+    job_yaml["script_loop"] = {
+        "enabled": True,
+        "entrypoint": "workspace/src/strategy.py",
+    }
     job_yaml_path.write_text(yaml.safe_dump(job_yaml, sort_keys=False))
 
     dataset_dir = root / "results" / "backtest"
@@ -158,6 +140,77 @@ def build_world_bundle(
         )
     )
     return job.id
+
+
+def install_agent_workspace(
+    *,
+    sandbox: Path,
+    repo_root: Path,
+    disable_mcp: bool = False,
+    mcp_url: str | None = None,
+) -> None:
+    """Make an isolated directory runnable by the real OpenCode agents."""
+    sandbox.mkdir(parents=True, exist_ok=True)
+    config_source = _config_source(repo_root)
+    target = sandbox / ".opencode"
+    if not target.exists():
+        workspace_source = (
+            repo_root / ".opencode"
+            if (repo_root / ".opencode").is_dir()
+            else config_source / ".opencode"
+        )
+        shutil.copytree(
+            workspace_source,
+            target,
+            ignore=shutil.ignore_patterns("node_modules"),
+            symlinks=False,
+        )
+    # opencode.json carries local provider credentials/settings and is
+    # intentionally untracked. Only this file falls back to the primary
+    # checkout; agents and plugins stay pinned to the declared SDK ref.
+    if not (target / "opencode.json").exists():
+        shutil.copy(config_source / ".opencode" / "opencode.json", target)
+    opencode_json = target / "opencode.json"
+    if opencode_json.exists():
+        config = json.loads(opencode_json.read_text())
+        for server in (config.get("mcp") or {}).values():
+            if isinstance(server, dict):
+                if disable_mcp:
+                    server["enabled"] = False
+                elif mcp_url:
+                    server.update(
+                        {
+                            "type": "remote",
+                            "url": mcp_url,
+                            "enabled": True,
+                            "timeout": 300_000,
+                        }
+                    )
+        opencode_json.write_text(json.dumps(config, indent=2) + "\n")
+    # Code must be INSIDE the sandbox (symlinks trip opencode's
+    # external_directory permission wall — found live on pilot wake 0);
+    # the venv stays a symlink, agents execute it but rarely read it.
+    code_source = repo_root
+    if not (code_source / "wayfinder_paths").is_dir():
+        raise FileNotFoundError(f"SDK package is missing: {code_source}")
+    for name in ("pyproject.toml", "poetry.lock"):
+        source = code_source / name
+        if source.exists() and not (sandbox / name).exists():
+            shutil.copy(source, sandbox / name)
+    package = sandbox / "wayfinder_paths"
+    if not package.exists():
+        shutil.copytree(
+            code_source / "wayfinder_paths",
+            package,
+            ignore=shutil.ignore_patterns("__pycache__", "*.pyc", "tests"),
+        )
+    venv_source = (
+        repo_root / ".venv"
+        if (repo_root / ".venv").exists()
+        else config_source / ".venv"
+    )
+    if venv_source.exists() and not (sandbox / ".venv").exists():
+        (sandbox / ".venv").symlink_to(venv_source)
 
 
 def run_agent_wakes(
@@ -182,25 +235,71 @@ def run_agent_wakes(
         prepared = prepare_job_worker_prompt(
             store=store, job_id=job_id, mode="intervene"
         )
-        title = f"wob-{job_id}-wake-{wake}"
-        command = [
-            str(opencode), "run", "--agent", agent, "-m", model,
-            "--dir", str(sandbox), "--title", title, prepared["prompt"],
-        ]
-        result = subprocess.run(
-            command, capture_output=True, text=True, timeout=timeout_s,
-            cwd=sandbox, check=False,
+        session = run_agent_prompt(
+            sandbox=sandbox,
+            prompt=prepared["prompt"],
+            model=model,
+            title=f"wob-{job_id}-wake-{wake}",
+            opencode=opencode,
+            agent=agent,
+            timeout_s=timeout_s,
         )
-        sessions.append(
-            {
-                "wake": wake,
-                "title": title,
-                "exit_code": result.returncode,
-                "stdout_tail": result.stdout[-800:],
-                "stderr_tail": result.stderr[-500:],
-            }
-        )
+        sessions.append({"wake": wake, **session})
     return sessions
+
+
+def run_agent_prompt(
+    *,
+    sandbox: Path,
+    prompt: str,
+    model: str,
+    variant: str | None = None,
+    title: str,
+    session_id: str | None = None,
+    opencode: Path = DEFAULT_OPENCODE,
+    agent: str = DEFAULT_AGENT,
+    timeout_s: int = 1800,
+    env: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Run one bounded prompt through the real OpenCode harness.
+
+    Campaign benchmarks and synthetic optimizer wakes intentionally share this
+    seam: model, agent definition, working directory, timeout behavior, and
+    session-title metering must not drift between benchmark lanes.
+    """
+    command = [
+        str(opencode),
+        "run",
+        "--agent",
+        agent,
+        "-m",
+        model,
+        "--dir",
+        str(sandbox),
+    ]
+    if variant:
+        command.extend(["--variant", variant])
+    if session_id:
+        command.extend(["--session", session_id])
+    else:
+        command.extend(["--title", title])
+    command.append(prompt)
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=timeout_s,
+        cwd=sandbox,
+        check=False,
+        env=env,
+    )
+    return {
+        "title": title,
+        "session_id": session_id,
+        "exit_code": result.returncode,
+        "stdout_tail": result.stdout[-1_500:],
+        "stderr_tail": result.stderr[-800:],
+    }
 
 
 def meter_sessions(
@@ -417,5 +516,8 @@ def harvest_lineage(*, sandbox: Path, job_id: str) -> dict[str, Any]:
             selected = Genome.from_dict(active_spec)
         except (KeyError, TypeError):
             selected = None
-    return {"lineage": [(g, 0.0) for g in lineage], "selected": selected,
-            "optimizer": "agent"}
+    return {
+        "lineage": [(g, 0.0) for g in lineage],
+        "selected": selected,
+        "optimizer": "agent",
+    }

--- a/wayfinder_paths/jobs/bundles.py
+++ b/wayfinder_paths/jobs/bundles.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import os
 import shutil
 import tempfile
+from collections.abc import Mapping
 from pathlib import Path
+from typing import Any
 
 
 def copy_job_bundle(
@@ -37,3 +39,24 @@ def copy_job_bundle(
     except Exception:
         shutil.rmtree(temporary, ignore_errors=True)
         raise
+
+
+def resolve_bundle_script_entrypoint(bundle: Path, job_data: Mapping[str, Any]) -> Path:
+    """Resolve an entrypoint after its workspace was copied into a bundle.
+
+    Job YAML may retain a repo-relative ``.wayfinder/jobs/.../workspace`` path
+    or an absolute path from the source box. Both name the copied workspace,
+    not a path that should still exist in the benchmark controller.
+    """
+    raw = str((job_data.get("script_loop") or {}).get("entrypoint") or "").strip()
+    if not raw:
+        raise FileNotFoundError("bundle script_loop.entrypoint is missing")
+    path = Path(raw)
+    if "workspace" in path.parts:
+        index = max(
+            position for position, part in enumerate(path.parts) if part == "workspace"
+        )
+        return bundle / "workspace" / Path(*path.parts[index + 1 :])
+    if not path.is_absolute():
+        return bundle / path
+    raise ValueError("absolute bundle entrypoint is outside workspace")

--- a/wayfinder_paths/jobs/candidate_shadow.py
+++ b/wayfinder_paths/jobs/candidate_shadow.py
@@ -119,7 +119,11 @@ async def _run_candidate_shadows(
             )
             if outcomes:
                 targets = probation_targets(store, job_id)
-    maybe_adjudicate_probation(store, job_id)
+    maybe_adjudicate_probation(
+        store,
+        job_id,
+        now=now.to_pydatetime() if now is not None else None,
+    )
     return results
 
 

--- a/wayfinder_paths/jobs/evolution_campaign.py
+++ b/wayfinder_paths/jobs/evolution_campaign.py
@@ -1476,12 +1476,22 @@ def _commit_designed_attempt(
         }
     postmortem = outcome.pop("postmortem", None)
     if not isinstance(postmortem, dict):
+        evidence = outcome.get("evidence")
+        if isinstance(evidence, dict):
+            error = str(evidence.get("error") or "").strip()
+        else:
+            error = str(evidence or "").strip()
         postmortem = {
             "viable": False,
             "primary_failure": "invalid_execution",
             "failure_codes": ["invalid_execution"],
             "behavior_diff": {"material_change": False},
         }
+        if error:
+            # The repair worker reads only this bounded artifact. Preserve the
+            # deterministic validator cause so it does not have to rediscover
+            # the failure through broad reads or forbidden tool discovery.
+            postmortem["repair_context"] = {"error": error[:500]}
     receipt_relative = f"{attempt_relative}/receipt.json"
     postmortem_relative = f"{attempt_relative}/postmortem.json"
     atomic_write_json(store.job_dir(job_id) / receipt_relative, receipt)

--- a/wayfinder_paths/jobs/evolution_campaign.py
+++ b/wayfinder_paths/jobs/evolution_campaign.py
@@ -50,6 +50,7 @@ from wayfinder_paths.jobs.evolution_diagnostics import (
     compact_postmortem,
     resolve_json_pointer,
     result_receipt,
+    valid_evidence_pointers,
 )
 from wayfinder_paths.jobs.evolution_funnel import summarize_evolution_funnel
 from wayfinder_paths.jobs.execution.features import parse_feature_specs
@@ -210,7 +211,7 @@ def evolution_compute_window_open(
     windows = schedule.get("blocked_windows_utc") or []
     if not windows:
         return True
-    current = _aware(now or datetime.now(UTC))
+    current = _campaign_now(now)
     duration = timedelta(microseconds=1)
     if reserve_campaign:
         duration = timedelta(
@@ -260,7 +261,7 @@ def campaign_due(store: JobStore, job_id: str, *, now: datetime | None = None) -
     existing = campaign_status(store, job_id)
     if existing.get("status") in {"active", "finalizing"}:
         return False
-    current = _aware(now or datetime.now(UTC))
+    current = _campaign_now(now)
     if not evolution_compute_window_open(
         store, job_id, now=current, reserve_campaign=True
     ):
@@ -295,7 +296,7 @@ def maybe_start_campaign(
                 return existing
             cadence_anchor = existing.get("started_at")
             if cadence_anchor:
-                elapsed = _aware(now or datetime.now(UTC)) - _parse(cadence_anchor)
+                elapsed = _campaign_now(now) - _parse(cadence_anchor)
                 cadence = timedelta(
                     hours=float(
                         spec.evolution.get("start_interval_hours")
@@ -338,7 +339,7 @@ def _start_campaign(
             + ", ".join(eligibility["reasons"])
         )
     existing = campaign_status(store, job_id)
-    current = _aware(now or datetime.now(UTC))
+    current = _campaign_now(now)
     if existing.get("status") in {"active", "finalizing"} and not force:
         return existing
     cadence_anchor = existing.get("started_at")
@@ -779,7 +780,7 @@ def submit_research_seed(
     Submission confers no evidence or deployment authority.  The seed is a
     source-aware parent only and must re-earn every evolution/probation gate.
     """
-    current = _aware(now or datetime.now(UTC))
+    current = _campaign_now(now)
     root = store.job_dir(job_id).resolve()
     source = candidate_root.resolve()
     if not source.is_relative_to(root):
@@ -877,7 +878,7 @@ def _prepare_candidate(
     now: datetime | None = None,
 ) -> dict[str, Any]:
     state = _active_campaign(store, job_id)
-    if _aware(now or datetime.now(UTC)) >= _parse(state["deadline_at"]):
+    if _campaign_now(now) >= _parse(state["deadline_at"]):
         raise ValueError("evolution campaign generation deadline has elapsed")
     manifest = _campaign_manifest(store, job_id, str(state["campaign_id"]))
     policy = manifest["policy"]
@@ -1147,9 +1148,7 @@ def evaluate_candidate(
         candidate = _candidate(state, candidate_id)
         if candidate["status"] == "quick_running":
             try:
-                claim_age = datetime.now(UTC) - _parse(
-                    candidate["evaluation_claimed_at"]
-                )
+                claim_age = _campaign_now() - _parse(candidate["evaluation_claimed_at"])
             except (KeyError, TypeError, ValueError):
                 claim_age = timedelta.max
             if claim_age < timedelta(hours=2):
@@ -1516,7 +1515,7 @@ def _commit_designed_attempt(
         policy.get("max_quick_attempts")
         or int(policy["generated_programs"]) * max_attempts
     )
-    before_drain = datetime.now(UTC) < _parse(state["deadline_at"]) - CAMPAIGN_DRAIN
+    before_drain = _campaign_now() < _parse(state["deadline_at"]) - CAMPAIGN_DRAIN
     room = attempt_index < max_attempts and counts["quick_attempts"] < global_cap
     repair = bool(
         before_drain
@@ -2266,7 +2265,7 @@ def recover_lost_candidate_evaluations(
     proving that no evaluator process is running.
     """
     recovered: list[str] = []
-    recovered_at = _aware(now or datetime.now(UTC)).isoformat()
+    recovered_at = _campaign_now(now).isoformat()
     with job_state_lock(store.repo_root, job_id, name="evolution_campaign"):
         state = campaign_status(store, job_id)
         if state.get("status") not in {"active", "finalizing"}:
@@ -2316,7 +2315,7 @@ def campaign_prompt_block(
             "status": "blocked",
             "reason": "evolution worker paused during peak model pricing",
         }
-    current = _aware(now or datetime.now(UTC))
+    current = _campaign_now(now)
     deadline = _parse(state["deadline_at"])
     manifest = store.read_json(job_id, str(state["manifest"]), default={}) or {}
     candidates = state.get("candidates") or []
@@ -2336,6 +2335,7 @@ def campaign_prompt_block(
                 "campaign_id": state["campaign_id"],
                 "stage": "design",
                 "session_stage": "finalize",
+                "artifact_key": "finalize",
                 "agent_name": "wayfinder-evolution-worker",
                 "deadline_at": state["deadline_at"],
                 "counts": state["counts"],
@@ -2349,6 +2349,9 @@ def campaign_prompt_block(
         pack_path = (store.job_dir(job_id) / str(state["diagnostic_pack"])).resolve()
         manifest_path = (store.job_dir(job_id) / str(state["manifest"])).resolve()
         policy = manifest.get("policy") or {}
+        diagnostic_pack = (
+            store.read_json(job_id, str(state["diagnostic_pack"]), default={}) or {}
+        )
         slots = int(policy.get("generated_programs") or 8)
         wildcards = int(policy.get("wildcard_slots") or 2)
         return {
@@ -2356,6 +2359,7 @@ def campaign_prompt_block(
             "campaign_id": state["campaign_id"],
             "stage": "design",
             "session_stage": "design",
+            "artifact_key": "design",
             "agent_name": "wayfinder-evolution-designer",
             "deadline_at": state["deadline_at"],
             "counts": state["counts"],
@@ -2376,6 +2380,8 @@ def campaign_prompt_block(
                 "the detached result; end immediately after launch."
             ),
             "diagnostic_pack": str(pack_path),
+            "manifest_path": str(manifest_path),
+            "valid_evidence_pointers": valid_evidence_pointers(diagnostic_pack),
             "constraints": {
                 "paper_only": True,
                 "facts_constrain_claims_not_mechanisms": True,
@@ -2427,6 +2433,11 @@ def campaign_prompt_block(
             "the campaign policy assigns structural and parameter slots."
         )
     )
+    artifact_key = "finalize"
+    work_inputs: list[str] = []
+    editable_paths: list[str] = []
+    candidate_id: str | None = None
+    postmortem_path: str | None = None
     if awaiting_evaluation:
         candidate = awaiting_evaluation[0]
         candidate_root = resolve_candidate_bundle(
@@ -2436,6 +2447,13 @@ def campaign_prompt_block(
             campaign_id=str(state["campaign_id"]),
         )
         session_stage = f"candidate-{int(candidate.get('slot') or 0):02d}"
+        artifact_key = (
+            f"{session_stage}-attempt-"
+            f"{int(candidate.get('attempt_count') or 0) + 1:02d}"
+        )
+        candidate_id = str(candidate["candidate_id"])
+        work_inputs = [str(candidate_root / "candidate.json")]
+        editable_paths = [str(candidate_root)]
         mutation_instruction = (
             f"This is a parameter candidate: {_PARAMETER_SEARCH_GUIDANCE} "
             if candidate.get("mutation_kind") == "parameter"
@@ -2447,6 +2465,10 @@ def campaign_prompt_block(
         repair_instruction = ""
         if candidate.get("status") == "repair_pending":
             latest_attempt = (candidate.get("attempts") or [])[-1]
+            postmortem_path = str(
+                store.job_dir(job_id) / str(latest_attempt.get("postmortem_path") or "")
+            )
+            work_inputs.append(postmortem_path)
             repair_instruction = (
                 f"This is repair {int(candidate.get('attempt_count') or 0)} of "
                 f"at most {int(policy.get('max_attempts_per_idea') or 3)}. Read "
@@ -2464,11 +2486,12 @@ def campaign_prompt_block(
             f'job_id="{job_id}", candidate_id="{candidate["candidate_id"]}", '
             "and background=true. Do not wait for the detached result. END THIS "
             "STAGE immediately after launch; do not prepare another candidate. "
-            "The same bounded idea session will receive the compact postmortem "
+            "A fresh bounded attempt session will receive the compact postmortem "
             "if a repair is warranted."
         )
     elif deadline_elapsed:
         session_stage = "finalize"
+        artifact_key = "finalize"
         next_action = (
             "Generation deadline elapsed. Call wayfinder_core_jobs with "
             f'action="evolution_finalize", job_id="{job_id}", background=true, '
@@ -2482,6 +2505,7 @@ def campaign_prompt_block(
         }
     elif len(candidates) < budget:
         session_stage = f"candidate-{len(candidates) + 1:02d}"
+        artifact_key = f"{session_stage}-attempt-01"
         preview = _parent_plan_handoff(next_parent_plan)
         next_action = (
             f"Next source plan: {json.dumps(preview, sort_keys=True)}. "
@@ -2498,6 +2522,7 @@ def campaign_prompt_block(
         )
     else:
         session_stage = "finalize"
+        artifact_key = "finalize"
         next_action = (
             'Call wayfinder_core_jobs with action="evolution_finalize", '
             f'job_id="{job_id}", background=true, then END THIS STAGE. '
@@ -2508,10 +2533,15 @@ def campaign_prompt_block(
         "campaign_id": state["campaign_id"],
         "stage": state["stage"],
         "session_stage": session_stage,
+        "artifact_key": artifact_key,
         "deadline_at": state["deadline_at"],
         "counts": state["counts"],
         "next_action": next_action,
         "agent_name": "wayfinder-evolution-worker",
+        "candidate_id": candidate_id,
+        "work_inputs": work_inputs,
+        "editable_paths": editable_paths,
+        "postmortem_path": postmortem_path,
         "candidate_outcomes": [_candidate_handoff(item) for item in candidates],
         "historical_lessons": manifest.get("historical_lessons") or {},
         "research_context": manifest.get("research_context") or {},
@@ -4136,3 +4166,13 @@ def _parse(value: Any) -> datetime:
 
 def _aware(value: datetime) -> datetime:
     return value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)
+
+
+def _campaign_now(value: datetime | None = None) -> datetime:
+    if value is not None:
+        return _aware(value)
+    if os.getenv("WAYFINDER_BENCHMARK") == "1":
+        frozen = str(os.getenv("WAYFINDER_BENCHMARK_NOW") or "").strip()
+        if frozen:
+            return _parse(frozen)
+    return datetime.now(UTC)

--- a/wayfinder_paths/jobs/evolution_campaign.py
+++ b/wayfinder_paths/jobs/evolution_campaign.py
@@ -1323,6 +1323,7 @@ def _evaluate_candidate(
                     "evidence": (
                         "parameter behavior preview found no material intent change"
                     ),
+                    "quick_simulation_ran": False,
                     "behavior_preview": behavior_preview,
                     "postmortem": {
                         "viable": False,
@@ -1360,7 +1361,11 @@ def _evaluate_candidate(
         return {"status": "invalid", "evidence": {"error": str(exc)[:500]}}
     compact = _compact_result(result)
     if not result.validation.get("execution_valid"):
-        return {"status": "low_fidelity_rejected", "evidence": compact}
+        return {
+            "status": "low_fidelity_rejected",
+            "evidence": compact,
+            "quick_simulation_ran": True,
+        }
     common: dict[str, Any] = {
         "revision": revision,
         "quick": compact,
@@ -1368,6 +1373,7 @@ def _evaluate_candidate(
         "behavior": _behavior(result, quick, subject["spec"]),
         "execution_calibration": calibration,
         "tuning_eligible": search_space is not None,
+        "quick_simulation_ran": True,
     }
     if candidate.get("reference_bundle"):
         receipt = result_receipt(

--- a/wayfinder_paths/jobs/evolution_campaign.py
+++ b/wayfinder_paths/jobs/evolution_campaign.py
@@ -55,7 +55,11 @@ from wayfinder_paths.jobs.evolution_diagnostics import (
 from wayfinder_paths.jobs.evolution_funnel import summarize_evolution_funnel
 from wayfinder_paths.jobs.execution.features import parse_feature_specs
 from wayfinder_paths.jobs.execution.job import _load_dataset, _load_job_yaml
-from wayfinder_paths.jobs.execution.optimize import is_search_space, run_optuna_search
+from wayfinder_paths.jobs.execution.optimize import (
+    is_search_space,
+    run_optuna_search,
+    search_space_probe_variants,
+)
 from wayfinder_paths.jobs.execution.primitives import (
     DEFAULT_WARMUP_BARS,
     ExecutionSpec,
@@ -70,6 +74,7 @@ from wayfinder_paths.jobs.execution.simulator import (
 )
 from wayfinder_paths.jobs.execution.validation import (
     BOUNDED_WINDOW_HINT,
+    parameter_behavior_probe,
     resolve_execution_spec,
     validate_execution_job,
     window_invariance_probe,
@@ -1261,6 +1266,7 @@ def _evaluate_candidate(
         }
     policy = manifest.get("policy") or {}
     tuning_preview: dict[str, Any] | None = None
+    behavior_preview: dict[str, Any] | None = None
     try:
         subject = _load_subject(store, job_id, candidate_root, campaign_id=campaign_id)
         train_end, validation_end = _split_bounds(
@@ -1291,6 +1297,41 @@ def _evaluate_candidate(
                     },
                 },
             }
+        if (
+            bool(policy.get("behavior_preview_enabled"))
+            and candidate.get("mutation_kind") == "parameter"
+            and search_space is not None
+        ):
+            behavior_preview = parameter_behavior_probe(
+                subject["script"],
+                quick.bars,
+                subject["spec"],
+                params,
+                search_space_probe_variants(search_space),
+            )
+            if behavior_preview["status"] == "unchanged":
+                bars_probed = int(behavior_preview.get("bars_probed") or 0)
+                variants = int(behavior_preview.get("variants_declared") or 0)
+                error = (
+                    "Declared parameter endpoints changed no material order "
+                    f"intents across {bars_probed} sampled bars and {variants} "
+                    "bounded variants; change the search space or mechanism "
+                    "before simulation."
+                )
+                return {
+                    "status": "low_fidelity_rejected",
+                    "evidence": (
+                        "parameter behavior preview found no material intent change"
+                    ),
+                    "behavior_preview": behavior_preview,
+                    "postmortem": {
+                        "viable": False,
+                        "primary_failure": "no_behavior_change",
+                        "failure_codes": ["no_behavior_change"],
+                        "behavior_diff": {"material_change": False},
+                        "repair_context": {"error": error},
+                    },
+                }
         result = simulate_execution(subject["script"], quick, subject["spec"], params)
         if (
             candidate.get("mutation_kind") == "parameter"
@@ -1320,7 +1361,7 @@ def _evaluate_candidate(
     compact = _compact_result(result)
     if not result.validation.get("execution_valid"):
         return {"status": "low_fidelity_rejected", "evidence": compact}
-    common = {
+    common: dict[str, Any] = {
         "revision": revision,
         "quick": compact,
         "objective": _objective(result.stats, params),
@@ -1356,6 +1397,8 @@ def _evaluate_candidate(
         common["tuning_skip_reason"] = "no_typed_search_space"
     if tuning_preview is not None:
         common["tuning_preview"] = tuning_preview
+    if behavior_preview is not None:
+        common["behavior_preview"] = behavior_preview
     if int(result.stats.get("trade_count") or 0) <= 0:
         return {
             **common,

--- a/wayfinder_paths/jobs/evolution_diagnostics.py
+++ b/wayfinder_paths/jobs/evolution_diagnostics.py
@@ -164,6 +164,41 @@ def resolve_json_pointer(document: Mapping[str, Any], pointer: str) -> Any:
     return current
 
 
+def valid_evidence_pointers(
+    document: Mapping[str, Any], *, limit: int = 96
+) -> list[str]:
+    """Return a bounded, deterministic menu of citeable non-empty leaves.
+
+    The campaign pack remains the authority.  This is only a prompt-time index
+    over that pack so the designer does not spend model turns guessing paths
+    that are absent or present-but-empty.
+    """
+
+    pointers: list[str] = []
+
+    def escaped(value: Any) -> str:
+        return str(value).replace("~", "~0").replace("/", "~1")
+
+    def visit(value: Any, pointer: str) -> None:
+        if len(pointers) >= max(int(limit), 0):
+            return
+        if isinstance(value, Mapping):
+            for key in sorted(value, key=str):
+                visit(value[key], f"{pointer}/{escaped(key)}")
+            return
+        if isinstance(value, Sequence) and not isinstance(
+            value, (str, bytes, bytearray)
+        ):
+            for index, item in enumerate(value):
+                visit(item, f"{pointer}/{index}")
+            return
+        if value is not None and value != "":
+            pointers.append(pointer)
+
+    visit(document, "")
+    return pointers
+
+
 def build_postmortem(
     candidate: Mapping[str, Any],
     reference: Mapping[str, Any],

--- a/wayfinder_paths/jobs/evolution_diagnostics.py
+++ b/wayfinder_paths/jobs/evolution_diagnostics.py
@@ -288,7 +288,7 @@ def attempt_made_progress(postmortem: Mapping[str, Any]) -> bool:
 
 def compact_postmortem(postmortem: Mapping[str, Any]) -> dict[str, Any]:
     behavior = postmortem.get("behavior_diff") or {}
-    return {
+    compact = {
         "viable": bool(postmortem.get("viable")),
         "primary_failure": postmortem.get("primary_failure"),
         "failure_codes": list(postmortem.get("failure_codes") or [])[:6],
@@ -307,6 +307,12 @@ def compact_postmortem(postmortem: Mapping[str, Any]) -> dict[str, Any]:
             if behavior.get(key) is not None
         },
     }
+    repair_error = str(
+        (postmortem.get("repair_context") or {}).get("error") or ""
+    ).strip()
+    if repair_error:
+        compact["repair_context"] = {"error": repair_error[:500]}
+    return compact
 
 
 def participation_adjusted_score(

--- a/wayfinder_paths/jobs/evolution_ledger.py
+++ b/wayfinder_paths/jobs/evolution_ledger.py
@@ -121,7 +121,7 @@ def build_process_efficiency(store: JobStore, job_id: str) -> dict[str, Any]:
 
     wakes_with_learning = len(learning_wakes)
     activity_only = len(activity_wakes - learning_wakes)
-    return {
+    result: dict[str, Any] = {
         "wakes_total": len(wakes),
         "wakes_with_valid_learning": wakes_with_learning,
         "activity_only_wakes": activity_only,
@@ -134,6 +134,41 @@ def build_process_efficiency(store: JobStore, job_id: str) -> dict[str, Any]:
             round(len(wakes) / wakes_with_learning, 3) if wakes_with_learning else None
         ),
     }
+    evolution_sessions = [
+        row for row in journal if row.get("type") == "evolution_session_retired"
+    ]
+    if evolution_sessions:
+        metric_keys = (
+            "wall_seconds",
+            "model_seconds",
+            "tool_seconds",
+            "other_seconds",
+            "tool_calls",
+            "tool_output_bytes",
+        )
+        agent_summary: dict[str, Any] = {
+            "sessions": len(evolution_sessions),
+            **{
+                key: round(
+                    sum(
+                        float((row.get("metrics") or {}).get(key) or 0)
+                        for row in evolution_sessions
+                    ),
+                    3,
+                )
+                for key in metric_keys
+            },
+            "behavior_changed_attempts": sum(
+                row.get("behavior_changed") is True for row in evolution_sessions
+            ),
+            "behavior_unchanged_attempts": sum(
+                row.get("behavior_changed") is False for row in evolution_sessions
+            ),
+        }
+        agent_summary["tool_calls"] = int(agent_summary["tool_calls"])
+        agent_summary["tool_output_bytes"] = int(agent_summary["tool_output_bytes"])
+        result["evolution_agent"] = agent_summary
+    return result
 
 
 def build_evolution_report(store: JobStore, job_id: str) -> dict[str, Any]:

--- a/wayfinder_paths/jobs/execution/optimize.py
+++ b/wayfinder_paths/jobs/execution/optimize.py
@@ -58,6 +58,53 @@ def is_search_space(payload: Any) -> bool:
             return False
 
 
+def search_space_probe_variants(
+    search_space: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    """Return bounded deterministic endpoint variants for a behavior probe.
+
+    This is deliberately not a sampler or optimizer. It asks the cheaper
+    prerequisite question: can any declared dimension change a material order
+    intent at all? Constants are included exactly as they are in every Optuna
+    trial, and at most ``2 * dimensions + 2`` variants are returned.
+    """
+    dimensions = {
+        name: dict(value)
+        for name, value in sorted(search_space.items())
+        if _is_typed_dimension(value)
+    }
+    constants = {
+        name: value for name, value in search_space.items() if name not in dimensions
+    }
+    endpoints: dict[str, list[Any]] = {}
+    for name, dimension in dimensions.items():
+        match str(dimension.get("type") or ""):
+            case "float":
+                values = [float(dimension["low"]), float(dimension["high"])]
+            case "int":
+                values = [int(dimension["low"]), int(dimension["high"])]
+            case "categorical":
+                choices = list(dimension.get("choices") or [])
+                values = choices[:1] + choices[-1:] if choices else []
+            case _:
+                values = []
+        endpoints[name] = list(dict.fromkeys(values))
+    variants = [
+        {**constants, name: value}
+        for name, values in endpoints.items()
+        for value in values
+    ]
+    lows = {name: values[0] for name, values in endpoints.items() if values}
+    highs = {name: values[-1] for name, values in endpoints.items() if values}
+    if len(endpoints) > 1:
+        variants.extend(({**constants, **lows}, {**constants, **highs}))
+    unique: dict[str, dict[str, Any]] = {}
+    for variant in variants:
+        key = repr(sorted(variant.items()))
+        unique.setdefault(key, variant)
+    return list(unique.values())
+
+
 # Grid-row axes where smaller is better; every other rank key maximizes.
 _MINIMIZE_AXES = frozenset({"max_drawdown_pct"})
 
@@ -130,6 +177,8 @@ def run_optuna_search(
         return float(row[rank_by] or 0)  # same coercion as grid ranking
 
     optuna.logging.set_verbosity(optuna.logging.WARNING)
+    sampler_name: str
+    sampler_impl: Any
     if objectives:
         # NSGA-II handles mixed int/float/categorical spaces; an explicit
         # sampler="motpe" opts into optuna's multi-objective TPE instead.

--- a/wayfinder_paths/jobs/execution/validation.py
+++ b/wayfinder_paths/jobs/execution/validation.py
@@ -7,7 +7,7 @@ import math
 import py_compile
 import re
 import tokenize
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -511,6 +511,151 @@ def _probe_values_match(left: Any, right: Any) -> bool:
             return left == right
 
 
+def _probe_indices(timestamps: Any, *, first: int, samples: int) -> list[int]:
+    span = len(timestamps) - 1 - first
+    count = max(1, min(samples, span + 1))
+    step = span / max(count - 1, 1)
+    return sorted({first + round(index * step) for index in range(count)})
+
+
+async def _probe_decided_intents(
+    script_entrypoint: str | Path | Callable[..., Any],
+    bars: CompletedBarsView,
+    spec: ExecutionSpec,
+    params: Mapping[str, Any],
+    *,
+    index: int,
+    lookback: int,
+) -> list[dict[str, Any]]:
+    from wayfinder_paths.jobs.execution.engine import (  # circular import
+        EngineState,
+        run_tick,
+    )
+    from wayfinder_paths.jobs.execution.simulator import (  # circular import
+        BacktestBroker,
+        _load_strategy,
+    )
+
+    params_data = dict(params)
+    strategy = _load_strategy(script_entrypoint, dict(params_data))
+    view = apply_precompute(strategy, bars.window(index, lookback))
+    trace = ExecutionTrace(execution_spec=spec.to_dict())
+    await run_tick(
+        strategy,
+        view=view,
+        brokers={"*": BacktestBroker()},
+        state=EngineState(),
+        spec=spec,
+        params=params_data,
+        timestamp=bars.timestamps[index],
+        snapshot=StateSnapshot(status="valid"),
+        trace=trace,
+    )
+    return trace.intents
+
+
+_MATERIAL_INTENT_KEYS = (
+    "action",
+    "venue",
+    "symbol",
+    "side",
+    "size",
+    "notional",
+    "reduce_only",
+    "bracket",
+    "limit_price",
+    "time_in_force",
+    "expires_after_bars",
+)
+
+
+def _material_intents(intents: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {key: intent.get(key) for key in _MATERIAL_INTENT_KEYS} for intent in intents
+    ]
+
+
+def parameter_behavior_probe(
+    script_entrypoint: str | Path | Callable[..., Any],
+    bars: CompletedBarsView,
+    execution_spec: ExecutionSpec | Mapping[str, Any] | None,
+    params: Mapping[str, Any],
+    variants: Sequence[Mapping[str, Any]],
+    *,
+    samples: int = 8,
+) -> dict[str, Any]:
+    """Check sampled material intents before paying for a full simulation."""
+    from wayfinder_paths.jobs.execution.simulator import _load_strategy
+
+    params_data = dict(params)
+    spec = ExecutionSpec.coerce(execution_spec)
+    window = resolve_compute_window(
+        params_data, _load_strategy(script_entrypoint, dict(params_data))
+    )
+    if not window.declared or window.size is None:
+        return {
+            "status": "skipped",
+            "reason": f"compute window is {window.source}, not declared",
+        }
+    if not variants:
+        return {"status": "skipped", "reason": "no parameter variants"}
+    timestamps = bars.timestamps
+    window_size = window.size
+    first = window_size - 1
+    if len(timestamps) - 1 < first:
+        return {
+            "status": "skipped",
+            "reason": "dataset does not cover the declared window",
+        }
+    indices = _probe_indices(timestamps, first=first, samples=samples)
+
+    async def probe() -> dict[str, Any]:
+        ticks = 0
+        for index in indices:
+            baseline = _material_intents(
+                await _probe_decided_intents(
+                    script_entrypoint,
+                    bars,
+                    spec,
+                    params_data,
+                    index=index,
+                    lookback=window_size,
+                )
+            )
+            ticks += 1
+            for variant in variants:
+                candidate = _material_intents(
+                    await _probe_decided_intents(
+                        script_entrypoint,
+                        bars,
+                        spec,
+                        {**params_data, **dict(variant)},
+                        index=index,
+                        lookback=window_size,
+                    )
+                )
+                ticks += 1
+                if not _probe_values_match(baseline, candidate):
+                    return {
+                        "status": "changed",
+                        "bar": timestamps[index].isoformat(),
+                        "window": window_size,
+                        "bars_probed": len(indices),
+                        "variants_declared": len(variants),
+                        "ticks_evaluated": ticks,
+                        "changed_params": dict(variant),
+                    }
+        return {
+            "status": "unchanged",
+            "window": window_size,
+            "bars_probed": len(indices),
+            "variants_declared": len(variants),
+            "ticks_evaluated": ticks,
+        }
+
+    return asyncio.run(probe())
+
+
 def window_invariance_probe(
     script_entrypoint: str | Path | Callable[..., Any],
     bars: CompletedBarsView,
@@ -523,14 +668,7 @@ def window_invariance_probe(
     min(available, W + WINDOW_PROBE_EXTRA_BARS) — from identical fresh state
     and require identical intents. A mismatch means decide() consumed history
     beyond its declared window: its backtest inputs are not its live inputs."""
-    from wayfinder_paths.jobs.execution.engine import (  # circular import
-        EngineState,
-        run_tick,
-    )
-    from wayfinder_paths.jobs.execution.simulator import (  # circular import
-        BacktestBroker,
-        _load_strategy,
-    )
+    from wayfinder_paths.jobs.execution.simulator import _load_strategy
 
     params_data = dict(params)
     spec = ExecutionSpec.coerce(execution_spec)
@@ -550,34 +688,27 @@ def window_invariance_probe(
             "status": "skipped",
             "reason": "dataset does not extend beyond the declared window",
         }
-    span = len(timestamps) - 1 - first
-    count = max(1, min(samples, span + 1))
-    step = span / max(count - 1, 1)
-    indices = sorted({first + round(k * step) for k in range(count)})
-
-    async def decided_intents(index: int, lookback: int) -> list[dict[str, Any]]:
-        # Fresh strategy + fresh engine state per replay: the two runs differ
-        # ONLY in view depth, so any intent difference is window dependence.
-        strategy = _load_strategy(script_entrypoint, dict(params_data))
-        view = apply_precompute(strategy, bars.window(index, lookback))
-        trace = ExecutionTrace(execution_spec=spec.to_dict())
-        await run_tick(
-            strategy,
-            view=view,
-            brokers={"*": BacktestBroker()},
-            state=EngineState(),
-            spec=spec,
-            params=params_data,
-            timestamp=timestamps[index],
-            snapshot=StateSnapshot(status="valid"),
-            trace=trace,
-        )
-        return trace.intents
+    indices = _probe_indices(timestamps, first=first, samples=samples)
 
     async def probe() -> dict[str, Any]:
         for index in indices:
-            base = await decided_intents(index, size)
-            wide = await decided_intents(index, size + WINDOW_PROBE_EXTRA_BARS)
+            # Fresh strategy + state per replay: view depth is the only delta.
+            base = await _probe_decided_intents(
+                script_entrypoint,
+                bars,
+                spec,
+                params_data,
+                index=index,
+                lookback=size,
+            )
+            wide = await _probe_decided_intents(
+                script_entrypoint,
+                bars,
+                spec,
+                params_data,
+                index=index,
+                lookback=size + WINDOW_PROBE_EXTRA_BARS,
+            )
             if not _probe_values_match(base, wide):
                 return {
                     "status": "failed",

--- a/wayfinder_paths/jobs/improver/spec.py
+++ b/wayfinder_paths/jobs/improver/spec.py
@@ -121,6 +121,10 @@ DEFAULT_IMPROVER: dict[str, Any] = {
         "inner_optuna_preview_trials": 3,
         "inner_optuna_preview_bars": 2_000,
         "inner_optuna_preview_timeout_seconds": 300,
+        # Experimental cheap preflight for parameter candidates. Keep off in
+        # production until its full-process A/B measures both compute saved
+        # and any false rejection of useful sparse behavior.
+        "behavior_preview_enabled": False,
         "inner_optuna_train_bars": 10_000,
         "inner_optuna_timeout_seconds": 1_800,
         "proposal_finalists": 1,

--- a/wayfinder_paths/jobs/paper_experiment.py
+++ b/wayfinder_paths/jobs/paper_experiment.py
@@ -1240,7 +1240,9 @@ def _daily_pnl_for_stream(
     for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
         try:
             row = json.loads(line)
-            stamp = pd.Timestamp(row.get("ts") or row.get("timestamp"))
+            stamp = pd.Timestamp(
+                row.get("closed_at") or row.get("timestamp") or row.get("ts")
+            )
             if since is not None and stamp < pd.Timestamp(since):
                 continue
             if until is not None and stamp >= pd.Timestamp(until):

--- a/wayfinder_paths/jobs/probation.py
+++ b/wayfinder_paths/jobs/probation.py
@@ -1113,6 +1113,7 @@ def _paired_forward_metrics(
     safety = _hard_constraint_metrics(store, job_id, candidate)
     return {
         "paired_days": len(deltas),
+        "daily_deltas": deltas,
         "estimate": round(sum(deltas), 8),
         "lcb": lcb,
         "ucb": ucb,

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -77,6 +77,130 @@ def _canonical_json(data: Any, *, max_chars: int | None = None) -> str:
     return text
 
 
+def _work_order(
+    *,
+    lane: str,
+    action: str,
+    objective: str,
+    inputs: list[str],
+    editable_paths: list[str],
+    exclusions: list[str],
+    completion: str,
+) -> dict[str, Any]:
+    """Build a prompt-context contract, never a durable workflow artifact."""
+    return {
+        "schema_version": "1.0",
+        "lane": lane,
+        "action": action,
+        "objective": objective,
+        "inputs": list(dict.fromkeys(item for item in inputs if item)),
+        "editable_paths": list(dict.fromkeys(item for item in editable_paths if item)),
+        "exclusions": list(dict.fromkeys(item for item in exclusions if item)),
+        "completion": completion,
+    }
+
+
+def _render_work_order(order: dict[str, Any]) -> str:
+    return "COMPILED WORK ORDER (one action):\n" + _canonical_json(
+        order, max_chars=4_500
+    )
+
+
+def _worker_work_order(
+    *,
+    job_id: str,
+    mode: str,
+    apply_proposal_id: str | None,
+    maintenance_ready: bool,
+    remediation_overrides: bool,
+    restage_tasks: list[dict[str, Any]],
+    ideation_due: bool,
+    gate_red: bool,
+) -> dict[str, Any]:
+    base = f".wayfinder/jobs/{job_id}"
+    if apply_proposal_id:
+        lane = "maintenance" if maintenance_ready else "application"
+        return _work_order(
+            lane=lane,
+            action="validate_and_complete_application",
+            objective=(
+                f"Validate and complete approved proposal {apply_proposal_id} "
+                "using its existing candidate bundle."
+            ),
+            inputs=[
+                f"{base}/proposals/{apply_proposal_id}.json",
+                f"{base}/job.yaml",
+                f"{base}/workspace",
+            ],
+            editable_paths=["the proposal application candidate only"],
+            exclusions=[
+                "active workspace until deterministic promotion",
+                "new strategy research",
+                "new proposal creation",
+            ],
+            completion=(
+                "Call validate_application after material edits, then call "
+                "complete_application exactly once with applied or failed."
+            ),
+        )
+    if remediation_overrides:
+        return _work_order(
+            lane="remediation",
+            action="advance_regime_remediation",
+            objective="Advance the open regime-remediation case by one accountable outcome.",
+            inputs=[
+                f"{base}/state/regime_remediation.json",
+                f"{base}/results/research/regime_health.json",
+                f"{base}/results/research/attribution.json",
+                f"{base}/results/forward/summary.json",
+            ],
+            editable_paths=[
+                f"{base}/reports/intervene",
+                "an isolated proposal candidate when the evidence supports treatment",
+            ],
+            exclusions=[
+                "routine island search",
+                "replacement-alpha mining",
+                "owner provenance",
+                "blocking reduce-only exits",
+            ],
+            completion=(
+                "Produce one linked green proposal, one bounded evaluation plus "
+                "remediation_progress, or one structured blocker."
+            ),
+        )
+    if restage_tasks:
+        objective = "Complete the already-approved re-stage task without opening a new proposal."
+        action = "restage_approved_candidate"
+    elif ideation_due and mode == "intervene":
+        objective = "Complete one bounded external-research expedition and persist its artifact."
+        action = "complete_research_expedition"
+    elif gate_red:
+        objective = "Diagnose and advance the currently red deterministic gate."
+        action = "advance_red_gate"
+    else:
+        objective = "Perform the single highest-priority sensing or intervention action for this wake."
+        action = "run_intervention_wake" if mode == "intervene" else f"run_{mode}_wake"
+    return _work_order(
+        lane="intervention" if mode == "intervene" else mode,
+        action=action,
+        objective=objective,
+        inputs=[
+            f"{base}/job.yaml",
+            f"{base}/reports",
+            f"{base}/results/forward",
+            f"{base}/results/research",
+        ],
+        editable_paths=[f"{base}/reports/{mode}", f"{base}/research"],
+        exclusions=[
+            "ordinary alpha candidate generation when evolution is enabled",
+            "owner provenance",
+            "live-mode changes outside a proposal",
+        ],
+        completion="Write the lane report and finish after one accountable outcome.",
+    )
+
+
 def _trade_forensics_block(root: Path) -> dict[str, Any]:
     """Compact exit-quality context: per-trade path metrics the agent cannot
     read off PnL rows (MAE/MFE during the hold, post-exit excursion, stop
@@ -678,7 +802,7 @@ def _build_worker_prompt_sections(
     wake_source: str = "scheduled_timer",
     wake_triggers: list[str] | None = None,
     wake_id: str | None = None,
-) -> dict[str, str]:
+) -> dict[str, Any]:
     root = store.job_dir(job_id)
     from wayfinder_paths.jobs.improver.spec import ImproverSpec
 
@@ -1482,8 +1606,73 @@ def _build_worker_prompt_sections(
             "ledgers, memory, the research agenda/island agenda, or remediation "
             "reaffirmations.\n"
         )
+    apply_proposal: dict[str, Any] = next(
+        (
+            proposal
+            for proposal in snapshot.get("proposals") or []
+            if str(proposal.get("proposal_id") or proposal.get("id") or "")
+            == str(apply_proposal_id or "")
+        ),
+        {},
+    )
+    maintenance_ready = bool(
+        ((apply_proposal.get("candidate_report") or {}).get("maintenance") or {}).get(
+            "ready"
+        )
+        is True
+    )
+    work_order = _worker_work_order(
+        job_id=job_id,
+        mode=mode,
+        apply_proposal_id=apply_proposal_id,
+        maintenance_ready=maintenance_ready,
+        remediation_overrides=bool(remediation_overrides),
+        restage_tasks=list(restage_tasks or []),
+        ideation_due=bool(ideation_due),
+        gate_red=bool(gate_state and gate_state.get("live_ready") is False),
+    )
+    lane = str(work_order["lane"])
+    if lane == "remediation":
+        prompt_payload = {
+            key: dynamic_payload.get(key)
+            for key in (
+                "scorecard",
+                "forward",
+                "runner_links",
+                "proposals",
+                "proposal_queue",
+                "gate",
+                "trade_forensics",
+                "attribution",
+                "standing_checks",
+                "compute_status",
+                "wake",
+                "portfolio",
+            )
+            if dynamic_payload.get(key) not in (None, {}, [])
+        }
+    elif lane in {"maintenance", "application"}:
+        prompt_payload = {
+            key: dynamic_payload.get(key)
+            for key in (
+                "scorecard",
+                "runner_links",
+                "proposals",
+                "proposal_queue",
+                "reports",
+                "gate",
+                "standing_checks",
+                "compute_status",
+                "restage_tasks",
+                "wake",
+            )
+            if dynamic_payload.get(key) not in (None, {}, [])
+        }
+    else:
+        prompt_payload = dynamic_payload
     dynamic_context = (
         f"{DYNAMIC_CONTEXT_MARKER}\n"
+        f"{_render_work_order(work_order)}\n\n"
         f"{gate_alert}"
         f"{bootstrap_alert}"
         f"{remediation_directive}"
@@ -1492,7 +1681,7 @@ def _build_worker_prompt_sections(
         f"{ideation_directive}"
         f"Current wake id (pass verbatim to risk_block_symbol): {wake_id}\n"
         "Current snapshot:\n"
-        f"{_canonical_json(dynamic_payload, max_chars=12000)}\n\n"
+        f"{_canonical_json(prompt_payload, max_chars=12000)}\n\n"
         "Research agenda (research/agenda.md — cumulative exploration "
         "state; maintain it, do not restart it):\n"
         f"{research_agenda or '(none yet — bootstrap it on the next healthy ideation wake)'}\n\n"
@@ -1513,6 +1702,7 @@ def _build_worker_prompt_sections(
         "dynamic_context": dynamic_context,
         "stable_prefix_hash": hashlib.sha256(stable_prefix.encode()).hexdigest(),
         "dynamic_context_hash": hashlib.sha256(dynamic_context.encode()).hexdigest(),
+        "work_order": work_order,
     }
 
 
@@ -1919,6 +2109,7 @@ def recover_evolution_stage_session(
     if not campaign or campaign.get("status") == "blocked":
         return None
     desired_stage = str(campaign.get("session_stage") or "")
+    desired_artifact = str(campaign.get("artifact_key") or desired_stage)
     session = store.read_json(job_id, EVOLUTION_SESSION_PATH, default={}) or {}
     session_id = str(session.get("session_id") or "")
     if session_id and OPENCODE_CLIENT.session_statuses().get(session_id):
@@ -1928,7 +2119,9 @@ def recover_evolution_stage_session(
         or session.get("retired_at")
         or OPENCODE_CLIENT.session_exists(session_id) is False
     )
-    stage_changed = str(session.get("session_stage") or "") != desired_stage
+    stored_stage = str(session.get("session_stage") or "")
+    stored_artifact = str(session.get("artifact_key") or stored_stage)
+    artifact_changed = stored_artifact != desired_artifact
     stale = False
     try:
         prompted_at = dt.datetime.fromisoformat(str(session["last_prompt_at"]))
@@ -1937,7 +2130,7 @@ def recover_evolution_stage_session(
         stale = now - prompted_at >= EVOLUTION_STAGE_RETRY_AFTER
     except (KeyError, TypeError, ValueError):
         stale = bool(session_id)
-    if not (missing or stage_changed or stale):
+    if not (missing or artifact_changed or stale):
         return None
     if session_id and not session.get("retired_at") and not missing:
         retired = retire_evolution_session(
@@ -1959,7 +2152,7 @@ def build_evolution_stage_prompt(
     campaign: dict[str, Any],
     *,
     prior_handoff: dict[str, Any] | None = None,
-) -> dict[str, str]:
+) -> dict[str, Any]:
     """Render the production evolution stage prompt and its agent identity.
 
     The benchmark harness calls this same pure formatter. Keeping prompt
@@ -1972,37 +2165,110 @@ def build_evolution_stage_prompt(
     session_stage = str(campaign.get("session_stage") or "").strip()
     if not session_stage:
         raise ValueError("evolution session stage missing")
+    artifact_key = str(campaign.get("artifact_key") or session_stage).strip()
     campaign_payload = dict(campaign)
     prior_stage_text = (
-        _canonical_json(prior_handoff, max_chars=2_200) if prior_handoff else "null"
+        _canonical_json(prior_handoff, max_chars=1_500) if prior_handoff else "null"
     )
     candidate_outcomes = list(reversed(campaign_payload.pop("candidate_outcomes", [])))
     outcomes_text = _canonical_json(
-        {"order": "newest_first", "candidates": candidate_outcomes}, max_chars=4_000
+        {"order": "newest_first", "candidates": candidate_outcomes[:3]},
+        max_chars=3_000,
     )
-    title = f"job/{job_id}/evolution/{campaign_id}/{session_stage}"
+    lane = (
+        "evolution_design"
+        if session_stage == "design"
+        else "evolution_finalize"
+        if session_stage == "finalize"
+        else "evolution_repair"
+        if campaign_payload.get("postmortem_path")
+        else "evolution_candidate"
+    )
+    action = (
+        "submit_campaign_design"
+        if session_stage == "design"
+        else "launch_finalize"
+        if session_stage == "finalize"
+        else "repair_and_launch_evaluation"
+        if campaign_payload.get("postmortem_path")
+        else "prepare_edit_and_launch_evaluation"
+    )
+    inputs = list(campaign_payload.get("work_inputs") or [])
+    for key in ("diagnostic_pack", "manifest_path", "postmortem_path"):
+        if campaign_payload.get(key):
+            inputs.append(str(campaign_payload[key]))
+    editable_paths = list(campaign_payload.get("editable_paths") or [])
+    work_order = _work_order(
+        lane=lane,
+        action=action,
+        objective=(
+            "Design and submit the campaign's bounded hypothesis/slot allocation."
+            if session_stage == "design"
+            else "Launch deterministic campaign finalization and end the stage."
+            if session_stage == "finalize"
+            else "Change the assigned candidate mechanism and launch exactly one detached evaluation."
+        ),
+        inputs=inputs,
+        editable_paths=editable_paths,
+        exclusions=[
+            "active incumbent workspace",
+            "live trading or owner provenance",
+            "future or sealed holdout data",
+            "another candidate in the same stage",
+        ],
+        completion=(
+            "Call evolution_design once and end."
+            if session_stage == "design"
+            else "Call evolution_finalize with background=true and end."
+            if session_stage == "finalize"
+            else "Call evolution_evaluate with background=true and end without waiting."
+        ),
+    )
+    evidence_pointers = list(campaign_payload.get("valid_evidence_pointers") or [])
+    if evidence_pointers:
+        work_order["valid_evidence_pointers"] = evidence_pointers
+    title = f"job/{job_id}/evolution/{campaign_id}/{artifact_key}"
     agent_name = str(campaign_payload.pop("agent_name", "") or "")
     if agent_name not in {
         JOB_EVOLUTION_DESIGNER_AGENT_NAME,
         JOB_EVOLUTION_WORKER_AGENT_NAME,
     }:
         agent_name = JOB_EVOLUTION_WORKER_AGENT_NAME
+    control_keys = (
+        "campaign_id",
+        "stage",
+        "session_stage",
+        "artifact_key",
+        "deadline_at",
+        "deadline_elapsed",
+        "counts",
+        "constraints",
+        "forward_context_cutoff",
+    )
+    control_state = {
+        key: campaign_payload[key]
+        for key in control_keys
+        if campaign_payload.get(key) is not None
+    }
     prompt = (
         f"Run PAPER-ONLY evolution stage `{session_stage}`. Use the persisted "
         "candidate outcomes and prior-stage handoff; do not reload the retired "
-        "session or its raw tool results. Perform exactly this next action, then "
-        "end the stage:\n"
+        "session or its raw tool results.\n\n"
+        f"{_render_work_order(work_order)}\n\n"
+        "Perform exactly this next action, then end the stage:\n"
         f"{campaign_payload.get('next_action')}\n\n"
         f"Prior stage handoff:\n{prior_stage_text}\n\n"
         f"Persisted candidate outcomes:\n{outcomes_text}\n\n"
-        "Campaign control state:\n" + _canonical_json(campaign_payload, max_chars=3_500)
+        "Campaign control state:\n" + _canonical_json(control_state, max_chars=2_000)
     )
     return {
         "campaign_id": campaign_id,
         "session_stage": session_stage,
+        "artifact_key": artifact_key,
         "title": title,
         "agent_name": agent_name,
         "prompt": prompt,
+        "work_order": work_order,
     }
 
 
@@ -2017,11 +2283,13 @@ def _prompt_evolution_session(
     session_stage = str(campaign.get("session_stage") or "").strip()
     if not session_stage:
         return {"queued": False, "error": "evolution session stage missing"}
+    artifact_key = str(campaign.get("artifact_key") or session_stage).strip()
     prior_handoff = _latest_evolution_stage_handoff(store, job_id, campaign_id)
     existing = store.read_json(job_id, EVOLUTION_SESSION_PATH, default={}) or {}
     existing_id = str(existing.get("session_id") or "")
     existing_campaign = str(existing.get("campaign_id") or "")
     existing_stage = str(existing.get("session_stage") or "")
+    existing_artifact = str(existing.get("artifact_key") or existing_stage)
     existing_gone = bool(
         existing_id and OPENCODE_CLIENT.session_exists(existing_id) is False
     )
@@ -2030,7 +2298,7 @@ def _prompt_evolution_session(
         and not existing.get("retired_at")
         and (
             existing_campaign != campaign_id
-            or existing_stage != session_stage
+            or existing_artifact != artifact_key
             or existing_gone
         )
     )
@@ -2071,10 +2339,11 @@ def _prompt_evolution_session(
             session_id = str(session.get("session_id") or "")
             stored_campaign = str(session.get("campaign_id") or "")
             stored_stage = str(session.get("session_stage") or "")
+            stored_artifact = str(session.get("artifact_key") or stored_stage)
             reusable = bool(
                 session_id
                 and stored_campaign == campaign_id
-                and stored_stage == session_stage
+                and stored_artifact == artifact_key
                 and not session.get("retired_at")
                 and OPENCODE_CLIENT.session_exists(session_id) is not False
             )
@@ -2090,9 +2359,10 @@ def _prompt_evolution_session(
                     or ""
                 )
                 session = {
-                    "schema_version": "1.1",
+                    "schema_version": "1.2",
                     "campaign_id": campaign_id,
                     "session_stage": session_stage,
+                    "artifact_key": artifact_key,
                     "session_id": session_id,
                     "created_at": created_at,
                 }
@@ -2116,6 +2386,7 @@ def _prompt_evolution_session(
                     {
                         "campaign_id": campaign_id,
                         "session_stage": session_stage,
+                        "artifact_key": artifact_key,
                         "last_prompt_at": created_at,
                         "last_prompt_fingerprint": fingerprint,
                         "last_source": source,
@@ -2136,6 +2407,7 @@ def _prompt_evolution_session(
             else "Dedicated evolution wake could not be queued",
             "session_id": session_id,
             "session_stage": session_stage,
+            "artifact_key": artifact_key,
             "queued": queued,
             "source": source,
             "created_at": created_at,
@@ -2147,6 +2419,7 @@ def _prompt_evolution_session(
             "type": "evolution_worker_wakeup",
             "campaign_id": campaign.get("campaign_id"),
             "session_stage": session_stage,
+            "artifact_key": artifact_key,
             "session_id": session_id,
             "queued": queued,
             "source": source,
@@ -2157,32 +2430,10 @@ def _prompt_evolution_session(
 
 def _evolution_stage_handoff(entry: dict[str, Any]) -> dict[str, Any]:
     diagnostics = entry.get("diagnostics") or {}
-    metrics = entry.get("metrics") or {}
-    tool_calls = diagnostics.get("tool_calls") or []
     return {
         "from_stage": entry.get("session_stage"),
-        "retired_at": entry.get("retired_at") or entry.get("exported_at"),
-        "final_summary": str(diagnostics.get("final_assistant_text") or "")[-1_500:],
-        "tool_calls": [
-            {
-                key: call.get(key)
-                for key in ("tool", "action", "status", "error")
-                if call.get(key)
-            }
-            for call in tool_calls[-8:]
-            if isinstance(call, dict)
-        ],
-        "resource_usage": {
-            key: metrics.get(key)
-            for key in (
-                "tokens_in",
-                "tokens_out",
-                "tokens_reasoning",
-                "tool_calls",
-                "tool_result_bytes",
-            )
-            if metrics.get(key) is not None
-        },
+        "from_artifact": entry.get("artifact_key") or entry.get("session_stage"),
+        "final_summary": str(diagnostics.get("final_assistant_text") or "")[-1_200:],
     }
 
 
@@ -2194,6 +2445,39 @@ def _latest_evolution_stage_handoff(
         if str(entry.get("campaign_id") or "") == campaign_id:
             return _evolution_stage_handoff(entry)
     return None
+
+
+def _evolution_artifact_behavior_changed(
+    store: JobStore, job_id: str, session: dict[str, Any]
+) -> bool | None:
+    artifact_key = str(
+        session.get("artifact_key") or session.get("session_stage") or ""
+    )
+    parts = artifact_key.split("-")
+    if len(parts) != 4 or parts[0] != "candidate" or parts[2] != "attempt":
+        return None
+    try:
+        slot = int(parts[1])
+        attempt_index = int(parts[3])
+    except ValueError:
+        return None
+    state = store.read_json(job_id, "state/evolution_campaign.json", default={}) or {}
+    candidate = next(
+        (
+            item
+            for item in state.get("candidates") or []
+            if int(item.get("slot") or 0) == slot
+        ),
+        None,
+    )
+    if not candidate:
+        return None
+    attempts = list(candidate.get("attempts") or [])
+    if attempt_index < 1 or attempt_index > len(attempts):
+        return None
+    postmortem = attempts[attempt_index - 1].get("postmortem") or {}
+    value = (postmortem.get("behavior_diff") or {}).get("material_change")
+    return value if isinstance(value, bool) else None
 
 
 def retire_evolution_session(
@@ -2260,11 +2544,15 @@ def retire_evolution_session(
         exported = {
             "campaign_id": str(campaign_id),
             "session_stage": session.get("session_stage"),
+            "artifact_key": session.get("artifact_key") or session.get("session_stage"),
             "session_id": session_id,
             "created_at": session.get("created_at"),
             "exported_at": utc_now_iso(),
             "metrics": metrics,
             "diagnostics": diagnostics,
+            "behavior_changed": _evolution_artifact_behavior_changed(
+                store, job_id, session
+            ),
         }
         entries = [
             item
@@ -2303,7 +2591,11 @@ def retire_evolution_session(
                 "type": "evolution_session_retired",
                 "campaign_id": str(campaign_id),
                 "session_id": session_id,
+                "session_stage": session.get("session_stage"),
+                "artifact_key": session.get("artifact_key")
+                or session.get("session_stage"),
                 "metrics": metrics,
+                "behavior_changed": entries[-1].get("behavior_changed"),
             },
         )
         return {

--- a/wayfinder_paths/jobs/worker.py
+++ b/wayfinder_paths/jobs/worker.py
@@ -1954,6 +1954,58 @@ def recover_evolution_stage_session(
     )
 
 
+def build_evolution_stage_prompt(
+    job_id: str,
+    campaign: dict[str, Any],
+    *,
+    prior_handoff: dict[str, Any] | None = None,
+) -> dict[str, str]:
+    """Render the production evolution stage prompt and its agent identity.
+
+    The benchmark harness calls this same pure formatter. Keeping prompt
+    construction here makes prompt hashes meaningful: an A/B cannot quietly
+    compare a simplified benchmark instruction against the live worker.
+    """
+    campaign_id = str(campaign.get("campaign_id") or "").strip()
+    if not campaign_id:
+        raise ValueError("evolution campaign id missing")
+    session_stage = str(campaign.get("session_stage") or "").strip()
+    if not session_stage:
+        raise ValueError("evolution session stage missing")
+    campaign_payload = dict(campaign)
+    prior_stage_text = (
+        _canonical_json(prior_handoff, max_chars=2_200) if prior_handoff else "null"
+    )
+    candidate_outcomes = list(reversed(campaign_payload.pop("candidate_outcomes", [])))
+    outcomes_text = _canonical_json(
+        {"order": "newest_first", "candidates": candidate_outcomes}, max_chars=4_000
+    )
+    title = f"job/{job_id}/evolution/{campaign_id}/{session_stage}"
+    agent_name = str(campaign_payload.pop("agent_name", "") or "")
+    if agent_name not in {
+        JOB_EVOLUTION_DESIGNER_AGENT_NAME,
+        JOB_EVOLUTION_WORKER_AGENT_NAME,
+    }:
+        agent_name = JOB_EVOLUTION_WORKER_AGENT_NAME
+    prompt = (
+        f"Run PAPER-ONLY evolution stage `{session_stage}`. Use the persisted "
+        "candidate outcomes and prior-stage handoff; do not reload the retired "
+        "session or its raw tool results. Perform exactly this next action, then "
+        "end the stage:\n"
+        f"{campaign_payload.get('next_action')}\n\n"
+        f"Prior stage handoff:\n{prior_stage_text}\n\n"
+        f"Persisted candidate outcomes:\n{outcomes_text}\n\n"
+        "Campaign control state:\n" + _canonical_json(campaign_payload, max_chars=3_500)
+    )
+    return {
+        "campaign_id": campaign_id,
+        "session_stage": session_stage,
+        "title": title,
+        "agent_name": agent_name,
+        "prompt": prompt,
+    }
+
+
 def _prompt_evolution_session(
     store: JobStore, job_id: str, campaign: dict[str, Any], *, source: str
 ) -> dict[str, Any] | None:
@@ -1965,7 +2017,6 @@ def _prompt_evolution_session(
     session_stage = str(campaign.get("session_stage") or "").strip()
     if not session_stage:
         return {"queued": False, "error": "evolution session stage missing"}
-    campaign_payload = dict(campaign)
     prior_handoff = _latest_evolution_stage_handoff(store, job_id, campaign_id)
     existing = store.read_json(job_id, EVOLUTION_SESSION_PATH, default={}) or {}
     existing_id = str(existing.get("session_id") or "")
@@ -2003,32 +2054,14 @@ def _prompt_evolution_session(
             }
         if existing_campaign == campaign_id:
             prior_handoff = retired.get("handoff") or prior_handoff
-    prior_stage_text = (
-        _canonical_json(prior_handoff, max_chars=2_200) if prior_handoff else "null"
+    rendered = build_evolution_stage_prompt(
+        job_id, campaign, prior_handoff=prior_handoff
     )
-    candidate_outcomes = list(reversed(campaign_payload.pop("candidate_outcomes", [])))
-    outcomes_text = _canonical_json(
-        {"order": "newest_first", "candidates": candidate_outcomes}, max_chars=4_000
-    )
+    title = rendered["title"]
+    agent_name = rendered["agent_name"]
+    prompt = rendered["prompt"]
     controller_session_id = os.environ.get("OPENCODE_SESSION_ID") or os.environ.get(
         "OPENCODE_SESSIONID"
-    )
-    title = f"job/{job_id}/evolution/{campaign_id}/{session_stage}"
-    agent_name = str(campaign_payload.pop("agent_name", "") or "")
-    if agent_name not in {
-        JOB_EVOLUTION_DESIGNER_AGENT_NAME,
-        JOB_EVOLUTION_WORKER_AGENT_NAME,
-    }:
-        agent_name = JOB_EVOLUTION_WORKER_AGENT_NAME
-    prompt = (
-        f"Run PAPER-ONLY evolution stage `{session_stage}`. Use the persisted "
-        "candidate outcomes and prior-stage handoff; do not reload the retired "
-        "session or its raw tool results. Perform exactly this next action, then "
-        "end the stage:\n"
-        f"{campaign_payload.get('next_action')}\n\n"
-        f"Prior stage handoff:\n{prior_stage_text}\n\n"
-        f"Persisted candidate outcomes:\n{outcomes_text}\n\n"
-        "Campaign control state:\n" + _canonical_json(campaign_payload, max_chars=3_500)
     )
     fingerprint = hashlib.sha256(prompt.encode()).hexdigest()
     created_at = utc_now_iso()

--- a/wayfinder_paths/tests/test_execution_timing_validation.py
+++ b/wayfinder_paths/tests/test_execution_timing_validation.py
@@ -516,6 +516,23 @@ def _build_full_frame_strategy(params: dict[str, Any]) -> Any:
     return types.SimpleNamespace(decide=decide)
 
 
+def _build_parameterized_strategy(params: dict[str, Any]) -> Any:
+    size = float(params.get("order_size") or 1.0)
+
+    def decide(ctx: Any) -> list[OrderIntent]:
+        return [
+            OrderIntent(
+                action="OPEN",
+                venue="hyperliquid",
+                symbol="SNX",
+                side="long",
+                size=size,
+            )
+        ]
+
+    return types.SimpleNamespace(decide=decide)
+
+
 _PROBE_SPEC = {
     "market_kind": "perp",
     "data_contract": {"bar_interval": "5m", "symbols": ["SNX"]},
@@ -551,6 +568,34 @@ def test_window_invariance_probe_reds_full_frame_recompute() -> None:
     assert result["window"] == 30
     assert result["bar"]  # the differing bar is named
     assert result["base_intents"] != result["wide_intents"]
+
+
+def test_parameter_behavior_probe_distinguishes_material_and_noop_knobs() -> None:
+    from wayfinder_paths.jobs.execution.primitives import CompletedBarsView
+    from wayfinder_paths.jobs.execution.validation import parameter_behavior_probe
+
+    bars = CompletedBarsView.from_rows(_bars(140))
+    changed = parameter_behavior_probe(
+        _build_parameterized_strategy,
+        bars,
+        _PROBE_SPEC,
+        {"warmup_bars": 30, "order_size": 1.0},
+        [{"order_size": 1.0}, {"order_size": 2.0}],
+    )
+    unchanged = parameter_behavior_probe(
+        _build_parameterized_strategy,
+        bars,
+        _PROBE_SPEC,
+        {"warmup_bars": 30, "order_size": 1.0},
+        [{"unused_knob": 0.0}, {"unused_knob": 1.0}],
+    )
+
+    assert changed["status"] == "changed"
+    assert changed["changed_params"] == {"order_size": 2.0}
+    assert changed["ticks_evaluated"] < 8 * 3
+    assert unchanged["status"] == "unchanged"
+    assert unchanged["bars_probed"] == 8
+    assert unchanged["ticks_evaluated"] == 8 * 3
 
 
 def test_window_invariance_check_reds_validation_with_hint(tmp_path: Path) -> None:

--- a/wayfinder_paths/tests/test_jobs_agent_metering.py
+++ b/wayfinder_paths/tests/test_jobs_agent_metering.py
@@ -70,6 +70,73 @@ def test_session_meter_includes_cache_tokens_and_tool_payload_bytes(tmp_path) ->
     assert totals["tool_calls"] == 1
     assert totals["tool_result_bytes"] == len(tool_data)
     assert totals["tool_result_bytes_by_tool"] == {"read": len(tool_data)}
+    assert totals["tool_output_bytes"] == 50
+    assert totals["tool_output_bytes_by_tool"] == {"read": 50}
+    assert totals["wall_seconds"] == 0.0
+
+
+def test_session_meter_splits_model_tool_and_other_wall_time(tmp_path) -> None:
+    session_db = tmp_path / "opencode.db"
+    connection = sqlite3.connect(session_db)
+    connection.executescript(
+        """
+        CREATE TABLE session (id TEXT PRIMARY KEY);
+        CREATE TABLE message (
+          id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT
+        );
+        CREATE TABLE part (
+          id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT,
+          time_created INTEGER, data TEXT
+        );
+        """
+    )
+    connection.execute("INSERT INTO session VALUES (?)", ("session-1",))
+    connection.execute(
+        "INSERT INTO message VALUES (?,?,?,?)",
+        (
+            "message-1",
+            "session-1",
+            1_000,
+            json.dumps(
+                {
+                    "role": "assistant",
+                    "time": {"created": 1_000, "completed": 2_750},
+                    "tokens": {},
+                }
+            ),
+        ),
+    )
+    connection.execute(
+        "INSERT INTO part VALUES (?,?,?,?,?)",
+        (
+            "tool-1",
+            "message-1",
+            "session-1",
+            2_250,
+            json.dumps(
+                {
+                    "type": "tool",
+                    "tool": "read",
+                    "state": {
+                        "output": "hello",
+                        "time": {"start": 2_250, "end": 2_750},
+                    },
+                }
+            ),
+        ),
+    )
+    connection.commit()
+    connection.close()
+
+    totals = meter_session_ids(["session-1"], session_db=session_db)
+
+    assert totals["wall_seconds"] == 1.75
+    # OpenCode assistant intervals contain their tool calls. The split removes
+    # that overlap rather than billing the same 500ms as both model and tool.
+    assert totals["model_seconds"] == 1.25
+    assert totals["tool_seconds"] == 0.5
+    assert totals["other_seconds"] == 0.0
+    assert totals["tool_output_bytes"] == 5
 
 
 def test_session_meter_does_not_count_unknown_session(tmp_path) -> None:

--- a/wayfinder_paths/tests/test_jobs_bench_ab.py
+++ b/wayfinder_paths/tests/test_jobs_bench_ab.py
@@ -111,6 +111,10 @@ def test_world_split_is_chronological_and_sealed(tmp_path: Path) -> None:
     manifest_text = (world_dir / "world.json").read_text(encoding="utf-8")
     assert str(sealed_dir) not in manifest_text
     assert not sealed_dir.is_relative_to(world_dir)
+    baseline = world["manifest"]["baseline"]
+    assert baseline["bars"] == 72
+    assert baseline["partition"] == "development"
+    assert baseline["sha256"]
 
 
 def test_world_truncates_features_and_installs_only_development_prefix(
@@ -165,6 +169,13 @@ def test_world_truncates_features_and_installs_only_development_prefix(
         )
     )
     assert len(installed_bars["bars"]) == 72
+    installed_baseline = json.loads(
+        (arm_store.job_dir(arm_job_id) / "results/backtest/baseline.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert installed_baseline["scope"]["partition"] == "development"
+    assert installed_baseline["scope"]["bars"] == 72
 
 
 def test_race_is_deterministic_and_does_not_mutate_bundles(tmp_path: Path) -> None:
@@ -371,6 +382,19 @@ def test_identity_allows_only_pre_registered_model_difference() -> None:
     assert not compare_identities(base, other, allowed={"model", "variant"})[
         "comparable"
     ]
+
+    preview = {
+        **base,
+        "arm_parameters": {"campaign": {"behavior_preview_enabled": True}},
+    }
+    control = {
+        **base,
+        "arm_parameters": {"campaign": {"behavior_preview_enabled": False}},
+    }
+    assert compare_identities(control, preview, allowed={"arm_parameters"})[
+        "comparable"
+    ]
+    assert not compare_identities(control, preview, allowed=set())["comparable"]
     other["data"] = base["data"]
     other["initial_prompt_sha256"] = "different-prompt"
     assert not compare_identities(base, other, allowed={"model", "variant"})[
@@ -585,3 +609,25 @@ def test_single_seed_pilot_is_directional_only() -> None:
     assert report["primary"]["pairs"] == 1
     assert report["pilot"] is True
     assert report["decision"] == "pilot_directional_only"
+
+
+def test_behavior_preview_is_an_allowed_pre_registered_arm_parameter() -> None:
+    config = {
+        "schema_version": "1.0",
+        "pilot": True,
+        "arms": [
+            {
+                "name": "control",
+                "campaign": {"behavior_preview_enabled": False},
+            },
+            {
+                "name": "preview",
+                "campaign": {"behavior_preview_enabled": True},
+            },
+        ],
+        "allowed_identity_differences": ["arm_parameters"],
+        "worlds": [{"world_dir": "w", "sealed_dir": "s"}],
+        "seeds": [1],
+    }
+
+    _validate_config(config)

--- a/wayfinder_paths/tests/test_jobs_bench_ab.py
+++ b/wayfinder_paths/tests/test_jobs_bench_ab.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import shutil
+import subprocess
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -10,6 +11,7 @@ import pytest
 import yaml
 
 from wayfinder_paths.jobs.bench.aggregate import aggregate_experiment
+from wayfinder_paths.jobs.bench.env import sandbox_relative
 from wayfinder_paths.jobs.bench.forward_replay import race_bundles, replay_probation
 from wayfinder_paths.jobs.bench.identity import (
     compare_identities,
@@ -17,11 +19,16 @@ from wayfinder_paths.jobs.bench.identity import (
 )
 from wayfinder_paths.jobs.bench.mcp_server import core_jobs as bench_core_jobs
 from wayfinder_paths.jobs.bench.runner import (
+    _arm_env,
     _assert_bench_root,
     _install_job,
+    _resolve_runtime_opencode_config,
+    _set_provider_base_url,
     _validate_config,
 )
 from wayfinder_paths.jobs.bench.world import load_world, prepare_world
+from wayfinder_paths.jobs.benchmarks.agent_adapter import install_agent_workspace
+from wayfinder_paths.jobs.evolution_campaign import _campaign_now
 from wayfinder_paths.jobs.execution import ExecutionSpec
 from wayfinder_paths.jobs.gating import compute_workspace_revision
 from wayfinder_paths.jobs.models import WayfinderJob
@@ -239,6 +246,32 @@ def test_world_and_tool_isolation_fail_closed(tmp_path: Path) -> None:
         _assert_bench_root(tmp_path / ".wayfinder/jobs/a-bench")
 
 
+def test_benchmark_design_validation_is_inline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: dict = {}
+
+    async def fake_core_jobs(action: str, **kwargs: object) -> dict:
+        seen.update({"action": action, **kwargs})
+        return {"ok": True, "result": {}}
+
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.bench.mcp_server._production_core_jobs",
+        fake_core_jobs,
+    )
+
+    asyncio.run(
+        bench_core_jobs(
+            "evolution_design",
+            job_id="bench-only",
+            campaign_design={"hypotheses": [], "slots": []},
+            background=True,
+        )
+    )
+
+    assert seen["background"] is False
+
+
 def test_compressed_replay_uses_real_burn_in_and_day14_endpoint(
     tmp_path: Path,
 ) -> None:
@@ -291,8 +324,35 @@ def test_campaign_prompt_formatter_is_the_production_formatter() -> None:
     rendered = build_evolution_stage_prompt("majors-5m-lab", campaign)
 
     assert rendered["agent_name"] == "wayfinder-evolution-designer"
+    assert rendered["artifact_key"] == "design"
+    assert rendered["work_order"]["lane"] == "evolution_design"
     assert "submit the design" in rendered["prompt"]
     assert '"candidate_id": "c01"' in rendered["prompt"]
+
+
+def test_campaign_repair_prompt_is_a_compact_artifact_work_order() -> None:
+    campaign = {
+        "campaign_id": "campaign-1",
+        "session_stage": "candidate-01",
+        "artifact_key": "candidate-01-attempt-02",
+        "next_action": "repair and evaluate candidate one",
+        "candidate_id": "c01",
+        "postmortem_path": ".wayfinder/jobs/demo/attempts/c01/a01/postmortem.json",
+        "work_inputs": [".wayfinder/jobs/demo/candidates/c01/candidate.json"],
+        "editable_paths": [".wayfinder/jobs/demo/candidates/c01"],
+        "candidate_outcomes": [{"candidate_id": "c01", "attempt_count": 1}],
+        "cases": [{"blob": "must-not-be-repeated"}],
+    }
+
+    rendered = build_evolution_stage_prompt("majors-5m-lab", campaign)
+
+    assert rendered["artifact_key"] == "candidate-01-attempt-02"
+    assert rendered["work_order"]["lane"] == "evolution_repair"
+    assert rendered["work_order"]["editable_paths"] == [
+        ".wayfinder/jobs/demo/candidates/c01"
+    ]
+    assert "postmortem.json" in rendered["prompt"]
+    assert "must-not-be-repeated" not in rendered["prompt"]
 
 
 def test_identity_allows_only_pre_registered_model_difference() -> None:
@@ -344,6 +404,105 @@ def test_flash_max_is_declared_as_model_plus_variant(tmp_path: Path) -> None:
     assert "deepseek-v4-flash" in loaded["provider"]["wayfinder"]["models"]
 
 
+def test_shell_runtime_config_is_copied_and_dev_endpoint_is_explicit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "sdk"
+    (repo / ".opencode/agents").mkdir(parents=True)
+    (repo / ".opencode/opencode.json").write_text(
+        json.dumps({"provider": {"wayfinder": {"models": {}}}}), encoding="utf-8"
+    )
+    (repo / "wayfinder_paths").mkdir()
+    runtime = tmp_path / "shell-opencode.json"
+    runtime.write_text(
+        json.dumps(
+            {
+                "provider": {
+                    "wayfinder": {
+                        "options": {"baseURL": "https://llm.wayfinder.ai/v1"},
+                        "models": {
+                            "deepseek-v4-pro": {},
+                            "deepseek-v4-flash": {},
+                        },
+                    }
+                },
+                "mcp": {"wayfinder": {"enabled": False}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("BENCH_RUNTIME_CONFIG", str(runtime))
+    resolved = _resolve_runtime_opencode_config(
+        {
+            "_config_dir": str(tmp_path),
+            "runtime_opencode_config": "{env:BENCH_RUNTIME_CONFIG}",
+        }
+    )
+    sandbox = tmp_path / "sandbox"
+
+    install_agent_workspace(
+        sandbox=sandbox,
+        repo_root=repo,
+        runtime_config=resolved,
+        mcp_url="http://127.0.0.1:4321/mcp",
+    )
+    installed = sandbox / ".opencode/opencode.json"
+    _set_provider_base_url(
+        installed,
+        provider="wayfinder",
+        base_url="https://llm-dev.wayfinder.ai/v1/",
+    )
+    loaded = json.loads(installed.read_text(encoding="utf-8"))
+
+    assert set(loaded["provider"]["wayfinder"]["models"]) == {
+        "deepseek-v4-pro",
+        "deepseek-v4-flash",
+    }
+    assert (
+        loaded["provider"]["wayfinder"]["options"]["baseURL"]
+        == "https://llm-dev.wayfinder.ai/v1"
+    )
+    assert loaded["mcp"]["wayfinder"]["url"] == "http://127.0.0.1:4321/mcp"
+    project_root = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=sandbox,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert Path(project_root).resolve() == sandbox.resolve()
+
+
+def test_arm_environment_isolates_user_home_and_clock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    virtual_now = datetime(2026, 8, 10, 15, 25, tzinfo=UTC)
+    env = _arm_env(tmp_path / "arm", virtual_now=virtual_now)
+
+    assert env["HOME"] == str(tmp_path / "arm/.bench-home")
+    assert Path(env["HOME"]).is_dir()
+    assert env["WAYFINDER_BENCHMARK_NOW"] == virtual_now.isoformat()
+    monkeypatch.setenv("WAYFINDER_BENCHMARK", "1")
+    monkeypatch.setenv("WAYFINDER_BENCHMARK_NOW", env["WAYFINDER_BENCHMARK_NOW"])
+    assert _campaign_now() == virtual_now
+
+
+def test_sandbox_paths_are_rendered_relative_for_production_permissions(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "arm"
+    absolute = root / ".wayfinder/jobs/bench/research/diagnostic_pack.json"
+
+    rendered = sandbox_relative(
+        {"next_action": f"Read `{absolute}`", "paths": [str(absolute)]}, root=root
+    )
+
+    assert rendered == {
+        "next_action": "Read `.wayfinder/jobs/bench/research/diagnostic_pack.json`",
+        "paths": [".wayfinder/jobs/bench/research/diagnostic_pack.json"],
+    }
+
+
 def test_budget_parity_is_explicit_and_four_seeds_are_required_by_config() -> None:
     config = {
         "schema_version": "1.0",
@@ -373,3 +532,34 @@ def test_budget_parity_is_explicit_and_four_seeds_are_required_by_config() -> No
     assert report["primary"]["pairs"] == 4
     assert report["cost_parity"]["matched"] is True
     assert report["decision"] == "a_wins"
+
+
+def test_single_seed_pilot_is_directional_only() -> None:
+    config = {
+        "schema_version": "1.0",
+        "pilot": True,
+        "arms": [{"name": "a"}, {"name": "b"}],
+        "worlds": [{"world_dir": "w", "sealed_dir": "s"}],
+        "seeds": [1],
+    }
+    _validate_config(config)
+    rows = [
+        {
+            "arm": arm,
+            "world_id": "world",
+            "seed": 1,
+            "holdout": {
+                "paired_daily_utility_delta": {"estimate": 0.02 if arm == "a" else 0.0}
+            },
+            "cost": {"tokens_in": 100, "tokens_out": 10},
+            "funnel": {},
+            "forward": {},
+        }
+        for arm in ("a", "b")
+    ]
+
+    report = aggregate_experiment(rows, arm_order=["a", "b"], pilot=True)
+
+    assert report["primary"]["pairs"] == 1
+    assert report["pilot"] is True
+    assert report["decision"] == "pilot_directional_only"

--- a/wayfinder_paths/tests/test_jobs_bench_ab.py
+++ b/wayfinder_paths/tests/test_jobs_bench_ab.py
@@ -291,11 +291,17 @@ def test_session_isolation_separates_denied_attempts_from_breaches(
     connection = sqlite3.connect(database)
     connection.execute("CREATE TABLE part (session_id TEXT, data TEXT)")
 
-    def tool_part(*, path: Path, status: str, error: str | None = None) -> str:
+    def tool_part(
+        *,
+        path: Path,
+        status: str,
+        error: str | None = None,
+        tool: str = "read",
+    ) -> str:
         return json.dumps(
             {
                 "type": "tool",
-                "tool": "read",
+                "tool": tool,
                 "state": {
                     "status": status,
                     "input": {"filePath": str(path)},
@@ -324,6 +330,15 @@ def test_session_isolation_separates_denied_attempts_from_breaches(
                 "session-breach",
                 tool_part(path=escaped_path, status="completed"),
             ),
+            (
+                "session-invalid-url",
+                tool_part(
+                    path=escaped_path,
+                    status="error",
+                    error="URL must start with http:// or https://",
+                    tool="webfetch",
+                ),
+            ),
         ],
     )
     connection.commit()
@@ -345,6 +360,23 @@ def test_session_isolation_separates_denied_attempts_from_breaches(
             "session_id": "session-denied",
             "tool": "read",
             "path": str(denied_path),
+        }
+    ]
+
+    invalid_url_result = _audit_session_isolation(
+        ["session-invalid-url"],
+        session_db=database,
+        sandbox=sandbox,
+        protected_roots=[],
+        missing_transcripts=[],
+    )
+    assert invalid_url_result["passed"] is True
+    assert invalid_url_result["breaches"] == []
+    assert invalid_url_result["denied_attempts"] == [
+        {
+            "type": "denied_network_or_shell_tool",
+            "session_id": "session-invalid-url",
+            "tool": "webfetch",
         }
     ]
 

--- a/wayfinder_paths/tests/test_jobs_bench_ab.py
+++ b/wayfinder_paths/tests/test_jobs_bench_ab.py
@@ -409,6 +409,20 @@ def test_shell_runtime_config_is_copied_and_dev_endpoint_is_explicit(
 ) -> None:
     repo = tmp_path / "sdk"
     (repo / ".opencode/agents").mkdir(parents=True)
+    relative_rule = '    ".wayfinder/jobs/**": allow\n'
+    (repo / ".opencode/agents/wayfinder-evolution-designer.md").write_text(
+        "read:\n" + relative_rule,
+        encoding="utf-8",
+    )
+    (repo / ".opencode/agents/wayfinder-evolution-worker.md").write_text(
+        "read:\n"
+        + relative_rule
+        + "write:\n"
+        + relative_rule
+        + "edit:\n"
+        + relative_rule,
+        encoding="utf-8",
+    )
     (repo / ".opencode/opencode.json").write_text(
         json.dumps({"provider": {"wayfinder": {"models": {}}}}), encoding="utf-8"
     )
@@ -463,6 +477,14 @@ def test_shell_runtime_config_is_copied_and_dev_endpoint_is_explicit(
         == "https://llm-dev.wayfinder.ai/v1"
     )
     assert loaded["mcp"]["wayfinder"]["url"] == "http://127.0.0.1:4321/mcp"
+    normalized_rule = '    "**/.wayfinder/jobs/**": allow\n'
+    installed_agents = sandbox / ".opencode/agents"
+    assert (installed_agents / "wayfinder-evolution-designer.md").read_text().count(
+        normalized_rule
+    ) == 1
+    assert (installed_agents / "wayfinder-evolution-worker.md").read_text().count(
+        normalized_rule
+    ) == 3
     project_root = subprocess.run(
         ["git", "rev-parse", "--show-toplevel"],
         cwd=sandbox,

--- a/wayfinder_paths/tests/test_jobs_bench_ab.py
+++ b/wayfinder_paths/tests/test_jobs_bench_ab.py
@@ -31,6 +31,7 @@ from wayfinder_paths.jobs.bench.runner import (
 )
 from wayfinder_paths.jobs.bench.world import load_world, prepare_world
 from wayfinder_paths.jobs.benchmarks.agent_adapter import install_agent_workspace
+from wayfinder_paths.jobs.bundles import resolve_bundle_script_entrypoint
 from wayfinder_paths.jobs.evolution_campaign import _campaign_now
 from wayfinder_paths.jobs.execution import ExecutionSpec
 from wayfinder_paths.jobs.gating import compute_workspace_revision
@@ -118,6 +119,24 @@ def test_world_split_is_chronological_and_sealed(tmp_path: Path) -> None:
     assert baseline["bars"] == 72
     assert baseline["partition"] == "development"
     assert baseline["sha256"]
+
+
+def test_bundle_entrypoint_rebinds_repo_relative_live_job_path(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    expected = bundle / "workspace/src/strategy.py"
+
+    resolved = resolve_bundle_script_entrypoint(
+        bundle,
+        {
+            "script_loop": {
+                "entrypoint": (
+                    ".wayfinder/jobs/majors-5m-lab/workspace/src/strategy.py"
+                )
+            }
+        },
+    )
+
+    assert resolved == expected
 
 
 def test_world_truncates_features_and_installs_only_development_prefix(

--- a/wayfinder_paths/tests/test_jobs_bench_ab.py
+++ b/wayfinder_paths/tests/test_jobs_bench_ab.py
@@ -19,6 +19,7 @@ from wayfinder_paths.jobs.bench.forward_replay import race_bundles, replay_proba
 from wayfinder_paths.jobs.bench.identity import (
     compare_identities,
     ensure_model_declared,
+    runtime_identity,
 )
 from wayfinder_paths.jobs.bench.mcp_server import core_jobs as bench_core_jobs
 from wayfinder_paths.jobs.bench.runner import (
@@ -543,6 +544,32 @@ def test_identity_allows_only_pre_registered_model_difference() -> None:
     assert not compare_identities(base, other, allowed={"model", "variant"})[
         "comparable"
     ]
+
+
+def test_runtime_identity_uses_the_frozen_sdk_ref(tmp_path: Path) -> None:
+    agents = tmp_path / ".opencode" / "agents"
+    agents.mkdir(parents=True)
+    (agents / "worker.md").write_text("---\ntemperature: 0.1\n---\n", encoding="utf-8")
+    (tmp_path / ".opencode" / "opencode.json").write_text("{}\n", encoding="utf-8")
+
+    identity = runtime_identity(
+        sdk_ref="registered-before-run",
+        sandbox=tmp_path,
+        model="wayfinder/model",
+        variant=None,
+        repeat_seed=101,
+        world_manifest={
+            "world_id": "world",
+            "dataset": {},
+            "source_revision": "source",
+        },
+        prompt_hashes=[],
+        declared_differences=["model"],
+        arm_parameters={},
+        opencode=Path("/usr/bin/true"),
+    )
+
+    assert identity["sdk_ref"] == "registered-before-run"
 
 
 def test_flash_max_is_declared_as_model_plus_variant(tmp_path: Path) -> None:

--- a/wayfinder_paths/tests/test_jobs_bench_ab.py
+++ b/wayfinder_paths/tests/test_jobs_bench_ab.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+import yaml
+
+from wayfinder_paths.jobs.bench.aggregate import aggregate_experiment
+from wayfinder_paths.jobs.bench.forward_replay import race_bundles, replay_probation
+from wayfinder_paths.jobs.bench.identity import (
+    compare_identities,
+    ensure_model_declared,
+)
+from wayfinder_paths.jobs.bench.mcp_server import core_jobs as bench_core_jobs
+from wayfinder_paths.jobs.bench.runner import (
+    _assert_bench_root,
+    _install_job,
+    _validate_config,
+)
+from wayfinder_paths.jobs.bench.world import load_world, prepare_world
+from wayfinder_paths.jobs.execution import ExecutionSpec
+from wayfinder_paths.jobs.gating import compute_workspace_revision
+from wayfinder_paths.jobs.models import WayfinderJob
+from wayfinder_paths.jobs.probation import stage_evolution_probation
+from wayfinder_paths.jobs.store import JobStore
+from wayfinder_paths.jobs.worker import build_evolution_stage_prompt
+
+
+def _bars(count: int = 456) -> list[dict]:
+    start = datetime(2026, 1, 1, tzinfo=UTC)
+    return [
+        {
+            "timestamp": (start + timedelta(hours=index)).isoformat(),
+            "symbol": "IMX",
+            "open": 10.0 + index * 0.01,
+            "high": 10.1 + index * 0.01,
+            "low": 9.9 + index * 0.01,
+            "close": 10.0 + index * 0.01,
+            "volume": 100.0,
+        }
+        for index in range(count)
+    ]
+
+
+def _job(tmp_path: Path) -> tuple[JobStore, str, list[dict]]:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new(
+        "majors-5m-lab",
+        name="Majors lab",
+        script="workspace/src/strategy.py",
+        agent_mode="intervene",
+        execution_contract="jobs_v1",
+        interval_seconds=3600,
+    )
+    spec = ExecutionSpec()
+    spec.data_contract.update({"bar_interval": "1h", "symbols": ["IMX"]})
+    job.execution_spec = spec.to_dict()
+    job.execution_params = {
+        "symbols": ["IMX"],
+        "initial_capital": 10_000.0,
+        "warmup_bars": 20,
+    }
+    store.save(job)
+    root = store.job_dir(job.id)
+    (root / "workspace/src/strategy.py").write_text(
+        "def decide(ctx):\n    return []\n", encoding="utf-8"
+    )
+    rows = _bars()
+    (root / "results/backtest/input_bars.json").write_text(
+        json.dumps({"metadata": {"days": 19}, "bars": rows}), encoding="utf-8"
+    )
+    return store, job.id, rows
+
+
+def _world(tmp_path: Path) -> tuple[JobStore, str, Path, Path, list[dict]]:
+    store, job_id, rows = _job(tmp_path / "source")
+    cutoff = datetime(2026, 1, 3, 23, tzinfo=UTC)
+    end = datetime(2026, 1, 19, 23, tzinfo=UTC)
+    world_dir = tmp_path / "world"
+    sealed_dir = tmp_path / "owner-sealed"
+    prepare_world(
+        store.job_dir(job_id),
+        world_dir,
+        generation_cutoff=cutoff,
+        holdout_end=end,
+        sealed_dir=sealed_dir,
+        world_id="majors-losing",
+    )
+    return store, job_id, world_dir, sealed_dir, rows
+
+
+def test_world_split_is_chronological_and_sealed(tmp_path: Path) -> None:
+    _, _, world_dir, sealed_dir, _ = _world(tmp_path)
+
+    world = load_world(world_dir, sealed_dir)
+
+    assert world["manifest"]["development_bars"] == 72
+    assert world["manifest"]["holdout_bars"] == 384
+    assert "holdout" not in (world_dir / "bars.json").read_text(encoding="utf-8")
+    manifest_text = (world_dir / "world.json").read_text(encoding="utf-8")
+    assert str(sealed_dir) not in manifest_text
+    assert not sealed_dir.is_relative_to(world_dir)
+
+
+def test_world_truncates_features_and_installs_only_development_prefix(
+    tmp_path: Path,
+) -> None:
+    store, job_id, rows = _job(tmp_path / "source")
+    root = store.job_dir(job_id)
+    job_yaml = yaml.safe_load((root / "job.yaml").read_text(encoding="utf-8"))
+    job_yaml["execution_spec"]["data_contract"]["features"] = [
+        {"name": "breadth", "path": "state/features.jsonl"}
+    ]
+    (root / "job.yaml").write_text(
+        yaml.safe_dump(job_yaml, sort_keys=False), encoding="utf-8"
+    )
+    feature_path = root / "state/features.jsonl"
+    feature_path.parent.mkdir(parents=True, exist_ok=True)
+    feature_path.write_text(
+        "".join(
+            json.dumps(
+                {
+                    "timestamp": row["timestamp"],
+                    "name": "breadth",
+                    "value": index,
+                    "symbol": None,
+                }
+            )
+            + "\n"
+            for index, row in enumerate(rows)
+        ),
+        encoding="utf-8",
+    )
+    world_dir = tmp_path / "world"
+    sealed_dir = tmp_path / "sealed"
+    prepare_world(
+        root,
+        world_dir,
+        generation_cutoff=datetime(2026, 1, 3, 23, tzinfo=UTC),
+        holdout_end=datetime(2026, 1, 19, 23, tzinfo=UTC),
+        sealed_dir=sealed_dir,
+    )
+
+    manifest = load_world(world_dir, sealed_dir)["manifest"]
+    assert manifest["features"][0]["rows"] == 72
+    arm_store, arm_job_id = _install_job(
+        tmp_path / "arm", world_dir=world_dir, policy={}
+    )
+    installed = arm_store.job_dir(arm_job_id) / "state/features.jsonl"
+    assert len(installed.read_text(encoding="utf-8").splitlines()) == 72
+    installed_bars = json.loads(
+        (arm_store.job_dir(arm_job_id) / "results/backtest/input_bars.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert len(installed_bars["bars"]) == 72
+
+
+def test_race_is_deterministic_and_does_not_mutate_bundles(tmp_path: Path) -> None:
+    _, _, world_dir, sealed_dir, _ = _world(tmp_path)
+    a = world_dir / "incumbent"
+    b = tmp_path / "bundle-b"
+    shutil.copytree(a, b)
+    revisions = (compute_workspace_revision(a), compute_workspace_revision(b))
+
+    output = tmp_path / "race"
+    first = race_bundles(
+        a,
+        b,
+        world_dir=world_dir,
+        sealed_dir=sealed_dir,
+        output_dir=output,
+    )
+    second = race_bundles(a, b, world_dir=world_dir, sealed_dir=sealed_dir)
+
+    assert first["verdict"] == "invalid"
+    assert first["paired_daily_utility_delta"] == second["paired_daily_utility_delta"]
+    assert revisions == (
+        compute_workspace_revision(a),
+        compute_workspace_revision(b),
+    )
+    assert (output / "results/a/trades.json").exists()
+    assert (output / "results/b/equity.json").exists()
+    assert (output / "results/compare.json").exists()
+
+
+def test_bench_job_is_forced_to_paper_without_wallet(tmp_path: Path) -> None:
+    store, job_id, _ = _job(tmp_path / "source")
+    source = store.job_dir(job_id)
+    job_yaml = yaml.safe_load((source / "job.yaml").read_text(encoding="utf-8"))
+    job_yaml["script_loop"]["mode"] = "live"
+    job_yaml["execution_params"]["wallet_label"] = "must-not-survive"
+    (source / "job.yaml").write_text(
+        yaml.safe_dump(job_yaml, sort_keys=False), encoding="utf-8"
+    )
+    world_dir = tmp_path / "world"
+    sealed_dir = tmp_path / "sealed"
+    prepare_world(
+        source,
+        world_dir,
+        generation_cutoff=datetime(2026, 1, 3, 23, tzinfo=UTC),
+        holdout_end=datetime(2026, 1, 19, 23, tzinfo=UTC),
+        sealed_dir=sealed_dir,
+    )
+
+    arm_store, arm_job_id = _install_job(
+        tmp_path / "arm", world_dir=world_dir, policy={}
+    )
+    installed = yaml.safe_load(
+        (arm_store.job_dir(arm_job_id) / "job.yaml").read_text(encoding="utf-8")
+    )
+
+    assert installed["script_loop"]["mode"] == "paper"
+    assert "wallet_label" not in installed["execution_params"]
+
+
+def test_world_and_tool_isolation_fail_closed(tmp_path: Path) -> None:
+    store, job_id, _ = _job(tmp_path / "source")
+    world_dir = tmp_path / "world"
+    with pytest.raises(ValueError, match="physically outside"):
+        prepare_world(
+            store.job_dir(job_id),
+            world_dir,
+            generation_cutoff=datetime(2026, 1, 3, 23, tzinfo=UTC),
+            holdout_end=datetime(2026, 1, 19, 23, tzinfo=UTC),
+            sealed_dir=world_dir / "sealed",
+        )
+    with pytest.raises(ValueError, match="unavailable in benchmark mode"):
+        asyncio.run(
+            bench_core_jobs(  # type: ignore[arg-type]
+                "fetch_dataset", job_id="bench-only"
+            )
+        )
+    with pytest.raises(ValueError, match="cannot live inside"):
+        _assert_bench_root(tmp_path / ".wayfinder/jobs/a-bench")
+
+
+def test_compressed_replay_uses_real_burn_in_and_day14_endpoint(
+    tmp_path: Path,
+) -> None:
+    store, job_id, world_dir, sealed_dir, _ = _world(tmp_path)
+    root = store.job_dir(job_id)
+    candidate = root / "research/candidates/candidate-1"
+    candidate.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(world_dir / "incumbent", candidate)
+    (candidate / "workspace/src/strategy.py").write_text(
+        "# candidate\ndef decide(ctx):\n    return []\n", encoding="utf-8"
+    )
+    cutoff = datetime.fromisoformat(
+        load_world(world_dir, sealed_dir)["manifest"]["generation_cutoff"]
+    )
+    stage_evolution_probation(
+        store,
+        job_id,
+        candidate_id="candidate-1",
+        candidate_root=candidate,
+        revision=compute_workspace_revision(candidate),
+        source="evolution_campaign",
+        family="test-family",
+        now=cutoff,
+    )
+    world = load_world(world_dir, sealed_dir)
+
+    result = replay_probation(
+        store,
+        job_id,
+        development_rows=world["development"]["bars"],
+        holdout_rows=world["holdout"]["bars"],
+        generation_cutoff=cutoff,
+    )
+
+    assert result["burn_in"]["status"] == "passed"
+    assert result["status"] == "inconclusive"
+    assert result["forward"]["max_paired_days"] == 14
+    assert (root / "results/forward/probation").exists()
+
+
+def test_campaign_prompt_formatter_is_the_production_formatter() -> None:
+    campaign = {
+        "campaign_id": "campaign-1",
+        "session_stage": "design",
+        "agent_name": "wayfinder-evolution-designer",
+        "next_action": "submit the design",
+        "candidate_outcomes": [{"candidate_id": "c01"}],
+    }
+
+    rendered = build_evolution_stage_prompt("majors-5m-lab", campaign)
+
+    assert rendered["agent_name"] == "wayfinder-evolution-designer"
+    assert "submit the design" in rendered["prompt"]
+    assert '"candidate_id": "c01"' in rendered["prompt"]
+
+
+def test_identity_allows_only_pre_registered_model_difference() -> None:
+    base = {
+        "sdk_ref": "abc",
+        "model": "pro",
+        "variant": None,
+        "agent_hashes": {"worker": "same"},
+        "data": {"sha": "same"},
+        "initial_prompt_sha256": "same-prompt",
+    }
+    other = {**base, "model": "flash", "variant": "max"}
+
+    assert compare_identities(base, other, allowed={"model", "variant"})["comparable"]
+    other["data"] = {"sha": "different"}
+    assert not compare_identities(base, other, allowed={"model", "variant"})[
+        "comparable"
+    ]
+    other["data"] = base["data"]
+    other["initial_prompt_sha256"] = "different-prompt"
+    assert not compare_identities(base, other, allowed={"model", "variant"})[
+        "comparable"
+    ]
+
+
+def test_flash_max_is_declared_as_model_plus_variant(tmp_path: Path) -> None:
+    config = tmp_path / "opencode.json"
+    config.write_text(
+        json.dumps(
+            {
+                "provider": {
+                    "wayfinder": {
+                        "models": {
+                            "deepseek-v4-pro": {
+                                "name": "DeepSeek V4 Pro",
+                                "limit": {"context": 128000, "output": 28000},
+                            }
+                        }
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert ensure_model_declared(config, "wayfinder/deepseek-v4-flash") is True
+    assert ensure_model_declared(config, "wayfinder/deepseek-v4-flash") is False
+    loaded = json.loads(config.read_text(encoding="utf-8"))
+    assert "deepseek-v4-flash" in loaded["provider"]["wayfinder"]["models"]
+
+
+def test_budget_parity_is_explicit_and_four_seeds_are_required_by_config() -> None:
+    config = {
+        "schema_version": "1.0",
+        "arms": [{"name": "a"}, {"name": "b"}],
+        "worlds": [{"world_dir": "w", "sealed_dir": "s"}],
+        "seeds": [1, 2, 3, 4],
+    }
+    _validate_config(config)
+    rows = [
+        {
+            "arm": arm,
+            "world_id": "world",
+            "seed": seed,
+            "holdout": {
+                "paired_daily_utility_delta": {"estimate": 0.02 if arm == "a" else 0.0}
+            },
+            "cost": {"tokens_in": 100, "tokens_out": 10},
+            "funnel": {},
+            "forward": {},
+        }
+        for seed in config["seeds"]
+        for arm in ("a", "b")
+    ]
+
+    report = aggregate_experiment(rows, arm_order=["a", "b"])
+
+    assert report["primary"]["pairs"] == 4
+    assert report["cost_parity"]["matched"] is True
+    assert report["decision"] == "a_wins"

--- a/wayfinder_paths/tests/test_jobs_bench_ab.py
+++ b/wayfinder_paths/tests/test_jobs_bench_ab.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import shutil
+import sqlite3
 import subprocess
 import threading
 import time
@@ -23,6 +24,7 @@ from wayfinder_paths.jobs.bench.mcp_server import core_jobs as bench_core_jobs
 from wayfinder_paths.jobs.bench.runner import (
     _arm_env,
     _assert_bench_root,
+    _audit_session_isolation,
     _install_job,
     _resolve_runtime_opencode_config,
     _scorecard,
@@ -278,6 +280,92 @@ def test_world_and_tool_isolation_fail_closed(tmp_path: Path) -> None:
         )
     with pytest.raises(ValueError, match="cannot live inside"):
         _assert_bench_root(tmp_path / ".wayfinder/jobs/a-bench")
+
+
+def test_session_isolation_separates_denied_attempts_from_breaches(
+    tmp_path: Path,
+) -> None:
+    sandbox = tmp_path / "arm"
+    sandbox.mkdir()
+    database = tmp_path / "opencode.db"
+    connection = sqlite3.connect(database)
+    connection.execute("CREATE TABLE part (session_id TEXT, data TEXT)")
+
+    def tool_part(*, path: Path, status: str, error: str | None = None) -> str:
+        return json.dumps(
+            {
+                "type": "tool",
+                "tool": "read",
+                "state": {
+                    "status": status,
+                    "input": {"filePath": str(path)},
+                    "error": error,
+                },
+            }
+        )
+
+    denied_path = tmp_path / "denied" / "future.json"
+    escaped_path = tmp_path / "escaped" / "future.json"
+    connection.executemany(
+        "INSERT INTO part(session_id, data) VALUES (?, ?)",
+        [
+            (
+                "session-denied",
+                tool_part(
+                    path=denied_path,
+                    status="error",
+                    error=(
+                        "The user has specified a rule which prevents you from "
+                        "using this specific tool call."
+                    ),
+                ),
+            ),
+            (
+                "session-breach",
+                tool_part(path=escaped_path, status="completed"),
+            ),
+        ],
+    )
+    connection.commit()
+    connection.close()
+
+    denied_result = _audit_session_isolation(
+        ["session-denied"],
+        session_db=database,
+        sandbox=sandbox,
+        protected_roots=[],
+        missing_transcripts=[],
+    )
+
+    assert denied_result["passed"] is True
+    assert denied_result["breaches"] == []
+    assert denied_result["denied_attempts"] == [
+        {
+            "type": "denied_filesystem_escape",
+            "session_id": "session-denied",
+            "tool": "read",
+            "path": str(denied_path),
+        }
+    ]
+
+    result = _audit_session_isolation(
+        ["session-breach"],
+        session_db=database,
+        sandbox=sandbox,
+        protected_roots=[],
+        missing_transcripts=[],
+    )
+
+    assert result["passed"] is False
+    assert result["breaches"] == [
+        {
+            "type": "filesystem_escape",
+            "session_id": "session-breach",
+            "tool": "read",
+            "path": str(escaped_path),
+        }
+    ]
+    assert result["denied_attempts"] == []
 
 
 def test_benchmark_design_validation_is_inline(
@@ -591,6 +679,9 @@ def test_budget_parity_is_explicit_and_four_seeds_are_required_by_config() -> No
             "cost": {"tokens_in": 100, "tokens_out": 10},
             "funnel": {},
             "forward": {},
+            "isolation": {
+                "denied_attempts": ([{"type": "denied"}] if arm == "a" else [])
+            },
         }
         for seed in config["seeds"]
         for arm in ("a", "b")
@@ -601,6 +692,8 @@ def test_budget_parity_is_explicit_and_four_seeds_are_required_by_config() -> No
     assert report["primary"]["pairs"] == 4
     assert report["cost_parity"]["matched"] is True
     assert report["decision"] == "a_wins"
+    assert report["by_arm"]["a"]["process"]["policy_denied_attempts"] == 4
+    assert report["by_arm"]["b"]["process"]["policy_denied_attempts"] == 0
 
 
 def test_single_seed_pilot_is_directional_only() -> None:

--- a/wayfinder_paths/tests/test_jobs_bench_ab.py
+++ b/wayfinder_paths/tests/test_jobs_bench_ab.py
@@ -25,6 +25,7 @@ from wayfinder_paths.jobs.bench.runner import (
     _assert_bench_root,
     _install_job,
     _resolve_runtime_opencode_config,
+    _scorecard,
     _set_provider_base_url,
     _validate_config,
     run_experiment,
@@ -659,6 +660,40 @@ def test_behavior_preview_is_an_allowed_pre_registered_arm_parameter() -> None:
     config["max_parallel_arms"] = 9
     with pytest.raises(ValueError, match="max_parallel_arms"):
         _validate_config(config)
+
+
+def test_scorecard_counts_preview_ticks_and_avoided_quick_simulation() -> None:
+    scorecard = _scorecard(
+        state={
+            "counts": {},
+            "candidates": [
+                {
+                    "attempts": [
+                        {
+                            "postmortem": {"behavior_diff": {"material_change": False}},
+                            "outcome": {
+                                "quick_simulation_ran": False,
+                                "behavior_preview": {
+                                    "status": "unchanged",
+                                    "ticks_evaluated": 24,
+                                },
+                            },
+                        }
+                    ]
+                }
+            ],
+        },
+        funnel={},
+        forward={},
+        holdout={},
+        sessions=[],
+        cost={},
+    )
+
+    assert scorecard["process"]["behavior_unchanged_attempts"] == 1
+    assert scorecard["process"]["quick_simulations"] == 0
+    assert scorecard["process"]["behavior_preview_rejections"] == 1
+    assert scorecard["process"]["behavior_preview_ticks"] == 24
 
 
 def test_experiment_runs_isolated_arms_concurrently_and_preserves_order(

--- a/wayfinder_paths/tests/test_jobs_bench_ab.py
+++ b/wayfinder_paths/tests/test_jobs_bench_ab.py
@@ -4,6 +4,8 @@ import asyncio
 import json
 import shutil
 import subprocess
+import threading
+import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -25,6 +27,7 @@ from wayfinder_paths.jobs.bench.runner import (
     _resolve_runtime_opencode_config,
     _set_provider_base_url,
     _validate_config,
+    run_experiment,
 )
 from wayfinder_paths.jobs.bench.world import load_world, prepare_world
 from wayfinder_paths.jobs.benchmarks.agent_adapter import install_agent_workspace
@@ -631,3 +634,72 @@ def test_behavior_preview_is_an_allowed_pre_registered_arm_parameter() -> None:
     }
 
     _validate_config(config)
+
+    config["max_parallel_arms"] = 4
+    _validate_config(config)
+    config["max_parallel_arms"] = 9
+    with pytest.raises(ValueError, match="max_parallel_arms"):
+        _validate_config(config)
+
+
+def test_experiment_runs_isolated_arms_concurrently_and_preserves_order(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import wayfinder_paths.jobs.bench.runner as runner_module
+
+    output = tmp_path / "experiment"
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "pilot": True,
+                "output_dir": str(output),
+                "arms": [{"name": "a"}, {"name": "b"}],
+                "worlds": [{"world_dir": "world", "sealed_dir": "sealed"}],
+                "seeds": [1, 2],
+                "max_parallel_arms": 2,
+            }
+        ),
+        encoding="utf-8",
+    )
+    guard = threading.Lock()
+    active = 0
+    peak = 0
+
+    def fake_arm(*, arm, seed, **kwargs):
+        nonlocal active, peak
+        with guard:
+            active += 1
+            peak = max(peak, active)
+        time.sleep(0.03 if arm["name"] == "a" else 0.01)
+        with guard:
+            active -= 1
+        name = str(arm["name"])
+        return {
+            "run_id": f"world-{seed}-{name}",
+            "world_id": "world",
+            "seed": seed,
+            "arm": name,
+            "identity": {"same": True},
+            "invalid_reason": None,
+            "holdout": {
+                "paired_daily_utility_delta": {"estimate": 0.01 if name == "a" else 0}
+            },
+            "cost": {"tokens_in": 10, "tokens_out": 1},
+        }
+
+    monkeypatch.setattr(runner_module, "_runtime_pins", lambda *args: {})
+    monkeypatch.setattr(runner_module, "_run_arm_in_declared_sdk", fake_arm)
+
+    result = run_experiment(config_path)
+
+    assert peak == 2
+    assert result["pilot"] is True
+    assert result["primary"]["pairs"] == 2
+    assert sorted(path.name for path in (output / "runs").glob("*.json")) == [
+        "world-1-a.json",
+        "world-1-b.json",
+        "world-2-a.json",
+        "world-2-b.json",
+    ]

--- a/wayfinder_paths/tests/test_jobs_coverage.py
+++ b/wayfinder_paths/tests/test_jobs_coverage.py
@@ -654,6 +654,34 @@ def test_process_efficiency_classifies_learning_activity_and_waste(
     assert build_evolution_report(store, job_id)["process_efficiency"] == efficiency
     assert evolution_snapshot_block(store, job_id)["process_efficiency"] == efficiency
 
+    store.append_journal(
+        job_id,
+        {
+            "type": "evolution_session_retired",
+            "metrics": {
+                "wall_seconds": 12.0,
+                "model_seconds": 8.0,
+                "tool_seconds": 3.0,
+                "other_seconds": 1.0,
+                "tool_calls": 4,
+                "tool_output_bytes": 512,
+            },
+            "behavior_changed": True,
+        },
+    )
+    evolution_efficiency = build_process_efficiency(store, job_id)["evolution_agent"]
+    assert evolution_efficiency == {
+        "sessions": 1,
+        "wall_seconds": 12.0,
+        "model_seconds": 8.0,
+        "tool_seconds": 3.0,
+        "other_seconds": 1.0,
+        "tool_calls": 4,
+        "tool_output_bytes": 512,
+        "behavior_changed_attempts": 1,
+        "behavior_unchanged_attempts": 0,
+    }
+
     from click.testing import CliRunner
 
     import wayfinder_paths.jobs.cli as cli_module

--- a/wayfinder_paths/tests/test_jobs_evolution_campaign.py
+++ b/wayfinder_paths/tests/test_jobs_evolution_campaign.py
@@ -2920,6 +2920,7 @@ def test_behavior_preview_rejects_noop_parameter_before_simulation(
     result = evaluate_candidate(store, job_id, parameter["candidate_id"])
 
     assert result["status"] == "low_fidelity_rejected", json.dumps(result, indent=2)
+    assert result["quick_simulation_ran"] is False
     assert result["behavior_preview"]["status"] == "unchanged"
     assert result["postmortem"]["primary_failure"] == "no_behavior_change"
     assert result["postmortem"]["behavior_diff"]["material_change"] is False

--- a/wayfinder_paths/tests/test_jobs_evolution_campaign.py
+++ b/wayfinder_paths/tests/test_jobs_evolution_campaign.py
@@ -2887,6 +2887,44 @@ def test_evaluate_rejects_oversized_candidate_search_space(tmp_path) -> None:
     assert "three-dimension evolution budget" in json.dumps(result["evidence"])
 
 
+def test_behavior_preview_rejects_noop_parameter_before_simulation(
+    tmp_path, monkeypatch
+) -> None:
+    import wayfinder_paths.jobs.evolution_campaign as campaign_module
+
+    store, job_id = _evaluatable_job(tmp_path, source_params={"warmup_bars": 20})
+    improver = store.job_dir(job_id) / "improver.yaml"
+    policy = yaml.safe_load(improver.read_text(encoding="utf-8"))
+    policy["evolution"]["behavior_preview_enabled"] = True
+    improver.write_text(yaml.safe_dump(policy), encoding="utf-8")
+    started = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    start_campaign(store, job_id, now=started)
+    parameter = _prepare_campaign_candidates(store, job_id, started)[-1]
+    assert parameter["mutation_kind"] == "parameter"
+    bundle = store.job_dir(job_id) / parameter["bundle"]
+    job_yaml = yaml.safe_load((bundle / "job.yaml").read_text(encoding="utf-8"))
+    job_yaml["execution_params"]["warmup_bars"] = 20
+    (bundle / "job.yaml").write_text(
+        yaml.safe_dump(job_yaml, sort_keys=False), encoding="utf-8"
+    )
+    (bundle / "search_space.json").write_text(
+        json.dumps({"unused_knob": {"type": "int", "low": 1, "high": 2}}),
+        encoding="utf-8",
+    )
+
+    def simulation_must_not_run(*args, **kwargs):
+        raise AssertionError("full quick simulation ran before behavior preview")
+
+    monkeypatch.setattr(campaign_module, "simulate_execution", simulation_must_not_run)
+
+    result = evaluate_candidate(store, job_id, parameter["candidate_id"])
+
+    assert result["status"] == "low_fidelity_rejected", json.dumps(result, indent=2)
+    assert result["behavior_preview"]["status"] == "unchanged"
+    assert result["postmortem"]["primary_failure"] == "no_behavior_change"
+    assert result["postmortem"]["behavior_diff"]["material_change"] is False
+
+
 def test_evaluate_releases_claim_when_compute_is_transiently_busy(
     tmp_path, monkeypatch
 ) -> None:

--- a/wayfinder_paths/tests/test_jobs_evolution_campaign.py
+++ b/wayfinder_paths/tests/test_jobs_evolution_campaign.py
@@ -250,6 +250,11 @@ def test_investigative_campaign_requires_and_freezes_one_design_turn(tmp_path) -
     assert state["stage"] == "design"
     prompt = campaign_prompt_block(store, job_id, now=started + timedelta(minutes=1))
     assert prompt and prompt["agent_name"] == "wayfinder-evolution-designer"
+    assert prompt["artifact_key"] == "design"
+    assert "/baseline/reason" in prompt["valid_evidence_pointers"]
+    assert (
+        "/research_context/validated_positives" not in prompt["valid_evidence_pointers"]
+    )
     assert prompt["constraints"]["idea_slots"] == 8
     assert prompt["constraints"]["wildcards"] == 2
     with pytest.raises(ValueError, match="design must be accepted"):
@@ -345,6 +350,13 @@ def test_investigative_attempts_repair_failures_but_close_viable_ideas(
     store.write_json(job_id, "state/evolution_campaign.json", state)
     assert candidate["status"] == "repair_pending"
     assert state["counts"]["quick_evaluated"] == 0
+    repair_prompt = campaign_prompt_block(
+        store, job_id, now=started + timedelta(minutes=2)
+    )
+    assert repair_prompt and repair_prompt["artifact_key"] == (
+        "candidate-01-attempt-02"
+    )
+    assert repair_prompt["postmortem_path"].endswith("a01/postmortem.json")
 
     script.write_text(script.read_text() + "\nATTEMPT_2 = True\n")
     _commit_designed_attempt(
@@ -2101,6 +2113,103 @@ def test_parentless_evolution_nudges_reuse_persisted_campaign_session(
     assert client.prompts == ["session-1", "session-1"]
 
 
+def test_evolution_repair_rotates_to_a_fresh_attempt_session(
+    tmp_path, monkeypatch
+) -> None:
+    store, job_id = _job(tmp_path, "majors-5m-lab")
+    store.write_json(
+        job_id,
+        "state/evolution_campaign.json",
+        {
+            "campaign_id": "campaign-1",
+            "status": "active",
+            "candidates": [
+                {
+                    "slot": 1,
+                    "attempts": [
+                        {"postmortem": {"behavior_diff": {"material_change": True}}}
+                    ],
+                }
+            ],
+        },
+    )
+    store.write_json(
+        job_id,
+        "reports/evolution/session.json",
+        {
+            "schema_version": "1.2",
+            "campaign_id": "campaign-1",
+            "session_stage": "candidate-01",
+            "artifact_key": "candidate-01-attempt-01",
+            "session_id": "session-1",
+        },
+    )
+
+    class RepairClient:
+        def __init__(self) -> None:
+            self.sessions = {"session-1"}
+            self.deleted: list[str] = []
+
+        def healthy(self) -> bool:
+            return True
+
+        def session_exists(self, session_id: str) -> bool:
+            return session_id in self.sessions
+
+        def session_statuses(self) -> dict[str, Any]:
+            return {}
+
+        def delete_session(self, session_id: str) -> bool:
+            self.deleted.append(session_id)
+            self.sessions.discard(session_id)
+            return True
+
+        def find_child_session(self, *, parent_id: Any, title: str) -> None:
+            assert title.endswith("/candidate-01-attempt-02")
+            return None
+
+        def create_session(self, **kwargs: Any) -> str:
+            self.sessions.add("session-2")
+            return "session-2"
+
+        def prompt_async(self, **kwargs: Any) -> bool:
+            return True
+
+    client = RepairClient()
+    monkeypatch.setattr("wayfinder_paths.jobs.worker.OPENCODE_CLIENT", client)
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.evolution_campaign.campaign_prompt_block",
+        lambda store, job_id: {
+            "campaign_id": "campaign-1",
+            "session_stage": "candidate-01",
+            "artifact_key": "candidate-01-attempt-02",
+            "next_action": "repair candidate one",
+            "postmortem_path": "attempts/c01/a01/postmortem.json",
+        },
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.benchmarks.agent_adapter.meter_session_ids",
+        lambda session_ids: {"sessions": 1, "tool_calls": 2},
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.benchmarks.agent_adapter.session_diagnostic_summary",
+        lambda session_id: {
+            "tool_calls": [],
+            "final_assistant_text": "attempt one evaluated",
+        },
+    )
+
+    result = nudge_evolution_session(store, job_id)
+
+    assert result == {"queued": True, "session_id": "session-2"}
+    assert client.deleted == ["session-1"]
+    current = store.read_json(job_id, "reports/evolution/session.json")
+    assert current["artifact_key"] == "candidate-01-attempt-02"
+    retired = store.read_json(job_id, "reports/evolution/sessions.json")["sessions"]
+    assert retired[0]["artifact_key"] == "candidate-01-attempt-01"
+    assert retired[0]["behavior_changed"] is True
+
+
 def test_evaluation_completion_rotates_stage_and_passes_bounded_handoff(
     tmp_path, monkeypatch
 ) -> None:
@@ -2208,7 +2317,7 @@ def test_evaluation_completion_rotates_stage_and_passes_bounded_handoff(
     assert "candidate-02" in prompt
     assert "candidate one improved drawdown" in prompt
     assert "candidate one authored and evaluation launched" in prompt
-    assert "tool_result_bytes" in prompt
+    assert "tool_result_bytes" not in prompt
     assert "raw result must never enter the next prompt" not in prompt
     current = store.read_json(job_id, "reports/evolution/session.json")
     assert current["session_id"] == "session-2"

--- a/wayfinder_paths/tests/test_jobs_evolution_campaign.py
+++ b/wayfinder_paths/tests/test_jobs_evolution_campaign.py
@@ -415,6 +415,40 @@ def test_investigative_attempts_repair_failures_but_close_viable_ideas(
     assert state["counts"]["repairs"] == 2
 
 
+def test_invalid_investigative_attempt_preserves_bounded_repair_cause(
+    tmp_path,
+) -> None:
+    store, job_id = _investigative_job(tmp_path)
+    started = datetime(2099, 8, 25, 12, tzinfo=UTC)
+    start_campaign(store, job_id, now=started)
+    submit_campaign_design(store, job_id, campaign_design=_campaign_design())
+    prepare_candidate(store, job_id, now=started + timedelta(minutes=1))
+    state = campaign_status(store, job_id)
+    candidate = state["candidates"][0]
+
+    _commit_designed_attempt(
+        store,
+        job_id,
+        state=state,
+        candidate=candidate,
+        outcome={
+            "status": "invalid",
+            "evidence": {
+                "error": "window-invariance probe consumed more than warmup_bars"
+            },
+        },
+    )
+
+    repair_context = candidate["attempts"][0]["postmortem"]["repair_context"]
+    assert "warmup_bars" in repair_context["error"]
+    persisted = store.read_json(
+        job_id,
+        candidate["attempts"][0]["postmortem_path"],
+        default={},
+    )
+    assert persisted["repair_context"] == repair_context
+
+
 def test_sensor_research_seed_is_frozen_then_consumed_as_real_parent(
     tmp_path, monkeypatch
 ) -> None:

--- a/wayfinder_paths/tests/test_jobs_evolution_diagnostics.py
+++ b/wayfinder_paths/tests/test_jobs_evolution_diagnostics.py
@@ -9,6 +9,7 @@ from wayfinder_paths.jobs.evolution_diagnostics import (
     attempt_made_progress,
     build_diagnostic_pack,
     build_postmortem,
+    compact_postmortem,
     participation_adjusted_score,
     resolve_json_pointer,
     valid_evidence_pointers,
@@ -83,6 +84,21 @@ def test_noop_and_negative_attempts_are_machine_legible_and_compound() -> None:
     second = build_postmortem(improved, baseline, previous=baseline, min_trades=1)
     assert second["viable"] is False
     assert attempt_made_progress(second) is True
+
+
+def test_compact_postmortem_preserves_bounded_repair_cause() -> None:
+    report = compact_postmortem(
+        {
+            "viable": False,
+            "primary_failure": "invalid_execution",
+            "failure_codes": ["invalid_execution"],
+            "behavior_diff": {"material_change": False},
+            "repair_context": {"error": "window invariant failed " + "x" * 900},
+        }
+    )
+
+    assert report["repair_context"]["error"].startswith("window invariant failed")
+    assert len(report["repair_context"]["error"]) == 500
 
 
 def test_diagnostic_pack_is_bounded_and_citations_are_exact(tmp_path) -> None:

--- a/wayfinder_paths/tests/test_jobs_evolution_diagnostics.py
+++ b/wayfinder_paths/tests/test_jobs_evolution_diagnostics.py
@@ -11,6 +11,7 @@ from wayfinder_paths.jobs.evolution_diagnostics import (
     build_postmortem,
     participation_adjusted_score,
     resolve_json_pointer,
+    valid_evidence_pointers,
 )
 
 
@@ -112,6 +113,9 @@ def test_diagnostic_pack_is_bounded_and_citations_are_exact(tmp_path) -> None:
 
     assert len(json.dumps(pack).encode()) <= DIAGNOSTIC_PACK_MAX_BYTES
     assert resolve_json_pointer(pack, "/baseline/reason") == "no runnable fixture"
+    pointers = valid_evidence_pointers(pack)
+    assert "/baseline/reason" in pointers
+    assert "/research_context/validated_positives" not in pointers
     with pytest.raises(ValueError, match="does not exist"):
         resolve_json_pointer(pack, "/baseline/invented")
 

--- a/wayfinder_paths/tests/test_jobs_optuna.py
+++ b/wayfinder_paths/tests/test_jobs_optuna.py
@@ -17,7 +17,11 @@ import pytest
 from wayfinder_paths.jobs.execution import ExecutionSpec
 from wayfinder_paths.jobs.execution import optimize as optimize_module
 from wayfinder_paths.jobs.execution.experiments import promote_params, run_experiment
-from wayfinder_paths.jobs.execution.optimize import is_search_space, run_optuna_search
+from wayfinder_paths.jobs.execution.optimize import (
+    is_search_space,
+    run_optuna_search,
+    search_space_probe_variants,
+)
 from wayfinder_paths.jobs.execution.simulator import (
     ExecutionBacktestResult,
     PreparedExecutionDataset,
@@ -100,6 +104,30 @@ def test_is_search_space_distinguishes_formats() -> None:
     assert not is_search_space({"x": [1, 2, 3]})
     assert not is_search_space({"x": 5, "y": "SNX"})
     assert not is_search_space([{"x": 1}])
+
+
+def test_search_space_probe_variants_are_bounded_endpoints() -> None:
+    variants = search_space_probe_variants(
+        {
+            "lookback": {"type": "int", "low": 12, "high": 96},
+            "threshold": {"type": "float", "low": 0.1, "high": 0.8},
+            "side": {"type": "categorical", "choices": ["long", "short"]},
+            "initial_capital": 1_000.0,
+        }
+    )
+
+    assert len(variants) <= 8
+    assert all(row["initial_capital"] == 1_000.0 for row in variants)
+    assert {row["lookback"] for row in variants if "lookback" in row} == {12, 96}
+    assert {row["threshold"] for row in variants if "threshold" in row} == {
+        0.1,
+        0.8,
+    }
+    assert {row["side"] for row in variants if "side" in row} == {
+        "long",
+        "short",
+    }
+    assert len({repr(sorted(row.items())) for row in variants}) == len(variants)
 
 
 def test_missing_optuna_error_mentions_ml_group(

--- a/wayfinder_paths/tests/test_jobs_paper_experiment.py
+++ b/wayfinder_paths/tests/test_jobs_paper_experiment.py
@@ -9,6 +9,7 @@ import pytest
 from wayfinder_paths.jobs.gating import compute_workspace_revision
 from wayfinder_paths.jobs.models import WayfinderJob
 from wayfinder_paths.jobs.paper_experiment import (
+    _daily_pnl_for_stream,
     _normalize_control_revision,
     _proposal_verdict,
     _resource_cost,
@@ -112,6 +113,34 @@ def _write_days(
             (stream / "trades.jsonl").write_text(
                 "\n".join(trades) + "\n", encoding="utf-8"
             )
+
+
+def test_daily_pnl_prefers_trade_close_time_over_write_time(tmp_path: Path) -> None:
+    stream = tmp_path / "stream"
+    stream.mkdir()
+    (stream / "ticks.jsonl").write_text(
+        json.dumps({"bar_ts": "2026-08-12T00:00:00+00:00"}) + "\n",
+        encoding="utf-8",
+    )
+    (stream / "trades.jsonl").write_text(
+        json.dumps(
+            {
+                "closed_at": "2026-08-12T12:00:00+00:00",
+                "ts": "2026-09-01T13:00:00+00:00",
+                "net_pnl": -3.5,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    daily = _daily_pnl_for_stream(
+        stream,
+        since=datetime(2026, 8, 11, tzinfo=UTC),
+        until=datetime(2026, 8, 13, tzinfo=UTC),
+    )
+
+    assert daily == {"2026-08-12": -3.5}
 
 
 @pytest.mark.parametrize(

--- a/wayfinder_paths/tests/test_jobs_unified_probation.py
+++ b/wayfinder_paths/tests/test_jobs_unified_probation.py
@@ -388,6 +388,8 @@ def test_two_paired_days_emit_no_interval_bounds_but_keep_estimate(
     assert metrics["lcb"] is None
     assert metrics["ucb"] is None
     assert metrics["estimate"] > 0
+    assert len(metrics["daily_deltas"]) == 2
+    assert all(delta > 0 for delta in metrics["daily_deltas"])
     assert metrics["candidate_net_pnl"] == 15.0
     assert metrics["reference_net_pnl"] == 0.0
     synced = snapshot_job(job_id, store=store)["probation"]["trials"][0]

--- a/wayfinder_paths/tests/test_wayfinder_jobs.py
+++ b/wayfinder_paths/tests/test_wayfinder_jobs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 import yaml
 
 from wayfinder_paths.jobs.application import (
@@ -423,6 +424,60 @@ def test_worker_prompt_includes_apply_lifecycle(tmp_path: Path) -> None:
     assert 'core_jobs(action="validate_application"' in prompt
     assert 'core_jobs(action="complete_application"' in prompt
     assert "runner loops pause only after the apply worker claims" in prompt
+
+
+def test_worker_prompt_compiles_maintenance_work_order(tmp_path: Path) -> None:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("maintenance-prompt", agent_mode="intervene")
+    store.save(job)
+    proposal = {
+        "proposal_id": "prop_eq",
+        "candidate_report": {"maintenance": {"ready": True}},
+    }
+
+    sections = _build_worker_prompt_sections(
+        store=store,
+        job_id=job.id,
+        mode="intervene",
+        snapshot=_worker_snapshot(job, proposals=[proposal]),
+        apply_proposal_id="prop_eq",
+    )
+
+    assert sections["work_order"]["lane"] == "maintenance"
+    assert sections["work_order"]["action"] == "validate_and_complete_application"
+    assert sections["work_order"]["editable_paths"] == [
+        "the proposal application candidate only"
+    ]
+    assert "COMPILED WORK ORDER (one action)" in sections["dynamic_context"]
+
+
+def test_worker_prompt_compiles_focused_remediation_work_order(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = JobStore(repo_root=tmp_path)
+    job = WayfinderJob.new("remediation-prompt", agent_mode="intervene")
+    store.save(job)
+    store.write_json(
+        job.id,
+        "state/regime_remediation.json",
+        {"case_id": "rem-1", "state": "open", "attempts": 0},
+    )
+    monkeypatch.setattr(
+        "wayfinder_paths.jobs.worker.remediation_backed_off",
+        lambda store, job_id, case: False,
+    )
+
+    sections = _build_worker_prompt_sections(
+        store=store,
+        job_id=job.id,
+        mode="intervene",
+        snapshot=_worker_snapshot(job),
+    )
+
+    assert sections["work_order"]["lane"] == "remediation"
+    assert sections["work_order"]["action"] == "advance_regime_remediation"
+    assert "state/regime_remediation.json" in json.dumps(sections["work_order"])
+    assert '"research_substrate"' not in sections["dynamic_context"]
 
 
 def test_worker_report_includes_cache_metadata(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary\n\n- add a frozen-world, paper-only evolution A/B harness using production prompts, simulators, gates, probation replay, identity pins, and sealed holdout data\n- compile prompt-only work orders for evolution, intervention, remediation, maintenance, and application lanes; each names one action, exact inputs/edit scope, exclusions, and completion condition\n- rotate evolution sessions at each design, candidate-attempt, and finalize artifact boundary, retaining a compact handoff instead of raw tool history\n- add lightweight process accounting to existing session journals and benchmark scorecards: non-overlapping model/tool/other wall time, tool calls/output bytes, and behavior-changed attempts\n- add an optional pre-simulation behavior preview for parameter search spaces; behavior-identical variants are rejected using bounded decision probes before a full quick simulation\n- fix replay accounting to use trade close time rather than wall-clock write time and persist the paired daily deltas used by probation adjudication\n\n## Safety / scope\n\n- paper only; wallet labels are removed and job mode is forced to paper\n- no apply, approve, live, or market-data tool path exists in benchmark MCP\n- work orders are in-memory prompt context, not a second durable orchestration protocol\n- no evaluation-math fork: the harness reuses production simulation, invariance, economic gate, campaign funnel, and probation code\n- runs pin the SDK revision, agent/config hashes, model/variant, frozen data commitments, and declared arm differences\n- pilot mode is directional and cannot declare a winner\n\n## Completed A/B results\n\n### DeepSeek v4 Pro vs Flash Max — four matched seeds\n\n- Pro: 32 generated, 8 screen-positive, 8 full-development, 1 finalist evaluated, 0 staged; 4 Optuna jobs\n- Flash: 32 generated, 14 screen-positive, 12 full-development, 1 finalist evaluated, 1 staged; 7 Optuna jobs\n- pre-registered decision: invalid_cost_mismatch; Pro used 1.5985x Flash tokens and the paired quality interval did not establish a winner\n- the lone Flash survivor was not good: sealed holdout return -11.18% and max drawdown -12.15%, versus incumbent +0.43% and -4.47%\n\n### Behavior preview off vs on — Flash Max, four matched seeds\n\n- both arms: 32 candidates and 11 full-development evaluations\n- preview off: 75 attempts, 67 quick simulations, 14 screen-positive, 8 Optuna jobs, 1 staged\n- preview on: 76 attempts, 54 quick simulations, 11 screen-positive, 5 Optuna jobs, 8 behavior-identical attempts skipped using 555 decision ticks, 0 staged\n- observed quick simulations fell 19.4%; eight skips are directly attributable to preview and the remainder reflects independently sampled candidate mixes\n- wall time fell 574.7 seconds, or 2.9%; preview-on token cost was 2.7% higher, within the pre-registered cost-parity bound\n- full-development yield was unchanged and the paired quality decision was no_significant_difference\n- the preview-off survivor was forward-inconclusive and poor: corrected 14-day replay candidate PnL -10.60 versus incumbent +0.93; paired utility estimate -0.001153 with 90% interval [-0.002415, +0.000116]\n\n## Validation\n\n- 237 focused tests pass across benchmark, campaign, Optuna, validation, metering, paper experiment, and probation paths\n- Ruff and formatting clean on all changed Python files\n- mypy clean on 20 changed production files, excluding unavailable third-party stubs\n- both completed A/Bs have four valid matched pairs, zero isolation/identity-invalid runs, and frozen data/config parity\n