### PR TITLE
BRAP Swaps - Direct Route Prerequisite Execution

### DIFF
--- a/.claude/skills/using-brap-adapter/rules/execution-opportunities.md
+++ b/.claude/skills/using-brap-adapter/rules/execution-opportunities.md
@@ -22,8 +22,16 @@
   its compact preview. Use `onchain_swap` for Solana-source execution.
 - What it can do:
   - Build a tx dict from `quote["calldata"]`
-  - Submit ERC20 approvals if needed
+  - Submit the route's `prerequisite_transactions` in order, waiting for each
+    successful receipt before continuing (including two-step Permit2 approvals)
+  - Use the existing ERC20 allowance helper for routes without solver-managed approvals
   - Broadcast the swap tx
+
+The same prerequisite handling applies to `onchain_swap`, including when
+`wait_for_receipt=false`: only the final swap may skip its receipt wait. A failed
+prerequisite stops execution. Direct Pons and Uniswap routes are supported when
+the backend returns an executable quote; `atomic_calls` / `pons_v2_batch` routes
+require a batch-capable executor and are rejected, never split into separate swaps.
 
 ## Safety rails
 

--- a/wayfinder_paths/adapters/brap_adapter/adapter.py
+++ b/wayfinder_paths/adapters/brap_adapter/adapter.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-from web3 import Web3
-
 from wayfinder_paths.adapters.ledger_adapter.adapter import LedgerAdapter
 from wayfinder_paths.adapters.token_adapter.adapter import TokenAdapter
 from wayfinder_paths.core.adapters.BaseAdapter import BaseAdapter
@@ -12,6 +10,10 @@ from wayfinder_paths.core.clients.BRAPClient import BRAP_CLIENT
 from wayfinder_paths.core.clients.LedgerClient import TransactionRecord
 from wayfinder_paths.core.clients.TokenClient import TOKEN_CLIENT
 from wayfinder_paths.core.constants.chains import SVM_CHAIN_IDS
+from wayfinder_paths.core.utils.brap import (
+    prepare_brap_transactions,
+    uses_solver_approvals,
+)
 from wayfinder_paths.core.utils.tokens import (
     ensure_allowance,
     is_native_token,
@@ -167,31 +169,16 @@ class BRAPAdapter(BaseAdapter):
         if chain_id in SVM_CHAIN_IDS:
             return (False, "Use onchain_swap for Solana-source execution.")
 
-        calldata = quote.get("calldata")
-        if not isinstance(calldata, dict) or not calldata.get("data"):
-            return (
-                False,
-                "Quote missing complete calldata. Use BRAPClient's best_quote or "
-                "the MCP quote's execution_quote; do not reconstruct a transaction "
-                "from the compact preview's hex data.",
+        try:
+            transaction, prerequisites = prepare_brap_transactions(
+                quote, chain_id=chain_id, sender=from_address
             )
-        if calldata.get("chainId") is not None and int(calldata["chainId"]) != chain_id:
-            return (
-                False,
-                "Quote calldata chain does not match the source token chain.",
-            )
+        except (TypeError, ValueError) as exc:
+            return False, str(exc)
 
-        transaction = {
-            **calldata,
-            "chainId": chain_id,
-            "from": Web3.to_checksum_address(from_address),
-        }
-        if "value" in calldata:
-            value = calldata["value"]
-            transaction["value"] = (
-                int(value, 16)
-                if isinstance(value, str) and value.startswith("0x")
-                else int(value)
+        for prerequisite in prerequisites:
+            await send_transaction(
+                prerequisite, self.sign_callback, wait_for_receipt=True, confirmations=0
             )
 
         approve_amount = (
@@ -211,8 +198,10 @@ class BRAPAdapter(BaseAdapter):
             and spender
             and approve_amount
             and not is_native_token(token_address)
+            and not prerequisites
+            and not uses_solver_approvals(quote)
         ):
-            await ensure_allowance(
+            approved, approval_hash = await ensure_allowance(
                 token_address=token_address,
                 owner=from_address,
                 spender=spender,
@@ -220,6 +209,11 @@ class BRAPAdapter(BaseAdapter):
                 chain_id=chain_id,
                 signing_callback=self.sign_callback,
             )
+            if not approved:
+                return (
+                    False,
+                    f"Approval not ready; swap was not submitted ({approval_hash}).",
+                )
 
         txn_hash = await send_transaction(transaction, self.sign_callback)
         self.logger.info(f"Swap broadcast: tx={txn_hash}")

--- a/wayfinder_paths/core/clients/BRAPClient.py
+++ b/wayfinder_paths/core/clients/BRAPClient.py
@@ -61,6 +61,8 @@ class BRAPQuoteEntry(TypedDict):
     fee_estimate: Required[FeeEstimate]
     wrap_transaction: NotRequired[dict[str, Any] | None]
     unwrap_transaction: NotRequired[dict[str, Any] | None]
+    prerequisite_transactions: NotRequired[list[dict[str, Any]] | None]
+    atomic_calls: NotRequired[list[dict[str, Any]] | None]
     native_input: Required[bool]
     native_output: Required[bool]
     safety_warnings: NotRequired[list[dict[str, Any]] | None]

--- a/wayfinder_paths/core/utils/brap.py
+++ b/wayfinder_paths/core/utils/brap.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Any
+
+from eth_utils import to_checksum_address
+
+from wayfinder_paths.core.utils.web3 import get_transaction_chain_id
+
+
+def uses_solver_approvals(quote: dict[str, Any]) -> bool:
+    """Direct solvers check allowances themselves, including both Permit2 grants."""
+    return quote.get("provider") in {
+        "uniswap_v3",
+        "uniswap_v4",
+        "pons_v2",
+        "pons_v2_batch",
+    }
+
+
+def _prepare_transaction(
+    calldata: Any, *, chain_id: int, sender: str, prerequisite: bool = False
+) -> dict[str, Any]:
+    if (
+        not isinstance(calldata, dict)
+        or not calldata.get("to")
+        or not calldata.get("data")
+    ):
+        raise ValueError(
+            "Quote missing complete calldata. Use BRAPClient's best_quote or "
+            "the MCP quote's execution_quote, not the compact preview."
+        )
+    if "calls" in calldata:
+        raise ValueError("Atomic BRAP routes require a batch-capable executor.")
+    # Older single-swap quotes can omit chainId; prerequisites must be explicit.
+    if prerequisite or calldata.get("chainId") is not None:
+        if get_transaction_chain_id(calldata) != chain_id:
+            raise ValueError(
+                "Quote transaction chain does not match the source token chain."
+            )
+    if (
+        calldata.get("from") is not None
+        and to_checksum_address(calldata["from"]) != sender
+    ):
+        raise ValueError("Quote transaction sender does not match the signing wallet.")
+    data = calldata["data"]
+    if not isinstance(data, str) or not data.startswith("0x"):
+        raise ValueError("Quote transaction data must be hex calldata.")
+    bytes.fromhex(data[2:])
+    value = calldata.get("value", 0)
+    value = (
+        int(value, 16)
+        if isinstance(value, str) and value.startswith("0x")
+        else int(value)
+    )
+    if value < 0:
+        raise ValueError("Quote transaction value cannot be negative.")
+    transaction = {
+        **calldata,
+        "chainId": chain_id,
+        "from": sender,
+        "to": to_checksum_address(calldata["to"]),
+        "value": value,
+    }
+    transaction.pop("description", None)  # Display metadata is not a signing field.
+    return transaction
+
+
+def prepare_brap_transactions(
+    quote: dict[str, Any], *, chain_id: int, sender: str
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Validate the entire source-chain sequence before signing any part of it."""
+    if quote.get("atomic_calls") or quote.get("provider") == "pons_v2_batch":
+        raise ValueError("Atomic BRAP routes require a batch-capable executor.")
+    sender = to_checksum_address(sender)
+    swap = _prepare_transaction(quote.get("calldata"), chain_id=chain_id, sender=sender)
+    prerequisites = quote.get("prerequisite_transactions")
+    if prerequisites is None:
+        prerequisites = []
+    if not isinstance(prerequisites, list):
+        raise ValueError("Quote prerequisite_transactions must be a list.")
+    return swap, [
+        _prepare_transaction(tx, chain_id=chain_id, sender=sender, prerequisite=True)
+        for tx in prerequisites
+    ]

--- a/wayfinder_paths/mcp/tools/execute.py
+++ b/wayfinder_paths/mcp/tools/execute.py
@@ -8,6 +8,10 @@ from solders.transaction import VersionedTransaction
 
 from wayfinder_paths.core.clients.BRAPClient import BRAP_CLIENT
 from wayfinder_paths.core.constants import ZERO_ADDRESS
+from wayfinder_paths.core.utils.brap import (
+    prepare_brap_transactions,
+    uses_solver_approvals,
+)
 from wayfinder_paths.core.utils.etherscan import get_etherscan_transaction_link
 from wayfinder_paths.core.utils.svm import (
     get_solana_explorer_link,
@@ -298,7 +302,8 @@ async def onchain_swap(
     user before running this. Same-chain swaps wait for the source receipt; cross-chain
     swaps additionally wait for the destination bridge leg to settle (via the
     BRAP wait-bridge-execution endpoint). Pass `wait_for_receipt=False` for
-    fire-and-forget broadcast (skips both waits).
+    fire-and-forget broadcast (skips both waits for the swap). Route prerequisites
+    always wait for successful receipts before the swap is submitted.
 
     Args:
         wallet_label: Wallet label.
@@ -317,7 +322,7 @@ async def onchain_swap(
             contract and acknowledges that it is not a canonical asset.
 
     Returns:
-        `{status: "submitted"|"confirmed"|"failed", sender, recipient, effects: {approval?, swap}, raw}`.
+        `{status: "submitted"|"confirmed"|"failed", sender, recipient, effects: {approval?, prerequisites?, swap?}, raw}`.
     """
     if not wallet_label.strip():
         return err("invalid_request", "wallet_label is required")
@@ -507,11 +512,26 @@ async def onchain_swap(
         )
         return ok(response)
 
-    swap_tx = dict(calldata)
-    swap_tx["chainId"] = int(from_chain_id)
-    swap_tx["from"] = to_checksum_address(sender)
-    if "value" in swap_tx:
-        swap_tx["value"] = int(swap_tx["value"])
+    try:
+        swap_tx, prerequisites = prepare_brap_transactions(
+            best_quote, chain_id=int(from_chain_id), sender=sender
+        )
+    except (TypeError, ValueError) as exc:
+        return err("quote_error", str(exc))
+
+    for prerequisite in prerequisites:
+        approved, approval = await _broadcast(
+            sign_callback,
+            prerequisite,
+            chain_id=int(from_chain_id),
+            wait_for_receipt=True,
+            confirmations=receipt_confirmations,
+        )
+        response["effects"].setdefault("prerequisites", []).append(approval)
+        if not approved:
+            response["status"] = "failed"
+            response["raw"] = compact_quote
+            return ok(response)
 
     spender = (
         best_quote.get("approvalAddress")
@@ -526,9 +546,11 @@ async def onchain_swap(
     )
 
     if (
-        from_token_addr.lower() != ZERO_ADDRESS.lower()
+        not is_native_token(from_token_addr)
         and spender
         and approve_amount is not None
+        and not prerequisites
+        and not uses_solver_approvals(best_quote)
     ):
         try:
             need = int(approve_amount)

--- a/wayfinder_paths/tests/test_brap_cross_chain.py
+++ b/wayfinder_paths/tests/test_brap_cross_chain.py
@@ -152,7 +152,7 @@ async def test_mcp_execution_quote_round_trips_router_fee_and_approval(
         ),
         patch(
             "wayfinder_paths.adapters.brap_adapter.adapter.ensure_allowance",
-            new_callable=AsyncMock,
+            new=AsyncMock(return_value=(True, "0xapproval")),
         ) as approve,
         patch(
             "wayfinder_paths.adapters.brap_adapter.adapter.send_transaction",

--- a/wayfinder_paths/tests/test_brap_prerequisites.py
+++ b/wayfinder_paths/tests/test_brap_prerequisites.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Coroutine
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from eth_abi import encode
+from eth_utils import to_checksum_address
+
+from wayfinder_paths.adapters.brap_adapter import adapter as adapter_module
+from wayfinder_paths.core.constants import ZERO_ADDRESS
+from wayfinder_paths.core.utils import transaction as transaction_module
+from wayfinder_paths.core.utils.transaction import TransactionRevertedError
+from wayfinder_paths.mcp.tools import execute as execute_module
+
+CHAIN_ID = 4663
+OWNER = "0x000000000000000000000000000000000000dEaD"
+TOKEN = "0x73c2de14c7fa0a57cc2d9722b959ea70b881ffe4"
+PERMIT2 = "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+ROUTER = "0x8876789976DEcbFcBBBe364623c63652Db8C0904"
+
+
+@dataclass
+class SwapCase:
+    quote: dict[str, Any]
+    token: dict[str, Any]
+    send: AsyncMock
+    approve: AsyncMock
+    record: AsyncMock
+    execute: Callable[[bool], Coroutine[Any, Any, tuple[bool, Any]]]
+
+
+@pytest.fixture(params=["mcp", "adapter"])
+def swap_case(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> SwapCase:
+    # Same two-step allowance contract as the direct v4 solver: token -> Permit2,
+    # then Permit2 -> router. Never replace these with token -> router approval.
+    quote: dict[str, Any] = {
+        "provider": "uniswap_v4",
+        "input_amount": "1000000",
+        "output_amount": "2000000",
+        "calldata": {
+            "chainId": CHAIN_ID,
+            "from": OWNER.lower(),
+            "to": ROUTER,
+            "data": "0x1234",
+            "value": "0x0",
+        },
+        "prerequisite_transactions": [
+            {
+                "chainId": CHAIN_ID,
+                "from": OWNER.lower(),
+                "to": TOKEN,
+                "data": "0x095ea7b3"
+                + encode(["address", "uint256"], [PERMIT2, 2**256 - 1]).hex(),
+                "value": "0x0",
+                "description": "Approve Permit2 to move the token",
+            },
+            {
+                "chainId": CHAIN_ID,
+                "from": OWNER,
+                "to": PERMIT2,
+                "data": "0x87517c45"
+                + encode(
+                    ["address", "address", "uint160", "uint48"],
+                    [TOKEN, ROUTER, 2**160 - 1, 2**48 - 1],
+                ).hex(),
+                "value": "0",
+                "description": "Authorize the router through Permit2",
+            },
+        ],
+    }
+    token = {
+        "address": TOKEN,
+        "chain_id": CHAIN_ID,
+        "chain": {"id": CHAIN_ID},
+        "decimals": 6,
+        "symbol": "BOOMER",
+    }
+    destination = {**token, "address": ZERO_ADDRESS, "symbol": "ETH"}
+    send = AsyncMock(return_value="0xtest")
+    approve = AsyncMock(return_value=(True, "0xapproval"))
+    record = AsyncMock(return_value={})
+    signer = AsyncMock(return_value=b"signed")
+    signer.wallet_address = None
+    monkeypatch.setattr(execute_module, "send_transaction", send)
+    monkeypatch.setattr(execute_module, "ensure_allowance", approve)
+    monkeypatch.setattr(execute_module, "_annotate_profile", lambda **_: None)
+    monkeypatch.setattr(
+        execute_module, "_token_balance", AsyncMock(return_value=10**18)
+    )
+    monkeypatch.setattr(
+        execute_module,
+        "get_wallet_signing_callback_for_chain",
+        AsyncMock(return_value=(signer, OWNER)),
+    )
+    monkeypatch.setattr(
+        execute_module,
+        "find_wallet_leg_for_chain",
+        AsyncMock(return_value={"address": OWNER}),
+    )
+    monkeypatch.setattr(
+        execute_module.TokenResolver,
+        "resolve_token_meta",
+        AsyncMock(side_effect=[token, destination]),
+    )
+    monkeypatch.setattr(
+        execute_module.BRAP_CLIENT,
+        "get_quote",
+        AsyncMock(return_value={"best_quote": quote}),
+    )
+    monkeypatch.setattr("wayfinder_paths.mcp.utils._report_tool_metric", Mock())
+    monkeypatch.setattr(adapter_module, "send_transaction", send)
+    monkeypatch.setattr(adapter_module, "ensure_allowance", approve)
+    adapter = adapter_module.BRAPAdapter(sign_callback=signer)
+    monkeypatch.setattr(adapter, "_record_swap_operation", record)
+
+    async def execute(wait_for_receipt: bool = True) -> tuple[bool, Any]:
+        if request.param == "adapter":
+            try:
+                return await adapter.swap_from_quote(token, destination, OWNER, quote)
+            except (TransactionRevertedError, TimeoutError) as exc:
+                return False, str(exc)
+        result = await execute_module.onchain_swap(
+            wallet_label="main",
+            from_token="from",
+            to_token="to",
+            amount="1.0",
+            wait_for_receipt=wait_for_receipt,
+            receipt_confirmations=0,
+        )
+        return result["ok"] and result["result"]["status"] != "failed", result
+
+    return SwapCase(quote, token, send, approve, record, execute)
+
+
+@pytest.mark.asyncio
+async def test_direct_approvals_are_confirmed_in_order(swap_case: SwapCase) -> None:
+    original = deepcopy(swap_case.quote)
+    success, _ = await swap_case.execute(False)
+    assert success
+    assert swap_case.send.await_count == 3
+    swap_case.approve.assert_not_awaited()
+    calls = swap_case.send.await_args_list
+    expected = [*original["prerequisite_transactions"], original["calldata"]]
+    for call, transaction in zip(calls, expected, strict=True):
+        assert call.args[0] == {
+            "chainId": CHAIN_ID,
+            "from": OWNER,
+            "to": to_checksum_address(transaction["to"]),
+            "data": transaction["data"],
+            "value": 0,
+        }
+    for call in calls[:2]:
+        assert call.kwargs == {"wait_for_receipt": True, "confirmations": 0}
+    assert swap_case.quote == original
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("index", [0, 1])
+async def test_no_next_step_before_prerequisite_receipt(
+    swap_case: SwapCase, index: int
+) -> None:
+    waiting, release = asyncio.Event(), asyncio.Event()
+
+    async def send(*args: Any, **kwargs: Any) -> str:
+        if swap_case.send.await_count == index + 1:
+            waiting.set()
+            await release.wait()
+        return "0xtest"
+
+    swap_case.send.side_effect = send
+    task = asyncio.create_task(swap_case.execute(False))
+    try:
+        await asyncio.wait_for(waiting.wait(), timeout=2)
+        assert swap_case.send.await_count == index + 1
+        assert not task.done()
+    finally:
+        release.set()
+        await asyncio.wait_for(task, timeout=2)
+    assert task.result()[0]
+    assert swap_case.send.await_count == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("index", [0, 1])
+@pytest.mark.parametrize(
+    "failure",
+    [
+        TransactionRevertedError("0xbad", {"status": 0}),
+        TimeoutError("Receipt timed out"),
+    ],
+)
+async def test_prerequisite_failure_never_sends_swap(
+    swap_case: SwapCase, index: int, failure: Exception
+) -> None:
+    swap_case.send.side_effect = [*["0xapproval"] * index, failure]
+    success, result = await swap_case.execute(False)
+    assert not success
+    assert str(failure) in str(result)
+    assert swap_case.send.await_count == index + 1
+    swap_case.record.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("receipt_status", [0, 1])
+async def test_real_sender_checks_prerequisite_receipts(
+    swap_case: SwapCase, monkeypatch: pytest.MonkeyPatch, receipt_status: int
+) -> None:
+    events: list[str] = []
+
+    async def broadcast(chain_id: int, signed: bytes) -> str:
+        events.append("broadcast")
+        return "0xtest"
+
+    async def receipt(*args: Any, **kwargs: Any) -> dict[str, int]:
+        events.append("receipt")
+        return {"status": receipt_status, "blockNumber": 1}
+
+    # Exercise send_transaction's real receipt/revert handling without signing
+    # or submitting anything on-chain. Every network boundary is mocked.
+    for name in ("gas_limit_transaction", "nonce_transaction", "gas_price_transaction"):
+        monkeypatch.setattr(
+            transaction_module, name, AsyncMock(side_effect=lambda tx: tx)
+        )
+    monkeypatch.setattr(
+        transaction_module, "_is_gorlami_fork_chain", Mock(return_value=False)
+    )
+    monkeypatch.setattr(transaction_module, "broadcast_transaction", broadcast)
+    monkeypatch.setattr(transaction_module, "wait_for_transaction_receipt", receipt)
+    swap_case.send.side_effect = transaction_module.send_transaction
+    success, _ = await swap_case.execute(True)
+    assert success is bool(receipt_status)
+    assert events == ["broadcast", "receipt"] * (3 if receipt_status else 1)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["pons_v2", "uniswap_v3", "uniswap_v4"])
+@pytest.mark.parametrize("prerequisites", [None, []])
+async def test_already_approved_solver_needs_no_router_approval(
+    swap_case: SwapCase, provider: str, prerequisites: list[Any] | None
+) -> None:
+    swap_case.quote.update(provider=provider, prerequisite_transactions=prerequisites)
+    assert (await swap_case.execute(True))[0]
+    swap_case.approve.assert_not_awaited()
+    swap_case.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_pons_curve_uses_single_quoted_approval(swap_case: SwapCase) -> None:
+    swap_case.quote["provider"] = "pons_v2"
+    swap_case.quote["prerequisite_transactions"] = swap_case.quote[
+        "prerequisite_transactions"
+    ][:1]
+    assert (await swap_case.execute(True))[0]
+    assert swap_case.send.await_count == 2
+    swap_case.approve.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "native", [ZERO_ADDRESS, "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"]
+)
+@pytest.mark.parametrize("provider", ["lifi", "pons_v2", "uniswap_v4"])
+async def test_native_buy_does_not_approve(
+    swap_case: SwapCase, native: str, provider: str
+) -> None:
+    swap_case.token["address"] = native
+    swap_case.quote.update(provider=provider, prerequisite_transactions=[])
+    swap_case.quote["calldata"]["value"] = "0xf4240"
+    assert (await swap_case.execute(True))[0]
+    swap_case.approve.assert_not_awaited()
+    swap_case.send.assert_awaited_once()
+    assert swap_case.send.await_args is not None
+    assert swap_case.send.await_args.args[0]["value"] == 1000000
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("approved", [True, False])
+async def test_legacy_approval_is_still_required(
+    swap_case: SwapCase, approved: bool
+) -> None:
+    swap_case.quote.update(
+        provider="lifi", approval_address=PERMIT2, prerequisite_transactions=None
+    )
+    swap_case.approve.return_value = approved, "0xapproval"
+    assert (await swap_case.execute(True))[0] is approved
+    assert swap_case.approve.await_args is not None
+    assert swap_case.approve.await_args.kwargs["spender"] == PERMIT2
+    assert swap_case.approve.await_args.kwargs["amount"] == 1000000
+    assert swap_case.send.await_count == int(approved)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("target", ["swap", "last_prerequisite"])
+@pytest.mark.parametrize(
+    "change",
+    [
+        {"chainId": 1},
+        {"from": TOKEN},
+        {"to": "invalid"},
+        {"data": "0xnothex"},
+        {"value": "invalid"},
+        {"value": -1},
+        {"calls": []},
+    ],
+)
+async def test_all_transactions_validated_before_any_send(
+    swap_case: SwapCase, target: str, change: dict[str, Any]
+) -> None:
+    tx = (
+        swap_case.quote["calldata"]
+        if target == "swap"
+        else swap_case.quote["prerequisite_transactions"][-1]
+    )
+    tx.update(change)
+    assert not (await swap_case.execute(True))[0]
+    swap_case.send.assert_not_awaited()
+    swap_case.approve.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "change",
+    [
+        {"atomic_calls": [{"to": TOKEN, "data": "0x1234"}]},
+        {"provider": "pons_v2_batch"},
+        {"prerequisite_transactions": "invalid"},
+        {"prerequisite_transactions": [None]},
+        {"prerequisite_transactions": [{"to": TOKEN, "data": "0x1234"}]},
+    ],
+)
+async def test_unsupported_sequence_does_not_sign(
+    swap_case: SwapCase, change: dict[str, Any]
+) -> None:
+    swap_case.quote.update(change)
+    assert not (await swap_case.execute(True))[0]
+    swap_case.send.assert_not_awaited()
+    swap_case.approve.assert_not_awaited()


### PR DESCRIPTION
### Summary
- Add direct Pons/Uniswap prerequisite execution to both the agent onchain_swap tool and BRAPAdapter.swap_from_quote. Honor the quoted ERC20 and Permit2 approval sequence, waiting for each successful receipt before submitting the swap, even when the final swap uses fire-and-forget mode.
- Reuse existing signing, receipt, allowance, and native-token helpers. Share source-chain transaction validation between both entry points; reject mismatched chains/senders, malformed transactions, and atomic-only routes before any signing. Already-approved direct routes do not add an incorrect token-to-router approval.
- Preserve legacy routes, native value/relayer fees, and Solana execution. Stop the Python adapter when its legacy allowance check reports failure. No version bump, dependency changes, deployment, or live trades.
- Add 86 parameterized regression cases across agent and adapter execution: ordering, delayed receipts, reverts/timeouts, actual send_transaction receipt checks, native buys, legacy approvals, malformed/mismatched transactions, and atomic-route rejection. The primary new tests fail against unchanged main.
- Validation: 398 tests passed, 3 skipped, 5 excluded pre-existing sponsored-transaction tests (stale WALLET_CLIENT mock target; reproduced on main). Repository-wide Ruff lint and format pass. Mypy reports the same six pre-existing adapter typing errors as main, with no new findings.