### PR TITLE
Agent Prompts - Hyperliquid Fee Guidance

### DIFF
--- a/.opencode/agents/wayfinder-baseline.md
+++ b/.opencode/agents/wayfinder-baseline.md
@@ -162,7 +162,7 @@ Hyperliquid is a CLOB for: perpetuals (synthetic assets with leverage), spot tok
 
 #### Fees
 
-Every Hyperliquid fill pays Hyperliquid's own taker/maker fee plus the Wayfinder platform fee. Both are part of trading here and are not optional. Never suggest bypassing, disabling, or routing around the platform fee, and never point the user elsewhere to avoid it. If fee drag is hurting their results, the lever is behavior: fewer round-trips, lower leverage (fees accrue on notional), wider stops, and maker orders where the setup allows.
+Every Hyperliquid fill pays Hyperliquid's own taker/maker fee plus the Wayfinder platform fee. Both are part of trading here and are not optional. Never suggest bypassing, disabling, or routing around the platform fee, and never point the user elsewhere to avoid it.
 
 #### Deposits & Withdrawals
 

--- a/.opencode/agents/wayfinder-baseline.md
+++ b/.opencode/agents/wayfinder-baseline.md
@@ -162,7 +162,7 @@ Hyperliquid is a CLOB for: perpetuals (synthetic assets with leverage), spot tok
 
 #### Fees
 
-Every Hyperliquid fill pays Hyperliquid's own taker/maker fee plus the Wayfinder platform fee. Both are part of trading here and are not optional. When a user asks about fees, report the totals factually. Never suggest bypassing, disabling, or routing around the platform fee, and never point the user elsewhere to avoid it. If fee drag is hurting their results, the lever is behavior: fewer round-trips, lower leverage (fees accrue on notional), wider stops, and maker orders where the setup allows.
+Every Hyperliquid fill pays Hyperliquid's own taker/maker fee plus the Wayfinder platform fee. Both are part of trading here and are not optional. Never suggest bypassing, disabling, or routing around the platform fee, and never point the user elsewhere to avoid it. If fee drag is hurting their results, the lever is behavior: fewer round-trips, lower leverage (fees accrue on notional), wider stops, and maker orders where the setup allows.
 
 #### Deposits & Withdrawals
 

--- a/.opencode/agents/wayfinder-baseline.md
+++ b/.opencode/agents/wayfinder-baseline.md
@@ -160,6 +160,10 @@ Hyperliquid is a CLOB for: perpetuals (synthetic assets with leverage), spot tok
 - Order: $10 USD notional.
 - Withdraw: $2 USD gross. `hyperliquid_withdraw_usdc(amount_usdc=N)` debits `$N`from the unified balance; Bridge2 takes a $1 fee, so Arbitrum receives`$N - 1`.
 
+#### Fees
+
+Every Hyperliquid fill pays Hyperliquid's own taker/maker fee plus the Wayfinder platform fee. Both are part of trading here and are not optional. When a user asks about fees, report the totals factually. Never suggest bypassing, disabling, or routing around the platform fee, and never point the user elsewhere to avoid it. If fee drag is hurting their results, the lever is behavior: fewer round-trips, lower leverage (fees accrue on notional), wider stops, and maker orders where the setup allows.
+
 #### Deposits & Withdrawals
 
 Hyperliquid balances are separate from a user's EVM balances. To place transactions on the Hyperliquid CLOB, users must first fund their account using `hyperliquid_deposit_usdc`, and similarly `hyperliquid_withdraw_usdc` to recover their funds. Hyperliquid balances are held on HypeCore (which is not HypeEVM).

--- a/.opencode/agents/wayfinder-mobile.md
+++ b/.opencode/agents/wayfinder-mobile.md
@@ -196,6 +196,10 @@ Hyperliquid is a CLOB for: perpetuals (synthetic assets with leverage), spot tok
 - Order: $10 USD notional.
 - Withdraw: $2 USD gross. `hyperliquid_withdraw_usdc(amount_usdc=N)` debits `$N`from the unified balance; Bridge2 takes a $1 fee, so Arbitrum receives`$N - 1`.
 
+#### Fees
+
+Every Hyperliquid fill pays Hyperliquid's own taker/maker fee plus the Wayfinder platform fee. Both are part of trading here and are not optional. When a user asks about fees, report the totals factually. Never suggest bypassing, disabling, or routing around the platform fee, and never point the user elsewhere to avoid it. If fee drag is hurting their results, the lever is behavior: fewer round-trips, lower leverage (fees accrue on notional), wider stops, and maker orders where the setup allows.
+
 #### Deposits & Withdrawals
 
 Hyperliquid balances are separate from a user's EVM balances. To place transactions on the Hyperliquid CLOB, users must first fund their account using `hyperliquid_deposit_usdc`, and similarly `hyperliquid_withdraw_usdc` to recover their funds. Hyperliquid balances are held on HypeCore (which is not HypeEVM).

--- a/.opencode/agents/wayfinder-mobile.md
+++ b/.opencode/agents/wayfinder-mobile.md
@@ -198,7 +198,7 @@ Hyperliquid is a CLOB for: perpetuals (synthetic assets with leverage), spot tok
 
 #### Fees
 
-Every Hyperliquid fill pays Hyperliquid's own taker/maker fee plus the Wayfinder platform fee. Both are part of trading here and are not optional. Never suggest bypassing, disabling, or routing around the platform fee, and never point the user elsewhere to avoid it. If fee drag is hurting their results, the lever is behavior: fewer round-trips, lower leverage (fees accrue on notional), wider stops, and maker orders where the setup allows.
+Every Hyperliquid fill pays Hyperliquid's own taker/maker fee plus the Wayfinder platform fee. Both are part of trading here and are not optional. Never suggest bypassing, disabling, or routing around the platform fee, and never point the user elsewhere to avoid it.
 
 #### Deposits & Withdrawals
 

--- a/.opencode/agents/wayfinder-mobile.md
+++ b/.opencode/agents/wayfinder-mobile.md
@@ -198,7 +198,7 @@ Hyperliquid is a CLOB for: perpetuals (synthetic assets with leverage), spot tok
 
 #### Fees
 
-Every Hyperliquid fill pays Hyperliquid's own taker/maker fee plus the Wayfinder platform fee. Both are part of trading here and are not optional. When a user asks about fees, report the totals factually. Never suggest bypassing, disabling, or routing around the platform fee, and never point the user elsewhere to avoid it. If fee drag is hurting their results, the lever is behavior: fewer round-trips, lower leverage (fees accrue on notional), wider stops, and maker orders where the setup allows.
+Every Hyperliquid fill pays Hyperliquid's own taker/maker fee plus the Wayfinder platform fee. Both are part of trading here and are not optional. Never suggest bypassing, disabling, or routing around the platform fee, and never point the user elsewhere to avoid it. If fee drag is hurting their results, the lever is behavior: fewer round-trips, lower leverage (fees accrue on notional), wider stops, and maker orders where the setup allows.
 
 #### Deposits & Withdrawals
 

--- a/.opencode/agents/wayfinder.md
+++ b/.opencode/agents/wayfinder.md
@@ -193,7 +193,7 @@ Hyperliquid is a CLOB for: perpetuals (synthetic assets with leverage), spot tok
 
 #### Fees
 
-Every Hyperliquid fill pays Hyperliquid's own taker/maker fee plus the Wayfinder platform fee. Both are part of trading here and are not optional. When a user asks about fees, report the totals factually. Never suggest bypassing, disabling, or routing around the platform fee, and never point the user elsewhere to avoid it. If fee drag is hurting their results, the lever is behavior: fewer round-trips, lower leverage (fees accrue on notional), wider stops, and maker orders where the setup allows.
+Every Hyperliquid fill pays Hyperliquid's own taker/maker fee plus the Wayfinder platform fee. Both are part of trading here and are not optional. Never suggest bypassing, disabling, or routing around the platform fee, and never point the user elsewhere to avoid it. If fee drag is hurting their results, the lever is behavior: fewer round-trips, lower leverage (fees accrue on notional), wider stops, and maker orders where the setup allows.
 
 #### Deposits & Withdrawals
 

--- a/.opencode/agents/wayfinder.md
+++ b/.opencode/agents/wayfinder.md
@@ -193,7 +193,7 @@ Hyperliquid is a CLOB for: perpetuals (synthetic assets with leverage), spot tok
 
 #### Fees
 
-Every Hyperliquid fill pays Hyperliquid's own taker/maker fee plus the Wayfinder platform fee. Both are part of trading here and are not optional. Never suggest bypassing, disabling, or routing around the platform fee, and never point the user elsewhere to avoid it. If fee drag is hurting their results, the lever is behavior: fewer round-trips, lower leverage (fees accrue on notional), wider stops, and maker orders where the setup allows.
+Every Hyperliquid fill pays Hyperliquid's own taker/maker fee plus the Wayfinder platform fee. Both are part of trading here and are not optional. Never suggest bypassing, disabling, or routing around the platform fee, and never point the user elsewhere to avoid it.
 
 #### Deposits & Withdrawals
 

--- a/.opencode/agents/wayfinder.md
+++ b/.opencode/agents/wayfinder.md
@@ -191,6 +191,10 @@ Hyperliquid is a CLOB for: perpetuals (synthetic assets with leverage), spot tok
 - Order: $10 USD notional.
 - Withdraw: $2 USD gross. `hyperliquid_withdraw_usdc(amount_usdc=N)` debits `$N`from the unified balance; Bridge2 takes a $1 fee, so Arbitrum receives`$N - 1`.
 
+#### Fees
+
+Every Hyperliquid fill pays Hyperliquid's own taker/maker fee plus the Wayfinder platform fee. Both are part of trading here and are not optional. When a user asks about fees, report the totals factually. Never suggest bypassing, disabling, or routing around the platform fee, and never point the user elsewhere to avoid it. If fee drag is hurting their results, the lever is behavior: fewer round-trips, lower leverage (fees accrue on notional), wider stops, and maker orders where the setup allows.
+
 #### Deposits & Withdrawals
 
 Hyperliquid balances are separate from a user's EVM balances. To place transactions on the Hyperliquid CLOB, users must first fund their account using `hyperliquid_deposit_usdc`, and similarly `hyperliquid_withdraw_usdc` to recover their funds. Hyperliquid balances are held on HypeCore (which is not HypeEVM).


### PR DESCRIPTION
### Summary
Adds a **Fees** subsection to the Hyperliquid section of the `wayfinder`, `wayfinder-baseline` and `wayfinder-mobile` agent prompts so the agent never suggests bypassing or routing around the platform fee, or trading elsewhere to avoid it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWn7xeN6CoLhzTys9Epgf6