### PR TITLE
Mobile Agent - Allowlist Task Subagents

### DIFF
--- a/.opencode/agents/wayfinder-mobile.md
+++ b/.opencode/agents/wayfinder-mobile.md
@@ -4,16 +4,17 @@ mode: primary
 temperature: 0.1
 steps: 64
 permission:
+  # Allowlist: only our own subagents. Path-installed orchestrators carry their
+  # own permission policy (often bash "*": ask), and a permission prompt in a
+  # child session is unanswerable over the messaging channel — it freezes the
+  # child, the task tool, and the reply forever.
   task:
-    explore: deny
-    scout: deny
-    general: deny
-    wayfinder-mobile: deny
-    wayfinder-research: deny
-    wayfinder-quant: deny
-    wayfinder-planner: deny
+    "*": deny
+    wayfinder-research: allow
+    wayfinder-quant: allow
+    wayfinder-planner: allow
+    wayfinder-sports: allow
     wayfinder-visual: deny
-    wayfinder-sports: deny
 
   write: allow
   # Override opencode's built-in ask defaults: a permission prompt is


### PR DESCRIPTION
### Summary
`wayfinder-mobile` denied `task` only for the built-in subagents by name, so any path-installed orchestrator agent was spawnable from an iMessage session. Those agents carry their own permission policy — `dex-whale-watch-orchestrator` ships `bash "*": ask` — and a permission prompt in a child session is unanswerable over the messaging channel: the child's bash tool, the parent's `task` tool and the reply all froze forever (a user's channel went silent for 2+ days on 2026-09-07; the same subagent re-froze every later initiative turn). Same failure class #650 fixed for the mobile agent's own asks.

Flips the `task` block to an allowlist: `"*": deny`, then explicit `allow` for `wayfinder-research`, `wayfinder-quant`, `wayfinder-planner` and `wayfinder-sports`; `wayfinder-visual` stays denied (no chart surface on mobile). opencode evaluates rules with `findLast` over insertion-ordered config entries, so the explicit allows win over the leading wildcard deny.

Note: research/quant/planner/sports were previously `deny` on mobile (an unexplained side-change in #616) — this PR re-enables them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWn7xeN6CoLhzTys9Epgf6