### PR TITLE
jobs: paired equity curve on probation trials

### DIFF
--- a/wayfinder_paths/jobs/probation.py
+++ b/wayfinder_paths/jobs/probation.py
@@ -48,6 +48,12 @@ PLACEHOLDER_TRIAL_FAMILIES = frozenset({"", "evolution", GENERIC_TRIAL_FAMILY})
 # Below this many paired days every resample is the full (rotated) sample, so
 # the "interval" collapses to the point estimate — report no bounds instead.
 FORWARD_BOOTSTRAP_BLOCK_LEN = 5
+# Paired equity curve (candidate vs frozen incumbent) on forward trials:
+# hourly cumulative realized net PnL buckets since admission, capped so the
+# synced payload stays a few KB (14d x 24h = 336 buckets + the seed point).
+EQUITY_CURVE_BASIS = "realized"
+EQUITY_CURVE_BUCKET_SECONDS = 3600
+EQUITY_CURVE_MAX_POINTS = 400
 
 
 def load_probation(store: JobStore, job_id: str) -> dict[str, Any]:
@@ -58,6 +64,43 @@ def load_probation(store: JobStore, job_id: str) -> dict[str, Any]:
     doc.setdefault("trials", [])
     doc.setdefault("schema_version", PROBATION_SCHEMA_VERSION)
     return doc
+
+
+def probation_sync_payload(store: JobStore, job_id: str) -> dict[str, Any]:
+    """The synced probation document: probation.json with each trial's paired
+    equity curve attached from its sidecar. Trials without a curve (legacy,
+    pre-forward, absent streams) simply omit the field — the FE handles it."""
+    doc = store.read_json(job_id, PROBATION_PATH, default={"legs": []}) or {"legs": []}
+    if not isinstance(doc, dict):
+        return {"legs": []}
+    for trial in doc.get("trials") or []:
+        curve = trial_equity_curve_payload(
+            store, job_id, str(trial.get("trial_id") or "")
+        )
+        if curve is not None:
+            trial["equity_curve"] = curve
+    return doc
+
+
+def trial_equity_curve_payload(
+    store: JobStore, job_id: str, trial_id: str
+) -> dict[str, Any] | None:
+    """Wire shape of a trial's equity curve: points/updated_at/basis only —
+    the sidecar's byte-offset cursor is producer-internal."""
+    if not trial_id or Path(trial_id).name != trial_id:
+        return None
+    doc = store.read_json(job_id, _equity_curve_relative(trial_id), default=None)
+    if not isinstance(doc, dict) or not doc.get("points"):
+        return None
+    return {
+        "points": list(doc["points"])[:EQUITY_CURVE_MAX_POINTS],
+        "updated_at": doc.get("updated_at"),
+        "basis": doc.get("basis"),
+    }
+
+
+def _equity_curve_relative(trial_id: str) -> str:
+    return f"{PROBATION_FORWARD_ROOT}/{trial_id}/equity_curve.json"
 
 
 def record_probation_leg(
@@ -836,6 +879,12 @@ def maybe_adjudicate_probation(
             if trial.get("status") == "burn_in":
                 outcome = _adjudicate_burn_in(store, job_id, trial, current=current)
             elif trial.get("status") == "active":
+                # Display artifact — a curve bug must never stall the
+                # graduation/kill adjudication it rides along with.
+                try:
+                    _update_trial_equity_curve(store, job_id, trial, current=current)
+                except Exception:  # noqa: BLE001
+                    pass
                 outcome = _adjudicate_forward(store, job_id, trial, current=current)
             else:
                 outcome = None
@@ -1073,6 +1122,143 @@ def _paired_forward_metrics(
         **safety,
         "updated_at": current.isoformat(),
     }
+
+
+def _update_trial_equity_curve(
+    store: JobStore,
+    job_id: str,
+    trial: dict[str, Any],
+    *,
+    current: datetime,
+) -> None:
+    """Append newly completed hourly buckets to the trial's paired cumulative
+    equity curve (candidate vs frozen incumbent reference, zeroed at forward
+    admission), stored as a per-trial sidecar next to the streams.
+
+    Basis is REALIZED net PnL from each stream's trades.jsonl — the exact
+    series the forward adjudicator sums — attributed to the trade's close bar
+    time, so the curve endpoint matches the candidate/reference net PnL on
+    the trial card. Tick rows carry no mark price, so an unrealized basis
+    would need market fetches. Incremental by construction: a bucket only
+    finalizes once BOTH stream cursors have processed past its end, emitted
+    points never change, and each pass reads only bytes past the stored
+    per-stream offsets.
+    """
+    started_at = (trial.get("forward") or {}).get("started_at")
+    if not started_at:
+        return
+    started = int(_parse(started_at).timestamp())
+    root = store.job_dir(job_id)
+    streams: dict[str, Path] = {}
+    watermark: float | None = None
+    for role in ("candidate", "reference"):
+        target = trial.get(role) or {}
+        stream = str(target.get("stream") or "")
+        last_bar = target.get("last_processed_bar")
+        if not stream or not last_bar:
+            return
+        path = root / stream
+        if not path.is_dir():
+            return
+        streams[role] = path
+        bar_epoch = _parse(str(last_bar)).timestamp()
+        watermark = bar_epoch if watermark is None else min(watermark, bar_epoch)
+    assert watermark is not None
+    relative = _equity_curve_relative(str(trial["trial_id"]))
+    doc = store.read_json(job_id, relative, default=None)
+    if not isinstance(doc, dict) or doc.get("basis") != EQUITY_CURVE_BASIS:
+        doc = {
+            "basis": EQUITY_CURVE_BASIS,
+            "started_at": started_at,
+            "updated_at": None,
+            "points": [[started, 0.0, 0.0]],
+            "cursor": {
+                "candidate": {"offset": 0, "cum": 0.0},
+                "reference": {"offset": 0, "cum": 0.0},
+            },
+        }
+    points: list[list[float]] = [list(point) for point in doc["points"]]
+    if len(points) >= EQUITY_CURVE_MAX_POINTS:
+        return
+    # Largest emittable bucket end: hour-aligned to admission, bounded by the
+    # slower stream's cursor AND the point cap (so consumed bytes always land
+    # in an emitted bucket — nothing is read and then dropped).
+    complete_hours = int(watermark - started) // EQUITY_CURVE_BUCKET_SECONDS
+    cap_hours = (int(points[-1][0]) - started) // EQUITY_CURVE_BUCKET_SECONDS + (
+        EQUITY_CURVE_MAX_POINTS - len(points)
+    )
+    boundary = started + min(complete_hours, cap_hours) * EQUITY_CURVE_BUCKET_SECONDS
+    cursor = doc["cursor"]
+    changed = False
+    pending: dict[str, list[tuple[float, float]]] = {}
+    for role, path in streams.items():
+        rows, consumed = _consume_stream_trades(
+            path, offset=int(cursor[role]["offset"]), boundary=float(boundary)
+        )
+        pending[role] = rows
+        if consumed != int(cursor[role]["offset"]):
+            cursor[role]["offset"] = consumed
+            changed = True
+    next_end = int(points[-1][0]) + EQUITY_CURVE_BUCKET_SECONDS
+    while next_end <= boundary and len(points) < EQUITY_CURVE_MAX_POINTS:
+        values: list[float] = []
+        for role in ("candidate", "reference"):
+            cum = float(cursor[role]["cum"]) + sum(
+                pnl for close, pnl in pending[role] if close < next_end
+            )
+            pending[role] = [
+                (close, pnl) for close, pnl in pending[role] if close >= next_end
+            ]
+            cursor[role]["cum"] = cum
+            values.append(round(cum, 4))
+        points.append([next_end, values[0], values[1]])
+        changed = True
+        next_end += EQUITY_CURVE_BUCKET_SECONDS
+    if not changed and doc.get("updated_at") is not None:
+        return
+    doc["points"] = points
+    doc["updated_at"] = current.isoformat()
+    atomic_write_json(root / relative, doc)
+
+
+def _consume_stream_trades(
+    stream: Path, *, offset: int, boundary: float
+) -> tuple[list[tuple[float, float]], int]:
+    """Parse complete trades.jsonl lines from `offset` as (close_epoch, pnl),
+    stopping BEFORE the first close at/after `boundary` — its bucket is not
+    final yet, so those bytes are re-read once the watermark passes. Rows are
+    appended in bar order, which makes the early stop safe."""
+    path = stream / "trades.jsonl"
+    if not path.exists() or offset >= path.stat().st_size:
+        return [], offset
+    with path.open("rb") as handle:
+        handle.seek(offset)
+        blob = handle.read()
+    rows: list[tuple[float, float]] = []
+    consumed = offset
+    for line in blob.splitlines(keepends=True):
+        if not line.endswith(b"\n"):
+            break  # partially flushed tail — retry next pass
+        try:
+            row = json.loads(line.decode("utf-8", errors="replace"))
+            stamp = pd.Timestamp(
+                row.get("closed_at") or row.get("timestamp") or row.get("ts")
+            )
+            if pd.isna(stamp):
+                raise ValueError(line.decode("utf-8", errors="replace"))
+            close_epoch = stamp.timestamp()
+        except (TypeError, ValueError):
+            consumed += len(line)
+            continue
+        if close_epoch >= boundary:
+            break
+        try:
+            pnl = float(row.get("net_pnl") or row.get("realized_pnl_delta") or 0.0)
+        except (TypeError, ValueError):
+            pnl = 0.0
+        rows.append((close_epoch, pnl))
+        consumed += len(line)
+    return rows, consumed
 
 
 def _stream_hard_constraint_metrics(

--- a/wayfinder_paths/jobs/sync.py
+++ b/wayfinder_paths/jobs/sync.py
@@ -21,6 +21,7 @@ from wayfinder_paths.jobs.forward import load_forward_snapshot
 from wayfinder_paths.jobs.gating import evaluate_live_gate
 from wayfinder_paths.jobs.halt import read_halt
 from wayfinder_paths.jobs.models import utc_now_iso
+from wayfinder_paths.jobs.probation import probation_sync_payload
 from wayfinder_paths.jobs.runner_bridge import RunnerBridge
 from wayfinder_paths.jobs.store import JobStore
 
@@ -265,7 +266,9 @@ def snapshot_job(job_id: str, *, store: JobStore | None = None) -> dict[str, Any
         "forward": load_forward_snapshot(job_id, store=store, limit=25),
         "runner_links": runner_links,
         "proposals": store.proposals(job_id),
-        "probation": store.read_json(job_id, "probation.json", default={"legs": []}),
+        # probation.json enriched with each trial's paired equity curve —
+        # curve points live in per-trial sidecars, never in probation.json.
+        "probation": probation_sync_payload(store, job_id),
         "risk_overrides": risk_overrides_snapshot(store, job_id),
         "post_apply_shadow": _shadow_topline(store, job_id),
         "regime_health": regime_health,

--- a/wayfinder_paths/tests/test_jobs_unified_probation.py
+++ b/wayfinder_paths/tests/test_jobs_unified_probation.py
@@ -697,6 +697,175 @@ def test_probation_capacity_is_three_active_and_three_queued(tmp_path: Path) -> 
     assert statuses == ["burn_in"] * 3 + ["queued"] * 3 + ["deferred"]
 
 
+def _forward_trial(store: JobStore, job_id: str, name: str, started: datetime) -> dict:
+    candidate, revision = _candidate(store, job_id, name)
+    stage_evolution_probation(
+        store,
+        job_id,
+        candidate_id=f"{name}-candidate",
+        candidate_root=candidate,
+        revision=revision,
+        source="evolution_campaign",
+        family=f"{name}-family",
+        now=started,
+    )
+    doc = load_probation(store, job_id)
+    trial = doc["trials"][0]
+    trial["status"] = "active"
+    trial["phase"] = "forward"
+    trial["burn_in"]["status"] = "passed"
+    trial["forward"]["started_at"] = started.isoformat()
+    trial["forward"]["deadline_at"] = (started + timedelta(days=14)).isoformat()
+    for role in ("candidate", "reference"):
+        trial[role]["stream"] = (
+            f"results/forward/probation/{trial['trial_id']}/forward/{role}"
+        )
+    store.write_json(job_id, "probation.json", doc)
+    return trial
+
+
+def _advance_cursors(store: JobStore, job_id: str, bar: datetime) -> None:
+    doc = load_probation(store, job_id)
+    for role in ("candidate", "reference"):
+        doc["trials"][0][role]["last_processed_bar"] = bar.isoformat()
+    store.write_json(job_id, "probation.json", doc)
+
+
+def _curve_sidecar(store: JobStore, job_id: str) -> dict | None:
+    trial = load_probation(store, job_id)["trials"][0]
+    return store.read_json(
+        job_id,
+        f"results/forward/probation/{trial['trial_id']}/equity_curve.json",
+        default=None,
+    )
+
+
+def test_equity_curve_builds_paired_hourly_points_zeroed_at_admission(
+    tmp_path: Path,
+) -> None:
+    store, job_id = _job(tmp_path)
+    started = datetime(2026, 8, 1, tzinfo=UTC)
+    trial = _forward_trial(store, job_id, "curve", started)
+    root = store.job_dir(job_id)
+    candidate_stream = root / trial["candidate"]["stream"]
+    reference_stream = root / trial["reference"]["stream"]
+    candidate_stream.mkdir(parents=True, exist_ok=True)
+    reference_stream.mkdir(parents=True, exist_ok=True)
+    _write_trade(candidate_stream, started + timedelta(minutes=10), 5.0)
+    _write_trade(candidate_stream, started + timedelta(minutes=40), 2.5)
+    _write_trade(candidate_stream, started + timedelta(hours=3, minutes=10), -1.0)
+    _write_trade(reference_stream, started + timedelta(hours=1, minutes=30), -2.0)
+    _advance_cursors(store, job_id, started + timedelta(hours=5))
+
+    maybe_adjudicate_probation(store, job_id, now=started + timedelta(hours=5))
+
+    curve = _curve_sidecar(store, job_id)
+    assert curve is not None
+    assert curve["basis"] == "realized"
+    epoch = int(started.timestamp())
+    assert curve["points"] == [
+        [epoch, 0.0, 0.0],
+        [epoch + 3600, 7.5, 0.0],
+        [epoch + 7200, 7.5, -2.0],
+        [epoch + 10800, 7.5, -2.0],
+        [epoch + 14400, 6.5, -2.0],
+        [epoch + 18000, 6.5, -2.0],
+    ]
+
+
+def test_equity_curve_appends_only_new_buckets_incrementally(tmp_path: Path) -> None:
+    store, job_id = _job(tmp_path)
+    started = datetime(2026, 8, 1, tzinfo=UTC)
+    trial = _forward_trial(store, job_id, "incremental", started)
+    root = store.job_dir(job_id)
+    candidate_stream = root / trial["candidate"]["stream"]
+    reference_stream = root / trial["reference"]["stream"]
+    candidate_stream.mkdir(parents=True, exist_ok=True)
+    reference_stream.mkdir(parents=True, exist_ok=True)
+    _write_trade(candidate_stream, started + timedelta(minutes=30), 111.5)
+    _advance_cursors(store, job_id, started + timedelta(hours=2))
+    maybe_adjudicate_probation(store, job_id, now=started + timedelta(hours=2))
+    first = _curve_sidecar(store, job_id)
+    assert first is not None
+    epoch = int(started.timestamp())
+    assert first["points"] == [
+        [epoch, 0.0, 0.0],
+        [epoch + 3600, 111.5, 0.0],
+        [epoch + 7200, 111.5, 0.0],
+    ]
+
+    # Mutate the already-consumed first trade IN PLACE (same byte length): an
+    # incremental producer never re-reads behind its offsets, so the emitted
+    # points must not change — only new buckets from the appended trade.
+    trades = candidate_stream / "trades.jsonl"
+    trades.write_bytes(trades.read_bytes().replace(b"111.5", b"999.9"))
+    _write_trade(candidate_stream, started + timedelta(hours=2, minutes=15), 3.0)
+    _advance_cursors(store, job_id, started + timedelta(hours=4))
+    maybe_adjudicate_probation(store, job_id, now=started + timedelta(hours=4))
+
+    second = _curve_sidecar(store, job_id)
+    assert second is not None
+    assert second["points"][:3] == first["points"]
+    assert second["points"][3:] == [
+        [epoch + 10800, 114.5, 0.0],
+        [epoch + 14400, 114.5, 0.0],
+    ]
+
+
+def test_equity_curve_hard_caps_at_400_points(tmp_path: Path) -> None:
+    store, job_id = _job(tmp_path)
+    started = datetime(2026, 8, 1, tzinfo=UTC)
+    trial = _forward_trial(store, job_id, "cap", started)
+    root = store.job_dir(job_id)
+    for role in ("candidate", "reference"):
+        (root / trial[role]["stream"]).mkdir(parents=True, exist_ok=True)
+    _advance_cursors(store, job_id, started + timedelta(hours=500))
+
+    maybe_adjudicate_probation(store, job_id, now=started + timedelta(hours=500))
+
+    curve = _curve_sidecar(store, job_id)
+    assert curve is not None
+    assert len(curve["points"]) == 400
+    assert curve["points"][-1][0] == int(started.timestamp()) + 399 * 3600
+
+
+def test_equity_curve_absent_streams_no_curve_no_crash(tmp_path: Path) -> None:
+    store, job_id = _job(tmp_path)
+    started = datetime(2026, 8, 1, tzinfo=UTC)
+    _forward_trial(store, job_id, "absent", started)
+    _advance_cursors(store, job_id, started + timedelta(hours=6))
+
+    maybe_adjudicate_probation(store, job_id, now=started + timedelta(hours=6))
+
+    assert _curve_sidecar(store, job_id) is None
+    synced = snapshot_job(job_id, store=store)["probation"]["trials"][0]
+    assert "equity_curve" not in synced
+
+
+def test_sync_ships_equity_curve_points_on_the_trial_payload(tmp_path: Path) -> None:
+    store, job_id = _job(tmp_path)
+    started = datetime(2026, 8, 1, tzinfo=UTC)
+    trial = _forward_trial(store, job_id, "wire", started)
+    root = store.job_dir(job_id)
+    candidate_stream = root / trial["candidate"]["stream"]
+    reference_stream = root / trial["reference"]["stream"]
+    candidate_stream.mkdir(parents=True, exist_ok=True)
+    reference_stream.mkdir(parents=True, exist_ok=True)
+    _write_trade(candidate_stream, started + timedelta(minutes=5), 4.0)
+    _advance_cursors(store, job_id, started + timedelta(hours=1))
+    maybe_adjudicate_probation(store, job_id, now=started + timedelta(hours=1))
+
+    synced = snapshot_job(job_id, store=store)["probation"]["trials"][0]
+    curve = synced["equity_curve"]
+    epoch = int(started.timestamp())
+    assert curve["basis"] == "realized"
+    assert curve["points"] == [[epoch, 0.0, 0.0], [epoch + 3600, 4.0, 0.0]]
+    assert curve["updated_at"] == (started + timedelta(hours=1)).isoformat()
+    assert "cursor" not in curve
+    # The on-disk registry never carries the points — sidecar only.
+    assert "equity_curve" not in load_probation(store, job_id)["trials"][0]
+
+
 @pytest.mark.asyncio
 async def test_symbol_block_removes_entries_but_preserves_reduce_only(
     tmp_path: Path,


### PR DESCRIPTION
## Paired equity curve

The owner could read a probation trial's verdict math but never SEE what the challenger changes. Each active forward trial now maintains a compact two-line cumulative-PnL curve — candidate vs frozen incumbent reference — from admission onward, shipped on the trial's sync payload for the probation card chart (frontend half: #2201).

### Equity basis: realized

Cumulative realized net PnL from each stream's `trades.jsonl` (`net_pnl` per close, `realized_pnl_delta` fallback), attributed to the trade's **close bar time** (`closed_at` → `timestamp` → `ts`). This is the exact series the forward adjudicator sums, so the curve endpoint agrees with the card's `candidate_net_pnl` / `reference_net_pnl`. Tick rows carry no mark price, so an unrealized/mark basis would require market fetches — out of budget for this producer. `basis: "realized"` is stamped on the artifact so the FE can label it honestly.

### Producer: incremental, zero LLM, zero fetches

`maybe_adjudicate_probation` updates the curve for every active forward trial before adjudicating it:

- Hourly buckets anchored at `forward.started_at`, seeded with a zero point at admission (since-admission zeroing).
- A bucket finalizes only once **both** stream cursors (`last_processed_bar`) have processed past its end — emitted points never change.
- Each pass reads only bytes past per-stream offsets stored in the sidecar; consumed rows always land in a bucket emitted the same pass, so nothing is read twice or recomputed. Partially flushed tail lines are left for the next pass.
- A curve failure is swallowed (display artifact) — it can never stall graduation/kill adjudication.

### Artifact + wire

- Sidecar per trial: `results/forward/probation/<trial_id>/equity_curve.json` holding `{points: [[epoch_s, candidate_cum, reference_cum]], updated_at, basis}` plus a producer-internal byte-offset cursor. Dollars, 4dp. Hard cap 400 points enforced at write time (14d × 24h = 336 + seed), so the payload stays a few KB.
- `snapshot_job` ships `equity_curve` (points/updated_at/basis only) on each trial in the `probation` payload via `probation_sync_payload`. `probation.json` itself never carries the points. Trials without a sidecar (legacy, pre-forward, absent streams) omit the field — FE handles absence. Jobs with no trials sync byte-identical payloads.

### Tests

- Hourly bucketing, both lines, since-admission zeroing from constructed streams.
- Incremental append: an already-consumed trade row mutated in place (same byte length) does not change emitted points; only new buckets from appended trades appear.
- 400-point hard cap.
- Absent streams → no sidecar, no crash, no `equity_curve` on the wire.
- Sync payload carries points/basis/updated_at, strips the cursor, and the on-disk registry stays lean.

`pytest -q -k "jobs or runner or mcp"` on this base: **1448 passed, 9 skipped, 1 failed** — only the known pre-existing `test_eval_wayfinder_jobs.py::test_wayfinder_jobs_eval_validates_hard_execution_backtest`. Ruff clean on changed files; scoped mypy adds no new errors (only the pre-existing pandas-stubs import note).

> Note: this work originally targeted #764 (`probation-display-honesty`), which merged as 0c79b5b1 while it was being built; retargeted here onto `wayfinder-jobs-v1` as a clean cherry-pick (identical trees).
