### PR TITLE
feat(jobs): add diverse intraday starter strategies

### DIFF
--- a/wayfinder_paths/jobs/starter_leverage_evidence.py
+++ b/wayfinder_paths/jobs/starter_leverage_evidence.py
@@ -32,6 +32,13 @@ MAKER_MEAN_REVERSION_HALT = -0.08
 OTHER_STARTER_HALT = -0.20
 
 STARTER_LEVERAGE_RESULTS: dict[str, tuple[dict[str, Any], ...]] = {
+    "bullish-regime-rotation-5m": (
+        _result(1, 1.4347, 2.6261, -0.1758, 156, 508.61, OTHER_STARTER_HALT),
+        _result(2, 3.8763, 2.6081, -0.3271, 155, 1662.44, OTHER_STARTER_HALT),
+        _result(3, 7.3691, 2.6326, -0.4562, 155, 3745.28, OTHER_STARTER_HALT),
+        _result(4, 11.7071, 2.6322, -0.5653, 155, 6984.70, OTHER_STARTER_HALT),
+        _result(5, 16.6030, 2.5928, -0.6565, 156, 11614.16, OTHER_STARTER_HALT),
+    ),
     "mixed-rsi-snapback-1h": (
         _result(1, 0.0815, 1.6318, -0.0279, 182, 213.81, MEAN_REVERSION_HALT),
         _result(2, 0.1670, 1.6406, -0.0554, 182, 445.13, MEAN_REVERSION_HALT),
@@ -87,6 +94,27 @@ STARTER_LEVERAGE_RESULTS: dict[str, tuple[dict[str, Any], ...]] = {
         _result(3, 0.5335, 1.2668, -0.2732, 143, 607.34, OTHER_STARTER_HALT),
         _result(4, 0.6290, 1.1954, -0.3986, 149, 836.47, OTHER_STARTER_HALT),
         _result(5, 0.7307, 1.2168, -0.4753, 151, 1129.24, OTHER_STARTER_HALT),
+    ),
+    "diversified-trend-sleeves-15m": (
+        _result(1, 0.8443, 2.6780, -0.1107, 889, 674.93, OTHER_STARTER_HALT),
+        _result(2, 2.4468, 2.8853, -0.2010, 889, 1950.41, OTHER_STARTER_HALT),
+        _result(3, 4.6532, 2.8889, -0.2803, 889, 3901.41, OTHER_STARTER_HALT),
+        _result(4, 6.5567, 2.6873, -0.4352, 888, 5886.12, OTHER_STARTER_HALT),
+        _result(5, 9.8576, 2.7212, -0.4940, 888, 9152.52, OTHER_STARTER_HALT),
+    ),
+    "diversified-momentum-taker-15m": (
+        _result(1, 0.4537, 1.4236, -0.1821, 1634, 1437.92, OTHER_STARTER_HALT),
+        _result(2, 1.0001, 1.5156, -0.3365, 1634, 3335.48, OTHER_STARTER_HALT),
+        _result(3, 1.3086, 1.4482, -0.4665, 1633, 5120.84, OTHER_STARTER_HALT),
+        _result(4, 1.4081, 1.4072, -0.5808, 1628, 6478.78, OTHER_STARTER_HALT),
+        _result(5, 1.6692, 1.4850, -0.6666, 1629, 8240.02, OTHER_STARTER_HALT),
+    ),
+    "crypto-gold-regime-relay-15m": (
+        _result(1, 0.7023, 1.6410, -0.1716, 276, 634.06, OTHER_STARTER_HALT),
+        _result(2, 1.4739, 1.6620, -0.3178, 275, 1477.88, OTHER_STARTER_HALT),
+        _result(3, 2.2541, 1.7124, -0.4417, 275, 2463.38, OTHER_STARTER_HALT),
+        _result(4, 2.8333, 1.7457, -0.5461, 275, 3412.28, OTHER_STARTER_HALT),
+        _result(5, 2.9776, 1.7550, -0.6336, 277, 4054.20, OTHER_STARTER_HALT),
     ),
     "hype-passive-rsi-full-5m": (
         _result(1, 0.2566, 1.6639, -0.0627, 244, 613.80, MAKER_MEAN_REVERSION_HALT),

--- a/wayfinder_paths/jobs/starters.py
+++ b/wayfinder_paths/jobs/starters.py
@@ -29,7 +29,7 @@ from wayfinder_paths.jobs.strategies._starter_utils import (
     RANKING_STOP_DEFAULTS,
 )
 
-STARTER_CATALOG_VERSION = "1.9.0"
+STARTER_CATALOG_VERSION = "2.0.0"
 STARTER_STRATEGY_INCEPTION_AT = "2026-08-24T00:00:00+00:00"
 # Catalog launch policy: every off-the-shelf starter launches with the agent
 # loop ON in intervene mode. Fleet evidence (two launches of the identical
@@ -122,6 +122,7 @@ class StarterDefinition:
     rules: tuple[str, ...]
     params: dict[str, Any]
     research_evidence: dict[str, Any]
+    strategy_inception_at: str = STARTER_STRATEGY_INCEPTION_AT
     cautions: tuple[str, ...] = ()
 
     def configured_params(self) -> dict[str, Any]:
@@ -219,7 +220,9 @@ class StarterDefinition:
         }
         payload["research_evidence"] = {
             **payload["research_evidence"],
-            "strategy_revision": STARTER_EVIDENCE_REVISION,
+            "strategy_revision": payload["research_evidence"].get(
+                "strategy_revision", STARTER_EVIDENCE_REVISION
+            ),
             "risk_overlay_backtest_status": "validated",
             "risk_overlay_backtest_scope": "per_position_ohlc_stops",
             "risk_overlay_note": (
@@ -233,6 +236,10 @@ class StarterDefinition:
                     "The jobs_v1 engine figures include the current per-position "
                     "stop overlay. Live pair-group and account monitors run between "
                     "strategy bars and are not included in these historical figures."
+                    if self.family == "relative_value_pair"
+                    else "The jobs_v1 engine figures include the current per-position "
+                    "stop overlay. The live account monitor runs between strategy "
+                    "bars and is not included in these historical figures."
                 )
             ),
             "jobs_v1_leverage_sweep": {
@@ -259,7 +266,7 @@ class StarterDefinition:
         payload.update(
             {
                 "catalog_version": STARTER_CATALOG_VERSION,
-                "strategy_inception_at": STARTER_STRATEGY_INCEPTION_AT,
+                "strategy_inception_at": self.strategy_inception_at,
                 "execution_contract": "jobs_v1",
                 "default_mode": "paper",
                 "selectable": True,
@@ -380,8 +387,346 @@ _MAKER_RESEARCH_METHOD = {
     ),
 }
 
+_DIVERSE_INTRADAY_RESEARCH_METHOD = {
+    "source": "Hydromancer Reservoir 1-second Hyperliquid candles aggregated to 15m",
+    "window_start": "2025-10-02T13:30:00+00:00",
+    "window_end": "2026-08-25T00:00:00+00:00",
+    "calendar_days": 326.4,
+    "fill_model": "decision on completed close; fill at next bar open",
+    "costs": {"taker_fee_bps_per_side": 4.5, "slippage_bps_per_side": 3.5},
+    "funding_included": False,
+    "funding": "not included; long and short carry can change live returns",
+    "validation": (
+        "parameter grids ranked on the first 60% of common asset history; the "
+        "next 20%, final 20%, jobs_v1 replay, and every UTC rebalance phase were "
+        "reported separately but reviewed before publication; no sealed holdout"
+    ),
+}
+
+_BULLISH_5M_RESEARCH_METHOD = {
+    "source": "Binance USD-M native 5m candles via the SDK CCXT dataset fetcher",
+    "window_start": "2025-09-04T15:25:00+00:00",
+    "window_end": "2026-09-04T15:15:00+00:00",
+    "calendar_days": 365.0,
+    "fill_model": "decision on completed 5m close; fill at next 5m bar open",
+    "costs": {"taker_fee_bps_per_side": 4.5, "slippage_bps_per_side": 3.5},
+    "funding_included": False,
+    "funding": "not included; long carry can change live returns",
+    "validation": (
+        "native-resolution cross-venue replay of a mechanism developed on an "
+        "independent Hyperliquid 15m panel; all slices were reviewed before "
+        "publication, so forward paper results remain the real holdout"
+    ),
+}
+
 
 STARTER_DEFINITIONS: tuple[StarterDefinition, ...] = (
+    StarterDefinition(
+        id="bullish-regime-rotation-5m",
+        name="Bullish Regime Rotation · 5m",
+        family="regime_rotation",
+        summary=(
+            "Owns one confirmed medium-term leader during broad uptrends and "
+            "otherwise holds cash, using a deliberately modest 40% gross allocation."
+        ),
+        timeframe="5m",
+        module="wayfinder_paths.jobs.strategies.regime_rotation",
+        symbols=("BNB", "PAXG", "HYPE", "ZEC", "MORPHO"),
+        crypto_assets=("BNB", "PAXG", "HYPE", "ZEC", "MORPHO"),
+        tokenized_equities=(),
+        rules=(
+            "Treat an asset as bullish only when its 24-hour average and price are above its 5-day average and its trailing 3-day return is positive.",
+            "Hold the strongest 3-day leader only when at least three of five assets are bullish; otherwise hold cash.",
+            "Re-evaluate daily at 12:00 UTC and cap target gross exposure at 40%.",
+        ),
+        params={
+            "risk_symbols": ["BNB", "PAXG", "HYPE", "ZEC", "MORPHO"],
+            "defensive_symbol": None,
+            "momentum_bars": 864,
+            "fast_sma_bars": 288,
+            "slow_sma_bars": 1440,
+            "require_trend_alignment": True,
+            "minimum_breadth": 0.5,
+            "top_n": 1,
+            "gross_exposure": 0.4,
+            "rebalance_bars": 288,
+            "rebalance_offset": 144,
+            "rebalance_threshold": 0.10,
+            "stop_atr_period": 180,
+        },
+        research_evidence={
+            **_BULLISH_5M_RESEARCH_METHOD,
+            "strategy_revision": "2.0.0",
+            "strategy_family": "long-only breadth-confirmed momentum rotation",
+            "sharpe": 2.6261,
+            "max_drawdown": -0.1758,
+            "chronological_fold_method": (
+                "fixed-parameter continuous jobs_v1 path divided into four "
+                "contiguous quarters"
+            ),
+            "chronological_fold_returns": [0.5858, 0.0182, 0.5495, -0.0269],
+            "hyperliquid_mechanism_check": {
+                "bar_interval": "15m",
+                "window_start": "2025-10-02T13:30:00+00:00",
+                "window_end": "2026-08-25T00:00:00+00:00",
+                "return_after_fees_and_slippage": 0.8949,
+                "sharpe": 2.5219,
+                "max_drawdown": -0.1748,
+                "btc_bull_regime_return": 0.7200,
+                "btc_bear_regime_return": 0.1017,
+                "rebalance_phases_passing_return_and_sharpe_target": 57,
+                "rebalance_phases_checked": 96,
+            },
+            "jobs_v1_engine": {
+                "return_after_fees_and_slippage": 1.4347,
+                "sharpe": 2.6261,
+                "max_drawdown": -0.1758,
+                "trade_count": 156,
+                "total_fees_usd": 508.61,
+                "stop_count": 0,
+                "full_period_vs_no_stop": "unchanged",
+                "chronological_folds_non_regressing": 4,
+                "funding_included": False,
+                "trace_valid": True,
+            },
+        },
+        strategy_inception_at="2026-09-04T00:00:00+00:00",
+        cautions=(
+            "Native 5m validation used Binance USD-M candles; the same mechanism also passed on Hyperliquid 15m bars, but venue-specific forward behavior can differ.",
+            "The newest chronological quarter lost 2.7%; this is a paper-first bullish specialist, not an all-regime claim.",
+            "Funding is not included and the strategy can concentrate its full 40% target in one asset.",
+            "Only the default 1x setting stayed within the -20% account-halt threshold in the leverage sweep.",
+        ),
+    ),
+    StarterDefinition(
+        id="diversified-trend-sleeves-15m",
+        name="Diversified Trend Sleeves · 15m",
+        family="cross_sectional_momentum",
+        summary=(
+            "Runs four independent relative-trend sleeves across underused crypto "
+            "markets, so no single leader decides the whole portfolio."
+        ),
+        timeframe="15m",
+        module="wayfinder_paths.jobs.strategies.mixed_sleeve_momentum",
+        symbols=("HYPE", "DOGE", "ZEC", "SUI", "MORPHO", "AAVE", "PAXG", "AVAX"),
+        crypto_assets=("HYPE", "DOGE", "ZEC", "SUI", "MORPHO", "AAVE", "PAXG", "AVAX"),
+        tokenized_equities=(),
+        rules=(
+            "Compare trailing 3-day returns within HYPE/DOGE, ZEC/SUI, MORPHO/AAVE, and PAXG/AVAX.",
+            "Long each sleeve winner and short its loser at 12.5% per leg; gross 100%, net 0%.",
+            "Re-rank every 48 hours on a 00:00 UTC completed bar.",
+        ),
+        params={
+            "sleeves": [
+                ["HYPE", "DOGE"],
+                ["ZEC", "SUI"],
+                ["MORPHO", "AAVE"],
+                ["PAXG", "AVAX"],
+            ],
+            "momentum_bars": 288,
+            "rebalance_bars": 192,
+            "rebalance_offset": 0,
+            "weight_per_leg": 0.125,
+            "rebalance_threshold": 0.10,
+            "stop_atr_period": 96,
+            "stop_atr_multiple": 20.0,
+            "stop_min_pct": 0.60,
+            "stop_max_pct": 0.80,
+            "stop_cooldown_seconds": 0,
+        },
+        research_evidence={
+            **_DIVERSE_INTRADAY_RESEARCH_METHOD,
+            "strategy_revision": "2.0.0",
+            "strategy_family": "cross-sectional sleeve momentum",
+            "sharpe": 2.6780,
+            "max_drawdown": -0.1107,
+            "chronological_fold_method": (
+                "fixed-parameter continuous jobs_v1 path divided into four "
+                "contiguous quarters"
+            ),
+            "chronological_fold_returns": [0.1534, 0.1117, 0.3104, 0.0977],
+            "phase_robustness": {
+                "rebalance_phases_passing_return_and_sharpe_target": 159,
+                "rebalance_phases_checked": 192,
+                "full_period_sharpe_median": 2.0398,
+            },
+            "jobs_v1_engine": {
+                "return_after_fees_and_slippage": 0.8443,
+                "sharpe": 2.6780,
+                "max_drawdown": -0.1107,
+                "trade_count": 889,
+                "total_fees_usd": 674.93,
+                "stop_count": 0,
+                "full_period_vs_no_stop": "unchanged",
+                "chronological_folds_non_regressing": 4,
+                "funding_included": False,
+                "trace_valid": True,
+            },
+        },
+        strategy_inception_at="2026-09-04T00:00:00+00:00",
+        cautions=(
+            "Funding is not included and four short legs can create material carry costs.",
+            "The evidence spans roughly eleven months and includes an exceptional ZEC trend; forward diversification may be weaker.",
+            "Only the default 1x setting stayed within the -20% account-halt threshold in the leverage sweep.",
+        ),
+    ),
+    StarterDefinition(
+        id="diversified-momentum-taker-15m",
+        name="Diversified Momentum Taker · 15m",
+        family="cross_sectional_momentum",
+        summary=(
+            "Trades only the strongest and weakest momentum tails of a broad "
+            "ten-asset crypto panel using marketable rebalances."
+        ),
+        timeframe="15m",
+        module="wayfinder_paths.jobs.strategies.mixed_momentum_rank",
+        symbols=(
+            "BNB",
+            "DOGE",
+            "SUI",
+            "LINK",
+            "AAVE",
+            "AVAX",
+            "PAXG",
+            "HYPE",
+            "ZEC",
+            "MORPHO",
+        ),
+        crypto_assets=(
+            "BNB",
+            "DOGE",
+            "SUI",
+            "LINK",
+            "AAVE",
+            "AVAX",
+            "PAXG",
+            "HYPE",
+            "ZEC",
+            "MORPHO",
+        ),
+        tokenized_equities=(),
+        rules=(
+            "Rank all ten assets by trailing 5-day return.",
+            "Long the top three and short the bottom three at one-sixth per leg; leave the middle four flat.",
+            "Use taker orders to re-rank every 12 hours at 00:00 and 12:00 UTC.",
+        ),
+        params={
+            "momentum_bars": 480,
+            "rank_legs": 3,
+            "rebalance_bars": 48,
+            "rebalance_offset": 0,
+            "weight_per_leg": 1 / 6,
+            "rebalance_threshold": 0.10,
+            "stop_atr_period": 96,
+            "stop_atr_multiple": 20.0,
+            "stop_min_pct": 0.60,
+            "stop_max_pct": 0.80,
+            "stop_cooldown_seconds": 0,
+        },
+        research_evidence={
+            **_DIVERSE_INTRADAY_RESEARCH_METHOD,
+            "strategy_revision": "2.0.0",
+            "strategy_family": "broad cross-sectional taker momentum",
+            "sharpe": 1.4236,
+            "max_drawdown": -0.1821,
+            "chronological_fold_method": (
+                "fixed-parameter continuous jobs_v1 path divided into four "
+                "contiguous quarters"
+            ),
+            "chronological_fold_returns": [0.0190, 0.1071, 0.3487, -0.0446],
+            "phase_robustness": {
+                "rebalance_phases_passing_return_and_sharpe_target": 40,
+                "rebalance_phases_checked": 48,
+                "full_period_sharpe_median": 1.7995,
+            },
+            "jobs_v1_engine": {
+                "return_after_fees_and_slippage": 0.4537,
+                "sharpe": 1.4236,
+                "max_drawdown": -0.1821,
+                "trade_count": 1634,
+                "total_fees_usd": 1437.92,
+                "stop_count": 0,
+                "full_period_vs_no_stop": "unchanged",
+                "chronological_folds_non_regressing": 4,
+                "funding_included": False,
+                "trace_valid": True,
+            },
+        },
+        strategy_inception_at="2026-09-04T00:00:00+00:00",
+        cautions=(
+            "The full-period Sharpe only narrowly clears 1.4 and the newest chronological quarter lost 4.5%.",
+            "This is an intentionally active taker strategy: the replay paid $1,438 in fees and modeled slippage on $10,000 initial capital.",
+            "Funding is not included and can materially alter a persistent long/short basket.",
+            "Only the default 1x setting stayed within the -20% account-halt threshold in the leverage sweep.",
+        ),
+    ),
+    StarterDefinition(
+        id="crypto-gold-regime-relay-15m",
+        name="Crypto–Gold Regime Relay · 15m",
+        family="regime_rotation",
+        summary=(
+            "Rotates between a concentrated crypto leader and tokenized gold, "
+            "with cash as the fallback when neither side has positive momentum."
+        ),
+        timeframe="15m",
+        module="wayfinder_paths.jobs.strategies.regime_rotation",
+        symbols=("BNB", "HYPE", "ZEC", "MORPHO", "PAXG"),
+        crypto_assets=("BNB", "HYPE", "ZEC", "MORPHO", "PAXG"),
+        tokenized_equities=(),
+        rules=(
+            "Measure trailing 10-day momentum in BNB, HYPE, ZEC, and MORPHO.",
+            "When at least two risk assets have positive momentum, own the strongest at 40% gross; otherwise own PAXG at 40% only if its own momentum is positive.",
+            "Re-evaluate every eight hours at 00:00, 08:00, and 16:00 UTC; hold cash when neither side qualifies.",
+        ),
+        params={
+            "risk_symbols": ["BNB", "HYPE", "ZEC", "MORPHO"],
+            "defensive_symbol": "PAXG",
+            "momentum_bars": 960,
+            "require_trend_alignment": False,
+            "minimum_breadth": 0.5,
+            "top_n": 1,
+            "gross_exposure": 0.4,
+            "rebalance_bars": 32,
+            "rebalance_offset": 0,
+            "rebalance_threshold": 0.10,
+            "stop_atr_period": 96,
+        },
+        research_evidence={
+            **_DIVERSE_INTRADAY_RESEARCH_METHOD,
+            "strategy_revision": "2.0.0",
+            "strategy_family": "risk-on crypto / defensive gold relay",
+            "sharpe": 1.6410,
+            "max_drawdown": -0.1716,
+            "chronological_fold_method": (
+                "fixed-parameter continuous jobs_v1 path divided into four "
+                "contiguous quarters"
+            ),
+            "chronological_fold_returns": [0.1737, 0.1426, 0.2226, 0.0384],
+            "phase_robustness": {
+                "rebalance_phases_passing_return_and_sharpe_target": 32,
+                "rebalance_phases_checked": 32,
+                "full_period_sharpe_minimum": 1.5580,
+            },
+            "jobs_v1_engine": {
+                "return_after_fees_and_slippage": 0.7023,
+                "sharpe": 1.6410,
+                "max_drawdown": -0.1716,
+                "trade_count": 276,
+                "total_fees_usd": 634.06,
+                "stop_count": 0,
+                "full_period_vs_no_stop": "unchanged",
+                "chronological_folds_non_regressing": 4,
+                "funding_included": False,
+                "trace_valid": True,
+            },
+        },
+        strategy_inception_at="2026-09-04T00:00:00+00:00",
+        cautions=(
+            "PAXG is a traded asset, not cash; it can fall during risk-off periods and carries venue-specific basis and liquidity risk.",
+            "Funding is not included and the evidence spans roughly eleven months.",
+            "Only the default 1x setting stayed within the -20% account-halt threshold in the leverage sweep.",
+        ),
+    ),
     StarterDefinition(
         id="mixed-rsi-snapback-1h",
         name="Mixed RSI Snapback · 1h",
@@ -1490,7 +1835,7 @@ def create_starter_job(
     job.controller["starter"] = {
         "id": definition.id,
         "catalog_version": STARTER_CATALOG_VERSION,
-        "strategy_inception_at": STARTER_STRATEGY_INCEPTION_AT,
+        "strategy_inception_at": definition.strategy_inception_at,
         "job_tracking_inception_at": job.created_at,
         "paper_only": True,
         "risk_limits": definition.risk_limits(),

--- a/wayfinder_paths/jobs/strategies/_starter_utils.py
+++ b/wayfinder_paths/jobs/strategies/_starter_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
 from typing import Any
@@ -191,13 +192,31 @@ def stop_brackets(
 
 
 def ranked_weights(
-    scores: Mapping[str, float], *, weight_per_leg: float
+    scores: Mapping[str, float], *, weight_per_leg: float, legs: int | None = None
 ) -> dict[str, float]:
-    """Long the upper half and short the lower half, deterministically."""
+    """Long the leaders and short the laggards, deterministically.
+
+    ``legs=None`` preserves the original half-long/half-short behavior.  A
+    smaller explicit count leaves the middle ranks flat, which lets broader
+    universes express only their strongest cross-sectional signals.
+    """
     ranked = sorted(scores, key=lambda symbol: (scores[symbol], symbol))
-    midpoint = len(ranked) // 2
-    weights = dict.fromkeys(ranked[:midpoint], -weight_per_leg)
-    weights.update(dict.fromkeys(ranked[midpoint:], weight_per_leg))
+    if legs is None:
+        midpoint = len(ranked) // 2
+        weights = dict.fromkeys(ranked[:midpoint], -weight_per_leg)
+        weights.update(dict.fromkeys(ranked[midpoint:], weight_per_leg))
+        return weights
+    if isinstance(legs, bool):
+        raise ValueError("ranked leg count must be a whole number")
+    candidate = float(legs)
+    if not math.isfinite(candidate) or not candidate.is_integer():
+        raise ValueError("ranked leg count must be a whole number")
+    leg_count = int(candidate)
+    if leg_count <= 0 or leg_count * 2 > len(ranked):
+        raise ValueError("ranked leg count must cover at most half the universe")
+    weights = dict.fromkeys(ranked, 0.0)
+    weights.update(dict.fromkeys(ranked[:leg_count], -weight_per_leg))
+    weights.update(dict.fromkeys(ranked[-leg_count:], weight_per_leg))
     return weights
 
 

--- a/wayfinder_paths/jobs/strategies/mixed_momentum_rank.py
+++ b/wayfinder_paths/jobs/strategies/mixed_momentum_rank.py
@@ -1,4 +1,4 @@
-"""One-hour cross-asset momentum rank, rebalanced daily at 12:00 UTC."""
+"""Configurable cross-asset momentum ranking strategy."""
 
 from __future__ import annotations
 
@@ -25,6 +25,7 @@ class MixedMomentumRankStrategy:
         "symbols": ["BTC", "SOL", "xyz:XYZ100", "xyz:TSLA"],
         "venue": "hyperliquid",
         "momentum_bars": 336,
+        "rank_legs": None,
         "rebalance_bars": 24,
         "rebalance_offset": 12,
         "weight_per_leg": 0.25,
@@ -36,6 +37,14 @@ class MixedMomentumRankStrategy:
 
     def __init__(self, params: dict[str, Any] | None = None) -> None:
         self.params = merge_params(self.default_params, params)
+        rank_legs = self.params.get("rank_legs")
+        if rank_legs is not None:
+            ranked_weights(
+                dict.fromkeys(self.params["symbols"], 0.0),
+                weight_per_leg=0.0,
+                legs=rank_legs,
+            )
+            self.params["rank_legs"] = int(rank_legs)
         self.warmup_bars = (
             max(
                 int(self.params["momentum_bars"]),
@@ -63,7 +72,13 @@ class MixedMomentumRankStrategy:
         if scores is None:
             return []
         weights = ranked_weights(
-            scores, weight_per_leg=float(self.params["weight_per_leg"])
+            scores,
+            weight_per_leg=float(self.params["weight_per_leg"]),
+            legs=(
+                int(self.params["rank_legs"])
+                if self.params.get("rank_legs") is not None
+                else None
+            ),
         )
         return target_weights_to_intents(
             ctx,

--- a/wayfinder_paths/jobs/strategies/mixed_sleeve_momentum.py
+++ b/wayfinder_paths/jobs/strategies/mixed_sleeve_momentum.py
@@ -1,4 +1,4 @@
-"""Fifteen-minute crypto/equity sleeve momentum, rebalanced daily."""
+"""Configurable cross-asset sleeve momentum strategy."""
 
 from __future__ import annotations
 

--- a/wayfinder_paths/jobs/strategies/regime_rotation.py
+++ b/wayfinder_paths/jobs/strategies/regime_rotation.py
@@ -1,0 +1,176 @@
+"""Long-only momentum rotation with an optional defensive asset relay."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from wayfinder_paths.jobs.execution.primitives import ExecutionContext
+from wayfinder_paths.jobs.indicators import bounded_span, trailing_return
+from wayfinder_paths.jobs.strategies._starter_utils import (
+    RANKING_STOP_DEFAULTS,
+    add_stop_atr,
+    current_feature_values,
+    merge_params,
+    stop_brackets,
+)
+from wayfinder_paths.jobs.strategies.portfolio import target_weights_to_intents
+
+
+class RegimeRotationStrategy:
+    """Own the strongest confirmed uptrend or relay to a defensive asset.
+
+    The strategy is intentionally long-only.  When too few risk assets have
+    positive momentum it either holds cash or, when configured, owns the
+    defensive symbol only while that symbol has positive momentum itself.
+    """
+
+    default_params: dict[str, Any] = {
+        "symbols": ["BNB", "PAXG", "HYPE", "ZEC", "MORPHO"],
+        "risk_symbols": ["BNB", "PAXG", "HYPE", "ZEC", "MORPHO"],
+        "defensive_symbol": None,
+        "venue": "hyperliquid",
+        "momentum_bars": 288,
+        "fast_sma_bars": 96,
+        "slow_sma_bars": 480,
+        "require_trend_alignment": True,
+        "minimum_breadth": 0.5,
+        "top_n": 1,
+        "gross_exposure": 0.4,
+        "rebalance_bars": 96,
+        "rebalance_offset": 48,
+        "rebalance_threshold": 0.10,
+        "min_trade_notional": 25.0,
+        **RANKING_STOP_DEFAULTS,
+        "stop_atr_period": 96,
+    }
+
+    def __init__(self, params: dict[str, Any] | None = None) -> None:
+        self.params = merge_params(self.default_params, params)
+        self.risk_symbols = [
+            str(symbol) for symbol in self.params.get("risk_symbols") or []
+        ]
+        self.defensive_symbol = (
+            str(self.params["defensive_symbol"])
+            if self.params.get("defensive_symbol")
+            else None
+        )
+        symbols = list(self.params["symbols"])
+        if not self.risk_symbols or not set(self.risk_symbols).issubset(symbols):
+            raise ValueError("risk_symbols must be a non-empty subset of symbols")
+        if self.defensive_symbol and self.defensive_symbol not in symbols:
+            raise ValueError("defensive_symbol must be present in symbols")
+        for name in (
+            "momentum_bars",
+            "fast_sma_bars",
+            "slow_sma_bars",
+            "rebalance_bars",
+            "stop_atr_period",
+        ):
+            if int(self.params[name]) <= 0:
+                raise ValueError(f"{name} must be positive")
+        top_n = int(self.params["top_n"])
+        if top_n <= 0 or top_n > len(self.risk_symbols):
+            raise ValueError("top_n must fit inside risk_symbols")
+        breadth = float(self.params["minimum_breadth"])
+        if not 0 < breadth <= 1:
+            raise ValueError("minimum_breadth must be in (0, 1]")
+        gross = float(self.params["gross_exposure"])
+        if not 0 < gross <= 1:
+            raise ValueError("gross_exposure must be in (0, 1]")
+        indicator_bars = [
+            int(self.params["momentum_bars"]),
+            bounded_span(int(self.params["stop_atr_period"])),
+        ]
+        if bool(self.params["require_trend_alignment"]):
+            indicator_bars.extend(
+                (
+                    int(self.params["fast_sma_bars"]),
+                    int(self.params["slow_sma_bars"]),
+                )
+            )
+        self.warmup_bars = max(indicator_bars) + 4
+
+    def precompute(self, frames: dict[str, pd.DataFrame]) -> dict[str, pd.DataFrame]:
+        momentum_bars = int(self.params["momentum_bars"])
+        fast_bars = int(self.params["fast_sma_bars"])
+        slow_bars = int(self.params["slow_sma_bars"])
+        derived: dict[str, pd.DataFrame] = {}
+        for symbol, frame in frames.items():
+            close = pd.to_numeric(frame["close"], errors="coerce")
+            features = {"starter_momentum": trailing_return(close, momentum_bars)}
+            if bool(self.params["require_trend_alignment"]):
+                features.update(
+                    {
+                        "starter_fast_sma": close.rolling(
+                            fast_bars, min_periods=fast_bars
+                        ).mean(),
+                        "starter_slow_sma": close.rolling(
+                            slow_bars, min_periods=slow_bars
+                        ).mean(),
+                    }
+                )
+            derived[symbol] = pd.DataFrame(features)
+        return add_stop_atr(derived, frames, period=int(self.params["stop_atr_period"]))
+
+    def decide(self, ctx: ExecutionContext) -> list[dict[str, Any]]:
+        if ctx.bar_index < self.warmup_bars or not ctx.every_n_bars(
+            int(self.params["rebalance_bars"]),
+            offset=int(self.params["rebalance_offset"]),
+        ):
+            return []
+        symbols = list(self.params["symbols"])
+        momentum = current_feature_values(ctx, symbols, "starter_momentum")
+        closes = current_feature_values(ctx, symbols, "close")
+        if momentum is None or closes is None:
+            return []
+        require_alignment = bool(self.params["require_trend_alignment"])
+        fast_sma = (
+            current_feature_values(ctx, symbols, "starter_fast_sma")
+            if require_alignment
+            else None
+        )
+        slow_sma = (
+            current_feature_values(ctx, symbols, "starter_slow_sma")
+            if require_alignment
+            else None
+        )
+        if require_alignment and (fast_sma is None or slow_sma is None):
+            return []
+        eligible: dict[str, float] = {}
+        for symbol in self.risk_symbols:
+            aligned = (
+                fast_sma is not None
+                and slow_sma is not None
+                and fast_sma[symbol] > slow_sma[symbol]
+                and closes[symbol] > slow_sma[symbol]
+            )
+            if momentum[symbol] > 0 and (aligned or not require_alignment):
+                eligible[symbol] = momentum[symbol]
+
+        breadth = len(eligible) / len(self.risk_symbols)
+        weights = dict.fromkeys(symbols, 0.0)
+        if breadth >= float(self.params["minimum_breadth"]):
+            selected = sorted(
+                eligible, key=lambda symbol: (eligible[symbol], symbol), reverse=True
+            )[: int(self.params["top_n"])]
+            for symbol in selected:
+                weights[symbol] = float(self.params["gross_exposure"]) / len(selected)
+        elif self.defensive_symbol:
+            defensive_momentum = momentum[self.defensive_symbol]
+            if defensive_momentum > 0:
+                weights[self.defensive_symbol] = float(self.params["gross_exposure"])
+
+        return target_weights_to_intents(
+            ctx,
+            weights,
+            venue=str(self.params["venue"]),
+            rebalance_threshold=float(self.params["rebalance_threshold"]),
+            min_trade_notional=float(self.params["min_trade_notional"]),
+            brackets=stop_brackets(ctx, symbols, self.params),
+        )
+
+
+def build_strategy(params: dict[str, Any] | None = None) -> RegimeRotationStrategy:
+    return RegimeRotationStrategy(params)

--- a/wayfinder_paths/tests/test_jobs_starters.py
+++ b/wayfinder_paths/tests/test_jobs_starters.py
@@ -63,6 +63,7 @@ from wayfinder_paths.jobs.strategies.mixed_volume_capitulation import (
 from wayfinder_paths.jobs.strategies.pair_relative_strength import (
     PairRelativeStrengthStrategy,
 )
+from wayfinder_paths.jobs.strategies.regime_rotation import RegimeRotationStrategy
 from wayfinder_paths.jobs.sync import snapshot_job
 
 
@@ -241,7 +242,7 @@ def dataset_fetch_spawns(monkeypatch) -> list[dict[str, Any]]:
 
 def test_starter_catalog_has_mixed_maker_and_pair_paper_strategies() -> None:
     catalog = starter_catalog()
-    assert len(catalog) == 12
+    assert len(catalog) == 16
     assert {item["timeframe"] for item in catalog} == {
         "5m",
         "15m",
@@ -249,8 +250,8 @@ def test_starter_catalog_has_mixed_maker_and_pair_paper_strategies() -> None:
         "4h",
         "1d",
     }
-    assert [item["timeframe"] for item in catalog].count("5m") == 2
-    assert [item["timeframe"] for item in catalog].count("15m") == 2
+    assert [item["timeframe"] for item in catalog].count("5m") == 3
+    assert [item["timeframe"] for item in catalog].count("15m") == 5
     assert [item["timeframe"] for item in catalog].count("1h") == 5
     assert [item["timeframe"] for item in catalog].count("4h") == 1
     assert [item["timeframe"] for item in catalog].count("1d") == 2
@@ -266,6 +267,7 @@ def test_starter_catalog_has_mixed_maker_and_pair_paper_strategies() -> None:
             "maker_mean_reversion",
             "mean_reversion",
             "low_volatility_ranking",
+            "regime_rotation",
             "relative_value_pair",
         }
         assert isinstance(item["cautions"], list)
@@ -306,11 +308,45 @@ def test_starter_catalog_has_mixed_maker_and_pair_paper_strategies() -> None:
         assert sweep["account_halt_simulated"] is False
         assert [row["leverage"] for row in sweep["results"]] == [1, 2, 3, 4, 5]
         assert all(row["liquidation_count"] == 0 for row in sweep["results"])
+        assert all(
+            row["within_account_halt_threshold"]
+            == (row["max_drawdown"] >= row["account_halt_threshold"])
+            for row in sweep["results"]
+        )
         assert sweep["results"][0]["return_after_fees_and_slippage"] == pytest.approx(
             engine["return_after_fees_and_slippage"], abs=0.0001
         )
 
     by_id = {item["id"]: item for item in catalog}
+    new_intraday_ids = {
+        "bullish-regime-rotation-5m",
+        "diversified-trend-sleeves-15m",
+        "diversified-momentum-taker-15m",
+        "crypto-gold-regime-relay-15m",
+    }
+    for starter_id in new_intraday_ids:
+        engine = by_id[starter_id]["research_evidence"]["jobs_v1_engine"]
+        assert by_id[starter_id]["strategy_inception_at"] == (
+            "2026-09-04T00:00:00+00:00"
+        )
+        assert by_id[starter_id]["research_evidence"]["strategy_revision"] == "2.0.0"
+        assert engine["return_after_fees_and_slippage"] > 0.15
+        assert engine["sharpe"] > 1.4
+        assert (
+            engine["max_drawdown"] >= by_id[starter_id]["risk_limits"]["max_drawdown"]
+        )
+    bull_regimes = by_id["bullish-regime-rotation-5m"]["research_evidence"][
+        "hyperliquid_mechanism_check"
+    ]
+    assert bull_regimes["btc_bull_regime_return"] > 0
+    assert bull_regimes["btc_bear_regime_return"] >= 0
+    assert by_id["mixed-rsi-snapback-1h"]["strategy_inception_at"] == (
+        "2026-08-24T00:00:00+00:00"
+    )
+    assert (
+        by_id["mixed-rsi-snapback-1h"]["research_evidence"]["strategy_revision"]
+        == "1.8.0"
+    )
     crypto_momentum = by_id["crypto-momentum-persistence-4h"]
     assert crypto_momentum["params"]["score_volatility_bars"] == 168
     assert crypto_momentum["params"]["broad_bull_momentum_threshold"] == 0.10
@@ -337,6 +373,10 @@ def test_starter_catalog_has_mixed_maker_and_pair_paper_strategies() -> None:
         "hype-passive-rsi-full-5m": (3.0, 0.001, 0.20),
         "hype-passive-rsi-staged-5m": (3.0, 0.001, 0.20),
         "btc-eth-relative-strength-1d": (15.0, 0.40, 0.60),
+        "bullish-regime-rotation-5m": (12.0, 0.25, 0.50),
+        "diversified-trend-sleeves-15m": (20.0, 0.60, 0.80),
+        "diversified-momentum-taker-15m": (20.0, 0.60, 0.80),
+        "crypto-gold-regime-relay-15m": (12.0, 0.25, 0.50),
     }
     for starter_id, expected in expected_stops.items():
         params = by_id[starter_id]["params"]
@@ -406,6 +446,10 @@ EXPECTED_STARTER_LOOKBACK_BARS = {
     "hype-passive-rsi-staged-5m": 136,
     "btc-eth-relative-strength-1d": 184,
     "bch-ltc-relative-strength-1d": 184,
+    "bullish-regime-rotation-5m": 1464,
+    "diversified-trend-sleeves-15m": 792,
+    "diversified-momentum-taker-15m": 792,
+    "crypto-gold-regime-relay-15m": 984,
 }
 
 
@@ -580,6 +624,122 @@ def test_momentum_rank_longs_leaders_and_shorts_laggards() -> None:
         "C": "sell",
         "D": "sell",
     }
+
+
+def test_momentum_rank_can_leave_middle_assets_flat() -> None:
+    symbols = list("ABCDEFGHIJ")
+    strategy = MixedMomentumRankStrategy(
+        {
+            "symbols": symbols,
+            "momentum_bars": 2,
+            "rank_legs": 3,
+            "rebalance_bars": 1,
+            "stop_atr_period": 1,
+            "min_trade_notional": 0.0,
+        }
+    )
+    ctx = _context(
+        strategy,
+        {
+            symbol: [100.0, 100.0, 90.0 + 3.0 * index]
+            for index, symbol in enumerate(symbols)
+        },
+        interval="15min",
+    )
+
+    assert _sides(strategy.decide(ctx)) == {
+        "A": "sell",
+        "B": "sell",
+        "C": "sell",
+        "H": "buy",
+        "I": "buy",
+        "J": "buy",
+    }
+
+
+def test_momentum_rank_preserves_odd_universe_default_and_validates_rank_legs() -> None:
+    from wayfinder_paths.jobs.strategies._starter_utils import ranked_weights
+
+    assert ranked_weights({"A": 1.0, "B": 2.0, "C": 3.0}, weight_per_leg=0.25) == {
+        "A": -0.25,
+        "B": 0.25,
+        "C": 0.25,
+    }
+    with pytest.raises(ValueError, match="whole number"):
+        MixedMomentumRankStrategy({"symbols": list("ABCD"), "rank_legs": 1.5})
+    with pytest.raises(ValueError, match="at most half"):
+        MixedMomentumRankStrategy({"symbols": list("ABCD"), "rank_legs": 3})
+
+
+def test_bullish_regime_rotation_owns_leader_or_cash() -> None:
+    symbols = list("ABCDE")
+    params = {
+        "symbols": symbols,
+        "risk_symbols": symbols,
+        "momentum_bars": 2,
+        "fast_sma_bars": 2,
+        "slow_sma_bars": 3,
+        "minimum_breadth": 0.5,
+        "rebalance_bars": 1,
+        "stop_atr_period": 1,
+        "min_trade_notional": 0.0,
+    }
+    strategy = RegimeRotationStrategy(params)
+    bull = _context(
+        strategy,
+        {
+            "A": [100.0, 105.0, 120.0],
+            "B": [100.0, 104.0, 112.0],
+            "C": [100.0, 103.0, 108.0],
+            "D": [100.0, 98.0, 96.0],
+            "E": [100.0, 97.0, 94.0],
+        },
+        interval="5min",
+    )
+    bull_intents = strategy.decide(bull)
+    assert _sides(bull_intents) == {"A": "buy"}
+    assert bull_intents[0]["notional"] == 4_000.0
+
+    bear = _context(
+        strategy,
+        {
+            symbol: [100.0, 95.0 - index, 90.0 - index]
+            for index, symbol in enumerate(symbols)
+        },
+        interval="5min",
+    )
+    assert strategy.decide(bear) == []
+
+
+def test_regime_rotation_relays_to_positive_defensive_asset() -> None:
+    strategy = RegimeRotationStrategy(
+        {
+            "symbols": ["A", "B", "C", "D", "PAXG"],
+            "risk_symbols": ["A", "B", "C", "D"],
+            "defensive_symbol": "PAXG",
+            "momentum_bars": 2,
+            "require_trend_alignment": False,
+            "minimum_breadth": 0.5,
+            "rebalance_bars": 1,
+            "stop_atr_period": 1,
+            "min_trade_notional": 0.0,
+        }
+    )
+    ctx = _context(
+        strategy,
+        {
+            "A": [100.0, 95.0, 90.0],
+            "B": [100.0, 96.0, 91.0],
+            "C": [100.0, 97.0, 92.0],
+            "D": [100.0, 98.0, 93.0],
+            "PAXG": [100.0, 103.0, 108.0],
+        },
+        interval="15min",
+    )
+
+    intents = strategy.decide(ctx)
+    assert _sides(intents) == {"PAXG": "buy"}
+    assert intents[0]["notional"] == 4_000.0
 
 
 def test_crypto_momentum_concentrates_in_risk_adjusted_extremes() -> None:


### PR DESCRIPTION
## Summary

Adds four paper-first intraday starters at the top of the catalog:

- Bullish Regime Rotation at 5m: breadth-confirmed, long-only leader rotation with cash fallback
- Diversified Trend Sleeves at 15m: four independent long/short relative-trend sleeves
- Diversified Momentum Taker at 15m: top/bottom three ranking across a ten-asset universe
- Crypto–Gold Regime Relay at 15m: rotates between a crypto leader, PAXG, and cash

The implementation adds one reusable regime-rotation strategy, reuses the existing sleeve strategy, and extends the existing ranking helper with an optional explicit leg count while preserving its legacy behavior.

Stacked on #768.

## Engine evidence at 1x

| Starter | Net return | Sharpe | Max drawdown | Fills |
| --- | ---: | ---: | ---: | ---: |
| Bullish Regime Rotation 5m | +143.47% | 2.626 | -17.58% | 156 |
| Diversified Trend Sleeves 15m | +84.43% | 2.678 | -11.07% | 889 |
| Diversified Momentum Taker 15m | +45.37% | 1.424 | -18.21% | 1,634 |
| Crypto–Gold Regime Relay 15m | +70.23% | 1.641 | -17.16% | 276 |

All figures are from jobs_v1 execution replays with 4.5 bps taker fees and 3.5 bps modeled slippage per side. All four clear the requested return above 15% and Sharpe above 1.4 at the default 1x setting and stay inside the -20% account-halt threshold. Higher leverage did not stay inside that threshold, so the catalog says so rather than recommending it.

## Evidence boundaries

- The 5m starter uses one year of native Binance USD-M bars and has a separate Hyperliquid 15m mechanism check.
- The 15m starters use about eleven months of Hyperliquid-derived bars.
- Funding is not included.
- Parameters and all chronological slices were reviewed before publication; these are not sealed holdouts and remain paper-first.
- The two weakest latest quarters are disclosed in the catalog rather than hidden.

## Validation

- ruff format --check on all touched files
- ruff check on all touched files
- pytest --no-cov -q wayfinder_paths/tests/test_jobs_starters.py wayfinder_paths/tests/test_jobs_evolution_campaign.py wayfinder_paths/tests/test_runner_view_server.py
- 201 passed
- git diff --check