### PR TITLE
BRAP - Cross-chain recipients and complete execution quotes

### DIFF
--- a/.claude/skills/using-brap-adapter/rules/execution-opportunities.md
+++ b/.claude/skills/using-brap-adapter/rules/execution-opportunities.md
@@ -11,12 +11,15 @@
   - `amount` (string, **raw base units**)
   - `slippage` (float, decimal fraction)
   - optional: `strategy_name` (for ledger tagging)
+  - `to_address`: destination-chain wallet; required when bridging EVM → Solana
 - Output:
   - On success: a ledger record (or a structured operation object) depending on ledger availability.
 
 ### Swap from a quote
 
 - Call: `BRAPAdapter.swap_from_quote(from_token, to_token, from_address, quote, ...)`
+- Pass the complete `BRAPClient` best quote or the MCP's `execution_quote`, not
+  its compact preview. Use `onchain_swap` for Solana-source execution.
 - What it can do:
   - Build a tx dict from `quote["calldata"]`
   - Submit ERC20 approvals if needed
@@ -25,9 +28,11 @@
 ## Safety rails
 
 - Some tokens require clearing allowance to 0 before re-approving (handled in adapter).
+- Preserve the quoted transaction's **value even when selling an ERC-20**: bridge
+  routes may need native currency for relayer fees. Approve the quote's spender
+  and keep its calldata intact; do not rebuild and broadcast from the hex data alone.
 
 ## Claude Code MCP “single write gateway”
 
 For interactive use in Claude Code:
 - Use `mcp__wayfinder__onchain_swap` so the review hook can prompt before execution.
-

--- a/.claude/skills/using-brap-adapter/rules/gotchas.md
+++ b/.claude/skills/using-brap-adapter/rules/gotchas.md
@@ -30,6 +30,12 @@
 ## Recipient safety
 
 - Treat `recipient != sender` as a high-risk condition. Require explicit user confirmation and display the mismatch clearly.
+- For EVM ↔ Solana, different source/destination addresses are expected: resolve
+  both legs of the selected wallet ring and show the destination before confirming.
+  Missing a destination leg is an error, not a reason to reuse the source address.
+- Wayfinder's internal Solana chain ID is `900`. LI.FI's external ID is
+  `1151111081099710`; the backend translates it. Do not change the ID or bypass the
+  execution tools on a quote error—check the recipient first.
 
 ## Native token sends (execute tool)
 

--- a/.claude/skills/using-brap-adapter/rules/high-value-reads.md
+++ b/.claude/skills/using-brap-adapter/rules/high-value-reads.md
@@ -16,6 +16,8 @@
   - `from_wallet` (EVM address)
   - `from_amount` (string, **raw base units**, not human units)
   - optional: `slippage` (float, e.g. `0.005` for 0.5%)
+  - `to_wallet`: destination wallet address; required for EVM ↔ Solana. Use the
+    destination-chain leg of the same wallet ring, not the source-chain address.
 - Output:
   - A quote payload that typically contains `quotes`, `best_quote`, and `calldata` for execution.
   - Treat response as schema-flexible; check keys before indexing.
@@ -23,6 +25,9 @@
 ### Best quote (adapter convenience)
 
 - Call: `BRAPAdapter.best_quote(...)`
+- For EVM → Solana, pass `to_address=<Solana wallet address>` explicitly. The
+  adapter forwards this as the client's `to_wallet`; it cannot infer a wallet ring
+  from a bare source address. Same-family routes may omit it as before.
 - Returns the “best_quote” object (a single route) or an error string.
   - If you pass `preferred_providers=[...]`, it will try to select the best route among those providers first.
 
@@ -38,6 +43,10 @@ BRAP route diagnostics are easiest by inspecting the raw quote response:
 If you’re exploring interactively, prefer:
 - `mcp__wayfinder__onchain_quote_swap` (does token lookup + decimal human→raw conversion + returns a preview + compact best-quote summary; `amount` must include a decimal point, e.g. `"1000.0"`)
   - Use `include_calldata=true` only if you explicitly need calldata in the response (it can be large).
+  - With that option, `result.execution_quote` is the complete backend quote,
+    including `calldata.to`, `calldata.value`, `calldata.chainId`, and approval data.
+    The compact `quote.best_quote.calldata` string is retained for compatibility;
+    it is **not** a complete execution transaction.
 
 ### Token identifiers (avoid ambiguous lookups)
 

--- a/wayfinder_paths/adapters/brap_adapter/adapter.py
+++ b/wayfinder_paths/adapters/brap_adapter/adapter.py
@@ -11,6 +11,7 @@ from wayfinder_paths.core.adapters.models import SWAP
 from wayfinder_paths.core.clients.BRAPClient import BRAP_CLIENT
 from wayfinder_paths.core.clients.LedgerClient import TransactionRecord
 from wayfinder_paths.core.clients.TokenClient import TOKEN_CLIENT
+from wayfinder_paths.core.constants.chains import SVM_CHAIN_IDS
 from wayfinder_paths.core.utils.tokens import (
     ensure_allowance,
     is_native_token,
@@ -113,7 +114,10 @@ class BRAPAdapter(BaseAdapter):
         preferred_providers: list[str] | None = None,
         retries: int = 1,
         slippage: float | None = None,
+        *,
+        to_address: str | None = None,
     ) -> tuple[bool, dict[str, Any] | str]:
+        """Quote raw token amounts; EVM/Solana routes require a destination address."""
         last_error = "No quotes available"
         for attempt in range(retries):
             try:
@@ -125,6 +129,7 @@ class BRAPAdapter(BaseAdapter):
                     from_wallet=from_address,
                     from_amount=amount,
                     slippage=slippage,
+                    to_wallet=to_address,
                 )
 
                 all_quotes, quote = data.get("quotes", []), data.get("best_quote")
@@ -159,10 +164,22 @@ class BRAPAdapter(BaseAdapter):
         strategy_name: str | None = None,
     ) -> tuple[bool, Any]:
         chain_id = from_token["chain"]["id"]
+        if chain_id in SVM_CHAIN_IDS:
+            return (False, "Use onchain_swap for Solana-source execution.")
 
         calldata = quote.get("calldata")
-        if not calldata or not calldata.get("data"):
-            return (False, "Quote missing calldata")
+        if not isinstance(calldata, dict) or not calldata.get("data"):
+            return (
+                False,
+                "Quote missing complete calldata. Use BRAPClient's best_quote or "
+                "the MCP quote's execution_quote; do not reconstruct a transaction "
+                "from the compact preview's hex data.",
+            )
+        if calldata.get("chainId") is not None and int(calldata["chainId"]) != chain_id:
+            return (
+                False,
+                "Quote calldata chain does not match the source token chain.",
+            )
 
         transaction = {
             **calldata,
@@ -170,7 +187,12 @@ class BRAPAdapter(BaseAdapter):
             "from": Web3.to_checksum_address(from_address),
         }
         if "value" in calldata:
-            transaction["value"] = int(calldata["value"])
+            value = calldata["value"]
+            transaction["value"] = (
+                int(value, 16)
+                if isinstance(value, str) and value.startswith("0x")
+                else int(value)
+            )
 
         approve_amount = (
             quote.get("input_amount")
@@ -179,7 +201,11 @@ class BRAPAdapter(BaseAdapter):
         )
         token_address = from_token.get("address")
 
-        spender = transaction.get("to")
+        spender = (
+            quote.get("approval_address")
+            or quote.get("approvalAddress")
+            or transaction.get("to")
+        )
         if (
             token_address
             and spender
@@ -232,6 +258,8 @@ class BRAPAdapter(BaseAdapter):
         preferred_providers: list[str] | None = None,
         retries: int = 1,
         slippage: float | None = None,
+        *,
+        to_address: str | None = None,
     ) -> tuple[bool, Any]:
         from_token = await TOKEN_CLIENT.get_token_details(from_token_id)
         to_token = await TOKEN_CLIENT.get_token_details(to_token_id)
@@ -250,6 +278,7 @@ class BRAPAdapter(BaseAdapter):
             preferred_providers=preferred_providers,
             retries=retries,
             slippage=slippage,
+            to_address=to_address,
         )
         if not success:
             return (False, quote)

--- a/wayfinder_paths/core/clients/BRAPClient.py
+++ b/wayfinder_paths/core/clients/BRAPClient.py
@@ -7,6 +7,7 @@ from loguru import logger
 
 from wayfinder_paths.core.clients.WayfinderClient import WayfinderClient
 from wayfinder_paths.core.config import get_api_base_url
+from wayfinder_paths.core.constants.chains import SVM_CHAIN_IDS
 
 
 class QuoteTx(TypedDict, total=False):
@@ -86,6 +87,13 @@ class BRAPClient(WayfinderClient):
         to_wallet: str | None = None,
         allow_unverified_output: bool = False,
     ) -> BRAPQuoteResponse:  # type: ignore # noqa: E501
+        if (from_chain in SVM_CHAIN_IDS) != (to_chain in SVM_CHAIN_IDS) and not (
+            to_wallet and to_wallet.strip()
+        ):
+            raise ValueError(
+                "to_wallet is required for EVM/Solana swaps. Pass the destination "
+                "chain's wallet address, not the source wallet address."
+            )
         logger.info(
             f"Getting BRAP quote: {from_token} -> {to_token} (chain {from_chain} -> {to_chain})"
         )

--- a/wayfinder_paths/mcp/tools/execute.py
+++ b/wayfinder_paths/mcp/tools/execute.py
@@ -351,8 +351,18 @@ async def onchain_swap(
         wallet_label, from_chain_id
     )
     to_leg = await find_wallet_leg_for_chain(wallet_label, to_chain_id)
-    dest_default = normalize_address(to_leg.get("address")) if to_leg else sender
+    dest_default = normalize_address(to_leg.get("address")) if to_leg else None
+    if not dest_default and is_solana_chain(from_chain_id) == is_solana_chain(
+        to_chain_id
+    ):
+        dest_default = sender
     rcpt = normalize_address(recipient) or dest_default
+    if not rcpt:
+        return err(
+            "invalid_wallet",
+            f"Wallet {wallet_label} has no destination address for chain {to_chain_id}. "
+            "Provide recipient explicitly or add the destination-chain wallet leg.",
+        )
     response: dict[str, Any] = {
         "sender": sender,
         "recipient": rcpt,

--- a/wayfinder_paths/mcp/tools/quotes.py
+++ b/wayfinder_paths/mcp/tools/quotes.py
@@ -91,8 +91,10 @@ async def onchain_quote_swap(
         slippage_bps: Slippage cap in basis points (50 = 0.50%).
         recipient: Optional destination override. Defaults to the destination-chain
             leg of the same wallet ring.
-        include_calldata: Include the raw tx calldata in the response (off by default to keep
-            payload small; only the `len` is reported when false).
+        include_calldata: Include an unmodified execution_quote (router, value, chain,
+            approvals and transaction data). Off by default to keep payloads small.
+            Prefer onchain_swap(**suggested_swap_request) after user confirmation;
+            never rebuild a transaction from the compact preview's hex data.
         allow_unverified_output: Override a protected-identity safety block. Set
             true only after the user explicitly confirms the exact destination
             contract and acknowledges that it is not a canonical asset.
@@ -138,15 +140,21 @@ async def onchain_quote_swap(
 
     # Cross-chain swaps send from the source-chain leg and land on the
     # destination-chain leg of the same wallet ring (e.g. EVM→Solana pays out to
-    # the ring's SVM address). Same-chain swaps resolve both to the one leg;
-    # missing a chain-specific leg falls back to the default (EVM) leg.
-    from_leg = leg_for_chain(ring, from_chain_id) or ring[0]
-    to_leg = leg_for_chain(ring, to_chain_id) or ring[0]
+    # the ring's SVM address). Never substitute a different chain family's leg.
+    from_leg = leg_for_chain(ring, from_chain_id)
+    to_leg = leg_for_chain(ring, to_chain_id)
+    if not from_leg:
+        return err(
+            "invalid_wallet",
+            f"Wallet {wallet_label} has no source address for chain {from_chain_id}",
+        )
     sender = normalize_address(from_leg.get("address"))
     if not sender:
         return err("invalid_wallet", f"Wallet {wallet_label} missing address")
 
-    rcpt = normalize_address(recipient) or normalize_address(to_leg.get("address"))
+    rcpt = normalize_address(recipient) or (
+        normalize_address(to_leg.get("address")) if to_leg else None
+    )
     if not rcpt:
         return err(
             "invalid_wallet",
@@ -241,7 +249,7 @@ async def onchain_quote_swap(
     from_token_id = from_meta.get("token_id") or from_token
     to_token_id = to_meta.get("token_id") or to_token
 
-    result = {
+    result: dict[str, Any] = {
         "preview": preview,
         "quote": {
             "best_quote": best_out,
@@ -262,4 +270,8 @@ async def onchain_quote_swap(
             "allow_unverified_output": allow_unverified_output,
         },
     }
+    if include_calldata:
+        # Keep the legacy compact calldata string for existing consumers, but
+        # expose the complete quote for scripts without dropping fees or SVM data.
+        result["execution_quote"] = best_quote
     return ok(result)

--- a/wayfinder_paths/tests/test_brap_cross_chain.py
+++ b/wayfinder_paths/tests/test_brap_cross_chain.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from wayfinder_paths.adapters.brap_adapter.adapter import BRAPAdapter
+from wayfinder_paths.core.clients.BRAPClient import BRAP_CLIENT
+from wayfinder_paths.mcp.tools.execute import onchain_swap
+from wayfinder_paths.mcp.tools.quotes import onchain_quote_swap
+
+EVM = "0x000000000000000000000000000000000000dEaD"
+SVM = "BTXGZD6APaEPLUnELUT3Q1HWUYaWatu42WXT3YCU1vxY"
+ROUTER = "0x" + "11" * 20
+SPENDER = "0x" + "22" * 20
+TOKEN = "0x" + "33" * 20
+RELAYER_FEE = 940000000000000
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("from_chain,to_chain", [(4663, 900), (900, 4663)])
+@pytest.mark.parametrize("recipient", [None, "", " "])
+async def test_client_requires_cross_family_destination_before_network(
+    from_chain: int, to_chain: int, recipient: str | None
+) -> None:
+    with patch.object(
+        BRAP_CLIENT, "_authed_request", new_callable=AsyncMock
+    ) as request:
+        with pytest.raises(ValueError, match="to_wallet is required"):
+            await BRAP_CLIENT.get_quote(
+                from_token=TOKEN,
+                to_token=TOKEN,
+                from_chain=from_chain,
+                to_chain=to_chain,
+                from_wallet=EVM if from_chain == 4663 else SVM,
+                to_wallet=recipient,
+                from_amount="1000000",
+            )
+        request.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "from_chain,to_chain,sender,recipient",
+    [
+        (4663, 900, EVM, SVM),
+        (900, 4663, SVM, EVM),
+        (4663, 1, EVM, None),
+        (900, 900, SVM, None),
+    ],
+)
+async def test_client_preserves_destination_and_internal_chain_ids(
+    from_chain: int, to_chain: int, sender: str, recipient: str | None
+) -> None:
+    response = httpx.Response(
+        200,
+        json={"quotes": []},
+        request=httpx.Request("GET", "https://example.test/quote"),
+    )
+    with patch.object(
+        BRAP_CLIENT, "_authed_request", new=AsyncMock(return_value=response)
+    ) as request:
+        await BRAP_CLIENT.get_quote(
+            from_token=TOKEN,
+            to_token=TOKEN,
+            from_chain=from_chain,
+            to_chain=to_chain,
+            from_wallet=sender,
+            to_wallet=recipient,
+            from_amount="1000000",
+        )
+    params = request.await_args.kwargs["params"]
+    assert params["from_chain"] == from_chain
+    assert params["to_chain"] == to_chain
+    assert params.get("to_wallet") == recipient
+
+
+@pytest.mark.asyncio
+async def test_token_id_swap_passes_recipient_through_adapter_to_client() -> None:
+    adapter = BRAPAdapter()
+    from_token = {"address": TOKEN, "chain": {"id": 4663}}
+    to_token = {"address": SVM, "chain": {"id": 900}}
+    quote = {"provider": "lifi", "output_amount": "123"}
+    with (
+        patch(
+            "wayfinder_paths.adapters.brap_adapter.adapter.TOKEN_CLIENT.get_token_details",
+            new=AsyncMock(side_effect=[from_token, to_token]),
+        ),
+        patch.object(
+            BRAP_CLIENT, "get_quote", new=AsyncMock(return_value={"best_quote": quote})
+        ) as request,
+        patch.object(
+            adapter, "swap_from_quote", new=AsyncMock(return_value=(True, {}))
+        ) as execute,
+    ):
+        success, _ = await adapter.swap_from_token_ids(
+            "from", "to", EVM, "1000", to_address=SVM
+        )
+    assert success
+    assert request.await_args.kwargs["to_wallet"] == SVM
+    assert execute.await_args.kwargs["quote"] == quote
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", [RELAYER_FEE, str(RELAYER_FEE), hex(RELAYER_FEE)])
+async def test_mcp_execution_quote_round_trips_router_fee_and_approval(
+    value: int | str,
+) -> None:
+    from_token = {
+        "token_id": "from",
+        "symbol": "PONS",
+        "address": TOKEN,
+        "chain_id": 4663,
+        "chain": {"id": 4663},
+        "decimals": 18,
+    }
+    to_token = {
+        "token_id": "to",
+        "symbol": "STONK",
+        "address": SVM,
+        "chain_id": 900,
+        "chain": {"id": 900},
+        "decimals": 6,
+    }
+    calldata = {"to": ROUTER, "data": "0x1234", "value": value, "chainId": 4663}
+    quote = {
+        "provider": "lifi",
+        "input_amount": "1000",
+        "output_amount": "2000",
+        "approval_address": SPENDER,
+        "calldata": calldata,
+    }
+    ring = [
+        {"address": EVM, "chain_type": "ethereum"},
+        {"address": SVM, "chain_type": "solana"},
+    ]
+    adapter = BRAPAdapter()
+    with (
+        patch("wayfinder_paths.mcp.utils._report_tool_metric"),
+        patch(
+            "wayfinder_paths.mcp.tools.quotes.load_wallet_ring",
+            new=AsyncMock(return_value=ring),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.quotes.TokenResolver.resolve_token_meta",
+            new=AsyncMock(side_effect=[from_token, to_token]),
+        ),
+        patch.object(
+            BRAP_CLIENT, "get_quote", new=AsyncMock(return_value={"best_quote": quote})
+        ),
+        patch(
+            "wayfinder_paths.adapters.brap_adapter.adapter.ensure_allowance",
+            new_callable=AsyncMock,
+        ) as approve,
+        patch(
+            "wayfinder_paths.adapters.brap_adapter.adapter.send_transaction",
+            new=AsyncMock(return_value="0xtest"),
+        ) as send,
+        patch.object(adapter, "_record_swap_operation", new=AsyncMock(return_value={})),
+    ):
+        preview = await onchain_quote_swap(
+            wallet_label="main",
+            from_token="from",
+            to_token="to",
+            amount="1.0",
+            include_calldata=True,
+        )
+        assert preview["ok"]
+        execution_quote = preview["result"]["execution_quote"]
+        assert execution_quote == quote
+        success, _ = await adapter.swap_from_quote(
+            from_token, to_token, EVM, execution_quote
+        )
+    assert success
+    tx = send.await_args.args[0]
+    assert tx["to"] == ROUTER
+    assert tx["value"] == RELAYER_FEE
+    assert tx["data"] == calldata["data"]
+    assert tx["chainId"] == 4663
+    assert approve.await_args.kwargs["spender"] == SPENDER
+    assert approve.await_args.kwargs["amount"] == 1000
+    assert calldata["value"] == value  # Do not mutate the provider's quote.
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "calldata", ["0x1234", {"to": ROUTER, "data": "0x1234", "chainId": 1}]
+)
+async def test_adapter_rejects_incomplete_or_wrong_chain_quote_before_approval(
+    calldata: Any,
+) -> None:
+    with (
+        patch(
+            "wayfinder_paths.adapters.brap_adapter.adapter.ensure_allowance",
+            new_callable=AsyncMock,
+        ) as approve,
+        patch(
+            "wayfinder_paths.adapters.brap_adapter.adapter.send_transaction",
+            new_callable=AsyncMock,
+        ) as send,
+    ):
+        success, _ = await BRAPAdapter().swap_from_quote(
+            {"address": TOKEN, "chain": {"id": 4663}},
+            {"chain": {"id": 900}},
+            EVM,
+            {"calldata": calldata},
+        )
+    assert not success
+    approve.assert_not_awaited()
+    send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_missing_destination_stops_before_balance_quote_or_broadcast() -> None:
+    with (
+        patch("wayfinder_paths.mcp.utils._report_tool_metric"),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.is_solana_enabled",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.TokenResolver.resolve_token_meta",
+            new=AsyncMock(
+                side_effect=[
+                    {"chain_id": 4663, "address": TOKEN},
+                    {"chain_id": 900, "address": SVM},
+                ]
+            ),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.get_wallet_signing_callback_for_chain",
+            new=AsyncMock(return_value=(AsyncMock(), EVM)),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.find_wallet_leg_for_chain",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute._token_balance", new_callable=AsyncMock
+        ) as balance,
+        patch.object(BRAP_CLIENT, "get_quote", new_callable=AsyncMock) as quote,
+        patch(
+            "wayfinder_paths.mcp.tools.execute._broadcast", new_callable=AsyncMock
+        ) as send,
+    ):
+        result = await onchain_swap(
+            wallet_label="main", from_token="from", to_token="to", amount="1.0"
+        )
+    assert not result["ok"]
+    assert result["error"]["code"] == "invalid_wallet"
+    balance.assert_not_awaited()
+    quote.assert_not_awaited()
+    send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_robinhood_to_solana_execution_keeps_recipient_and_native_fee() -> None:
+    quote = {
+        "provider": "lifi",
+        "input_amount": "1000000",
+        "output_amount": "900000",
+        "calldata": {
+            "to": ROUTER,
+            "data": "0x1234",
+            "value": str(RELAYER_FEE),
+            "chainId": 4663,
+        },
+    }
+    with (
+        patch("wayfinder_paths.mcp.utils._report_tool_metric"),
+        patch("wayfinder_paths.mcp.tools.execute._annotate_profile"),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.is_solana_enabled",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.TokenResolver.resolve_token_meta",
+            new=AsyncMock(
+                side_effect=[
+                    {"chain_id": 4663, "address": TOKEN, "decimals": 6},
+                    {"chain_id": 900, "address": SVM, "decimals": 6},
+                ]
+            ),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.get_wallet_signing_callback_for_chain",
+            new=AsyncMock(return_value=(AsyncMock(), EVM)),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute.find_wallet_leg_for_chain",
+            new=AsyncMock(return_value={"address": SVM}),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute._token_balance",
+            new=AsyncMock(return_value=1000000),
+        ),
+        patch.object(
+            BRAP_CLIENT, "get_quote", new=AsyncMock(return_value={"best_quote": quote})
+        ) as get_quote,
+        patch(
+            "wayfinder_paths.mcp.tools.execute._ensure_allowance",
+            new=AsyncMock(return_value=(True, None)),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.execute._broadcast",
+            new=AsyncMock(return_value=(True, {"txn_hash": "0xtest"})),
+        ) as send,
+    ):
+        result = await onchain_swap(
+            wallet_label="main", from_token="from", to_token="to", amount="1.0"
+        )
+    assert result["ok"]
+    assert result["result"]["recipient"] == SVM
+    assert get_quote.await_args.kwargs["to_wallet"] == SVM
+    assert send.await_args.args[1]["value"] == RELAYER_FEE
+    assert send.await_args.args[1]["to"] == ROUTER
+    assert send.await_args.kwargs["chain_id"] == 4663
+
+
+@pytest.mark.asyncio
+async def test_svm_execution_quote_keeps_serialized_transaction() -> None:
+    token = {
+        "token_id": "from",
+        "symbol": "SOL",
+        "chain_id": 900,
+        "decimals": 9,
+        "address": SVM,
+    }
+    quote = {
+        "provider": "jupiter",
+        "calldata": {
+            "serializedTransaction": "AQID",
+            "chainId": 900,
+            "chainType": "solana",
+            "lastValidBlockHeight": 123,
+        },
+    }
+    with (
+        patch("wayfinder_paths.mcp.utils._report_tool_metric"),
+        patch(
+            "wayfinder_paths.mcp.tools.quotes.load_wallet_ring",
+            new=AsyncMock(return_value=[{"address": SVM, "chain_type": "solana"}]),
+        ),
+        patch(
+            "wayfinder_paths.mcp.tools.quotes.TokenResolver.resolve_token_meta",
+            new=AsyncMock(return_value=token),
+        ),
+        patch.object(
+            BRAP_CLIENT, "get_quote", new=AsyncMock(return_value={"best_quote": quote})
+        ),
+    ):
+        result = await onchain_quote_swap(
+            wallet_label="main",
+            from_token="from",
+            to_token="to",
+            amount="1.0",
+            include_calldata=True,
+        )
+    assert result["ok"]
+    assert result["result"]["execution_quote"] == quote

--- a/wayfinder_paths/tests/test_mcp_quote_swap.py
+++ b/wayfinder_paths/tests/test_mcp_quote_swap.py
@@ -91,6 +91,7 @@ async def test_quote_swap_returns_compact_best_quote_by_default():
     assert out["ok"] is True
     res = out["result"]
     assert "raw" not in res["quote"]
+    assert "execution_quote" not in res
 
     best = res["quote"]["best_quote"]
     assert best["provider"] == "brap_best"
@@ -131,7 +132,12 @@ async def test_quote_swap_can_include_calldata_when_requested():
             return from_meta
         return to_meta
 
-    calldata = {"data": "0x" + ("cd" * 1024)}
+    calldata = {
+        "data": "0x" + ("cd" * 1024),
+        "to": EVM_ADDRESS,
+        "value": "940000000000000",
+        "chainId": 42161,
+    }
     fake_brap = AsyncMock()
     fake_brap.get_quote = AsyncMock(
         return_value={
@@ -172,6 +178,7 @@ async def test_quote_swap_can_include_calldata_when_requested():
     assert out["ok"] is True
     best = out["result"]["quote"]["best_quote"]
     assert best["calldata"] == calldata["data"]
+    assert out["result"]["execution_quote"]["calldata"] == calldata
     assert out["result"]["suggested_swap_request"]["allow_unverified_output"] is True
     assert fake_brap.get_quote.await_args.kwargs["allow_unverified_output"] is True
 
@@ -283,7 +290,11 @@ async def test_quote_swap_accepts_top_level_brap_shape():
 
 
 @pytest.mark.asyncio
-async def test_quote_swap_passes_destination_ring_leg_to_brap():
+@pytest.mark.parametrize("has_destination", [True, False])
+@pytest.mark.parametrize("explicit_recipient", [None, SVM_ADDRESS])
+async def test_quote_swap_passes_destination_ring_leg_to_brap(
+    has_destination: bool, explicit_recipient: str | None
+) -> None:
     ring = [
         {
             "address": EVM_ADDRESS,
@@ -298,6 +309,8 @@ async def test_quote_swap_passes_destination_ring_leg_to_brap():
             "chain_type": "solana",
         },
     ]
+    if not has_destination:
+        ring = ring[:1]
     from_meta = {
         "token_id": "usd-coin-base",
         "symbol": "USDC",
@@ -346,7 +359,14 @@ async def test_quote_swap_passes_destination_ring_leg_to_brap():
             from_token="from",
             to_token="to",
             amount="1.0",
+            recipient=explicit_recipient,
         )
+
+    if not has_destination and not explicit_recipient:
+        assert out["ok"] is False
+        assert out["error"]["code"] == "invalid_wallet"
+        fake_brap.get_quote.assert_not_awaited()
+        return
 
     assert out["ok"] is True
     assert out["result"]["suggested_swap_request"]["recipient"] == SVM_ADDRESS


### PR DESCRIPTION
### Summary

- Fix the adapter path that could quote EVM-to-Solana swaps without a destination wallet: add optional keyword-only `to_address` to `best_quote` and `swap_from_token_ids`, forwarding the existing client `to_wallet`. Cross-family requests with no destination fail before network access; existing same-family defaults remain supported.
- Stop MCP quote/execution tools from substituting the EVM sender when the destination wallet leg is absent. Reuse existing wallet-ring and chain-family helpers.
- When `include_calldata=true`, return an additive, unmodified `execution_quote` with router, native value, chain, approval and serialized SVM data. Keep legacy compact fields unchanged. Agent guidance directs scripts to this full payload and interactive execution to the existing confirmed swap tool.
- Preserve decimal and hex native fee values during adapter execution, honor supplied approval spenders, and reject compact-only/wrong-chain payloads before approval. Solana-source adapter execution returns guidance to use the existing SVM-aware MCP tool.
- Regression coverage includes Robinhood-to-Solana native relayer fees, reverse-direction recipients, missing wallet legs, same-family compatibility, full quote round-tripping and Solana serialized payloads. 60 focused SDK tests passed with outbound HTTP blocked and signing/broadcast mocked; repository Ruff lint and format checks pass.
- Quality review: no new production helper, dependency/version bump, image rollout or transactions. Targeted mypy reports the same six pre-existing adapter typing errors as main, with no introduced errors.