### PR TITLE
Paths - Restore sign_and_send_transaction compat shim

### DIFF
--- a/wayfinder_paths/core/utils/test_transaction.py
+++ b/wayfinder_paths/core/utils/test_transaction.py
@@ -568,3 +568,22 @@ class TestSendSponsoredTransaction:
             await send_sponsored_transaction(
                 RANDOM_USER_0, {"chainId": 1, "to": RANDOM_USER_0}
             )
+
+
+@pytest.mark.asyncio
+async def test_sign_and_send_transaction_signs_with_private_key_and_delegates():
+    from wayfinder_paths.core.utils.transaction import sign_and_send_transaction
+
+    private_key = "0x" + "11" * 32
+    tx = {"to": "0x" + "22" * 20, "value": 0, "gas": 21000, "gasPrice": 1, "nonce": 0, "chainId": 1}
+    with patch(
+        "wayfinder_paths.core.utils.transaction.send_transaction", new_callable=AsyncMock
+    ) as mock_send:
+        mock_send.return_value = "0xhash"
+        result = await sign_and_send_transaction(tx, private_key, wait_for_receipt=False)
+    assert result == "0xhash"
+    _, sign_callback = mock_send.call_args.args
+    assert sign_callback.wallet_address is None
+    assert mock_send.call_args.kwargs == {"wait_for_receipt": False, "confirmations": 0}
+    raw = await sign_callback(tx)
+    assert isinstance(raw, bytes) and len(raw) > 60

--- a/wayfinder_paths/core/utils/test_transaction.py
+++ b/wayfinder_paths/core/utils/test_transaction.py
@@ -575,12 +575,22 @@ async def test_sign_and_send_transaction_signs_with_private_key_and_delegates():
     from wayfinder_paths.core.utils.transaction import sign_and_send_transaction
 
     private_key = "0x" + "11" * 32
-    tx = {"to": "0x" + "22" * 20, "value": 0, "gas": 21000, "gasPrice": 1, "nonce": 0, "chainId": 1}
+    tx = {
+        "to": "0x" + "22" * 20,
+        "value": 0,
+        "gas": 21000,
+        "gasPrice": 1,
+        "nonce": 0,
+        "chainId": 1,
+    }
     with patch(
-        "wayfinder_paths.core.utils.transaction.send_transaction", new_callable=AsyncMock
+        "wayfinder_paths.core.utils.transaction.send_transaction",
+        new_callable=AsyncMock,
     ) as mock_send:
         mock_send.return_value = "0xhash"
-        result = await sign_and_send_transaction(tx, private_key, wait_for_receipt=False)
+        result = await sign_and_send_transaction(
+            tx, private_key, wait_for_receipt=False
+        )
     assert result == "0xhash"
     _, sign_callback = mock_send.call_args.args
     assert sign_callback.wallet_address is None

--- a/wayfinder_paths/core/utils/transaction.py
+++ b/wayfinder_paths/core/utils/transaction.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from typing import Any, cast
 
 import httpx
+from eth_account import Account
 from loguru import logger
 from web3 import AsyncWeb3
 
@@ -430,6 +431,29 @@ async def send_transaction(
         if status is not None and int(status) == 0:
             _raise_revert_error(txn_hash, receipt, transaction)
     return txn_hash
+
+
+async def sign_and_send_transaction(
+    transaction: dict,
+    private_key: str,
+    wait_for_receipt: bool = True,
+    confirmations: int = 0,
+) -> str:
+    """Compat wrapper kept for paths published against 0.11.0, which import it
+    by name; removed in #472 while pyproject still said 0.11.0, so same-minor
+    runtimes must keep exporting it."""
+    account = Account.from_key(private_key)
+
+    async def sign_callback(tx: dict) -> bytes:
+        return account.sign_transaction(tx).raw_transaction
+
+    sign_callback.wallet_address = None
+    return await send_transaction(
+        transaction,
+        sign_callback,
+        wait_for_receipt=wait_for_receipt,
+        confirmations=confirmations,
+    )
 
 
 async def encode_call(


### PR DESCRIPTION
### Summary
- Re-adds `sign_and_send_transaction(tx, private_key, wait_for_receipt, confirmations)` as a thin wrapper over `send_transaction` with a local-account sign callback.
- It was removed in #472 while the package version stayed 0.11.0, so published paths that import it break on any 0.11.x runtime that treats same-minor as compatible (#774). A live scan of published paths found it as the one remaining 0.11.0-era import missing from main.
- Test covers delegation and that the callback signs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Ngvd6Gnq7pdE3veBXyp89
