### PR TITLE
MCP - Harden startup and runtime reliability

### DIFF
--- a/.github/workflows/test-pipeline.yml
+++ b/.github/workflows/test-pipeline.yml
@@ -213,7 +213,11 @@ jobs:
       run: poetry install --no-interaction
 
     - name: Run MCP tests
-      run: poetry run pytest wayfinder_paths/tests/test_mcp*.py wayfinder_paths/tests/test_delta_lab_resources.py -v --maxfail=5 -m "not local"
+      run: >-
+        poetry run pytest wayfinder_paths/tests/test_mcp*.py
+        wayfinder_paths/tests/test_delta_lab_resources.py
+        wayfinder_paths/core/clients/test_hyperliquid_info_client.py
+        -v --maxfail=5 -m "not local"
 
   # Integration Tests (strategies with multiple adapters)
   integration-tests:

--- a/wayfinder_paths/core/clients/HyperliquidInfoClient.py
+++ b/wayfinder_paths/core/clients/HyperliquidInfoClient.py
@@ -4,7 +4,7 @@ import asyncio
 from functools import cache
 from typing import Any
 
-from hyperliquid.info import Info
+from hyperliquid.api import API
 from hyperliquid.utils import constants
 from hyperliquid.utils.error import (  # type: ignore[import-untyped]
     ClientError,
@@ -20,8 +20,9 @@ _RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
 
 
 @cache
-def _public_info() -> Info:
-    return Info(constants.MAINNET_API_URL, skip_ws=True, timeout=DEFAULT_HTTP_TIMEOUT)
+def _public_info() -> API:
+    # Raw /info posts do not need Info's eager market-metadata requests.
+    return API(constants.MAINNET_API_URL, timeout=DEFAULT_HTTP_TIMEOUT)
 
 
 def _is_retryable(exc: Exception) -> bool:
@@ -32,9 +33,9 @@ def _is_retryable(exc: Exception) -> bool:
 
 class HyperliquidInfoClient:
     async def post(self, body: dict[str, Any]) -> Any:
+        client = _public_info()
         return await retry_async(
-            # Info initialization also performs blocking metadata requests.
-            lambda: asyncio.to_thread(lambda: _public_info().post("/info", body)),
+            lambda: asyncio.to_thread(client.post, "/info", body),
             should_retry=_is_retryable,
         )
 

--- a/wayfinder_paths/core/clients/HyperliquidInfoClient.py
+++ b/wayfinder_paths/core/clients/HyperliquidInfoClient.py
@@ -11,7 +11,9 @@ from hyperliquid.utils.error import (  # type: ignore[import-untyped]
     ServerError,
 )
 from requests import ConnectionError as RequestsConnectionError
+from requests import Timeout as RequestsTimeout
 
+from wayfinder_paths.core.constants.base import DEFAULT_HTTP_TIMEOUT
 from wayfinder_paths.core.utils.retry import retry_async
 
 _RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
@@ -19,19 +21,20 @@ _RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
 
 @cache
 def _public_info() -> Info:
-    return Info(constants.MAINNET_API_URL, skip_ws=True)
+    return Info(constants.MAINNET_API_URL, skip_ws=True, timeout=DEFAULT_HTTP_TIMEOUT)
 
 
 def _is_retryable(exc: Exception) -> bool:
     if isinstance(exc, (ClientError, ServerError)):
         return getattr(exc, "status_code", None) in _RETRYABLE_STATUS_CODES
-    return isinstance(exc, RequestsConnectionError)
+    return isinstance(exc, (RequestsConnectionError, RequestsTimeout))
 
 
 class HyperliquidInfoClient:
     async def post(self, body: dict[str, Any]) -> Any:
         return await retry_async(
-            lambda: asyncio.to_thread(_public_info().post, "/info", body),
+            # Info initialization also performs blocking metadata requests.
+            lambda: asyncio.to_thread(lambda: _public_info().post("/info", body)),
             should_retry=_is_retryable,
         )
 

--- a/wayfinder_paths/core/clients/test_hyperliquid_info_client.py
+++ b/wayfinder_paths/core/clients/test_hyperliquid_info_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import threading
 from unittest.mock import Mock
 
 import pytest
@@ -9,10 +10,12 @@ from hyperliquid.utils.error import (  # type: ignore[import-untyped]
     ServerError,
 )
 from requests import ConnectionError as RequestsConnectionError
+from requests import Timeout as RequestsTimeout
 
 from wayfinder_paths.core.clients.HyperliquidInfoClient import (
     HyperliquidInfoClient,
 )
+from wayfinder_paths.core.constants.base import DEFAULT_HTTP_TIMEOUT
 from wayfinder_paths.core.utils import retry as retry_utils
 
 client_module = importlib.import_module(
@@ -45,6 +48,7 @@ def mock_info(monkeypatch: pytest.MonkeyPatch) -> Mock:
         ServerError(500, "null"),
         ClientError(429, None, "rate limited", {}),
         RequestsConnectionError("connection reset"),
+        RequestsTimeout("read timed out"),
     ],
 )
 async def test_post_retries_transient_failures(
@@ -94,3 +98,34 @@ async def test_post_reraises_after_bounded_attempts(
     assert raised.value is error
     assert mock_info.post.call_count == 3
     assert no_retry_sleep == [0.25, 0.5]
+
+
+@pytest.mark.asyncio
+async def test_cold_client_initialization_runs_off_event_loop_with_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    loop_thread = threading.get_ident()
+    threads: list[int] = []
+    info = Mock()
+    info.post.return_value = {"ETH": "2000"}
+
+    def build_info(*args: object, **kwargs: object) -> Mock:
+        threads.append(threading.get_ident())
+        return info
+
+    factory = Mock(side_effect=build_info)
+    monkeypatch.setattr(client_module, "Info", factory)
+    client_module._public_info.cache_clear()
+    try:
+        client = HyperliquidInfoClient()
+        for _ in range(2):
+            assert await client.post({"type": "allMids"}) == {"ETH": "2000"}
+        assert len(threads) == 1
+        assert threads[0] != loop_thread
+        factory.assert_called_once_with(
+            client_module.constants.MAINNET_API_URL,
+            skip_ws=True,
+            timeout=DEFAULT_HTTP_TIMEOUT,
+        )
+    finally:
+        client_module._public_info.cache_clear()

--- a/wayfinder_paths/core/clients/test_hyperliquid_info_client.py
+++ b/wayfinder_paths/core/clients/test_hyperliquid_info_client.py
@@ -101,30 +101,35 @@ async def test_post_reraises_after_bounded_attempts(
 
 
 @pytest.mark.asyncio
-async def test_cold_client_initialization_runs_off_event_loop_with_timeout(
+async def test_client_reuses_transport_without_metadata_requests(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     loop_thread = threading.get_ident()
     threads: list[int] = []
-    info = Mock()
-    info.post.return_value = {"ETH": "2000"}
+    expected = {"ETH": "2000"}
+    response = Mock(status_code=200)
+    response.json.return_value = expected
 
-    def build_info(*args: object, **kwargs: object) -> Mock:
+    def post(*args: object, **kwargs: object) -> Mock:
         threads.append(threading.get_ident())
-        return info
+        return response
 
-    factory = Mock(side_effect=build_info)
-    monkeypatch.setattr(client_module, "Info", factory)
+    transport = Mock()
+    transport.post.side_effect = post
+    factory = Mock(return_value=transport)
+    monkeypatch.setattr("requests.Session", factory)
     client_module._public_info.cache_clear()
     try:
         client = HyperliquidInfoClient()
         for _ in range(2):
-            assert await client.post({"type": "allMids"}) == {"ETH": "2000"}
-        assert len(threads) == 1
-        assert threads[0] != loop_thread
-        factory.assert_called_once_with(
-            client_module.constants.MAINNET_API_URL,
-            skip_ws=True,
+            assert await client.post({"type": "allMids"}) == expected
+        assert len(threads) == 2
+        assert all(thread != loop_thread for thread in threads)
+        factory.assert_called_once_with()
+        assert transport.post.call_count == 2
+        transport.post.assert_called_with(
+            f"{client_module.constants.MAINNET_API_URL}/info",
+            json={"type": "allMids"},
             timeout=DEFAULT_HTTP_TIMEOUT,
         )
     finally:

--- a/wayfinder_paths/paths/client.py
+++ b/wayfinder_paths/paths/client.py
@@ -433,7 +433,15 @@ class PathsApiClient:
             raise PathsApiError(
                 f"Batch install heartbeat failed ({resp.status_code}): {resp.text}"
             )
-        return resp.json()
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            raise PathsApiError(
+                "Batch install heartbeat returned invalid JSON"
+            ) from exc
+        if not isinstance(data, dict) or not isinstance(data.get("results"), list):
+            raise PathsApiError("Batch install heartbeat returned invalid results")
+        return data
 
     def emit_signal(
         self,

--- a/wayfinder_paths/paths/client.py
+++ b/wayfinder_paths/paths/client.py
@@ -422,7 +422,13 @@ class PathsApiClient:
         if source:
             body["source"] = source
 
-        resp = self._client.post(url, json=body, headers=self._headers())
+        # Best-effort startup reporting must not stall MCP for the normal 60s timeout.
+        try:
+            resp = self._client.post(
+                url, json=body, headers=self._headers(), timeout=5.0
+            )
+        except httpx.HTTPError as exc:
+            raise PathsApiError(f"Batch install heartbeat failed: {exc}") from exc
         if resp.status_code >= 400:
             raise PathsApiError(
                 f"Batch install heartbeat failed ({resp.status_code}): {resp.text}"

--- a/wayfinder_paths/paths/heartbeat.py
+++ b/wayfinder_paths/paths/heartbeat.py
@@ -173,29 +173,30 @@ def maybe_heartbeat_installed_paths(
             trigger=trigger,
         )
 
-    results = response.get("results")
-    sent = 0
-    if isinstance(results, list):
-        sent = sum(
-            1
-            for item in results
-            if isinstance(item, dict) and item.get("status") == "recorded"
-        )
-
-    state_path.parent.mkdir(parents=True, exist_ok=True)
-    state_path.write_text(
-        json.dumps(
-            {
-                "schemaVersion": "0.1",
-                "last_success_at": current_time.isoformat(),
-                "last_trigger": trigger,
-                "attempted": len(heartbeats),
-                "sent": sent,
-            },
-            indent=2,
-        )
-        + "\n"
+    sent = sum(
+        1
+        for item in response["results"]
+        if isinstance(item, dict) and item.get("status") == "recorded"
     )
+
+    try:
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        state_path.write_text(
+            json.dumps(
+                {
+                    "schemaVersion": "0.1",
+                    "last_success_at": current_time.isoformat(),
+                    "last_trigger": trigger,
+                    "attempted": len(heartbeats),
+                    "sent": sent,
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+    except OSError as exc:
+        # Reporting succeeded; a local cooldown-file failure must not block startup.
+        logger.warning("Could not save installed-path heartbeat cooldown: {}", exc)
     return PathHeartbeatResult(
         status="recorded",
         reason="sent",

--- a/wayfinder_paths/runner/daemon.py
+++ b/wayfinder_paths/runner/daemon.py
@@ -84,7 +84,7 @@ def _tail_text(path: Path, *, max_bytes: int = 4000) -> str | None:
             size = f.tell()
             start = max(0, size - int(max_bytes))
             f.seek(start, os.SEEK_SET)
-            data = f.read()
+            data = f.read(max_bytes)
     except OSError:
         return None
     text = data.decode("utf-8", errors="replace").strip()
@@ -361,11 +361,8 @@ class RunnerDaemon:
         status: str,
         exit_code: int | None,
     ) -> None:
-        log_output = ""
-        try:
-            log_output = rp.log_path.read_text(errors="replace")
-        except Exception:  # noqa: BLE001
-            pass
+        # Keep reporting bounded even when a job emits a very large log.
+        log_output = _tail_text(rp.log_path, max_bytes=64_000) or ""
         SCHEDULED_JOBS_CLIENT.report_run(
             rp.job_name,
             {

--- a/wayfinder_paths/tests/test_mcp_server_build.py
+++ b/wayfinder_paths/tests/test_mcp_server_build.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
-import subprocess
+import asyncio
+import json
 import sys
-import time
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
 
 
 def test_build_mcp_registers_tools() -> None:
@@ -32,31 +39,76 @@ def test_build_mcp_registers_tools() -> None:
         assert required in names, f"missing tool: {required}"
 
 
-def test_mcp_server_starts_and_stays_alive() -> None:
-    # `python -m wayfinder_paths.mcp.server` is the production entrypoint. Spawn it
-    # and confirm it survives long enough to be serving on stdio — that proves
-    # `main()` (heartbeat + build_mcp + transport boot) ran without crashing,
-    # which `build_mcp()` alone won't catch.
-    proc = subprocess.Popen(
-        [sys.executable, "-m", "wayfinder_paths.mcp.server"],
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "body"),
+    [
+        (200, b'{"results": [{"status": "recorded"}]}'),
+        (200, b"null"),
+        (503, b"Unavailable"),
+        (200, None),
+    ],
+)
+async def test_mcp_server_serves_tools_after_startup_heartbeat(
+    tmp_path: Path, status: int, body: bytes | None
+) -> None:
+    # Exercise the real entrypoint and MCP handshake, not just a process that may
+    # be alive but stuck before binding. Only the heartbeat backend is a stub.
+    requests: list[str] = []
+    release_request = threading.Event()
+
+    class HeartbeatHandler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            self.rfile.read(int(self.headers["Content-Length"]))
+            requests.append(self.path)
+            if body is None:
+                # Stall until the client has timed out and MCP is ready.
+                release_request.wait(timeout=40)
+                return
+            self.send_response(status)
+            self.end_headers()
+            self.wfile.write(body)
+
+    state_dir = tmp_path / ".wayfinder"
+    state_dir.mkdir()
+    (state_dir / "paths.lock.json").write_text(
+        json.dumps(
+            {"paths": {"demo": {"installation_id": "test", "heartbeat_token": "test"}}}
+        )
     )
-    try:
-        time.sleep(5)
-        early_exit = proc.poll()
-        if early_exit is not None:
-            stdout, stderr = proc.communicate(timeout=5)
-            raise AssertionError(
-                f"mcp server exited early with code {early_exit}\n"
-                f"stdout={stdout.decode(errors='replace')}\n"
-                f"stderr={stderr.decode(errors='replace')}"
-            )
-    finally:
-        proc.terminate()
+    with ThreadingHTTPServer(("127.0.0.1", 0), HeartbeatHandler) as backend:
+        thread = threading.Thread(
+            target=backend.serve_forever, kwargs={"poll_interval": 0.05}, daemon=True
+        )
+        thread.start()
+        params = StdioServerParameters(
+            command=sys.executable,
+            args=["-m", "wayfinder_paths.mcp.server"],
+            cwd=tmp_path,
+            env={
+                "PYTHONPATH": str(Path(__file__).resolve().parents[2]),
+                "WAYFINDER_CONFIG_PATH": str(tmp_path / "config.json"),
+                "WAYFINDER_PATHS_API_URL": f"http://127.0.0.1:{backend.server_port}",
+                "OPENCODE_INSTANCE_ID": "test-instance",
+                "HOME": str(tmp_path),
+            },
+        )
         try:
-            proc.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            proc.wait(timeout=5)
+            async with asyncio.timeout(30), stdio_client(params) as (read, write):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    result = await session.list_tools()
+                    names = {tool.name for tool in result.tools}
+                    assert {
+                        "core_get_wallets",
+                        "onchain_swap",
+                        "visual_add_workspace_chart_overlay",
+                    } <= names
+        finally:
+            release_request.set()
+            backend.shutdown()
+            thread.join(timeout=2)
+    assert requests == ["/api/v1/paths/installations/heartbeat-batch/"]
+    assert (state_dir / "paths-heartbeat.json").exists() == (
+        status == 200 and body is not None and b"recorded" in body
+    )

--- a/wayfinder_paths/tests/test_mcp_startup_heartbeat.py
+++ b/wayfinder_paths/tests/test_mcp_startup_heartbeat.py
@@ -1,17 +1,10 @@
 from __future__ import annotations
 
-import json
-from pathlib import Path
-from unittest.mock import Mock
-
 import click
-import httpx
 import pytest
 
 from wayfinder_paths.mcp import cli as mcp_cli
 from wayfinder_paths.mcp import server as mcp_server
-from wayfinder_paths.paths import heartbeat
-from wayfinder_paths.paths.client import PathsApiClient
 
 
 def _make_fake_group() -> click.Group:
@@ -143,39 +136,3 @@ def test_mcp_server_main_accepts_profile_host_port_and_transport(monkeypatch) ->
 
     assert calls == ["mcp-server"]
     assert runs == [("0.0.0.0", 8123, "streamable-http")]
-
-
-def test_mcp_server_starts_after_heartbeat_read_timeout(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setenv("WAYFINDER_PATHS_API_URL", "https://paths.example")
-    monkeypatch.setenv("OPENCODE_INSTANCE_ID", "test-instance")
-    state_dir = tmp_path / ".wayfinder"
-    state_dir.mkdir()
-    (state_dir / "paths.lock.json").write_text(
-        json.dumps(
-            {
-                "paths": {
-                    "demo": {"installation_id": "install-1", "heartbeat_token": "test"}
-                }
-            }
-        )
-    )
-    requests: list[httpx.Request] = []
-
-    def handle(request: httpx.Request) -> httpx.Response:
-        requests.append(request)
-        raise httpx.ReadTimeout("The read operation timed out", request=request)
-
-    with httpx.Client(transport=httpx.MockTransport(handle)) as http:
-        client = PathsApiClient(api_base_url="https://paths.example", client=http)
-        monkeypatch.setattr(heartbeat, "PathsApiClient", lambda: client)
-        server = Mock()
-        monkeypatch.setattr(mcp_server, "build_mcp", Mock(return_value=server))
-
-        mcp_server.main(["--transport", "streamable-http"])
-
-    assert len(requests) == 1
-    server.run.assert_called_once_with(transport="streamable-http")
-    assert not (state_dir / "paths-heartbeat.json").exists()

--- a/wayfinder_paths/tests/test_mcp_startup_heartbeat.py
+++ b/wayfinder_paths/tests/test_mcp_startup_heartbeat.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
 import click
+import httpx
 import pytest
 
 from wayfinder_paths.mcp import cli as mcp_cli
 from wayfinder_paths.mcp import server as mcp_server
+from wayfinder_paths.paths import heartbeat
+from wayfinder_paths.paths.client import PathsApiClient
 
 
 def _make_fake_group() -> click.Group:
@@ -136,3 +143,39 @@ def test_mcp_server_main_accepts_profile_host_port_and_transport(monkeypatch) ->
 
     assert calls == ["mcp-server"]
     assert runs == [("0.0.0.0", 8123, "streamable-http")]
+
+
+def test_mcp_server_starts_after_heartbeat_read_timeout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("WAYFINDER_PATHS_API_URL", "https://paths.example")
+    monkeypatch.setenv("OPENCODE_INSTANCE_ID", "test-instance")
+    state_dir = tmp_path / ".wayfinder"
+    state_dir.mkdir()
+    (state_dir / "paths.lock.json").write_text(
+        json.dumps(
+            {
+                "paths": {
+                    "demo": {"installation_id": "install-1", "heartbeat_token": "test"}
+                }
+            }
+        )
+    )
+    requests: list[httpx.Request] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        raise httpx.ReadTimeout("The read operation timed out", request=request)
+
+    with httpx.Client(transport=httpx.MockTransport(handle)) as http:
+        client = PathsApiClient(api_base_url="https://paths.example", client=http)
+        monkeypatch.setattr(heartbeat, "PathsApiClient", lambda: client)
+        server = Mock()
+        monkeypatch.setattr(mcp_server, "build_mcp", Mock(return_value=server))
+
+        mcp_server.main(["--transport", "streamable-http"])
+
+    assert len(requests) == 1
+    server.run.assert_called_once_with(transport="streamable-http")
+    assert not (state_dir / "paths-heartbeat.json").exists()

--- a/wayfinder_paths/tests/test_path_heartbeat_startup.py
+++ b/wayfinder_paths/tests/test_path_heartbeat_startup.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -204,12 +205,23 @@ def test_maybe_heartbeat_installed_paths_reads_legacy_cooldown_state(
 
 
 @pytest.mark.parametrize(
-    "failure", [httpx.ReadTimeout, httpx.ConnectError, httpx.RemoteProtocolError, 503]
+    "failure",
+    [
+        httpx.ReadTimeout,
+        httpx.ConnectError,
+        httpx.RemoteProtocolError,
+        503,
+        "<html>Unavailable</html>",
+        "null",
+        "[]",
+        "{}",
+        '{"results": null}',
+    ],
 )
 def test_heartbeat_failure_does_not_start_cooldown(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    failure: type[httpx.RequestError] | int,
+    failure: type[httpx.RequestError] | int | str,
 ) -> None:
     _write_lockfile(tmp_path)
     monkeypatch.setenv("WAYFINDER_PATHS_API_URL", "https://paths.example")
@@ -219,6 +231,8 @@ def test_heartbeat_failure_does_not_start_cooldown(
     def handle(request: httpx.Request) -> httpx.Response:
         requests.append(request)
         if len(requests) == 1:
+            if isinstance(failure, str):
+                return httpx.Response(200, text=failure)
             if isinstance(failure, int):
                 return httpx.Response(failure, text="Unavailable")
             raise failure("Heartbeat unavailable", request=request)
@@ -246,3 +260,35 @@ def test_heartbeat_failure_does_not_start_cooldown(
         assert requests[0].url.path == "/api/v1/paths/installations/heartbeat-batch/"
         assert requests[0].extensions["timeout"] == httpx.Timeout(5).as_dict()
         assert http.timeout == httpx.Timeout(60)
+
+
+@pytest.mark.parametrize("operation", ["mkdir", "write_text"])
+def test_heartbeat_state_write_failure_is_nonfatal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, operation: str
+) -> None:
+    _write_lockfile(tmp_path)
+    monkeypatch.setenv("WAYFINDER_PATHS_API_URL", "https://paths.example")
+    monkeypatch.setenv("OPENCODE_INSTANCE_ID", "test-instance")
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"results": [{"status": "recorded"}]})
+
+    def fail_write(*args: object, **kwargs: object) -> None:
+        raise OSError(errno.ENOSPC, "No space left on device")
+
+    with httpx.Client(transport=httpx.MockTransport(handle)) as http:
+        client = PathsApiClient(api_base_url="https://paths.example", client=http)
+        with monkeypatch.context() as patch:
+            patch.setattr(Path, operation, fail_write)
+            result = maybe_heartbeat_installed_paths(
+                trigger="mcp-server", cwd=tmp_path, client=client
+            )
+
+        assert result.status == "recorded"
+        assert result.sent == 1
+        assert not (tmp_path / ".wayfinder" / "paths-heartbeat.json").exists()
+        recovered = maybe_heartbeat_installed_paths(
+            trigger="mcp-server", cwd=tmp_path, client=client
+        )
+        assert recovered.status == "recorded"
+        assert (tmp_path / ".wayfinder" / "paths-heartbeat.json").exists()

--- a/wayfinder_paths/tests/test_path_heartbeat_startup.py
+++ b/wayfinder_paths/tests/test_path_heartbeat_startup.py
@@ -4,6 +4,10 @@ import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+import httpx
+import pytest
+
+from wayfinder_paths.paths.client import PathsApiClient
 from wayfinder_paths.paths.heartbeat import maybe_heartbeat_installed_paths
 
 
@@ -197,3 +201,48 @@ def test_maybe_heartbeat_installed_paths_reads_legacy_cooldown_state(
 
     assert result.status == "skipped"
     assert result.reason == "cooldown_active"
+
+
+@pytest.mark.parametrize(
+    "failure", [httpx.ReadTimeout, httpx.ConnectError, httpx.RemoteProtocolError, 503]
+)
+def test_heartbeat_failure_does_not_start_cooldown(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure: type[httpx.RequestError] | int,
+) -> None:
+    _write_lockfile(tmp_path)
+    monkeypatch.setenv("WAYFINDER_PATHS_API_URL", "https://paths.example")
+    monkeypatch.setenv("OPENCODE_INSTANCE_ID", "test-instance")
+    requests: list[httpx.Request] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if len(requests) == 1:
+            if isinstance(failure, int):
+                return httpx.Response(failure, text="Unavailable")
+            raise failure("Heartbeat unavailable", request=request)
+        return httpx.Response(200, json={"results": [{"status": "recorded"}]})
+
+    with httpx.Client(transport=httpx.MockTransport(handle), timeout=60) as http:
+        client = PathsApiClient(api_base_url="https://paths.example", client=http)
+        result = maybe_heartbeat_installed_paths(
+            trigger="mcp-server", cwd=tmp_path, client=client
+        )
+
+        assert result.status == "error"
+        assert result.reason == "request_failed"
+        assert result.attempted == 1
+        assert result.sent == 0
+        assert not (tmp_path / ".wayfinder" / "paths-heartbeat.json").exists()
+
+        recovered = maybe_heartbeat_installed_paths(
+            trigger="mcp-server", cwd=tmp_path, client=client
+        )
+
+        assert recovered.status == "recorded"
+        assert recovered.sent == 1
+        assert len(requests) == 2
+        assert requests[0].url.path == "/api/v1/paths/installations/heartbeat-batch/"
+        assert requests[0].extensions["timeout"] == httpx.Timeout(5).as_dict()
+        assert http.timeout == httpx.Timeout(60)

--- a/wayfinder_paths/tests/test_runner_script_jobs.py
+++ b/wayfinder_paths/tests/test_runner_script_jobs.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 import sys
+from io import BytesIO
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
+
+import pytest
 
 from wayfinder_paths.core.clients.OpenCodeClient import OPENCODE_CLIENT
+from wayfinder_paths.core.clients.ScheduledJobsClient import SCHEDULED_JOBS_CLIENT
 from wayfinder_paths.runner.constants import JOB_TYPE_SCRIPT, RunStatus
-from wayfinder_paths.runner.daemon import RunnerDaemon, RunningProcess
+from wayfinder_paths.runner.daemon import RunnerDaemon, RunningProcess, _tail_text
 from wayfinder_paths.runner.db import RunnerDB
 from wayfinder_paths.runner.paths import RunnerPaths
 from wayfinder_paths.runner.script_resolver import resolve_script_path
@@ -21,6 +25,61 @@ def _paths(tmp_path: Path) -> RunnerPaths:
         logs_dir=runner_dir / "logs",
         sock_path=runner_dir / "runner.sock",
     )
+
+
+@pytest.mark.parametrize("log_size", [None, 0, 100, 2_000_000])
+def test_report_finished_run_sends_only_bounded_log_tail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, log_size: int | None
+) -> None:
+    log_path = tmp_path / "run.log"
+    content = ""
+    if log_size is not None:
+        content = "x" * log_size + "\nfinished" if log_size else ""
+        log_path.write_text(content)
+    report = Mock()
+    monkeypatch.setattr(SCHEDULED_JOBS_CLIENT, "report_run", report)
+    rp = RunningProcess(
+        run_id=1,
+        job_id=2,
+        job_name="test-job",
+        started_at=0,
+        reason="schedule",
+        scheduled_for=0,
+        timeout_seconds=None,
+        popen=Mock(),
+        log_path=log_path,
+    )
+    RunnerDaemon(paths=_paths(tmp_path))._report_finished_run(
+        rp, finished_at=10, status=RunStatus.OK, exit_code=0
+    )
+
+    report.assert_called_once()
+    name, payload = report.call_args.args
+    assert name == "test-job"
+    assert payload["log_output"] == content[-64_000:].strip()
+    assert payload["status"] == RunStatus.OK
+    assert payload["run_id"] == 1
+    assert payload["exit_code"] == 0
+    if log_size is not None:
+        assert log_path.read_text() == content
+
+
+def test_log_tail_bounds_read_even_if_file_grows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stream = MagicMock(wraps=BytesIO(b"x" * 100_000))
+    stream.__enter__.return_value = stream
+    monkeypatch.setattr(Path, "open", Mock(return_value=stream))
+
+    assert _tail_text(tmp_path / "run.log", max_bytes=64_000) == "x" * 64_000
+    stream.read.assert_called_once_with(64_000)
+
+
+def test_unreadable_log_tail_is_optional(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "open", Mock(side_effect=PermissionError("denied")))
+    assert _tail_text(tmp_path / "run.log") is None
 
 
 def test_resolve_script_path_only_allows_wayfinder_runs(tmp_path: Path) -> None:


### PR DESCRIPTION
### Summary

- Keep optional installed-path heartbeats from blocking MCP startup: use a 5-second request timeout, normalize transport/HTTP/malformed-response failures into PathsApiError, and tolerate local cooldown-file write errors. Failed requests do not create a cooldown.
- Reuse the Hyperliquid SDK base API transport instead of Info: raw info requests need no eager market-metadata downloads. Keep network requests off the event loop, reuse the 30-second timeout and bounded retry helper, and retry transient read timeouts.
- Reuse the runner log-tail helper to read/report at most 64 KB instead of loading whole job logs. Full local logs remain intact; reads stay bounded even while files grow.
- Replace the process-alive smoke check with real MCP initialization and tool listing against successful, malformed, unavailable, and stalled heartbeat backends. Add disk-failure, recovery, timeout/retry, transport-reuse, worker-thread, and bounded-log regressions. Include Hyperliquid client regressions in the existing MCP CI job.
- Quality pass removed the redundant mocked startup test and unnecessary Hyperliquid metadata work. Validation: 369 MCP/runner/client tests plus 45 Hyperliquid adapter tests passed, 3 skipped; repository-wide Ruff lint/format and targeted typechecks passed. Existing typing issues in untouched legacy code remain unchanged.
- No new helpers, dependencies, SDK version bump, or key-rotation changes. Production remains untouched; deployment requires a subsequent Shells image build and backend image-reference update.