### PR TITLE
RPC - Fail Fast and Bound Portfolio Scans

### DIFF
--- a/wayfinder_paths/adapters/moonwell_adapter/adapter.py
+++ b/wayfinder_paths/adapters/moonwell_adapter/adapter.py
@@ -6,6 +6,7 @@ from typing import Any, Literal
 from aiocache import Cache
 from eth_utils import to_checksum_address
 from eth_utils.abi import collapse_if_tuple
+from web3.exceptions import ContractLogicError
 
 from wayfinder_paths.adapters.multicall_adapter.adapter import MulticallAdapter
 from wayfinder_paths.core.adapters.BaseAdapter import BaseAdapter
@@ -90,8 +91,8 @@ class MoonwellAdapter(BaseAdapter):
         """
         Execute multicall in chunks.
 
-        If a chunk reverts, fall back to executing calls one-by-one so we can salvage
-        partial results (returning b"" for failed calls).
+        Only contract reverts fall back to individual calls. Transport failures
+        must propagate, not become zero balances or trigger a retry per token.
         """
         out: list[bytes] = []
         for chunk in self._chunks(calls, max(1, int(chunk_size))):
@@ -101,12 +102,12 @@ class MoonwellAdapter(BaseAdapter):
                 res = await multicall.aggregate(chunk)
                 out.extend(list(res.return_data))
                 continue
-            except Exception:  # noqa: BLE001 - fall back to individual calls
+            except ContractLogicError:
                 for call in chunk:
                     try:
                         r = await multicall.aggregate([call])
                         out.append(r.return_data[0] if r.return_data else b"")
-                    except Exception:  # noqa: BLE001
+                    except ContractLogicError:
                         out.append(b"")
         return out
 
@@ -559,7 +560,9 @@ class MoonwellAdapter(BaseAdapter):
         include_zero_positions: bool = False,
         multicall_chunk_size: int = 240,
         block_identifier: int | str | None = None,  # multicall ignores block id
+        timeout_seconds: float = 60.0,
     ) -> tuple[bool, dict[str, Any] | str]:
+        """Read one chain's positions within ``timeout_seconds``; failures are not zeros."""
         _ = block_identifier  # reserved for future per-call block pinning
         cid = self._chain_id(chain_id)
         acct = to_checksum_address(account) if account else self.wallet_address
@@ -569,7 +572,10 @@ class MoonwellAdapter(BaseAdapter):
         reward_distributor_address = self._reward_distributor(cid)
 
         try:
-            async with web3_from_chain_id(cid) as web3:
+            async with (
+                asyncio.timeout(timeout_seconds),
+                web3_from_chain_id(cid) as web3,
+            ):
                 multicall = MulticallAdapter(chain_id=cid, web3=web3)
 
                 comptroller = web3.eth.contract(
@@ -887,8 +893,13 @@ class MoonwellAdapter(BaseAdapter):
 
                 return True, out
 
+        except TimeoutError:
+            return False, (
+                f"Moonwell position scan timed out on chain {cid} "
+                f"(limit {timeout_seconds:g}s)"
+            )
         except Exception as exc:  # noqa: BLE001
-            return False, str(exc)
+            return False, str(exc) or type(exc).__name__
 
     async def get_all_markets(
         self,

--- a/wayfinder_paths/adapters/pendle_adapter/adapter.py
+++ b/wayfinder_paths/adapters/pendle_adapter/adapter.py
@@ -7,6 +7,7 @@ from typing import Any, Literal
 
 import httpx
 from eth_utils import to_checksum_address
+from web3.exceptions import ContractLogicError
 
 from wayfinder_paths.adapters.multicall_adapter.adapter import MulticallAdapter
 from wayfinder_paths.core.adapters.BaseAdapter import BaseAdapter
@@ -330,8 +331,8 @@ class PendleAdapter(BaseAdapter):
         """
         Execute multicall and decode each return as uint256.
 
-        If a chunk reverts, fall back to executing calls one-by-one so we can salvage
-        partial results (returning None for failed calls).
+        Only contract reverts fall back to individual calls. Transport failures
+        must propagate, not become zero balances or trigger a retry per token.
         """
         out: list[int | None] = []
         for chunk in self._chunks(calls, max(1, int(chunk_size))):
@@ -340,7 +341,7 @@ class PendleAdapter(BaseAdapter):
             try:
                 res = await multicall.aggregate(chunk)
                 out.extend([multicall.decode_uint256(b) for b in res.return_data])
-            except Exception:  # noqa: BLE001 - fall back to individual calls
+            except ContractLogicError:
                 for call in chunk:
                     try:
                         r = await multicall.aggregate([call])
@@ -348,7 +349,7 @@ class PendleAdapter(BaseAdapter):
                             out.append(multicall.decode_uint256(r.return_data[0]))
                         else:
                             out.append(None)
-                    except Exception:  # noqa: BLE001
+                    except ContractLogicError:
                         out.append(None)
         return out
 
@@ -2094,8 +2095,9 @@ class PendleAdapter(BaseAdapter):
         multicall_chunk_size: int = 400,
         include_prices: bool = False,
         price_concurrency: int = 8,
+        chain_timeout_seconds: float = 60.0,
     ) -> tuple[bool, dict[str, Any] | str]:
-        """Query all Pendle chains and return merged positions."""
+        """Merge positions, reporting failed/timed-out chains in ``errors``."""
         all_positions: list[dict[str, Any]] = []
         chains_queried: list[int] = []
         errors: list[str] = []
@@ -2110,6 +2112,7 @@ class PendleAdapter(BaseAdapter):
                 multicall_chunk_size=multicall_chunk_size,
                 include_prices=include_prices,
                 price_concurrency=price_concurrency,
+                timeout_seconds=chain_timeout_seconds,
             )
             if ok:
                 chain_data = result  # type: ignore[assignment]
@@ -2140,6 +2143,7 @@ class PendleAdapter(BaseAdapter):
         multicall_chunk_size: int = 400,
         include_prices: bool = False,
         price_concurrency: int = 8,
+        timeout_seconds: float = 60.0,
     ) -> tuple[bool, dict[str, Any] | str]:
         """
         Pendle "full user state" snapshot via on-chain ERC20 balance scan.
@@ -2148,154 +2152,166 @@ class PendleAdapter(BaseAdapter):
           1) Fetch markets from Pendle API (market/pt/yt/sy addresses + expiry metadata)
           2) Multicall ERC20.balanceOf(account) + ERC20.decimals() for PT/YT/LP/(SY)
           3) Optionally fetch market snapshots (API) for markets with positions
+
+        The whole scan is bounded by ``timeout_seconds``, including discovery.
         """
         chain_id = _as_chain_id(chain)
 
         try:
-            markets_resp = await self.fetch_markets(
-                chain_id=chain_id,
-                is_active=None if include_inactive else True,
-            )
-            markets = markets_resp.get("markets") or []
-
-            now = _now_utc()
-            normalized: list[dict[str, Any]] = []
-            for m in markets:
-                expiry_s = m.get("expiry")
-                try:
-                    expiry_dt = _parse_iso8601(str(expiry_s)) if expiry_s else None
-                except Exception:  # noqa: BLE001
-                    expiry_dt = None
-                days_to_expiry = (
-                    (expiry_dt - now).total_seconds() / 86400.0 if expiry_dt else None
+            async with asyncio.timeout(timeout_seconds):
+                markets_resp = await self.fetch_markets(
+                    chain_id=chain_id,
+                    is_active=None if include_inactive else True,
                 )
+                markets = markets_resp.get("markets") or []
 
-                normalized.append(
-                    {
-                        "chainId": int(m.get("chainId") or chain_id),
-                        "marketName": m.get("name"),
-                        "marketAddress": _as_address(str(m.get("address", ""))),
-                        "pt": _as_address(str(m.get("pt", ""))),
-                        "yt": _as_address(str(m.get("yt", ""))),
-                        "sy": _as_address(str(m.get("sy", ""))),
-                        "underlying": _as_address(str(m.get("underlyingAsset", ""))),
-                        "expiry": expiry_s,
-                        "daysToExpiry": days_to_expiry,
-                        "active": bool(m.get("isActive"))
-                        if m.get("isActive") is not None
-                        else None,
-                    }
-                )
-
-            async with web3_from_chain_id(chain_id) as web3:
-                user_ck = web3.to_checksum_address(account)
-                multicall = MulticallAdapter(chain_id=chain_id, web3=web3)
-
-                call_specs: list[tuple[int, str, str, str]] = []
-                calls: list[Any] = []
-
-                def add_token_calls(midx: int, kind: str, token: str) -> None:
-                    if not token:
-                        return
-                    token_ck = web3.to_checksum_address(token)
-                    erc20 = web3.eth.contract(address=token_ck, abi=ERC20_ABI)
-
-                    calls.append(
-                        multicall.build_call(
-                            token_ck,
-                            erc20.encode_abi("balanceOf", args=[user_ck]),
-                        )
-                    )
-                    call_specs.append((midx, kind, token_ck, "bal"))
-
-                    calls.append(
-                        multicall.build_call(
-                            token_ck,
-                            erc20.encode_abi("decimals", args=[]),
-                        )
-                    )
-                    call_specs.append((midx, kind, token_ck, "dec"))
-
-                for i, m in enumerate(normalized):
-                    add_token_calls(i, "pt", m["pt"])
-                    add_token_calls(i, "yt", m["yt"])
-                    add_token_calls(i, "lp", m["marketAddress"])
-                    if include_sy:
-                        add_token_calls(i, "sy", m["sy"])
-
-                decoded = await self._multicall_uint256_chunked(
-                    multicall=multicall,
-                    calls=calls,
-                    chunk_size=multicall_chunk_size,
-                )
-
-                per_market: list[dict[str, Any]] = [
-                    dict(m, balances={}) for m in normalized
-                ]
-
-                for spec, val in zip(call_specs, decoded, strict=False):
-                    midx, kind, token, which = spec
-                    if midx >= len(per_market):
-                        continue
-                    bucket = per_market[midx]["balances"].setdefault(
-                        kind,
-                        {
-                            "address": token,
-                            "raw": 0,
-                            "decimals": None,
-                        },
-                    )
-                    if which == "bal":
-                        bucket["raw"] = int(val or 0)
-                    else:
-                        bucket["decimals"] = int(val) if val is not None else None
-
-            positions: list[dict[str, Any]] = []
-            for m in per_market:
-                balances = m.get("balances") or {}
-                has_any = False
-                for kind in ("pt", "yt", "lp", "sy"):
-                    if kind in balances and int(balances[kind].get("raw") or 0) > 0:
-                        has_any = True
-                        break
-                if not include_zero_positions and not has_any:
-                    continue
-                positions.append(m)
-
-            if include_prices and positions:
-
-                async def fetch_one(pos: dict[str, Any]) -> dict[str, Any]:
-                    cid = int(pos.get("chainId") or chain_id)
-                    market_address = str(pos.get("marketAddress") or "").strip()
-                    if not market_address:
-                        return {}
+                now = _now_utc()
+                normalized: list[dict[str, Any]] = []
+                for m in markets:
+                    expiry_s = m.get("expiry")
                     try:
-                        return await self.fetch_market_snapshot(
-                            chain_id=cid, market_address=market_address
-                        )
+                        expiry_dt = _parse_iso8601(str(expiry_s)) if expiry_s else None
                     except Exception:  # noqa: BLE001
-                        return {}
+                        expiry_dt = None
+                    days_to_expiry = (
+                        (expiry_dt - now).total_seconds() / 86400.0
+                        if expiry_dt
+                        else None
+                    )
 
-                snapshots = await _gather_limited(
-                    [lambda pos=pos: fetch_one(pos) for pos in positions],
-                    concurrency=int(price_concurrency),
+                    normalized.append(
+                        {
+                            "chainId": int(m.get("chainId") or chain_id),
+                            "marketName": m.get("name"),
+                            "marketAddress": _as_address(str(m.get("address", ""))),
+                            "pt": _as_address(str(m.get("pt", ""))),
+                            "yt": _as_address(str(m.get("yt", ""))),
+                            "sy": _as_address(str(m.get("sy", ""))),
+                            "underlying": _as_address(
+                                str(m.get("underlyingAsset", ""))
+                            ),
+                            "expiry": expiry_s,
+                            "daysToExpiry": days_to_expiry,
+                            "active": bool(m.get("isActive"))
+                            if m.get("isActive") is not None
+                            else None,
+                        }
+                    )
+
+                async with web3_from_chain_id(chain_id) as web3:
+                    user_ck = web3.to_checksum_address(account)
+                    multicall = MulticallAdapter(chain_id=chain_id, web3=web3)
+
+                    call_specs: list[tuple[int, str, str, str]] = []
+                    calls: list[Any] = []
+
+                    def add_token_calls(midx: int, kind: str, token: str) -> None:
+                        if not token:
+                            return
+                        token_ck = web3.to_checksum_address(token)
+                        erc20 = web3.eth.contract(address=token_ck, abi=ERC20_ABI)
+
+                        calls.append(
+                            multicall.build_call(
+                                token_ck,
+                                erc20.encode_abi("balanceOf", args=[user_ck]),
+                            )
+                        )
+                        call_specs.append((midx, kind, token_ck, "bal"))
+
+                        calls.append(
+                            multicall.build_call(
+                                token_ck,
+                                erc20.encode_abi("decimals", args=[]),
+                            )
+                        )
+                        call_specs.append((midx, kind, token_ck, "dec"))
+
+                    for i, m in enumerate(normalized):
+                        add_token_calls(i, "pt", m["pt"])
+                        add_token_calls(i, "yt", m["yt"])
+                        add_token_calls(i, "lp", m["marketAddress"])
+                        if include_sy:
+                            add_token_calls(i, "sy", m["sy"])
+
+                    decoded = await self._multicall_uint256_chunked(
+                        multicall=multicall,
+                        calls=calls,
+                        chunk_size=multicall_chunk_size,
+                    )
+
+                    per_market: list[dict[str, Any]] = [
+                        dict(m, balances={}) for m in normalized
+                    ]
+
+                    for spec, val in zip(call_specs, decoded, strict=False):
+                        midx, kind, token, which = spec
+                        if midx >= len(per_market):
+                            continue
+                        bucket = per_market[midx]["balances"].setdefault(
+                            kind,
+                            {
+                                "address": token,
+                                "raw": 0,
+                                "decimals": None,
+                            },
+                        )
+                        if which == "bal":
+                            bucket["raw"] = int(val or 0)
+                        else:
+                            bucket["decimals"] = int(val) if val is not None else None
+
+                positions: list[dict[str, Any]] = []
+                for m in per_market:
+                    balances = m.get("balances") or {}
+                    has_any = False
+                    for kind in ("pt", "yt", "lp", "sy"):
+                        if kind in balances and int(balances[kind].get("raw") or 0) > 0:
+                            has_any = True
+                            break
+                    if not include_zero_positions and not has_any:
+                        continue
+                    positions.append(m)
+
+                if include_prices and positions:
+
+                    async def fetch_one(pos: dict[str, Any]) -> dict[str, Any]:
+                        cid = int(pos.get("chainId") or chain_id)
+                        market_address = str(pos.get("marketAddress") or "").strip()
+                        if not market_address:
+                            return {}
+                        try:
+                            return await self.fetch_market_snapshot(
+                                chain_id=cid, market_address=market_address
+                            )
+                        except Exception:  # noqa: BLE001
+                            return {}
+
+                    snapshots = await _gather_limited(
+                        [lambda pos=pos: fetch_one(pos) for pos in positions],
+                        concurrency=int(price_concurrency),
+                    )
+                    for pos, snap in zip(positions, snapshots, strict=False):
+                        if snap:
+                            pos["marketSnapshot"] = snap
+
+                return (
+                    True,
+                    {
+                        "protocol": "pendle",
+                        "source": "onchain_scan_multicall",
+                        "chainId": int(chain_id),
+                        "account": account,
+                        "positions": positions,
+                    },
                 )
-                for pos, snap in zip(positions, snapshots, strict=False):
-                    if snap:
-                        pos["marketSnapshot"] = snap
-
-            return (
-                True,
-                {
-                    "protocol": "pendle",
-                    "source": "onchain_scan_multicall",
-                    "chainId": int(chain_id),
-                    "account": account,
-                    "positions": positions,
-                },
+        except TimeoutError:
+            return False, (
+                f"Pendle position scan timed out on chain {chain_id} "
+                f"(limit {timeout_seconds:g}s)"
             )
         except Exception as exc:  # noqa: BLE001
-            return False, str(exc)
+            return False, str(exc) or type(exc).__name__
 
     # ---------------------------------------
     # Execute swap

--- a/wayfinder_paths/adapters/pendle_adapter/test_adapter.py
+++ b/wayfinder_paths/adapters/pendle_adapter/test_adapter.py
@@ -10,6 +10,7 @@ import httpx
 import pytest
 from web3 import Web3
 
+import wayfinder_paths.core.utils.web3 as web3_utils
 from wayfinder_paths.adapters.pendle_adapter.adapter import (
     PendleAdapter,
     pendle_api_get,
@@ -924,6 +925,65 @@ class TestPendleAdapter:
         assert best["ok"] is True
         assert best["selectedMarket"]["marketAddress"] == "0xM2"
         assert best["quote"]["effectiveApy"] == 0.09
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("arbitrum_pool_size", [0, 1])
+    async def test_full_user_state_reports_unconfigured_chain_and_continues(
+        self, arbitrum_pool_size: int
+    ) -> None:
+        adapter = PendleAdapter(config={})
+        adapter.fetch_markets = AsyncMock(
+            return_value={
+                "markets": [
+                    {
+                        "name": "PT-Example",
+                        "address": "0x" + "1" * 40,
+                        "pt": "0x" + "2" * 40,
+                    }
+                ]
+            }
+        )
+        # PT balance/decimals, then LP balance/decimals.
+        adapter._multicall_uint256_chunked = AsyncMock(return_value=[100, 18, 0, 18])
+        responses = [
+            httpx.Response(
+                200,
+                json={"size": size},
+                request=httpx.Request("GET", "https://example.invalid/count/"),
+            )
+            for size in (0, arbitrum_pool_size)
+        ]
+        with (
+            patch(
+                "wayfinder_paths.adapters.pendle_adapter.adapter.PENDLE_CHAIN_IDS",
+                {"sonic": 146, "arbitrum": 42161},
+            ),
+            patch.object(web3_utils, "_pool_size_cache", {}),
+            patch.object(web3_utils, "get_rpc_urls", return_value={}),
+            patch.object(web3_utils, "_wayfinder_auth_headers", return_value={}),
+            patch.object(web3_utils.httpx, "get", side_effect=responses) as probe,
+            patch.object(
+                web3_utils, "_get_web3", wraps=web3_utils._get_web3
+            ) as provider,
+        ):
+            ok, state = await adapter.get_full_user_state(account="0x" + "a" * 40)
+
+        assert probe.call_count == 2
+        assert provider.call_count == arbitrum_pool_size
+        assert adapter._multicall_uint256_chunked.await_count == arbitrum_pool_size
+        sonic_error = "chain 146: No RPC endpoints configured for chain 146"
+        if arbitrum_pool_size:
+            assert ok is True
+            assert isinstance(state, dict)
+            assert state["chains"] == [42161]
+            assert state["errors"] == [sonic_error]
+            assert len(state["positions"]) == 1
+            assert state["positions"][0]["balances"]["pt"]["raw"] == 100
+        else:
+            assert ok is False
+            assert state == (
+                f"{sonic_error}; chain 42161: No RPC endpoints configured for chain 42161"
+            )
 
     @pytest.mark.asyncio
     async def test_get_full_user_state_onchain_multicall_filters_zeros(

--- a/wayfinder_paths/core/utils/web3.py
+++ b/wayfinder_paths/core/utils/web3.py
@@ -79,24 +79,29 @@ def _wayfinder_auth_headers() -> dict[str, str]:
 _pool_size_cache: dict[int, int] = {}
 
 
-def _fetch_pool_size(chain_id: int) -> int:
+def _fetch_pool_size(chain_id: int) -> int | None:
     """Probes the proxy for its fan-out width; positive results cached per process.
 
     Synchronous, so the first call per chain blocks the asyncio loop for one
     HTTPS round-trip (~50-200ms). Failures are NOT cached so a transient
     network blip on the very first call doesn't pin the SDK to single-URL
-    fallback for the rest of the process lifetime.
+    fallback for the rest of the process lifetime. Zero means the proxy has no
+    RPCs configured; None means discovery failed. Neither is cached.
     """
     if (cached := _pool_size_cache.get(chain_id)) is not None:
         return cached
     url = f"{get_api_base_url()}/blockchain/rpc/{chain_id}/count/"
     try:
         resp = httpx.get(url, headers=_wayfinder_auth_headers(), timeout=5)
+        resp.raise_for_status()
         size = int(resp.json()["size"])
-    except (httpx.HTTPError, ValueError, KeyError) as exc:
+        if size < 0:
+            raise ValueError("RPC pool size must be non-negative")
+    except (httpx.HTTPError, ValueError, KeyError, TypeError) as exc:
         logger.warning("RPC pool-size probe failed for chain %s: %s", chain_id, exc)
-        return 0
-    _pool_size_cache[chain_id] = size
+        return None
+    if size > 0:
+        _pool_size_cache[chain_id] = size
     return size
 
 
@@ -109,11 +114,13 @@ def _get_rpcs_for_chain_id(chain_id: int) -> list:
     if rpcs is None:
         base = get_api_base_url()
         n = _fetch_pool_size(chain_id)
-        if n:
-            rpcs = [f"{base}/blockchain/rpc/{chain_id}/{i}/" for i in range(n)]
-        else:
+        if n is None:
             rpcs = [f"{base}/blockchain/rpc/{chain_id}/"]
+        else:
+            rpcs = [f"{base}/blockchain/rpc/{chain_id}/{i}/" for i in range(n)]
 
+    if not rpcs:
+        raise ValueError(f"No RPC endpoints configured for chain {chain_id}")
     if isinstance(rpcs, str):
         return [rpcs]
     return rpcs

--- a/wayfinder_paths/tests/test_config_resolution.py
+++ b/wayfinder_paths/tests/test_config_resolution.py
@@ -2,15 +2,19 @@ from __future__ import annotations
 
 import copy
 import json
+from collections.abc import Iterator
 from pathlib import Path
+from unittest.mock import Mock
 
+import httpx
 import pytest
 
 import wayfinder_paths.core.config as config
+import wayfinder_paths.core.utils.web3 as web3_utils
 
 
 @pytest.fixture
-def restore_global_config() -> None:
+def restore_global_config() -> Iterator[None]:
     original = copy.deepcopy(config.CONFIG)
     yield
     config.set_config(original)
@@ -92,11 +96,10 @@ async def test_web3s_fallback_to_rpc_proxy(
         }
     )
 
-    import wayfinder_paths.core.utils.web3 as web3_utils
     from wayfinder_paths.core.constants.chains import CHAIN_ID_BASE, CHAIN_ID_HYPEREVM
     from wayfinder_paths.core.utils.web3 import web3s_from_chain_id
 
-    monkeypatch.setattr(web3_utils, "_fetch_pool_size", lambda _chain_id: 0)
+    monkeypatch.setattr(web3_utils, "_fetch_pool_size", lambda _chain_id: None)
 
     async with web3s_from_chain_id(CHAIN_ID_BASE) as web3s:
         uri = web3s[0].provider.endpoint_uri
@@ -127,11 +130,10 @@ async def test_user_rpcs_override_proxy(
         }
     )
 
-    import wayfinder_paths.core.utils.web3 as web3_utils
     from wayfinder_paths.core.constants.chains import CHAIN_ID_ARBITRUM, CHAIN_ID_BASE
     from wayfinder_paths.core.utils.web3 import web3s_from_chain_id
 
-    monkeypatch.setattr(web3_utils, "_fetch_pool_size", lambda _chain_id: 0)
+    monkeypatch.setattr(web3_utils, "_fetch_pool_size", lambda _chain_id: None)
 
     async with web3s_from_chain_id(CHAIN_ID_BASE) as web3s:
         assert web3s[0].provider.endpoint_uri == "https://custom-rpc.example.com"
@@ -160,7 +162,6 @@ async def test_web3s_uses_indexed_rpc_proxy_pool(
         }
     )
 
-    import wayfinder_paths.core.utils.web3 as web3_utils
     from wayfinder_paths.core.constants.chains import CHAIN_ID_BASE
     from wayfinder_paths.core.utils.web3 import web3s_from_chain_id
 
@@ -182,6 +183,114 @@ def test_web3s_accept_int_rpc_url_keys(restore_global_config: None) -> None:
 
     w3 = get_web3s_from_chain_id(CHAIN_ID_BASE)[0]
     assert w3.provider.endpoint_uri == "https://example.invalid"
+
+
+@pytest.fixture
+def rpc_pool_probe(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    monkeypatch.setattr(web3_utils, "_pool_size_cache", {})
+    monkeypatch.setattr(web3_utils, "get_rpc_urls", lambda: {})
+    monkeypatch.setattr(web3_utils, "_wayfinder_auth_headers", lambda: {})
+    probe = Mock(
+        return_value=httpx.Response(
+            200,
+            json={"size": 0},
+            request=httpx.Request("GET", "https://example.invalid/count/"),
+        )
+    )
+    monkeypatch.setattr(web3_utils.httpx, "get", probe)
+    return probe
+
+
+@pytest.mark.parametrize("chain_id", [146, 123456])
+def test_unconfigured_rpc_fails_before_creating_provider(
+    rpc_pool_probe: Mock, monkeypatch: pytest.MonkeyPatch, chain_id: int
+) -> None:
+    create_provider = Mock()
+    monkeypatch.setattr(web3_utils, "_get_web3", create_provider)
+
+    with pytest.raises(
+        ValueError, match=f"No RPC endpoints configured for chain {chain_id}"
+    ):
+        web3_utils.get_web3s_from_chain_id(chain_id)
+
+    rpc_pool_probe.assert_called_once()
+    create_provider.assert_not_called()
+
+
+def test_unconfigured_rpc_is_rechecked_when_support_is_added(
+    rpc_pool_probe: Mock,
+) -> None:
+    with pytest.raises(ValueError, match="No RPC endpoints configured"):
+        web3_utils._get_rpcs_for_chain_id(146)
+
+    rpc_pool_probe.return_value = httpx.Response(
+        200,
+        json={"size": 2},
+        request=httpx.Request("GET", "https://example.invalid/count/"),
+    )
+    expected = [
+        f"{config.get_api_base_url()}/blockchain/rpc/146/{i}/" for i in range(2)
+    ]
+    assert web3_utils._get_rpcs_for_chain_id(146) == expected
+    assert web3_utils._get_rpcs_for_chain_id(146) == expected
+    assert rpc_pool_probe.call_count == 2  # Cache the positive result, not zero.
+
+
+@pytest.mark.parametrize(
+    ("status", "payload"),
+    [
+        (503, {"size": 0}),
+        (404, {}),
+        (200, {}),
+        (200, {"size": None}),
+        (200, {"size": -1}),
+    ],
+)
+def test_failed_pool_discovery_preserves_uncached_legacy_fallback(
+    rpc_pool_probe: Mock, status: int, payload: dict[str, int | None]
+) -> None:
+    rpc_pool_probe.return_value = httpx.Response(
+        status,
+        json=payload,
+        request=httpx.Request("GET", "https://example.invalid/count/"),
+    )
+    for _ in range(2):
+        assert web3_utils._get_rpcs_for_chain_id(146) == [
+            f"{config.get_api_base_url()}/blockchain/rpc/146/"
+        ]
+    assert rpc_pool_probe.call_count == 2
+
+
+def test_pool_discovery_timeout_preserves_fallback(rpc_pool_probe: Mock) -> None:
+    rpc_pool_probe.side_effect = httpx.ReadTimeout("timed out")
+
+    assert web3_utils._get_rpcs_for_chain_id(146) == [
+        f"{config.get_api_base_url()}/blockchain/rpc/146/"
+    ]
+    assert web3_utils._pool_size_cache == {}
+
+
+@pytest.mark.parametrize(
+    "rpc_urls", ["https://custom.example", ["https://custom.example"]]
+)
+def test_custom_rpc_bypasses_pool_discovery(
+    rpc_pool_probe: Mock, monkeypatch: pytest.MonkeyPatch, rpc_urls: str | list[str]
+) -> None:
+    monkeypatch.setattr(web3_utils, "get_rpc_urls", lambda: {"146": rpc_urls})
+
+    assert web3_utils._get_rpcs_for_chain_id(146) == ["https://custom.example"]
+    rpc_pool_probe.assert_not_called()
+
+
+@pytest.mark.parametrize("rpc_urls", ["", []])
+def test_empty_custom_rpc_configuration_fails_fast(
+    rpc_pool_probe: Mock, monkeypatch: pytest.MonkeyPatch, rpc_urls: str | list[str]
+) -> None:
+    monkeypatch.setattr(web3_utils, "get_rpc_urls", lambda: {"146": rpc_urls})
+
+    with pytest.raises(ValueError, match="No RPC endpoints configured for chain 146"):
+        web3_utils.get_web3s_from_chain_id(146)
+    rpc_pool_probe.assert_not_called()
 
 
 def test_gorlami_base_url_derived_from_api_base(

--- a/wayfinder_paths/tests/test_portfolio_rpc_failures.py
+++ b/wayfinder_paths/tests/test_portfolio_rpc_failures.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+
+import httpx
+import pytest
+from web3 import Web3
+from web3.exceptions import ContractLogicError, Web3RPCError
+
+import wayfinder_paths.adapters.moonwell_adapter.adapter as moonwell_module
+import wayfinder_paths.adapters.pendle_adapter.adapter as pendle_module
+from wayfinder_paths.adapters.moonwell_adapter.adapter import MoonwellAdapter
+from wayfinder_paths.adapters.multicall_adapter.adapter import (
+    MulticallAdapter,
+    MulticallResult,
+)
+from wayfinder_paths.adapters.pendle_adapter.adapter import PendleAdapter
+
+ACCOUNT = "0x" + "a" * 40
+MARKETS = {"markets": [{"address": "0x" + "1" * 40, "pt": "0x" + "2" * 40}]}
+type Adapter = PendleAdapter | MoonwellAdapter
+
+
+@pytest.fixture(params=[PendleAdapter, MoonwellAdapter], ids=["pendle", "moonwell"])
+def adapter(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> Adapter:
+    instance = request.param(config={})
+    if isinstance(instance, PendleAdapter):
+        monkeypatch.setattr(instance, "fetch_markets", AsyncMock(return_value=MARKETS))
+    return instance
+
+
+@pytest.fixture
+def web3_context(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    closed = Mock()
+
+    @asynccontextmanager
+    async def context(chain_id: int) -> AsyncIterator[Web3]:
+        try:
+            yield Web3()
+        finally:
+            closed(chain_id)
+
+    monkeypatch.setattr(pendle_module, "web3_from_chain_id", context)
+    monkeypatch.setattr(moonwell_module, "web3_from_chain_id", context)
+    return closed
+
+
+async def read_positions(
+    adapter: Adapter, *, timeout_seconds: float = 60.0
+) -> tuple[bool, dict[str, Any] | str]:
+    if isinstance(adapter, PendleAdapter):
+        return await adapter.get_full_user_state_per_chain(
+            chain=42161, account=ACCOUNT, timeout_seconds=timeout_seconds
+        )
+    return await adapter.get_full_user_state(
+        chain_id=8453,
+        account=ACCOUNT,
+        include_rewards=False,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        ConnectionError("RPC disconnected"),
+        ConnectionError(),
+        httpx.HTTPStatusError(
+            "RPC unavailable",
+            request=httpx.Request("POST", "https://example.invalid/rpc"),
+            response=httpx.Response(503),
+        ),
+        Web3RPCError("RPC rejected request"),
+        TimeoutError("RPC timed out"),
+    ],
+    ids=["disconnect", "empty-message", "http-503", "json-rpc", "timeout"],
+)
+@pytest.mark.parametrize("during_fallback", [False, True], ids=["batch", "fallback"])
+async def test_rpc_failure_is_not_an_empty_portfolio(
+    adapter: Adapter,
+    web3_context: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+    error: Exception,
+    during_fallback: bool,
+) -> None:
+    failures = (
+        [ContractLogicError("batch reverted"), error] if during_fallback else [error]
+    )
+    aggregate = AsyncMock(side_effect=failures)
+    monkeypatch.setattr(MulticallAdapter, "aggregate", aggregate)
+
+    ok, result = await read_positions(adapter)
+
+    assert ok is False
+    assert isinstance(result, str) and result
+    assert aggregate.await_count == len(failures)
+    web3_context.assert_called_once()
+
+
+async def test_position_timeout_cancels_work_and_closes_provider(
+    adapter: Adapter, web3_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cancelled = asyncio.Event()
+
+    async def stalled_read(*args: Any, **kwargs: Any) -> None:
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cancelled.set()
+
+    aggregate = AsyncMock(side_effect=stalled_read)
+    monkeypatch.setattr(MulticallAdapter, "aggregate", aggregate)
+
+    ok, result = await read_positions(adapter, timeout_seconds=0.01)
+
+    assert ok is False
+    assert isinstance(result, str) and "position scan timed out on chain" in result
+    assert cancelled.is_set()
+    aggregate.assert_awaited_once()
+    web3_context.assert_called_once()
+
+
+async def test_caller_cancellation_is_not_swallowed(
+    adapter: Adapter, web3_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    aggregate = AsyncMock(side_effect=asyncio.CancelledError)
+    monkeypatch.setattr(MulticallAdapter, "aggregate", aggregate)
+
+    with pytest.raises(asyncio.CancelledError):
+        await read_positions(adapter)
+
+    aggregate.assert_awaited_once()
+    web3_context.assert_called_once()
+
+
+async def test_successful_zero_balances_remain_successful(
+    adapter: Adapter, web3_context: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    if isinstance(adapter, PendleAdapter):
+        data = [value.to_bytes(32) for value in (0, 18, 0, 18)]
+    else:
+        codec = Web3().codec
+        data = [
+            codec.encode(["address[]"], [[]]),
+            codec.encode(["address[]"], [[]]),
+            codec.encode(["uint256", "uint256", "uint256"], [0, 0, 0]),
+        ]
+    monkeypatch.setattr(
+        MulticallAdapter,
+        "aggregate",
+        AsyncMock(return_value=MulticallResult(block_number=1, return_data=data)),
+    )
+
+    ok, result = await read_positions(adapter)
+
+    assert ok is True
+    assert isinstance(result, dict) and result["positions"] == []
+    web3_context.assert_called_once()
+
+
+async def test_contract_revert_still_salvages_individual_calls(
+    adapter: Adapter,
+) -> None:
+    encoded = (123).to_bytes(32)
+    multicall = Mock(spec=MulticallAdapter)
+    multicall.aggregate = AsyncMock(
+        side_effect=[
+            ContractLogicError("batch reverted"),
+            MulticallResult(block_number=1, return_data=[encoded]),
+            ContractLogicError("deprecated contract"),
+        ]
+    )
+    multicall.decode_uint256 = MulticallAdapter.decode_uint256
+    if isinstance(adapter, PendleAdapter):
+        values = await adapter._multicall_uint256_chunked(
+            multicall=multicall, calls=["first", "second"], chunk_size=400
+        )
+        assert values == [123, None]
+    else:
+        raw = await adapter._multicall_chunked(
+            multicall=multicall, calls=["first", "second"], chunk_size=240
+        )
+        assert raw == [encoded, b""]
+    assert multicall.aggregate.await_count == 3
+
+
+async def test_pendle_rpc_failure_keeps_other_chains_positions(
+    monkeypatch: pytest.MonkeyPatch, web3_context: Mock
+) -> None:
+    adapter = PendleAdapter(config={})
+    monkeypatch.setattr(adapter, "fetch_markets", AsyncMock(return_value=MARKETS))
+    monkeypatch.setattr(
+        pendle_module, "PENDLE_CHAIN_IDS", {"ethereum": 1, "arbitrum": 42161}
+    )
+    aggregate = AsyncMock(
+        side_effect=[
+            ConnectionError("RPC disconnected"),
+            MulticallResult(
+                block_number=1,
+                return_data=[value.to_bytes(32) for value in (100, 18, 0, 18)],
+            ),
+        ]
+    )
+    monkeypatch.setattr(MulticallAdapter, "aggregate", aggregate)
+
+    ok, result = await adapter.get_full_user_state(account=ACCOUNT)
+
+    assert ok is True
+    assert isinstance(result, dict)
+    assert result["chains"] == [42161]
+    assert result["errors"] == ["chain 1: RPC disconnected"]
+    assert result["positions"][0]["balances"]["pt"]["raw"] == 100
+    assert aggregate.await_count == 2
+    assert web3_context.call_count == 2
+
+
+@pytest.mark.parametrize("all_stalled", [False, True], ids=["partial", "all-chains"])
+async def test_pendle_market_discovery_timeout_continues_to_next_chain(
+    monkeypatch: pytest.MonkeyPatch, web3_context: Mock, all_stalled: bool
+) -> None:
+    adapter = PendleAdapter(config={})
+    cancelled: list[int] = []
+
+    async def fetch_markets(*, chain_id: int, **kwargs: Any) -> dict[str, Any]:
+        if chain_id == 1 or all_stalled:
+            try:
+                await asyncio.Event().wait()
+            finally:
+                cancelled.append(chain_id)
+        return MARKETS
+
+    monkeypatch.setattr(adapter, "fetch_markets", fetch_markets)
+    monkeypatch.setattr(
+        pendle_module, "PENDLE_CHAIN_IDS", {"ethereum": 1, "arbitrum": 42161}
+    )
+    monkeypatch.setattr(
+        MulticallAdapter,
+        "aggregate",
+        AsyncMock(
+            return_value=MulticallResult(
+                block_number=1,
+                return_data=[value.to_bytes(32) for value in (100, 18, 0, 18)],
+            )
+        ),
+    )
+
+    ok, result = await adapter.get_full_user_state(
+        account=ACCOUNT, chain_timeout_seconds=0.02
+    )
+
+    if all_stalled:
+        assert ok is False
+        assert (
+            isinstance(result, str) and "chain 42161" in result and "chain 1 " in result
+        )
+        assert cancelled == [1, 42161]
+        web3_context.assert_not_called()
+    else:
+        assert ok is True
+        assert isinstance(result, dict)
+        assert result["chains"] == [42161]
+        assert (
+            len(result["errors"]) == 1 and "timed out on chain 1" in result["errors"][0]
+        )
+        assert result["positions"][0]["balances"]["pt"]["raw"] == 100
+        assert cancelled == [1]
+        web3_context.assert_called_once_with(42161)


### PR DESCRIPTION
### Summary
- Fail fast when the shared RPC resolver confirms a chain has zero configured endpoints. Preserve custom RPC overrides and the existing fallback for transient discovery failures; do not cache zero results.
- In Pendle and Moonwell, reserve per-call multicall fallback for contract reverts. Propagate disconnects, HTTP failures, JSON-RPC errors, and timeouts instead of retrying every token and reporting an empty successful portfolio. Preserve existing contract-revert salvage behavior.
- Bound each position scan to 60 seconds by default, with optional keyword overrides. Pendle includes market discovery in the deadline and continues to other chains, returning their positions alongside explicit chain errors. Cancellation closes the provider and does not leave the scan running.
- Keep existing response formats and helpers; no new runtime abstraction, dependency, Sonic RPC configuration, SDK version bump, or instance/image changes.
- Validation: 144 focused tests passed (4 live tests deselected; the 5 Pendle/Moonwell fork tests were separately blocked by 401 without credentials), repository-wide Ruff lint/format and whitespace checks passed. New tests pass targeted mypy; the two adapter files retain the same 13 pre-existing mypy errors verified against the pre-change commit.
- Added regression coverage for batch and fallback RPC failures, blank exception messages, genuine zero balances, contract-revert salvage, scan deadlines, cancellation/provider cleanup, and healthy-chain retention when another chain fails or times out. Much of the Pendle diff is indentation around the timeout context; the underlying position calculation is unchanged.