### PR TITLE
Contracts - Drop the Etherscan key caveat from tool copy

### DIFF
--- a/wayfinder_paths/mcp/tools/contracts.py
+++ b/wayfinder_paths/mcp/tools/contracts.py
@@ -247,8 +247,9 @@ async def contracts_get(
     Resolution order:
       1. Local artifact store (contracts deployed via `contracts_deploy`) — returns full
          deployment metadata + ABI.
-      2. Etherscan V2 fetch — returns ABI only. If `resolve_proxy` is true and the address
-         is a proxy (EIP-1967 / ZeppelinOS / EIP-897), fetches the implementation's ABI.
+      2. Verified-source lookup — returns ABI only; the contract must be source-verified on
+         its chain's explorer. If `resolve_proxy` is true and the address is a proxy
+         (EIP-1967 / ZeppelinOS / EIP-897), fetches the implementation's ABI.
     """
     store = ContractArtifactStore.default()
     cid = int(chain_id)
@@ -297,7 +298,7 @@ async def contracts_get(
     try:
         abi_list = await fetch_contract_abi(cid, addr)
     except Exception as exc:
-        return err("abi_not_found", f"ABI not found locally or on Etherscan: {exc}")
+        return err("abi_not_found", f"ABI not found locally or from a verified source: {exc}")
 
     return ok(
         {

--- a/wayfinder_paths/mcp/tools/contracts.py
+++ b/wayfinder_paths/mcp/tools/contracts.py
@@ -298,7 +298,9 @@ async def contracts_get(
     try:
         abi_list = await fetch_contract_abi(cid, addr)
     except Exception as exc:
-        return err("abi_not_found", f"ABI not found locally or from a verified source: {exc}")
+        return err(
+            "abi_not_found", f"ABI not found locally or from a verified source: {exc}"
+        )
 
     return ok(
         {

--- a/wayfinder_paths/mcp/tools/evm_contract.py
+++ b/wayfinder_paths/mcp/tools/evm_contract.py
@@ -399,8 +399,8 @@ async def contracts_call(
     """Read from a deployed contract via eth_call.
 
     - Provide either `abi` (inline list or JSON string) or `abi_path` (JSON file inside this repo).
-    - If neither is provided, this tool falls back to fetching the ABI from Etherscan V2
-      (requires `system.etherscan_api_key` or `ETHERSCAN_API_KEY`, and the contract must be verified).
+    - If neither is provided, the verified ABI is looked up automatically (the contract
+      must be source-verified on its chain's explorer). No extra configuration is needed.
     - If the function is overloaded, pass `function_signature` like `deposit(uint256)`.
     """
     loaded_abi = await _resolve_abi(


### PR DESCRIPTION
### Summary
- `contracts_call` / `contracts_get` docstrings still told the model that ABI lookup "requires `system.etherscan_api_key` or `ETHERSCAN_API_KEY`". Since #771 that is no longer true on hosted instances, but the model was faithfully repeating the caveat to users even after a successful lookup. Reworded to "the verified ABI is looked up automatically; the contract must be source-verified".
- `abi_not_found` message no longer names Etherscan.
- Copy only; `source` / `abi_source` labels and behavior unchanged. Rides the next image roll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnDyDbKtYmp7ayGCEW2URZ
